### PR TITLE
IGNITE-14918 Externalize ClusterService lifecycle management

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -22,9 +22,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -35,27 +34,34 @@ public class IgniteUtils {
     private static final int MASK = 0xf;
 
     /** Version of the JDK. */
-    private static final String jdkVer = System.getProperty("java.specification.version");
+    private static String jdkVer;
 
     /** Class loader used to load Ignite. */
     private static final ClassLoader igniteClassLoader = IgniteUtils.class.getClassLoader();
 
     /** Primitive class map. */
-    private static final Map<String, Class<?>> primitiveMap = Map.of(
-        "byte", byte.class,
-        "short", short.class,
-        "int", int.class,
-        "long", long.class,
-        "float", float.class,
-        "double", double.class,
-        "char", char.class,
-        "boolean", boolean.class,
-        "void", void.class
-    );
+    private static final Map<String, Class<?>> primitiveMap = new HashMap<>(16, .5f);
 
     /** */
     private static final ConcurrentMap<ClassLoader, ConcurrentMap<String, Class>> classCache =
         new ConcurrentHashMap<>();
+
+    /*
+      Initializes enterprise check.
+     */
+    static {
+        IgniteUtils.jdkVer = System.getProperty("java.specification.version");
+
+        primitiveMap.put("byte", byte.class);
+        primitiveMap.put("short", short.class);
+        primitiveMap.put("int", int.class);
+        primitiveMap.put("long", long.class);
+        primitiveMap.put("float", float.class);
+        primitiveMap.put("double", double.class);
+        primitiveMap.put("char", char.class);
+        primitiveMap.put("boolean", boolean.class);
+        primitiveMap.put("void", void.class);
+    }
 
     /**
      * Get JDK version.
@@ -328,49 +334,5 @@ public class IgniteUtils {
         }
 
         return cls;
-    }
-
-    /**
-     * Shuts down the given executor service gradually, first disabling new submissions and later, if
-     * necessary, cancelling remaining tasks.
-     *
-     * <p>The method takes the following steps:
-     *
-     * <ol>
-     *   <li>calls {@link ExecutorService#shutdown()}, disabling acceptance of new submitted tasks.
-     *   <li>awaits executor service termination for half of the specified timeout.
-     *   <li>if the timeout expires, it calls {@link ExecutorService#shutdownNow()}, cancelling
-     *       pending tasks and interrupting running tasks.
-     *   <li>awaits executor service termination for the other half of the specified timeout.
-     * </ol>
-     *
-     * <p>If, at any step of the process, the calling thread is interrupted, the method calls {@link
-     * ExecutorService#shutdownNow()} and returns.
-     *
-     * @param service the {@code ExecutorService} to shut down
-     * @param timeout the maximum time to wait for the {@code ExecutorService} to terminate
-     * @param unit the time unit of the timeout argument
-     */
-    public static void shutdownAndAwaitTermination(ExecutorService service, long timeout, TimeUnit unit) {
-        long halfTimeoutNanos = unit.toNanos(timeout) / 2;
-
-        // Disable new tasks from being submitted
-        service.shutdown();
-
-        try {
-            // Wait for half the duration of the timeout for existing tasks to terminate
-            if (!service.awaitTermination(halfTimeoutNanos, TimeUnit.NANOSECONDS)) {
-                // Cancel currently executing tasks
-                service.shutdownNow();
-                // Wait the other half of the timeout for tasks to respond to being cancelled
-                service.awaitTermination(halfTimeoutNanos, TimeUnit.NANOSECONDS);
-            }
-        }
-        catch (InterruptedException ie) {
-            // Preserve interrupt status
-            Thread.currentThread().interrupt();
-            // (Re-)Cancel if current thread also interrupted
-            service.shutdownNow();
-        }
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -22,8 +22,9 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
-
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -34,34 +35,27 @@ public class IgniteUtils {
     private static final int MASK = 0xf;
 
     /** Version of the JDK. */
-    private static String jdkVer;
+    private static final String jdkVer = System.getProperty("java.specification.version");
 
     /** Class loader used to load Ignite. */
     private static final ClassLoader igniteClassLoader = IgniteUtils.class.getClassLoader();
 
     /** Primitive class map. */
-    private static final Map<String, Class<?>> primitiveMap = new HashMap<>(16, .5f);
+    private static final Map<String, Class<?>> primitiveMap = Map.of(
+        "byte", byte.class,
+        "short", short.class,
+        "int", int.class,
+        "long", long.class,
+        "float", float.class,
+        "double", double.class,
+        "char", char.class,
+        "boolean", boolean.class,
+        "void", void.class
+    );
 
     /** */
     private static final ConcurrentMap<ClassLoader, ConcurrentMap<String, Class>> classCache =
         new ConcurrentHashMap<>();
-
-    /*
-      Initializes enterprise check.
-     */
-    static {
-        IgniteUtils.jdkVer = System.getProperty("java.specification.version");
-
-        primitiveMap.put("byte", byte.class);
-        primitiveMap.put("short", short.class);
-        primitiveMap.put("int", int.class);
-        primitiveMap.put("long", long.class);
-        primitiveMap.put("float", float.class);
-        primitiveMap.put("double", double.class);
-        primitiveMap.put("char", char.class);
-        primitiveMap.put("boolean", boolean.class);
-        primitiveMap.put("void", void.class);
-    }
 
     /**
      * Get JDK version.
@@ -334,5 +328,49 @@ public class IgniteUtils {
         }
 
         return cls;
+    }
+
+    /**
+     * Shuts down the given executor service gradually, first disabling new submissions and later, if
+     * necessary, cancelling remaining tasks.
+     *
+     * <p>The method takes the following steps:
+     *
+     * <ol>
+     *   <li>calls {@link ExecutorService#shutdown()}, disabling acceptance of new submitted tasks.
+     *   <li>awaits executor service termination for half of the specified timeout.
+     *   <li>if the timeout expires, it calls {@link ExecutorService#shutdownNow()}, cancelling
+     *       pending tasks and interrupting running tasks.
+     *   <li>awaits executor service termination for the other half of the specified timeout.
+     * </ol>
+     *
+     * <p>If, at any step of the process, the calling thread is interrupted, the method calls {@link
+     * ExecutorService#shutdownNow()} and returns.
+     *
+     * @param service the {@code ExecutorService} to shut down
+     * @param timeout the maximum time to wait for the {@code ExecutorService} to terminate
+     * @param unit the time unit of the timeout argument
+     */
+    public static void shutdownAndAwaitTermination(ExecutorService service, long timeout, TimeUnit unit) {
+        long halfTimeoutNanos = unit.toNanos(timeout) / 2;
+
+        // Disable new tasks from being submitted
+        service.shutdown();
+
+        try {
+            // Wait for half the duration of the timeout for existing tasks to terminate
+            if (!service.awaitTermination(halfTimeoutNanos, TimeUnit.NANOSECONDS)) {
+                // Cancel currently executing tasks
+                service.shutdownNow();
+                // Wait the other half of the timeout for tasks to respond to being cancelled
+                service.awaitTermination(halfTimeoutNanos, TimeUnit.NANOSECONDS);
+            }
+        }
+        catch (InterruptedException ie) {
+            // Preserve interrupt status
+            Thread.currentThread().interrupt();
+            // (Re-)Cancel if current thread also interrupted
+            service.shutdownNow();
+        }
     }
 }

--- a/modules/metastorage-client/src/integrationTest/java/org/apache/ignite/internal/metastorage/client/ITMetaStorageServiceTest.java
+++ b/modules/metastorage-client/src/integrationTest/java/org/apache/ignite/internal/metastorage/client/ITMetaStorageServiceTest.java
@@ -1013,11 +1013,7 @@ public class ITMetaStorageServiceTest {
     private MetaStorageService prepareMetaStorage(KeyValueStorage keyValStorageMock) {
         List<Peer> peers = List.of(new Peer(cluster.get(0).topologyService().localMember().address()));
 
-        metaStorageRaftSrv = new RaftServerImpl(
-            cluster.get(0),
-            FACTORY,
-            true
-        );
+        metaStorageRaftSrv = new RaftServerImpl(cluster.get(0), FACTORY);
 
         metaStorageRaftSrv.
             startRaftGroup(METASTORAGE_RAFT_GROUP_NAME, new MetaStorageListener(keyValStorageMock), peers);
@@ -1029,8 +1025,7 @@ public class ITMetaStorageServiceTest {
             10_000,
             peers,
             true,
-            200,
-            true
+            200
         );
 
         return new MetaStorageServiceImpl(metaStorageRaftGrpSvc);

--- a/modules/network/src/main/java/org/apache/ignite/network/scalecube/ScaleCubeClusterServiceFactory.java
+++ b/modules/network/src/main/java/org/apache/ignite/network/scalecube/ScaleCubeClusterServiceFactory.java
@@ -103,6 +103,10 @@ public class ScaleCubeClusterServiceFactory implements ClusterServiceFactory {
 
             /** {@inheritDoc} */
             @Override public void shutdown() {
+                // local member will be null, if cluster has not been started
+                if (cluster.member() == null)
+                    return;
+
                 stopJmxMonitor();
 
                 cluster.shutdown();

--- a/modules/raft-client/src/main/java/org/apache/ignite/raft/client/service/impl/RaftGroupServiceImpl.java
+++ b/modules/raft-client/src/main/java/org/apache/ignite/raft/client/service/impl/RaftGroupServiceImpl.java
@@ -90,9 +90,6 @@ public class RaftGroupServiceImpl implements RaftGroupService {
     /** */
     private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
 
-    /** */
-    private final boolean reuse;
-
     /**
      * @param groupId Group id.
      * @param cluster A cluster.
@@ -101,7 +98,6 @@ public class RaftGroupServiceImpl implements RaftGroupService {
      * @param peers Initial group configuration.
      * @param refreshLeader {@code True} to synchronously refresh leader on service creation.
      * @param retryDelay Retry delay.
-     * @param reuse {@code True} to reuse cluster service (avoid lifecycle management).
      */
     public RaftGroupServiceImpl(
         String groupId,
@@ -110,8 +106,7 @@ public class RaftGroupServiceImpl implements RaftGroupService {
         int timeout,
         List<Peer> peers,
         boolean refreshLeader,
-        long retryDelay,
-        boolean reuse
+        long retryDelay
     ) {
         this.cluster = requireNonNull(cluster);
         this.peers = requireNonNull(peers);
@@ -119,10 +114,6 @@ public class RaftGroupServiceImpl implements RaftGroupService {
         this.timeout = timeout;
         this.groupId = groupId;
         this.retryDelay = retryDelay;
-        this.reuse = reuse;
-
-        if (!reuse)
-            cluster.start();
 
         if (refreshLeader) {
             try {
@@ -342,8 +333,6 @@ public class RaftGroupServiceImpl implements RaftGroupService {
 
     /** {@inheritDoc} */
     @Override public void shutdown() {
-        if (!reuse)
-            cluster.shutdown();
     }
 
     /**

--- a/modules/raft-client/src/test/java/org/apache/ignite/raft/client/service/RaftGroupServiceTest.java
+++ b/modules/raft-client/src/test/java/org/apache/ignite/raft/client/service/RaftGroupServiceTest.java
@@ -118,7 +118,7 @@ public class RaftGroupServiceTest {
         mockLeaderRequest(false);
 
         RaftGroupService service =
-            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY, true);
+            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY);
 
         assertNull(service.leader());
 
@@ -140,7 +140,7 @@ public class RaftGroupServiceTest {
         leader = null;
 
         RaftGroupService service =
-            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY, true);
+            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY);
 
         assertNull(service.leader());
 
@@ -175,7 +175,7 @@ public class RaftGroupServiceTest {
         }, 500);
 
         RaftGroupService service =
-            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY, true);
+            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY);
 
         assertNull(service.leader());
 
@@ -194,7 +194,7 @@ public class RaftGroupServiceTest {
         mockLeaderRequest(true);
 
         RaftGroupService service =
-            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY, true);
+            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY);
 
         try {
             service.refreshLeader().get(500, TimeUnit.MILLISECONDS);
@@ -217,7 +217,7 @@ public class RaftGroupServiceTest {
         mockUserInput(false, null);
 
         RaftGroupService service =
-            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY, true);
+            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY);
 
         service.refreshLeader().get();
 
@@ -237,7 +237,7 @@ public class RaftGroupServiceTest {
         mockUserInput(false, null);
 
         RaftGroupService service =
-            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY, true);
+            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY);
 
         assertNull(service.leader());
 
@@ -259,7 +259,7 @@ public class RaftGroupServiceTest {
         mockUserInput(true, null);
 
         RaftGroupService service =
-            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY, true);
+            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY);
 
         try {
             service.run(new TestCommand()).get(500, TimeUnit.MILLISECONDS);
@@ -282,7 +282,7 @@ public class RaftGroupServiceTest {
         mockUserInput(false, null);
 
         RaftGroupService service =
-            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, true, DELAY, true);
+            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, true, DELAY);
 
         Peer leader = this.leader;
 
@@ -313,7 +313,7 @@ public class RaftGroupServiceTest {
         mockUserInput(false, null);
 
         RaftGroupService service =
-            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, true, DELAY, true);
+            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, true, DELAY);
 
         Peer leader = this.leader;
 
@@ -349,7 +349,7 @@ public class RaftGroupServiceTest {
         mockUserInput(false, NODES.get(0));
 
         RaftGroupService service =
-            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT * 3, NODES, true, DELAY, true);
+            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT * 3, NODES, true, DELAY);
 
         Peer leader = this.leader;
 
@@ -387,7 +387,7 @@ public class RaftGroupServiceTest {
         mockUserInput(false, null);
 
         RaftGroupService service =
-            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, true, DELAY, true);
+            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, true, DELAY);
 
         Peer leader = this.leader;
 
@@ -418,7 +418,7 @@ public class RaftGroupServiceTest {
         mockSnapshotRequest(1);
 
         RaftGroupService service =
-            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY, true);
+            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY);
 
         CompletableFuture<Void> fut = service.snapshot(new Peer("localhost:8082"));
 
@@ -442,7 +442,7 @@ public class RaftGroupServiceTest {
         mockSnapshotRequest(0);
 
         RaftGroupService service =
-            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY, true);
+            new RaftGroupServiceImpl(groupId, cluster, FACTORY, TIMEOUT, NODES, false, DELAY);
 
         CompletableFuture<Void> fut = service.snapshot(new Peer("localhost:8082"));
 

--- a/modules/raft/src/integrationTest/java/org/apache/ignite/raft/server/ITSimpleCounterServerTest.java
+++ b/modules/raft/src/integrationTest/java/org/apache/ignite/raft/server/ITSimpleCounterServerTest.java
@@ -19,12 +19,12 @@ package org.apache.ignite.raft.server;
 
 import java.util.List;
 import org.apache.ignite.internal.raft.server.RaftServer;
+import org.apache.ignite.internal.raft.server.impl.RaftServerImpl;
 import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.raft.client.Peer;
 import org.apache.ignite.raft.client.service.RaftGroupService;
 import org.apache.ignite.raft.client.service.impl.RaftGroupServiceImpl;
-import org.apache.ignite.internal.raft.server.impl.RaftServerImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -74,24 +74,42 @@ class ITSimpleCounterServerTest extends RaftServerAbstractTest {
 
         String id = "localhost:" + PORT;
 
-        ClusterService service = clusterService(id, PORT, List.of(), false);
+        ClusterService service = clusterService(id, PORT, List.of(), true);
 
-        server = new RaftServerImpl(service, FACTORY, false);
+        server = new RaftServerImpl(service, FACTORY) {
+            @Override public synchronized void shutdown() throws Exception {
+                super.shutdown();
 
-        ClusterNode serverNode = this.server.clusterService().topologyService().localMember();
+                service.shutdown();
+            }
+        };
 
-        this.server.startRaftGroup(COUNTER_GROUP_ID_0, new CounterListener(), List.of(new Peer(serverNode.address())));
-        this.server.startRaftGroup(COUNTER_GROUP_ID_1, new CounterListener(), List.of(new Peer(serverNode.address())));
+        ClusterNode serverNode = server.clusterService().topologyService().localMember();
 
-        ClusterService clientNode1 = clusterService("localhost:" + (PORT + 1), PORT + 1, List.of(id), false);
+        server.startRaftGroup(COUNTER_GROUP_ID_0, new CounterListener(), List.of(new Peer(serverNode.address())));
+        server.startRaftGroup(COUNTER_GROUP_ID_1, new CounterListener(), List.of(new Peer(serverNode.address())));
+
+        ClusterService clientNode1 = clusterService("localhost:" + (PORT + 1), PORT + 1, List.of(id), true);
 
         client1 = new RaftGroupServiceImpl(COUNTER_GROUP_ID_0, clientNode1, FACTORY, 1000,
-            List.of(new Peer(serverNode.address())), false, 200, false);
+            List.of(new Peer(serverNode.address())), false, 200) {
+            @Override public void shutdown() {
+                super.shutdown();
 
-        ClusterService clientNode2 = clusterService("localhost:" + (PORT + 2), PORT + 2, List.of(id), false);
+                clientNode1.shutdown();
+            }
+        };
+
+        ClusterService clientNode2 = clusterService("localhost:" + (PORT + 2), PORT + 2, List.of(id), true);
 
         client2 = new RaftGroupServiceImpl(COUNTER_GROUP_ID_1, clientNode2, FACTORY, 1000,
-            List.of(new Peer(serverNode.address())), false, 200, false);
+            List.of(new Peer(serverNode.address())), false, 200) {
+            @Override public void shutdown() {
+                super.shutdown();
+
+                clientNode2.shutdown();
+            }
+        };
 
         assertTrue(waitForTopology(service, 2, 1000));
         assertTrue(waitForTopology(clientNode1, 2, 1000));

--- a/modules/raft/src/main/java/org/apache/ignite/internal/raft/Loza.java
+++ b/modules/raft/src/main/java/org/apache/ignite/internal/raft/Loza.java
@@ -56,7 +56,7 @@ public class Loza {
     public Loza(ClusterService clusterNetSvc) {
         this.clusterNetSvc = clusterNetSvc;
 
-        this.raftServer = new RaftServerImpl(clusterNetSvc, FACTORY, true);
+        this.raftServer = new RaftServerImpl(clusterNetSvc, FACTORY);
     }
 
     /**
@@ -82,8 +82,7 @@ public class Loza {
             TIMEOUT,
             peers.stream().map(i -> new Peer(i.address())).collect(Collectors.toList()),
             true,
-            DELAY,
-            true
+            DELAY
         );
     }
 

--- a/modules/raft/src/main/java/org/apache/ignite/internal/raft/server/impl/JRaftServerImpl.java
+++ b/modules/raft/src/main/java/org/apache/ignite/internal/raft/server/impl/JRaftServerImpl.java
@@ -117,7 +117,7 @@ public class JRaftServerImpl implements RaftServer {
         if (opts.getClientExecutor() == null)
             opts.setClientExecutor(JRaftUtils.createClientExecutor(opts, opts.getServerName()));
 
-        rpcServer = new IgniteRpcServer(service, nodeManager, factory, opts);
+        rpcServer = new IgniteRpcServer(service, nodeManager, factory, JRaftUtils.createRequestExecutor(opts));
 
         rpcServer.init(null);
     }

--- a/modules/raft/src/main/java/org/apache/ignite/internal/raft/server/impl/JRaftServerImpl.java
+++ b/modules/raft/src/main/java/org/apache/ignite/internal/raft/server/impl/JRaftServerImpl.java
@@ -78,24 +78,21 @@ public class JRaftServerImpl implements RaftServer {
      * @param service Cluster service.
      * @param dataPath Data path.
      * @param factory The factory.
-     * @param reuse {@code True} to reuse cluster service (do not manage lifecyle)
      */
-    public JRaftServerImpl(ClusterService service, String dataPath, RaftClientMessagesFactory factory, boolean reuse) {
-        this(service, dataPath, factory, reuse, new NodeOptions());
+    public JRaftServerImpl(ClusterService service, String dataPath, RaftClientMessagesFactory factory) {
+        this(service, dataPath, factory, new NodeOptions());
     }
 
     /**
      * @param service Cluster service.
      * @param dataPath Data path.
      * @param factory The factory.
-     * @param reuse {@code True} to reuse cluster service (do not manage lifecyle)
      * @param opts Default node options.
      */
     public JRaftServerImpl(
         ClusterService service,
         String dataPath,
         RaftClientMessagesFactory factory,
-        boolean reuse,
         NodeOptions opts
     ) {
         this.service = service;
@@ -103,7 +100,7 @@ public class JRaftServerImpl implements RaftServer {
         this.nodeManager = new NodeManager();
         this.opts = opts;
 
-        assert !reuse || service.topologyService().localMember() != null;
+        assert service.topologyService().localMember() != null;
 
         if (opts.getServerName() == null)
             opts.setServerName(service.localConfiguration().getName());
@@ -120,7 +117,7 @@ public class JRaftServerImpl implements RaftServer {
         if (opts.getClientExecutor() == null)
             opts.setClientExecutor(JRaftUtils.createClientExecutor(opts, opts.getServerName()));
 
-        rpcServer = new IgniteRpcServer(service, reuse, nodeManager, factory, JRaftUtils.createRequestExecutor(opts));
+        rpcServer = new IgniteRpcServer(service, nodeManager, factory, opts);
 
         rpcServer.init(null);
     }
@@ -164,14 +161,12 @@ public class JRaftServerImpl implements RaftServer {
         nodeOptions.setFsm(new DelegatingStateMachine(lsnr));
 
         if (initialConf != null) {
-            List<PeerId> mapped = initialConf.stream().map(p -> {
-                return PeerId.fromPeer(p);
-            }).collect(Collectors.toList());
+            List<PeerId> mapped = initialConf.stream().map(PeerId::fromPeer).collect(Collectors.toList());
 
             nodeOptions.setInitialConf(new Configuration(mapped, null));
         }
 
-        IgniteRpcClient client = new IgniteRpcClient(service, true);
+        IgniteRpcClient client = new IgniteRpcClient(service);
 
         nodeOptions.setRpcClient(client);
 

--- a/modules/raft/src/main/java/org/apache/ignite/internal/raft/server/impl/RaftServerImpl.java
+++ b/modules/raft/src/main/java/org/apache/ignite/internal/raft/server/impl/RaftServerImpl.java
@@ -76,25 +76,16 @@ public class RaftServerImpl implements RaftServer {
     /** */
     private final Thread writeWorker;
 
-    /** */
-    private final boolean reuse;
-
     /**
      * @param service Network service.
      * @param clientMsgFactory Client message factory.
-     * @param reuse {@code True} to reuse cluster service.
      */
-    public RaftServerImpl(
-        ClusterService service,
-        RaftClientMessagesFactory clientMsgFactory,
-        boolean reuse
-    ) {
+    public RaftServerImpl(ClusterService service, RaftClientMessagesFactory clientMsgFactory) {
         Objects.requireNonNull(service);
         Objects.requireNonNull(clientMsgFactory);
 
         this.service = service;
         this.clientMsgFactory = clientMsgFactory;
-        this.reuse = reuse;
 
         readQueue = new ArrayBlockingQueue<>(QUEUE_SIZE);
         writeQueue = new ArrayBlockingQueue<>(QUEUE_SIZE);
@@ -123,9 +114,6 @@ public class RaftServerImpl implements RaftServer {
             }
             // TODO https://issues.apache.org/jira/browse/IGNITE-14775
         });
-
-        if (!reuse)
-            service.start();
 
         readWorker = new Thread(() -> processQueue(readQueue, RaftGroupListener::onRead), "read-cmd-worker#" + service.topologyService().localMember().toString());
         readWorker.setDaemon(true);
@@ -171,9 +159,6 @@ public class RaftServerImpl implements RaftServer {
 
         writeWorker.interrupt();
         writeWorker.join();
-
-        if (!reuse)
-            service.shutdown();
 
         LOG.info("Stopped replication server [node=" + service.toString() + ']');
     }

--- a/modules/raft/src/main/java/org/apache/ignite/raft/jraft/rpc/impl/IgniteRpcClient.java
+++ b/modules/raft/src/main/java/org/apache/ignite/raft/jraft/rpc/impl/IgniteRpcClient.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
-import org.apache.ignite.lang.IgniteInternalException;
 import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.network.NetworkMessage;
 import org.apache.ignite.network.TopologyEventHandler;
@@ -47,18 +46,11 @@ public class IgniteRpcClient implements RpcClientEx {
 
     private final ClusterService service;
 
-    private final boolean reuse;
-
     /**
      * @param service The service.
-     * @param reuse {@code True} to reuse already started service.
      */
-    public IgniteRpcClient(ClusterService service, boolean reuse) {
+    public IgniteRpcClient(ClusterService service) {
         this.service = service;
-        this.reuse = reuse;
-
-        if (!reuse) // TODO asch use init
-            service.start();
     }
 
     public ClusterService clusterService() {
@@ -181,13 +173,6 @@ public class IgniteRpcClient implements RpcClientEx {
 
     /** {@inheritDoc} */
     @Override public void shutdown() {
-        try {
-            if (!reuse)
-                service.shutdown();
-        }
-        catch (Exception e) {
-            throw new IgniteInternalException(e);
-        }
     }
 
     /** {@inheritDoc} */

--- a/modules/raft/src/main/java/org/apache/ignite/raft/jraft/rpc/impl/IgniteRpcServer.java
+++ b/modules/raft/src/main/java/org/apache/ignite/raft/jraft/rpc/impl/IgniteRpcServer.java
@@ -20,15 +20,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Executor;
-import org.apache.ignite.lang.IgniteInternalException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.network.NetworkMessage;
-import org.apache.ignite.network.NetworkMessageHandler;
 import org.apache.ignite.network.TopologyEventHandler;
 import org.apache.ignite.raft.client.message.RaftClientMessagesFactory;
+import org.apache.ignite.raft.jraft.JRaftUtils;
 import org.apache.ignite.raft.jraft.NodeManager;
+import org.apache.ignite.raft.jraft.option.NodeOptions;
 import org.apache.ignite.raft.jraft.rpc.RpcContext;
 import org.apache.ignite.raft.jraft.rpc.RpcProcessor;
 import org.apache.ignite.raft.jraft.rpc.RpcServer;
@@ -50,7 +52,6 @@ import org.apache.ignite.raft.jraft.rpc.impl.core.InstallSnapshotRequestProcesso
 import org.apache.ignite.raft.jraft.rpc.impl.core.ReadIndexRequestProcessor;
 import org.apache.ignite.raft.jraft.rpc.impl.core.RequestVoteRequestProcessor;
 import org.apache.ignite.raft.jraft.rpc.impl.core.TimeoutNowRequestProcessor;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * TODO https://issues.apache.org/jira/browse/IGNITE-14519 Unsubscribe on shutdown
@@ -59,31 +60,29 @@ public class IgniteRpcServer implements RpcServer<Void> {
     /** Factory. */
     private static final RaftClientMessagesFactory FACTORY = new RaftClientMessagesFactory();
 
-    /** The {@code true} to reuse cluster service. */
-    private final boolean reuse;
-
     private final ClusterService service;
 
-    private List<ConnectionClosedEventListener> listeners = new CopyOnWriteArrayList<>();
+    private final List<ConnectionClosedEventListener> listeners = new CopyOnWriteArrayList<>();
 
-    private Map<String, RpcProcessor> processors = new ConcurrentHashMap<>();
+    private final Map<String, RpcProcessor> processors = new ConcurrentHashMap<>();
+
+    private final ExecutorService rpcExecutor;
 
     /**
      * @param service The cluster service.
-     * @param reuse {@code True} to reuse service (do no manage lifecycle).
      * @param nodeManager The node manager.
      * @param factory Message factory.
-     * @param rpcExecutor The executor for RPC requests.
+     * @param opts Node options.
      */
     public IgniteRpcServer(
         ClusterService service,
-        boolean reuse,
         NodeManager nodeManager,
         RaftClientMessagesFactory factory,
-        @Nullable Executor rpcExecutor
+        NodeOptions opts
     ) {
-        this.reuse = reuse;
         this.service = service;
+
+        rpcExecutor = JRaftUtils.createRequestExecutor(opts);
 
         // raft server RPC
         AppendEntriesRequestProcessor appendEntriesRequestProcessor = new AppendEntriesRequestProcessor(rpcExecutor);
@@ -112,60 +111,48 @@ public class IgniteRpcServer implements RpcServer<Void> {
         registerProcessor(new ActionRequestProcessor(rpcExecutor, FACTORY));
         registerProcessor(new org.apache.ignite.raft.jraft.rpc.impl.client.SnapshotRequestProcessor(rpcExecutor, FACTORY));
 
-        service.messagingService().addMessageHandler(new NetworkMessageHandler() {
-            @Override public void onReceived(NetworkMessage msg, ClusterNode sender, String corellationId) {
-                Class<? extends NetworkMessage> cls = msg.getClass();
-                RpcProcessor prc = processors.get(cls.getName());
+        service.messagingService().addMessageHandler((msg, sender, corellationId) -> {
+            Class<? extends NetworkMessage> cls = msg.getClass();
+            RpcProcessor<NetworkMessage> prc = processors.get(cls.getName());
 
-                // TODO asch cache mapping https://issues.apache.org/jira/browse/IGNITE-14832
-                if (prc == null) {
-                    for (Class<?> iface : cls.getInterfaces()) {
-                        prc = processors.get(iface.getName());
+            // TODO asch cache mapping https://issues.apache.org/jira/browse/IGNITE-14832
+            if (prc == null) {
+                for (Class<?> iface : cls.getInterfaces()) {
+                    prc = processors.get(iface.getName());
 
-                        if (prc != null)
-                            break;
-                    }
+                    if (prc != null)
+                        break;
                 }
-
-                if (prc == null)
-                    return;
-
-                RpcProcessor.ExecutorSelector selector = prc.executorSelector();
-
-                Executor executor = null;
-
-                if (selector != null) {
-                    executor = selector.select(prc.getClass().getName(), msg, nodeManager);
-                }
-
-                if (executor == null)
-                    executor = prc.executor();
-
-                if (executor == null)
-                    executor = rpcExecutor;
-
-                RpcProcessor finalPrc = prc;
-
-                executor.execute(() -> {
-                    finalPrc.handleRequest(new RpcContext() {
-                        @Override public NodeManager getNodeManager() {
-                            return nodeManager;
-                        }
-
-                        @Override public void sendResponse(Object responseObj) {
-                            service.messagingService().send(sender, (NetworkMessage) responseObj, corellationId);
-                        }
-
-                        @Override public String getRemoteAddress() {
-                            return sender.address();
-                        }
-
-                        @Override public String getLocalAddress() {
-                            return service.topologyService().localMember().address();
-                        }
-                    }, msg);
-                });
             }
+
+            if (prc == null)
+                return;
+
+            RpcProcessor<NetworkMessage> finalPrc = prc;
+
+            var context = new RpcContext() {
+                @Override public NodeManager getNodeManager() {
+                    return nodeManager;
+                }
+
+                @Override public void sendResponse(Object responseObj) {
+                    service.messagingService().send(sender, (NetworkMessage) responseObj, corellationId);
+                }
+
+                @Override public String getRemoteAddress() {
+                    return sender.address();
+                }
+
+                @Override public String getLocalAddress() {
+                    return service.topologyService().localMember().address();
+                }
+            };
+
+            // TODO: this is hack for the ITNodeTest#testFollowerStartStopFollowing and should be removed
+            if (rpcExecutor.isShutdown())
+                finalPrc.handleRequest(context, msg);
+            else
+                rpcExecutor.execute(() -> finalPrc.handleRequest(context, msg));
         });
 
         service.topologyService().addEventHandler(new TopologyEventHandler() {
@@ -180,23 +167,24 @@ public class IgniteRpcServer implements RpcServer<Void> {
         });
     }
 
+    /** {@inheritDoc} */
     @Override public void registerConnectionClosedEventListener(ConnectionClosedEventListener listener) {
-        if (!listeners.contains(listeners))
+        if (!listeners.contains(listener))
             listeners.add(listener);
     }
 
+    /** {@inheritDoc} */
     @Override public void registerProcessor(RpcProcessor<?> processor) {
         processors.put(processor.interest(), processor);
     }
 
+    /** {@inheritDoc} */
     @Override public int boundPort() {
         return 0;
     }
 
+    /** {@inheritDoc} */
     @Override public boolean init(Void opts) {
-        if (!reuse)
-            service.start();
-
         return true;
     }
 
@@ -204,15 +192,8 @@ public class IgniteRpcServer implements RpcServer<Void> {
         return service;
     }
 
+    /** {@inheritDoc} */
     @Override public void shutdown() {
-        if (reuse)
-            return;
-
-        try {
-            service.shutdown();
-        }
-        catch (Exception e) {
-            throw new IgniteInternalException(e);
-        }
+        IgniteUtils.shutdownAndAwaitTermination(rpcExecutor, 10, TimeUnit.SECONDS);
     }
 }

--- a/modules/raft/src/test/java/org/apache/ignite/raft/jraft/rpc/IgniteRpcTest.java
+++ b/modules/raft/src/test/java/org/apache/ignite/raft/jraft/rpc/IgniteRpcTest.java
@@ -23,7 +23,6 @@ import org.apache.ignite.network.ClusterLocalConfiguration;
 import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.network.MessageSerializationRegistryImpl;
 import org.apache.ignite.network.scalecube.TestScaleCubeClusterServiceFactory;
-import org.apache.ignite.network.serialization.MessageSerializationRegistry;
 import org.apache.ignite.raft.jraft.NodeManager;
 import org.apache.ignite.raft.jraft.rpc.impl.IgniteRpcClient;
 import org.apache.ignite.raft.jraft.util.Endpoint;
@@ -32,17 +31,24 @@ import org.apache.ignite.raft.jraft.util.Endpoint;
  *
  */
 public class IgniteRpcTest extends AbstractRpcTest {
-    /**
-     * Serialization registry.
-     */
-    private static final MessageSerializationRegistry SERIALIZATION_REGISTRY = new MessageSerializationRegistryImpl();
-
     /** The counter. */
     private final AtomicInteger cntr = new AtomicInteger();
 
     /** {@inheritDoc} */
     @Override public RpcServer<?> createServer(Endpoint endpoint) {
-        return new TestIgniteRpcServer(endpoint, new NodeManager());
+        ClusterService service = createService(endpoint.toString(), endpoint.getPort(), List.of());
+
+        var server = new TestIgniteRpcServer(service, List.of(), new NodeManager()) {
+            @Override public void shutdown() {
+                super.shutdown();
+
+                service.shutdown();
+            }
+        };
+
+        service.start();
+
+        return server;
     }
 
     /** {@inheritDoc} */
@@ -51,7 +57,15 @@ public class IgniteRpcTest extends AbstractRpcTest {
 
         ClusterService service = createService("client" + i, endpoint.getPort() - i, List.of(endpoint.toString()));
 
-        IgniteRpcClient client = new IgniteRpcClient(service, false);
+        IgniteRpcClient client = new IgniteRpcClient(service) {
+            @Override public void shutdown() {
+                super.shutdown();
+
+                service.shutdown();
+            }
+        };
+
+        service.start();
 
         waitForTopology(client, 1 + i, 5_000);
 
@@ -64,8 +78,9 @@ public class IgniteRpcTest extends AbstractRpcTest {
      * @param servers Server nodes of the cluster.
      * @return The client cluster view.
      */
-    protected ClusterService createService(String name, int port, List<String> servers) {
-        var context = new ClusterLocalConfiguration(name, port, servers, SERIALIZATION_REGISTRY);
+    private static ClusterService createService(String name, int port, List<String> servers) {
+        var registry = new MessageSerializationRegistryImpl();
+        var context = new ClusterLocalConfiguration(name, port, servers, registry);
         var factory = new TestScaleCubeClusterServiceFactory();
 
         return factory.createClusterService(context);

--- a/modules/raft/src/test/java/org/apache/ignite/raft/jraft/rpc/TestIgniteRpcServer.java
+++ b/modules/raft/src/test/java/org/apache/ignite/raft/jraft/rpc/TestIgniteRpcServer.java
@@ -18,63 +18,27 @@
 package org.apache.ignite.raft.jraft.rpc;
 
 import java.util.List;
-import org.apache.ignite.network.ClusterLocalConfiguration;
-import org.apache.ignite.network.MessageSerializationRegistryImpl;
-import org.apache.ignite.network.scalecube.ScaleCubeClusterServiceFactory;
-import org.apache.ignite.network.scalecube.TestScaleCubeClusterServiceFactory;
-import org.apache.ignite.network.serialization.MessageSerializationRegistry;
+import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.raft.client.message.RaftClientMessagesFactory;
-import org.apache.ignite.raft.jraft.JRaftUtils;
 import org.apache.ignite.raft.jraft.NodeManager;
 import org.apache.ignite.raft.jraft.option.NodeOptions;
 import org.apache.ignite.raft.jraft.rpc.impl.IgniteRpcServer;
-import org.apache.ignite.raft.jraft.util.Endpoint;
 
 /**
  * RPC server configured for integration tests.
  */
 public class TestIgniteRpcServer extends IgniteRpcServer {
     /**
-     * The registry.
+     * @param clusterService cluster service
+     * @param servers server list
+     * @param nodeManager node manager
      */
-    /** */
-    private static final MessageSerializationRegistry SERIALIZATION_REGISTRY = new MessageSerializationRegistryImpl();
-
-    /**
-     * Service factory.
-     */
-    private final static ScaleCubeClusterServiceFactory SERVICE_FACTORY = new TestScaleCubeClusterServiceFactory();
-
-    /**
-     * Message factory.
-     */
-    private static final RaftClientMessagesFactory MSG_FACTORY = new RaftClientMessagesFactory();
-
-    /**
-     * @param endpoint The endpoint.
-     * @param nodeManager The node manager.
-     */
-    public TestIgniteRpcServer(Endpoint endpoint, NodeManager nodeManager) {
-        this(endpoint.getIp() + ":" + endpoint.getPort(), endpoint.getPort(), List.of(), nodeManager);
-    }
-
-    /**
-     * @param endpoint The endpoint.
-     * @param servers Server list.
-     * @param nodeManager The node manager.
-     */
-    public TestIgniteRpcServer(Endpoint endpoint, List<String> servers, NodeManager nodeManager) {
-        this(endpoint.getIp() + ":" + endpoint.getPort(), endpoint.getPort(), servers, nodeManager);
-    }
-
-    /**
-     * @param name The name.
-     * @param port The port.
-     * @param servers Server list.
-     * @param nodeManager The node manager.
-     */
-    public TestIgniteRpcServer(String name, int port, List<String> servers, NodeManager nodeManager) {
-        super(SERVICE_FACTORY.createClusterService(new ClusterLocalConfiguration(name, port, servers, SERIALIZATION_REGISTRY)),
-            false, nodeManager, MSG_FACTORY, JRaftUtils.createRequestExecutor(new NodeOptions()));
+    public TestIgniteRpcServer(ClusterService clusterService, List<String> servers, NodeManager nodeManager) {
+        super(
+            clusterService,
+            nodeManager,
+            new RaftClientMessagesFactory(),
+            new NodeOptions()
+        );
     }
 }

--- a/modules/raft/src/test/java/org/apache/ignite/raft/jraft/rpc/TestIgniteRpcServer.java
+++ b/modules/raft/src/test/java/org/apache/ignite/raft/jraft/rpc/TestIgniteRpcServer.java
@@ -20,6 +20,7 @@ package org.apache.ignite.raft.jraft.rpc;
 import java.util.List;
 import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.raft.client.message.RaftClientMessagesFactory;
+import org.apache.ignite.raft.jraft.JRaftUtils;
 import org.apache.ignite.raft.jraft.NodeManager;
 import org.apache.ignite.raft.jraft.option.NodeOptions;
 import org.apache.ignite.raft.jraft.rpc.impl.IgniteRpcServer;
@@ -38,7 +39,7 @@ public class TestIgniteRpcServer extends IgniteRpcServer {
             clusterService,
             nodeManager,
             new RaftClientMessagesFactory(),
-            new NodeOptions()
+            JRaftUtils.createRequestExecutor(new NodeOptions())
         );
     }
 }

--- a/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ITDistributedTableTest.java
+++ b/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ITDistributedTableTest.java
@@ -158,17 +158,13 @@ public class ITDistributedTableTest {
     public void partitionListener() throws Exception {
         String grpId = "part";
 
-        RaftServer partSrv = new RaftServerImpl(
-            cluster.get(0),
-            FACTORY,
-            true
-        );
+        RaftServer partSrv = new RaftServerImpl(cluster.get(0), FACTORY);
 
         List<Peer> conf = List.of(new Peer(cluster.get(0).topologyService().localMember().address()));
 
         partSrv.startRaftGroup(grpId, new PartitionListener(), conf);
 
-        RaftGroupService partRaftGrp = new RaftGroupServiceImpl(grpId, client, FACTORY, 10_000, conf, true, 200, true);
+        RaftGroupService partRaftGrp = new RaftGroupServiceImpl(grpId, client, FACTORY, 10_000, conf, true, 200);
 
         Row testRow = getTestRow();
 
@@ -222,13 +218,8 @@ public class ITDistributedTableTest {
     public void partitionedTable() {
         HashMap<ClusterNode, RaftServer> raftServers = new HashMap<>(NODES);
 
-        for (int i = 0; i < NODES; i++) {
-            raftServers.put(cluster.get(i).topologyService().localMember(), new RaftServerImpl(
-                cluster.get(i),
-                FACTORY,
-                true
-            ));
-        }
+        for (int i = 0; i < NODES; i++)
+            raftServers.put(cluster.get(i).topologyService().localMember(), new RaftServerImpl(cluster.get(i), FACTORY));
 
         List<List<ClusterNode>> assignment = RendezvousAffinityFunction.assignPartitions(
             cluster.stream().map(node -> node.topologyService().localMember()).collect(Collectors.toList()),
@@ -251,7 +242,7 @@ public class ITDistributedTableTest {
 
             rs.startRaftGroup(grpId, new PartitionListener(), conf);
 
-            partMap.put(p, new RaftGroupServiceImpl(grpId, client, FACTORY, 10_000, conf, true, 200, true));
+            partMap.put(p, new RaftGroupServiceImpl(grpId, client, FACTORY, 10_000, conf, true, 200));
 
             p++;
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-14918

Remove the `reuse` flag and make `ClusterService` lifecycle explicit. This is a more straightforward way of resource management: if you don't open the resource, you shouldn't close it. This also fixes the problems with different components trying to send messages over the closed service.