### PR TITLE
IGNITE-14870 Exchange metastorage node addresses on join

### DIFF
--- a/examples/config/ignite-config.json
+++ b/examples/config/ignite-config.json
@@ -1,5 +1,5 @@
 {
-    "node": {
+    "metastorage": {
         "metastorageNodes": [
             "node-0", "node-1", "node-2"
         ]

--- a/modules/api/src/main/java/org/apache/ignite/app/Ignition.java
+++ b/modules/api/src/main/java/org/apache/ignite/app/Ignition.java
@@ -19,6 +19,8 @@ package org.apache.ignite.app;
 
 import java.io.InputStream;
 import java.nio.file.Path;
+import org.apache.ignite.configuration.schemas.metastorage.MetaStorageConfigurationSchema;
+import org.apache.ignite.configuration.schemas.network.NetworkConfigurationSchema;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -42,8 +44,7 @@ public interface Ignition {
      *
      * @param name    Name of the node. Must not be {@code null}.
      * @param config  Optional node configuration based on
-     *                {@link org.apache.ignite.configuration.schemas.runner.NodeConfigurationSchema} and
-     *                {@link org.apache.ignite.configuration.schemas.network.NetworkConfigurationSchema}.
+     *                {@link MetaStorageConfigurationSchema} and {@link NetworkConfigurationSchema}.
      *                Following rules are used for applying the configuration properties:
      *                <ol>
      *                  <li>Specified property overrides existing one or just applies itself if it wasn't

--- a/modules/api/src/main/java/org/apache/ignite/app/IgnitionManager.java
+++ b/modules/api/src/main/java/org/apache/ignite/app/IgnitionManager.java
@@ -23,6 +23,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ServiceLoader;
+import org.apache.ignite.configuration.schemas.metastorage.MetaStorageConfigurationSchema;
+import org.apache.ignite.configuration.schemas.network.NetworkConfigurationSchema;
 import org.apache.ignite.lang.IgniteException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -40,8 +42,7 @@ public class IgnitionManager {
      *
      * @param nodeName  Name of the node. Must not be {@code null}.
      * @param configStr Optional node configuration based on
-     *                  {@link org.apache.ignite.configuration.schemas.runner.NodeConfigurationSchema} and
-     *                  {@link org.apache.ignite.configuration.schemas.network.NetworkConfigurationSchema}.
+     *                  {@link MetaStorageConfigurationSchema} and {@link NetworkConfigurationSchema}.
      *                  Following rules are used for applying the configuration properties:
      *                  <ol>
      *                      <li>Specified property overrides existing one or just applies itself if it wasn't

--- a/modules/api/src/main/java/org/apache/ignite/configuration/schemas/metastorage/MetaStorageConfigurationSchema.java
+++ b/modules/api/src/main/java/org/apache/ignite/configuration/schemas/metastorage/MetaStorageConfigurationSchema.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.configuration.schemas.metastorage;
+
+import org.apache.ignite.configuration.annotation.ConfigurationRoot;
+import org.apache.ignite.configuration.annotation.ConfigurationType;
+import org.apache.ignite.configuration.annotation.Value;
+import org.apache.ignite.configuration.validation.Min;
+
+/**
+ * Configuration for the Meta Storage component.
+ */
+@ConfigurationRoot(rootName = "metastorage", type = ConfigurationType.LOCAL)
+public class MetaStorageConfigurationSchema {
+    /**
+     * This is a temporary property that specifies names of the nodes that host the Meta Storage. It must be removed
+     * as soon as cluster-wide "init" command is implemented.
+     */
+    @Value(hasDefault = true)
+    public final String[] metastorageNodes = new String[0];
+
+    /**
+     * Startup poll interval in milliseconds.
+     * <p>
+     * When the Meta Storage component starts, it polls other nodes for some information regarding the cluster
+     * Meta Storage configuration. This parameter specifies the interval between unsuccessful polling attempts.
+     * <p>
+     * Default is 1 second.
+     */
+    @Value(hasDefault = true)
+    @Min(1)
+    public final long startupPollIntervalMillis = 1000;
+}

--- a/modules/api/src/main/java/org/apache/ignite/configuration/schemas/metastorage/package-info.java
+++ b/modules/api/src/main/java/org/apache/ignite/configuration/schemas/metastorage/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Configuration schema for the Meta Storage component.
+ */
+package org.apache.ignite.configuration.schemas.metastorage;

--- a/modules/cli/src/integrationTest/java/org/apache/ignite/cli/ITConfigCommandTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/cli/ITConfigCommandTest.java
@@ -104,7 +104,7 @@ public class ITConfigCommandTest extends AbstractCliTest {
             "--node-endpoint",
             "localhost:" + restPort,
             "--type", "node", //TODO: Fix in https://issues.apache.org/jira/browse/IGNITE-15306
-            "node.metastorageNodes=[\"localhost1\"]"
+            "metastorage.metastorageNodes=[\"localhost1\"]"
         );
 
         String nl = System.lineSeparator();
@@ -129,8 +129,8 @@ public class ITConfigCommandTest extends AbstractCliTest {
         assertEquals(0, exitCode);
         assertEquals(
             "\"{\"clientConnector\":{\"connectTimeout\":5000,\"port\":" + clientPort + ",\"portRange\":0}," +
+                "\"metastorage\":{\"metastorageNodes\":[\"localhost1\"],\"startupPollIntervalMillis\":1000}," +
                 "\"network\":{\"netClusterNodes\":[],\"port\":" + networkPort + "}," +
-                "\"node\":{\"metastorageNodes\":[\"localhost1\"]}," +
                 "\"rest\":{\"port\":" + restPort + ",\"portRange\":0}}\"" + nl,
             unescapeQuotes(out.toString())
         );

--- a/modules/core/src/test/java/org/apache/ignite/internal/testframework/matchers/CompletableFutureMatcher.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/testframework/matchers/CompletableFutureMatcher.java
@@ -31,7 +31,7 @@ import org.hamcrest.TypeSafeMatcher;
  */
 public class CompletableFutureMatcher<T> extends TypeSafeMatcher<CompletableFuture<T>> {
     /** */
-    private static final int TIMEOUT_SECONDS = 1;
+    private static final int TIMEOUT_SECONDS = 5;
 
     /** */
     private final Matcher<T> matcher;

--- a/modules/metastorage/pom.xml
+++ b/modules/metastorage/pom.xml
@@ -69,6 +69,46 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-network</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-configuration</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-network</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-metastorage-server</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
@@ -86,4 +126,29 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.ignite</groupId>
+                        <artifactId>ignite-network-annotation-processor</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.apache.ignite</groupId>
+                            <artifactId>ignite-network-annotation-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/ITMetaStorageManagerTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/ITMetaStorageManagerTest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.metastorage;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.apache.ignite.configuration.schemas.metastorage.MetaStorageConfiguration;
+import org.apache.ignite.internal.configuration.testframework.ConfigurationExtension;
+import org.apache.ignite.internal.configuration.testframework.InjectConfiguration;
+import org.apache.ignite.internal.manager.IgniteComponent;
+import org.apache.ignite.internal.metastorage.message.MetastorageMessagesFactory;
+import org.apache.ignite.internal.metastorage.server.SimpleInMemoryKeyValueStorage;
+import org.apache.ignite.internal.raft.Loza;
+import org.apache.ignite.internal.testframework.WorkDirectory;
+import org.apache.ignite.internal.testframework.WorkDirectoryExtension;
+import org.apache.ignite.internal.vault.VaultManager;
+import org.apache.ignite.internal.vault.inmemory.InMemoryVaultService;
+import org.apache.ignite.network.ClusterService;
+import org.apache.ignite.network.LocalPortRangeNodeFinder;
+import org.apache.ignite.network.NetworkAddress;
+import org.apache.ignite.network.NodeFinder;
+import org.apache.ignite.network.TestMessageSerializationRegistryImpl;
+import org.apache.ignite.network.scalecube.TestScaleCubeClusterServiceFactory;
+import org.apache.ignite.utils.ClusterServiceTestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willBe;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Integration tests for the {@link MetaStorageManager}.
+ */
+@ExtendWith(WorkDirectoryExtension.class)
+@ExtendWith(ConfigurationExtension.class)
+public class ITMetaStorageManagerTest {
+    /** */
+    @WorkDirectory
+    private Path workDir;
+
+    /** */
+    @InjectConfiguration
+    private MetaStorageConfiguration metaStorageConfiguration;
+
+    /** List of started components. */
+    private final List<IgniteComponent> components = new ArrayList<>();
+
+    /** */
+    @BeforeEach
+    void setUp() {
+        metaStorageConfiguration.change(c -> c.changeStartupPollIntervalMillis(100)).join();
+    }
+
+    /** */
+    @AfterEach
+    void tearDown() throws Exception {
+        Collections.reverse(components);
+
+        for (IgniteComponent component : components)
+            component.beforeNodeStop();
+
+        for (IgniteComponent component : components)
+            component.stop();
+    }
+
+    /**
+     * Creates a {@link MetaStorageManager} for tests.
+     */
+    private MetaStorageManager createMetaStore(
+        TestInfo testInfo, NetworkAddress thisNode, NodeFinder nodeFinder
+    ) throws Exception {
+        var vaultManager = new VaultManager(new InMemoryVaultService());
+
+        ClusterService clusterService = ClusterServiceTestUtils.clusterService(
+            testInfo,
+            thisNode.port(),
+            nodeFinder,
+            new TestMessageSerializationRegistryImpl(),
+            new TestScaleCubeClusterServiceFactory()
+        );
+
+        var raftManager = new Loza(clusterService, workDir);
+
+        var metaStorageManager = new MetaStorageManager(
+            vaultManager,
+            clusterService,
+            raftManager,
+            new SimpleInMemoryKeyValueStorage(),
+            new MetastorageMessagesFactory(),
+            metaStorageConfiguration
+        );
+
+        vaultManager.start();
+
+        components.add(vaultManager);
+
+        vaultManager.putName(thisNode.toString()).get(1, TimeUnit.SECONDS);
+
+        Stream.of(clusterService, raftManager, metaStorageManager).forEach(component -> {
+            component.start();
+
+            components.add(component);
+        });
+
+        return metaStorageManager;
+    }
+
+    /**
+     * Test the process of sending an "init" command to an established cluster.
+     */
+    @Test
+    void testClusterInit(TestInfo testInfo) throws Exception {
+        var allNodes = new LocalPortRangeNodeFinder(10000, 10003);
+
+        NetworkAddress addr0 = allNodes.findNodes().get(0);
+        NetworkAddress addr1 = allNodes.findNodes().get(1);
+        NetworkAddress addr2 = allNodes.findNodes().get(2);
+
+        MetaStorageManager metaStorageManager0 = createMetaStore(testInfo, addr0, allNodes);
+        MetaStorageManager metaStorageManager1 = createMetaStore(testInfo, addr1, allNodes);
+        MetaStorageManager metaStorageManager2 = createMetaStore(testInfo, addr2, allNodes);
+
+        // call "init" twice to emulate a race between "init" and address polling
+        metaStorageManager0.init(List.of(addr1.toString()));
+        metaStorageManager1.init(List.of(addr1.toString()));
+
+        CompletableFuture<Boolean> hasMetastorageNode0 = supplyAsync(metaStorageManager0::hasMetastorageLocally);
+        CompletableFuture<Boolean> hasMetastorageNode1 = supplyAsync(metaStorageManager1::hasMetastorageLocally);
+        CompletableFuture<Boolean> hasMetastorageNode2 = supplyAsync(metaStorageManager2::hasMetastorageLocally);
+
+        assertThat(hasMetastorageNode0, willBe(equalTo(false)));
+        assertThat(hasMetastorageNode1, willBe(equalTo(true)));
+        assertThat(hasMetastorageNode2, willBe(equalTo(false)));
+    }
+
+    /**
+     * Tests a scenario when a node joins a cluster that has already received an "init" command.
+     */
+    @Test
+    void testClusterJoin(TestInfo testInfo) throws Exception {
+        var allNodes = new LocalPortRangeNodeFinder(10000, 10002);
+
+        NetworkAddress addr0 = allNodes.findNodes().get(0);
+        NetworkAddress addr1 = allNodes.findNodes().get(1);
+
+        MetaStorageManager metaStorageManager = createMetaStore(testInfo, addr0, allNodes);
+        createMetaStore(testInfo, addr1, allNodes);
+
+        metaStorageManager.init(List.of(addr1.toString()));
+
+        NetworkAddress addr2 = new NetworkAddress("localhost", 10002);
+
+        MetaStorageManager metaStorageManager2 = createMetaStore(testInfo, addr2, allNodes);
+
+        CompletableFuture<Boolean> hasMetastorageNode2 = supplyAsync(metaStorageManager2::hasMetastorageLocally);
+
+        assertThat(hasMetastorageNode2, willBe(equalTo(false)));
+    }
+}

--- a/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/message/MetastorageMessages.java
+++ b/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/message/MetastorageMessages.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.metastorage.message;
+
+import org.apache.ignite.network.annotations.MessageGroup;
+
+/**
+ * Message group for the {@code ignite-metastorage} module.
+ */
+@MessageGroup(groupType = 5, groupName = "MetastorageMessages")
+public class MetastorageMessages {
+    /**
+     * Message type of the {@link MetastorageNodesRequest}.
+     */
+    public static final short METASTORAGE_NODES_REQUEST = 0;
+
+    /**
+     * Message type of the {@link MetastorageNodesResponse}.
+     */
+    public static final short METASTORAGE_NODES_RESPONSE = 1;
+
+    /**
+     * Message type of the {@link MetastorageNotReadyResponse}.
+     */
+    public static final short METASTORAGE_NOT_READY_RESPONSE = 2;
+}

--- a/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/message/MetastorageNodesRequest.java
+++ b/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/message/MetastorageNodesRequest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.metastorage.message;
+
+import java.io.Serializable;
+import org.apache.ignite.network.NetworkMessage;
+import org.apache.ignite.network.annotations.Transferable;
+
+/**
+ * Request that is sent by the Meta Storage component to obtain information about nodes that host the Meta Storage.
+ */
+@Transferable(value = MetastorageMessages.METASTORAGE_NODES_REQUEST, autoSerializable = false)
+public interface MetastorageNodesRequest extends NetworkMessage, Serializable {
+}

--- a/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/message/MetastorageNodesResponse.java
+++ b/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/message/MetastorageNodesResponse.java
@@ -15,18 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.configuration.schemas.runner;
+package org.apache.ignite.internal.metastorage.message;
 
-import org.apache.ignite.configuration.annotation.ConfigurationRoot;
-import org.apache.ignite.configuration.annotation.ConfigurationType;
-import org.apache.ignite.configuration.annotation.Value;
+import java.io.Serializable;
+import java.util.Collection;
+import org.apache.ignite.network.NetworkMessage;
+import org.apache.ignite.network.annotations.Transferable;
 
 /**
- * Local node configuration schema.
+ * Response for the {@link MetastorageNodesRequest}.
  */
-@ConfigurationRoot(rootName = "node", type = ConfigurationType.LOCAL)
-public class NodeConfigurationSchema {
-    /** It is a copy of appropriate property from the cluster configuration. */
-    @Value(hasDefault = true)
-    public final String[] metastorageNodes = new String[0];
+@Transferable(value = MetastorageMessages.METASTORAGE_NODES_RESPONSE, autoSerializable = false)
+public interface MetastorageNodesResponse extends NetworkMessage, Serializable {
+    /**
+     * List of node names that host the Meta Storage.
+     */
+    Collection<String> metastorageNodes();
 }

--- a/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/message/MetastorageNotReadyResponse.java
+++ b/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/message/MetastorageNotReadyResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.metastorage.message;
+
+import java.io.Serializable;
+import org.apache.ignite.network.NetworkMessage;
+import org.apache.ignite.network.annotations.Transferable;
+
+/**
+ * Response for the {@link MetastorageNodesRequest} in case the receiver does not yet have the requested information.
+ */
+@Transferable(value = MetastorageMessages.METASTORAGE_NOT_READY_RESPONSE, autoSerializable = false)
+public interface MetastorageNotReadyResponse extends NetworkMessage, Serializable {
+}

--- a/modules/metastorage/src/test/java/org/apache/ignite/internal/metastorage/MetaStorageManagerTest.java
+++ b/modules/metastorage/src/test/java/org/apache/ignite/internal/metastorage/MetaStorageManagerTest.java
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.metastorage;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import org.apache.ignite.configuration.ConfigurationValue;
+import org.apache.ignite.configuration.schemas.metastorage.MetaStorageConfiguration;
+import org.apache.ignite.internal.metastorage.message.MetastorageMessagesFactory;
+import org.apache.ignite.internal.metastorage.server.SimpleInMemoryKeyValueStorage;
+import org.apache.ignite.internal.raft.Loza;
+import org.apache.ignite.internal.vault.VaultManager;
+import org.apache.ignite.network.ClusterNode;
+import org.apache.ignite.network.ClusterService;
+import org.apache.ignite.network.MessagingService;
+import org.apache.ignite.network.NetworkAddress;
+import org.apache.ignite.network.NetworkMessage;
+import org.apache.ignite.network.TopologyService;
+import org.apache.ignite.raft.client.service.RaftGroupService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willBe;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the {@link MetaStorageManager}.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class MetaStorageManagerTest {
+    /** */
+    @Mock
+    private MessagingService messagingService;
+
+    /** */
+    private final MetastorageMessagesFactory msgFactory = new MetastorageMessagesFactory();
+
+    /** Holder class. */
+    private static class Node {
+        /** */
+        final MetaStorageManager manager;
+
+        /** */
+        final ClusterNode clusterNode;
+
+        /** */
+        Node(ClusterNode clusterNode, MetaStorageManager manager) {
+            this.manager = manager;
+            this.clusterNode = clusterNode;
+        }
+    }
+
+    /**
+     * Creates a "cluster" consisting of nodes of the given names, where every component is mocked, except for the
+     * {@link MetaStorageManager}.
+     */
+    private List<Node> createCluster(String... names) {
+        List<ClusterNode> nodes = Arrays.stream(names)
+            .map(MetaStorageManagerTest::createNode)
+            .collect(Collectors.toUnmodifiableList());
+
+        // Create the Raft component.
+        var raftManager = mock(Loza.class);
+
+        when(raftManager.prepareRaftGroup(anyString(), anyList(), any()))
+            .thenReturn(CompletableFuture.completedFuture(mock(RaftGroupService.class)));
+
+        // Create the Network component.
+        var topologyService = mock(TopologyService.class);
+
+        when(topologyService.allMembers()).thenReturn(nodes);
+
+        var clusterService = mock(ClusterService.class);
+
+        when(clusterService.messagingService()).thenReturn(messagingService);
+        when(clusterService.topologyService()).thenReturn(topologyService);
+
+        // Create a mock Meta Storage config with a poll interval of 1 ms.
+        var pollIntervalMillis = mock(ConfigurationValue.class);
+
+        when(pollIntervalMillis.value()).thenReturn(1L);
+
+        var config = mock(MetaStorageConfiguration.class);
+
+        when(config.startupPollIntervalMillis()).thenReturn(pollIntervalMillis);
+
+        return nodes.stream()
+            .map(node -> {
+                VaultManager vaultManager = mock(VaultManager.class);
+
+                when(vaultManager.name()).thenReturn(CompletableFuture.completedFuture(node.name()));
+
+                var metaStorageManager = new MetaStorageManager(
+                    vaultManager,
+                    clusterService,
+                    raftManager,
+                    new SimpleInMemoryKeyValueStorage(),
+                    msgFactory,
+                    config
+                );
+
+                return new Node(node, metaStorageManager);
+            })
+            .collect(Collectors.toUnmodifiableList());
+    }
+
+    /**
+     * Creates a {@code ClusterNode} on a random port.
+     */
+    private static ClusterNode createNode(String name) {
+        int port = ThreadLocalRandom.current().nextInt(0, 10000);
+
+        return new ClusterNode(name, name, new NetworkAddress("localhost", port));
+    }
+
+    /**
+     * Tests the startup of a single node that hosts the Meta Storage.
+     * It should simply block until the "init" command arrives.
+     */
+    @Test
+    void testSingleNodeHostStart() {
+        Node node = createCluster("foobar").get(0);
+
+        node.manager.start();
+
+        verify(messagingService, never()).send(any(NetworkAddress.class), any(), anyString());
+
+        CompletableFuture<Boolean> hasMetastorage = supplyAsync(node.manager::hasMetastorageLocally);
+
+        node.manager.init(List.of(node.clusterNode.name()));
+
+        assertThat(hasMetastorage, willBe(equalTo(true)));
+    }
+
+    /**
+     * Tests the startup of a single node that does not host the Meta Storage.
+     * It should simply block until the "init" command arrives.
+     */
+    @Test
+    void testSingleNodeNotHostStart() {
+        Node node = createCluster("foobar").get(0);
+
+        node.manager.start();
+
+        verify(messagingService, never()).send(any(NetworkAddress.class), any(), anyString());
+
+        CompletableFuture<Boolean> hasMetastorage = supplyAsync(node.manager::hasMetastorageLocally);
+
+        node.manager.init(List.of("barbaz"));
+
+        assertThat(hasMetastorage, willBe(equalTo(false)));
+    }
+
+    /**
+     * Tests a scenario when two nodes start and receive a broadcast "init" command.
+     */
+    @Test
+    void testZombieStateStart() {
+        NetworkMessage response = msgFactory.metastorageNotReadyResponse().build();
+
+        when(messagingService.invoke(any(ClusterNode.class), any(), anyLong()))
+            .thenReturn(CompletableFuture.completedFuture(response));
+
+        List<Node> nodes = createCluster("foo", "bar");
+
+        nodes.forEach(node -> node.manager.start());
+
+        CompletableFuture<Boolean> hasMetastorageNode0 = supplyAsync(nodes.get(0).manager::hasMetastorageLocally);
+        CompletableFuture<Boolean> hasMetastorageNode1 = supplyAsync(nodes.get(1).manager::hasMetastorageLocally);
+
+        var metaStorageNodes = List.of(nodes.get(0).clusterNode.name());
+
+        nodes.forEach(node -> node.manager.init(metaStorageNodes));
+
+        assertThat(hasMetastorageNode0, willBe(equalTo(true)));
+        assertThat(hasMetastorageNode1, willBe(equalTo(false)));
+    }
+
+    /**
+     * Tests a scenario when a single node receives the "init" command, while the second node obtains the
+     * Meta Storage nodes information through the join protocol.
+     */
+    @Test
+    void testNodeJoin() {
+        List<Node> nodes = createCluster("foo", "bar");
+
+        Node node0 = nodes.get(0);
+        Node node1 = nodes.get(1);
+
+        var metaStorageNodes = List.of(node1.clusterNode.name());
+
+        when(messagingService.invoke(eq(node0.clusterNode), any(), anyLong()))
+            .thenAnswer(invocation -> {
+                NetworkMessage response = msgFactory.metastorageNodesResponse()
+                    .metastorageNodes(metaStorageNodes)
+                    .build();
+
+                return CompletableFuture.completedFuture(response);
+            });
+
+        when(messagingService.invoke(eq(node1.clusterNode), any(), anyLong()))
+            .thenAnswer(invocation -> {
+                NetworkMessage response = msgFactory.metastorageNotReadyResponse().build();
+
+                return CompletableFuture.completedFuture(response);
+            });
+
+        node0.manager.start();
+        node0.manager.init(metaStorageNodes);
+
+        node1.manager.start();
+
+        CompletableFuture<Boolean> hasMetastorageNode0 = supplyAsync(node0.manager::hasMetastorageLocally);
+        CompletableFuture<Boolean> hasMetastorageNode1 = supplyAsync(node1.manager::hasMetastorageLocally);
+
+        assertThat(hasMetastorageNode0, willBe(equalTo(false)));
+        assertThat(hasMetastorageNode1, willBe(equalTo(true)));
+    }
+
+    /**
+     * Tests stopping two nodes before they receive the "init" command.
+     * Two nodes are started here to test two different stop scenarios: one node is simply blocked, because it started
+     * first, while the second node is continuously polling the first one.
+     */
+    @Test
+    void testStop() {
+        List<Node> nodes = createCluster("foo", "bar");
+
+        Node node0 = nodes.get(0);
+        Node node1 = nodes.get(1);
+
+        NetworkMessage response = msgFactory.metastorageNotReadyResponse().build();
+
+        when(messagingService.invoke(any(ClusterNode.class), any(), anyLong()))
+            .thenReturn(CompletableFuture.completedFuture(response));
+
+        node0.manager.start();
+        node1.manager.start();
+
+        node0.manager.beforeNodeStop();
+        node0.manager.stop();
+
+        node1.manager.beforeNodeStop();
+        node1.manager.stop();
+    }
+
+    /**
+     * Similar to {@link #testStop} but stops the nodes after having initiated the "init" command.
+     */
+    @Test
+    void testStopAfterInit() {
+        List<Node> nodes = createCluster("foo", "bar");
+
+        Node node0 = nodes.get(0);
+        Node node1 = nodes.get(1);
+
+        NetworkMessage response = msgFactory.metastorageNotReadyResponse().build();
+
+        when(messagingService.invoke(any(ClusterNode.class), any(), anyLong()))
+            .thenReturn(CompletableFuture.completedFuture(response));
+
+        node0.manager.start();
+        node1.manager.start();
+
+        node0.manager.init(List.of(nodes.get(0).clusterNode.name()));
+        node1.manager.init(List.of(nodes.get(0).clusterNode.name()));
+
+        node0.manager.beforeNodeStop();
+        node0.manager.stop();
+
+        node1.manager.beforeNodeStop();
+        node1.manager.stop();
+    }
+}

--- a/modules/raft/src/main/java/org/apache/ignite/internal/raft/server/impl/JRaftServerImpl.java
+++ b/modules/raft/src/main/java/org/apache/ignite/internal/raft/server/impl/JRaftServerImpl.java
@@ -75,10 +75,10 @@ public class JRaftServerImpl implements RaftServer {
     private final Path dataPath;
 
     /** Server instance. */
-    private IgniteRpcServer rpcServer;
+    private volatile IgniteRpcServer rpcServer;
 
     /** Started groups. */
-    private ConcurrentMap<String, RaftGroupService> groups = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, RaftGroupService> groups = new ConcurrentHashMap<>();
 
     /** Node manager. */
     private final NodeManager nodeManager;

--- a/modules/runner/pom.xml
+++ b/modules/runner/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>org.apache.ignite</groupId>
             <artifactId>ignite-rest</artifactId>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/AbstractSchemaChangeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/AbstractSchemaChangeTest.java
@@ -77,7 +77,7 @@ abstract class AbstractSchemaChangeTest {
         nodesBootstrapCfg.put(
             node0Name,
             "{\n" +
-            "  node.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
+            "  metastorage.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
             "  network: {\n" +
             "    port: " + PORTS[0] + "\n" +
             "    netClusterNodes: [ \"localhost:3344\", \"localhost:3345\", \"localhost:3346\" ]\n" +
@@ -88,7 +88,7 @@ abstract class AbstractSchemaChangeTest {
         nodesBootstrapCfg.put(
             node1Name,
             "{\n" +
-            "  node.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
+            "  metastorage.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
             "  network: {\n" +
             "    port: " + PORTS[1] + "\n" +
             "    netClusterNodes: [ \"localhost:3344\", \"localhost:3345\", \"localhost:3346\" ]\n" +
@@ -99,7 +99,7 @@ abstract class AbstractSchemaChangeTest {
         nodesBootstrapCfg.put(
             node2Name,
             "{\n" +
-            "  node.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
+            "  metastorage.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
             "  network: {\n" +
             "    port: " + PORTS[2] + "\n" +
             "    netClusterNodes: [ \"localhost:3344\", \"localhost:3345\", \"localhost:3346\" ]\n" +

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ITDynamicTableCreationTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ITDynamicTableCreationTest.java
@@ -76,7 +76,7 @@ class ITDynamicTableCreationTest {
         nodesBootstrapCfg.put(
             node0Name,
             "{\n" +
-                "  node.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
+                "  metastorage.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
                 "  network: {\n" +
                 "    port: " + PORTS[0] + "\n" +
                 "    netClusterNodes: [ \"localhost:3344\", \"localhost:3345\", \"localhost:3346\" ]\n" +
@@ -87,7 +87,7 @@ class ITDynamicTableCreationTest {
         nodesBootstrapCfg.put(
             node1Name,
             "{\n" +
-                "  node.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
+                "  metastorage.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
                 "  network: {\n" +
                 "    port: " + PORTS[1] + "\n" +
                 "    netClusterNodes: [ \"localhost:3344\", \"localhost:3345\", \"localhost:3346\" ]\n" +
@@ -98,7 +98,7 @@ class ITDynamicTableCreationTest {
         nodesBootstrapCfg.put(
             node2Name,
             "{\n" +
-                "  node.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
+                "  metastorage.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
                 "  network: {\n" +
                 "    port: " + PORTS[2] + "\n" +
                 "    netClusterNodes: [ \"localhost:3344\", \"localhost:3345\", \"localhost:3346\" ]\n" +

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ITIgniteNodeRestartTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ITIgniteNodeRestartTest.java
@@ -154,7 +154,7 @@ public class ITIgniteNodeRestartTest extends IgniteAbstractTest {
         String nodeName = testNodeName(testInfo, 3344);
 
         Ignite ignite = IgnitionManager.start(nodeName, "{\n" +
-            "  \"node\": {\n" +
+            "  \"metastorage\": {\n" +
             "    \"metastorageNodes\":[ " + nodeName + " ]\n" +
             "  },\n" +
             "  \"network\": {\n" +

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ITIgnitionTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ITIgnitionTest.java
@@ -65,7 +65,7 @@ class ITIgnitionTest {
         nodesBootstrapCfg.put(
             node0Name,
             "{\n" +
-                "  node.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
+                "  metastorage.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
                 "  network: {\n" +
                 "    port: " + PORTS[0] + "\n" +
                 "    netClusterNodes: [ \"localhost:3344\", \"localhost:3345\", \"localhost:3346\" ]\n" +
@@ -76,7 +76,7 @@ class ITIgnitionTest {
         nodesBootstrapCfg.put(
             node1Name,
             "{\n" +
-                "  node.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
+                "  metastorage.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
                 "  network: {\n" +
                 "    port: " + PORTS[1] + "\n" +
                 "    netClusterNodes: [ \"localhost:3344\", \"localhost:3345\", \"localhost:3346\" ]\n" +
@@ -87,7 +87,7 @@ class ITIgnitionTest {
         nodesBootstrapCfg.put(
             node2Name,
             "{\n" +
-                "  node.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
+                "  metastorage.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
                 "  network: {\n" +
                 "    port: " + PORTS[2] + "\n" +
                 "    netClusterNodes: [ \"localhost:3344\", \"localhost:3345\", \"localhost:3346\" ]\n" +

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ITTableCreationTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ITTableCreationTest.java
@@ -72,7 +72,7 @@ class ITTableCreationTest {
         nodesBootstrapCfg.put(
             node0Name,
             "{\n" +
-                "  node.metastorageNodes: [ \"" + node0Name + "\", \"" + node1Name + "\" ],\n" +
+                "  metastorage.metastorageNodes: [ \"" + node0Name + "\", \"" + node1Name + "\" ],\n" +
                 "  network: {\n" +
                 "    port: " + PORTS[0] + "\n" +
                 "    netClusterNodes: [ \"localhost:3344\", \"localhost:3345\", \"localhost:3346\" ]\n" +
@@ -158,7 +158,7 @@ class ITTableCreationTest {
         nodesBootstrapCfg.put(
             node1Name,
             "{\n" +
-                "  node.metastorageNodes: [ \"" + node0Name + "\", \"" + node1Name + "\" ],\n" +
+                "  metastorage.metastorageNodes: [ \"" + node0Name + "\", \"" + node1Name + "\" ],\n" +
                 "  network: {\n" +
                 "    port: " + PORTS[1] + "\n" +
                 "    netClusterNodes: [ \"localhost:3344\", \"localhost:3345\", \"localhost:3346\" ]\n" +
@@ -169,7 +169,7 @@ class ITTableCreationTest {
         nodesBootstrapCfg.put(
             node2Name,
             "{\n" +
-                "  node.metastorageNodes: [ \"" + node0Name + "\", \"" + node1Name + "\" ],\n" +
+                "  metastorage.metastorageNodes: [ \"" + node0Name + "\", \"" + node1Name + "\" ],\n" +
                 "  network: {\n" +
                 "    port: " + PORTS[2] + "\n" +
                 "    netClusterNodes: [ \"localhost:3344\", \"localhost:3345\", \"localhost:3346\" ]\n" +

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ITThinClientConnectionTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ITThinClientConnectionTest.java
@@ -73,7 +73,7 @@ public class ITThinClientConnectionTest extends IgniteAbstractTest {
         nodesBootstrapCfg.put(
             node0Name,
             "{\n" +
-                "  node.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
+                "  metastorage.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
                 "  network: {\n" +
                 "    port: " + 3344 + "\n" +
                 "    netClusterNodes: [ \"localhost:3344\", \"localhost:3345\" ]\n" +
@@ -84,7 +84,7 @@ public class ITThinClientConnectionTest extends IgniteAbstractTest {
         nodesBootstrapCfg.put(
             node1Name,
             "{\n" +
-                "  node.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
+                "  metastorage.metastorageNodes: [ \"" + node0Name + "\" ],\n" +
                 "  network: {\n" +
                 "    port: " + 3345 + "\n" +
                 "    netClusterNodes: [ \"localhost:3344\", \"localhost:3345\" ]\n" +

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -51,7 +51,7 @@ public class PlatformTestNodeRunner {
     /** Nodes bootstrap configuration. */
     private static final Map<String, String> nodesBootstrapCfg = new LinkedHashMap<>() {{
         put(NODE_NAME, "{\n" +
-                "  \"node\": {\n" +
+                "  \"metastorage\": {\n" +
                 "    \"metastorageNodes\":[ \"" + NODE_NAME + "\" ]\n" +
                 "  },\n" +
                 "  \"clientConnector\":{\"port\": 10942,\"portRange\":10}," +

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/jdbc/AbstractJdbcSelfTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/jdbc/AbstractJdbcSelfTest.java
@@ -49,7 +49,7 @@ public class AbstractJdbcSelfTest {
     public static void beforeAll(@TempDir Path temp, TestInfo testInfo) {
         String nodeName = testNodeName(testInfo, 47500);
 
-        String configStr = "node.metastorageNodes: [ \"" + nodeName + "\" ]";
+        String configStr = "metastorage.metastorageNodes: [ \"" + nodeName + "\" ]";
 
         clusterNodes.add(IgnitionManager.start(nodeName, configStr, temp.resolve(nodeName)));
     }

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/IgnitionImpl.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/IgnitionImpl.java
@@ -64,7 +64,7 @@ public class IgnitionImpl implements Ignition {
      * Node name to node instance mapping.
      * Please pay attention, that nodes in given map might be in any state: STARTING, STARTED, STOPPED.
      */
-    private static Map<String, IgniteImpl> nodes = new ConcurrentHashMap<>();
+    private static final Map<String, IgniteImpl> nodes = new ConcurrentHashMap<>();
 
     /** {@inheritDoc} */
     @Override public Ignite start(@NotNull String nodeName, @Nullable Path cfgPath, @NotNull Path workDir) {

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/TableManagerTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/TableManagerTest.java
@@ -27,8 +27,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.ignite.configuration.schemas.metastorage.MetaStorageConfiguration;
 import org.apache.ignite.configuration.schemas.runner.ClusterConfiguration;
-import org.apache.ignite.configuration.schemas.runner.NodeConfiguration;
 import org.apache.ignite.configuration.schemas.table.TablesConfiguration;
 import org.apache.ignite.internal.affinity.AffinityUtils;
 import org.apache.ignite.internal.baseline.BaselineManager;
@@ -149,7 +149,7 @@ public class TableManagerTest {
     void setUp() {
         try {
             nodeCfgMgr = new ConfigurationManager(
-                List.of(NodeConfiguration.KEY),
+                List.of(MetaStorageConfiguration.KEY),
                 Map.of(),
                 new TestConfigurationStorage(LOCAL),
                 List.of()
@@ -165,13 +165,7 @@ public class TableManagerTest {
             nodeCfgMgr.start();
             clusterCfgMgr.start();
 
-            nodeCfgMgr.bootstrap("{\n" +
-                "   \"node\":{\n" +
-                "      \"metastorageNodes\":[\n" +
-                "         \"" + NODE_NAME + "\"\n" +
-                "      ]\n" +
-                "   }\n" +
-                "}");
+            nodeCfgMgr.bootstrap(String.format("metastorage.metastorageNodes = [\"%s\"]", NODE_NAME));
         }
         catch (Exception e) {
             LOG.error("Failed to bootstrap the test configuration manager.", e);

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -61,8 +61,8 @@
         <junit.version>5.8.1</junit.version>
         <micronaut.version>2.1.2</micronaut.version>
         <micronaut.test.junit5.version>2.3.1</micronaut.test.junit5.version>
-        <mockito.framework.version>3.8.0</mockito.framework.version>
-        <mockito.junit.jupiter.version>3.3.3</mockito.junit.jupiter.version>
+        <mockito.framework.version>3.11.2</mockito.framework.version>
+        <mockito.junit.jupiter.version>3.11.2</mockito.junit.jupiter.version>
         <picocli.version>4.5.2</picocli.version>
         <slf4j.version>1.7.32</slf4j.version>
         <spoon.framework.version>8.4.0-beta-18</spoon.framework.version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-14870

1. Meta Storage Manager now tries to obtain the names of the nodes hosting the Meta Storage either from other nodes by sending messages or from the "init" command.
2. "init" command is emulated by a corresponding method in the Manager.
3.  `NodeConfigurationSchema` has been replaced with `MetaStorageConfigurationSchema`.