### PR TITLE
IGNITE-14754 Improved assertion message in meta storage server operation.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -24,11 +24,14 @@ import java.util.LinkedHashMap;
  * Collection of utility methods used throughout the system.
  */
 public class IgniteUtils {
+    /** Byte bit-mask. */
+    private static final int MASK = 0xf;
+
     /** Version of the JDK. */
     private static String jdkVer;
 
-    /**
-     * Initializes enterprise check.
+    /*
+      Initializes enterprise check.
      */
     static {
         IgniteUtils.jdkVer = System.getProperty("java.specification.version");
@@ -166,5 +169,45 @@ public class IgniteUtils {
         int val = (int)(key ^ (key >>> 32));
 
         return hash(val);
+    }
+
+    /**
+     * Converts byte array to hex string.
+     *
+     * @param arr Array of bytes.
+     * @return Hex string.
+     */
+    public static String toHexString(byte[] arr) {
+        return toHexString(arr, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Converts byte array to hex string.
+     *
+     * @param arr Array of bytes.
+     * @param maxLen Maximum length of result string. Rounds down to a power of two.
+     * @return Hex string.
+     */
+    public static String toHexString(byte[] arr, int maxLen) {
+        assert maxLen >= 0 : "maxLem must be not negative.";
+
+        int capacity = Math.min(arr.length << 1, maxLen);
+
+        int lim = capacity >> 1;
+
+        StringBuilder sb = new StringBuilder(capacity);
+
+        for (int i = 0; i < lim; i++)
+            addByteAsHex(sb, arr[i]);
+
+        return sb.toString().toUpperCase();
+    }
+
+    /**
+     * @param sb String builder.
+     * @param b Byte to add in hexadecimal format.
+     */
+    private static void addByteAsHex(StringBuilder sb, byte b) {
+        sb.append(Integer.toHexString(MASK & b >>> 4)).append(Integer.toHexString(MASK & b));
     }
 }

--- a/modules/metastorage-server/src/main/java/org/apache/ignite/internal/metastorage/server/Operation.java
+++ b/modules/metastorage-server/src/main/java/org/apache/ignite/internal/metastorage/server/Operation.java
@@ -17,8 +17,8 @@
 
 package org.apache.ignite.internal.metastorage.server;
 
-import java.util.Objects;
 import org.apache.ignite.internal.metastorage.common.OperationType;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -63,8 +63,9 @@ public final class Operation {
         assert (type == OperationType.NO_OP && key == null && val == null)
                 || (type == OperationType.PUT && key != null && val != null)
                 || (type == OperationType.REMOVE && key != null && val == null)
-                : "Invalid operation parameters: [type=" + type + ", key=" + Objects.toString(key,"null") +
-                ", val=" + Objects.toString(key,"null") + ']';
+                : "Invalid operation parameters: [type=" + type +
+                        ", key=" + (key == null ? "null" : IgniteUtils.toHexString(key, 256)) +
+                        ", val=" + (val == null ? "null" : IgniteUtils.toHexString(val, 256)) + ']';
 
         this.key = key;
         this.val = val;


### PR DESCRIPTION
Added `IgniteUtils.toHexString()` methods (actually copied from AI 2.x and renamed).
`Operation` constructor's assertion will print `key` and `val` as hex string.