### PR TITLE
IGNITE-15237 Thin 3.0: Fix ClientHandlerIntegrationTest flakiness

### DIFF
--- a/modules/client-handler/src/test/java/org/apache/ignite/client/handler/ClientHandlerIntegrationTest.java
+++ b/modules/client-handler/src/test/java/org/apache/ignite/client/handler/ClientHandlerIntegrationTest.java
@@ -19,6 +19,7 @@ package org.apache.ignite.client.handler;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.Collections;
 import io.netty.channel.ChannelFuture;
@@ -48,9 +49,12 @@ public class ClientHandlerIntegrationTest {
 
     private ConfigurationRegistry configurationRegistry;
 
+    private int serverPort;
+
     @BeforeEach
     public void setUp() throws Exception {
         serverFuture = startServer();
+        serverPort = ((InetSocketAddress)serverFuture.channel().localAddress()).getPort();
     }
 
     @AfterEach
@@ -62,7 +66,7 @@ public class ClientHandlerIntegrationTest {
 
     @Test
     void testHandshakeInvalidMagicHeaderDropsConnection() throws Exception {
-        try (var sock = new Socket("127.0.0.1", 10800)) {
+        try (var sock = new Socket("127.0.0.1", serverPort)) {
             OutputStream out = sock.getOutputStream();
             out.write(new byte[]{63, 64, 65, 66, 67});
             out.flush();
@@ -73,7 +77,7 @@ public class ClientHandlerIntegrationTest {
 
     @Test
     void testHandshakeValidReturnsSuccess() throws Exception {
-        try (var sock = new Socket("127.0.0.1", 10800)) {
+        try (var sock = new Socket("127.0.0.1", serverPort)) {
             OutputStream out = sock.getOutputStream();
 
             // Magic: IGNI
@@ -125,7 +129,7 @@ public class ClientHandlerIntegrationTest {
 
     @Test
     void testHandshakeInvalidVersionReturnsError() throws Exception {
-        try (var sock = new Socket("127.0.0.1", 10800)) {
+        try (var sock = new Socket("127.0.0.1", serverPort)) {
             OutputStream out = sock.getOutputStream();
 
             // Magic: IGNI

--- a/modules/client-handler/src/test/java/org/apache/ignite/client/handler/ClientHandlerIntegrationTest.java
+++ b/modules/client-handler/src/test/java/org/apache/ignite/client/handler/ClientHandlerIntegrationTest.java
@@ -61,6 +61,7 @@ public class ClientHandlerIntegrationTest {
     public void tearDown() throws Exception {
         serverFuture.cancel(true);
         serverFuture.await();
+        serverFuture.channel().closeFuture().await();
         configurationRegistry.stop();
     }
 

--- a/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
@@ -51,11 +51,15 @@ public abstract class AbstractClientTest {
 
     protected static Ignite client;
 
+    protected static int serverPort;
+
     @BeforeAll
     public static void beforeAll() throws Exception {
         ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
 
         serverFuture = startServer(null);
+        serverPort = ((InetSocketAddress)serverFuture.channel().localAddress()).getPort();
+
         client = startClient();
     }
 
@@ -74,11 +78,8 @@ public abstract class AbstractClientTest {
     }
 
     public static Ignite startClient(String... addrs) {
-        if (addrs == null || addrs.length == 0) {
-            var serverPort = ((InetSocketAddress)serverFuture.channel().localAddress()).getPort();
-
+        if (addrs == null || addrs.length == 0)
             addrs = new String[]{"127.0.0.2:" + serverPort};
-        }
 
         var builder = IgniteClient.builder().addresses(addrs);
 

--- a/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
@@ -68,6 +68,7 @@ public abstract class AbstractClientTest {
         client.close();
         serverFuture.cancel(true);
         serverFuture.await();
+        serverFuture.channel().closeFuture().await();
         configurationRegistry.stop();
     }
 

--- a/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -42,7 +42,7 @@ public class ConnectionTest extends AbstractClientTest {
 
     @Test
     public void testValidNodeAddresses() throws Exception {
-        testConnection("127.0.0.1:10800");
+        testConnection("127.0.0.1:" + serverPort);
     }
 
     @Test
@@ -55,13 +55,13 @@ public class ConnectionTest extends AbstractClientTest {
 
     @Test
     public void testValidInvalidNodeAddressesMix() throws Exception {
-        testConnection("127.0.0.1:47500", "127.0.0.1:10801", "127.0.0.1:10800");
+        testConnection("127.0.0.1:47500", "127.0.0.1:10801", "127.0.0.1:" + serverPort);
     }
 
     @Disabled("IPv6 is not enabled by default on some systems.")
     @Test
     public void testIPv6NodeAddresses() throws Exception {
-        testConnection("[::1]:10800");
+        testConnection("[::1]:" + serverPort);
     }
 
     private void testConnection(String... addrs) throws Exception {

--- a/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -46,7 +46,7 @@ public class ConnectionTest extends AbstractClientTest {
     }
 
     @Test
-    public void testInvalidNodeAddresses() throws Exception {
+    public void testInvalidNodeAddresses() {
         var ex = assertThrows(IgniteClientConnectionException.class,
                 () -> testConnection("127.0.0.1:47500"));
 


### PR DESCRIPTION
Connect to the actual server port, do not assume 10800: server can bind to any port from the range.