### PR TITLE
IGNITE-15210

### DIFF
--- a/modules/affinity/src/test/java/org/apache/ignite/internal/affinity/AffinityManagerTest.java
+++ b/modules/affinity/src/test/java/org/apache/ignite/internal/affinity/AffinityManagerTest.java
@@ -77,7 +77,7 @@ public class AffinityManagerTest {
 
     /** Before all test scenarios. */
     @BeforeEach
-    private void setUp() {
+    void setUp() {
         try {
             cfrMgr = new ConfigurationManager(rootConfigurationKeys(), Arrays.asList(
                 new TestConfigurationStorage(ConfigurationType.DISTRIBUTED)));
@@ -128,7 +128,7 @@ public class AffinityManagerTest {
 
     /** Stop configuration manager. */
     @AfterEach
-    private void tearDown() {
+    void tearDown() {
         cfrMgr.stop();
     }
 

--- a/modules/cli/src/test/java/org/apache/ignite/cli/IgniteCliInterfaceTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/cli/IgniteCliInterfaceTest.java
@@ -88,7 +88,7 @@ public class IgniteCliInterfaceTest extends AbstractCliTest {
     }
 
     @AfterEach
-    private void tearDown() {
+    void tearDown() {
         ctx.stop();
     }
 

--- a/modules/cli/src/test/java/org/apache/ignite/cli/ui/ProgressBarTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/cli/ui/ProgressBarTest.java
@@ -38,14 +38,14 @@ public class ProgressBarTest extends AbstractCliTest {
 
     /** */
     @BeforeEach
-    private void setUp() {
+    void setUp() {
         outputStream = new ByteArrayOutputStream();
         out = new PrintWriter(outputStream, true);
     }
 
     /** */
     @AfterEach
-    private void tearDown() throws IOException {
+    void tearDown() throws IOException {
         out.close();
         outputStream.close();
     }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/IgnitionTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/IgnitionTest.java
@@ -80,7 +80,7 @@ class IgnitionTest {
 
     /** */
     @AfterEach
-    private void tearDown() throws Exception {
+    void tearDown() throws Exception {
         IgniteUtils.closeAll(Lists.reverse(startedNodes));
     }
 

--- a/modules/schema/src/test/java/org/apache/ignite/internal/schema/configuration/SchemaConfigurationConverterTest.java
+++ b/modules/schema/src/test/java/org/apache/ignite/internal/schema/configuration/SchemaConfigurationConverterTest.java
@@ -92,7 +92,7 @@ public class SchemaConfigurationConverterTest {
     }
 
     @AfterEach
-    private void tearDown() {
+    void tearDown() {
         confRegistry.stop();
     }
 

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/TableManagerTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/TableManagerTest.java
@@ -140,7 +140,7 @@ public class TableManagerTest {
 
     /** Before all test scenarios. */
     @BeforeEach
-    private void setUp() {
+    void setUp() {
         try {
             cfrMgr = new ConfigurationManager(rootConfigurationKeys(), Arrays.asList(
                 new TestConfigurationStorage(ConfigurationType.LOCAL),
@@ -204,7 +204,7 @@ public class TableManagerTest {
 
     /** Stop configuration manager. */
     @AfterEach
-    private void tearDown() {
+    void tearDown() {
         cfrMgr.stop();
     }
 

--- a/modules/vault/src/test/java/org/apache/ignite/internal/vault/VaultServiceTest.java
+++ b/modules/vault/src/test/java/org/apache/ignite/internal/vault/VaultServiceTest.java
@@ -61,7 +61,7 @@ public abstract class VaultServiceTest {
 
     /** */
     @AfterEach
-    private void tearDown() throws Exception {
+    void tearDown() throws Exception {
         vaultService.stop();
     }
 


### PR DESCRIPTION
According to https://junit.org/junit5/docs/5.0.0/api/org/junit/jupiter/api/BeforeEach.html and https://junit.org/junit5/docs/5.0.0/api/org/junit/jupiter/api/AfterEach.html  both setUp and tearDown methods must not be private, however they are in some cases in our code.

Despite the fact that private seems to work fine, it's still better to follow documentation recommendations.
