### PR TITLE
IGNITE-15382 Decouple API and implementation for Tuple

### DIFF
--- a/modules/api/src/main/java/org/apache/ignite/table/Tuple.java
+++ b/modules/api/src/main/java/org/apache/ignite/table/Tuple.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.BitSet;
+import java.util.Map;
 import java.util.UUID;
 import org.apache.ignite.binary.BinaryObject;
 import org.jetbrains.annotations.NotNull;
@@ -35,7 +36,7 @@ public interface Tuple extends Iterable<Object> {
     /**
      * Creates a tuple.
      *
-     * @return Tuple.
+     * @return A new tuple.
      */
     static Tuple create() {
         return new TupleImpl();
@@ -45,10 +46,35 @@ public interface Tuple extends Iterable<Object> {
      * Creates a tuple with specified initial capacity.
      *
      * @param capacity Initial capacity.
-     * @return Tuple.
+     * @return A new tuple.
      */
     static Tuple create(int capacity) {
         return new TupleImpl(capacity);
+    }
+
+    /**
+     * Creates a tuple from given mapping.
+     *
+     * @param map Column values.
+     * @return A new tuple.
+     */
+    static Tuple create(Map<String, Object> map) {
+        TupleImpl tuple = new TupleImpl(map.size());
+
+        for (Map.Entry<String, Object> entry : map.entrySet())
+            tuple.set(entry.getKey(), entry.getValue());
+
+        return tuple;
+    }
+
+    /**
+     * Creates a tuple copy.
+     *
+     * @param tuple Tuple to copy.
+     * @return A new tuple.
+     */
+    static Tuple create(Tuple tuple) {
+        return new TupleImpl(tuple);
     }
 
     /**

--- a/modules/api/src/main/java/org/apache/ignite/table/TupleImpl.java
+++ b/modules/api/src/main/java/org/apache/ignite/table/TupleImpl.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Simple tuple implementation.
  */
-public class TupleImpl implements Tuple, Serializable {
+class TupleImpl implements Tuple, Serializable {
     /** Version UID. */
     private static final long serialVersionUID = 0L;
 
@@ -46,18 +46,18 @@ public class TupleImpl implements Tuple, Serializable {
      * <p>
      * Note: Transient because it's recoverable from {@link #colNames}.
      */
-    private transient Map<String, Integer> colIdxMap;
+    private transient Map<String, Integer> colMapping;
 
     /** Columns names. */
     private final List<String> colNames;
 
     /** Columns values. */
-    private final List<Object> vals;
+    private final List<Object> colValues;
 
     /**
      * Creates tuple.
      */
-    public TupleImpl() {
+    TupleImpl() {
         this(new HashMap<>(), new ArrayList<>(), new ArrayList<>());
     }
 
@@ -66,21 +66,8 @@ public class TupleImpl implements Tuple, Serializable {
      *
      * @param capacity Initial capacity.
      */
-    public TupleImpl(int capacity) {
+    TupleImpl(int capacity) {
         this(new HashMap<>(capacity), new ArrayList<>(capacity), new ArrayList<>(capacity));
-    }
-
-    /**
-     * Private constructor.
-     *
-     * @param columnNameMapping Column name mapping.
-     * @param columnNames Column names.
-     * @param values Column values.
-     */
-    private TupleImpl(Map<String, Integer> columnNameMapping, List<String> columnNames, List<Object> values) {
-        this.colIdxMap = columnNameMapping;
-        this.colNames = columnNames;
-        this.vals = values;
     }
 
     /**
@@ -88,23 +75,36 @@ public class TupleImpl implements Tuple, Serializable {
      *
      * @param tuple Tuple.
      */
-    public TupleImpl(@NotNull Tuple tuple) {
+    TupleImpl(@NotNull Tuple tuple) {
         this(tuple.columnCount());
 
         for (int i = 0, len = tuple.columnCount(); i < len; i++)
             set(tuple.columnName(i), tuple.value(i));
     }
 
+    /**
+     * A private constructor.
+     *
+     * @param columnMapping Column name-to-idx mapping.
+     * @param columnNames List of columns names.
+     * @param columnValues List of columns values.
+     */
+    private TupleImpl(Map<String, Integer> columnMapping, List<String> columnNames, List<Object> columnValues) {
+        this.colMapping = columnMapping;
+        this.colNames = columnNames;
+        this.colValues = columnValues;
+    }
+
     /** {@inheritDoc} */
     @Override public Tuple set(@NotNull String columnName, Object val) {
-        int idx = colIdxMap.computeIfAbsent(Objects.requireNonNull(columnName), name -> colIdxMap.size());
+        int idx = colMapping.computeIfAbsent(Objects.requireNonNull(columnName), name -> colMapping.size());
 
         if (idx == colNames.size()) {
             colNames.add(idx, columnName);
-            vals.add(idx, val);
+            colValues.add(idx, val);
         } else {
             colNames.set(idx, columnName);
-            vals.set(idx, val);
+            colValues.set(idx, val);
         }
 
         return this;
@@ -112,7 +112,7 @@ public class TupleImpl implements Tuple, Serializable {
 
     /** {@inheritDoc} */
     @Override public String columnName(int columnIndex) {
-        Objects.checkIndex(columnIndex, vals.size());
+        Objects.checkIndex(columnIndex, colValues.size());
 
         return colNames.get(columnIndex);
     }
@@ -121,7 +121,7 @@ public class TupleImpl implements Tuple, Serializable {
     @Override public int columnIndex(@NotNull String columnName) {
         Objects.requireNonNull(columnName);
 
-        Integer idx = colIdxMap.get(columnName);
+        Integer idx = colMapping.get(columnName);
 
         return idx == null ? -1 : idx;
     }
@@ -135,7 +135,7 @@ public class TupleImpl implements Tuple, Serializable {
     @Override public <T> T valueOrDefault(@NotNull String columnName, T def) {
         int idx = columnIndex(columnName);
 
-        return (idx == -1) ? def : (T)vals.get(idx);
+        return (idx == -1) ? def : (T)colValues.get(idx);
     }
 
     /** {@inheritDoc} */
@@ -145,14 +145,14 @@ public class TupleImpl implements Tuple, Serializable {
         if (idx == -1)
             throw new IllegalArgumentException("Column not found: columnName=" + columnName);
 
-        return (T)vals.get(idx);
+        return (T)colValues.get(idx);
     }
 
     /** {@inheritDoc} */
     @Override public <T> T value(int columnIndex) {
-        Objects.checkIndex(columnIndex, vals.size());
+        Objects.checkIndex(columnIndex, colValues.size());
 
-        return (T)vals.get(columnIndex);
+        return (T)colValues.get(columnIndex);
     }
 
     /** {@inheritDoc} */
@@ -303,12 +303,12 @@ public class TupleImpl implements Tuple, Serializable {
 
             /** {@inheritDoc} */
             @Override public boolean hasNext() {
-                return cur < vals.size();
+                return cur < colValues.size();
             }
 
             /** {@inheritDoc} */
             @Override public Object next() {
-                return hasNext() ? vals.get(cur++) : null;
+                return hasNext() ? colValues.get(cur++) : null;
             }
         };
     }
@@ -324,9 +324,9 @@ public class TupleImpl implements Tuple, Serializable {
         in.defaultReadObject();
 
         // Recover column name->index mapping.
-        colIdxMap = new HashMap<>(colNames.size());
+        colMapping = new HashMap<>(colNames.size());
 
         for (int i = 0; i < colNames.size(); i++)
-            colIdxMap.put(colNames.get(i), i);
+            colMapping.put(colNames.get(i), i);
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientTupleTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientTupleTest.java
@@ -33,7 +33,6 @@ import org.apache.ignite.internal.client.table.ClientSchema;
 import org.apache.ignite.internal.client.table.ClientTuple;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.table.Tuple;
-import org.apache.ignite.table.TupleImpl;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -341,7 +340,7 @@ public class ClientTupleTest {
                               .set("datetime", datetime)
                               .set("timestamp", timestamp);
 
-        var tuple = new TupleImpl();
+        var tuple = Tuple.create();
 
         for (int i = 0; i < clientTuple.columnCount(); i++)
             tuple.set(clientTuple.columnName(i), clientTuple.value(i));

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/MutableRowTupleAdapter.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/MutableRowTupleAdapter.java
@@ -30,7 +30,6 @@ import org.apache.ignite.binary.BinaryObject;
 import org.apache.ignite.internal.schema.SchemaDescriptor;
 import org.apache.ignite.internal.schema.row.Row;
 import org.apache.ignite.table.Tuple;
-import org.apache.ignite.table.TupleImpl;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -45,17 +44,17 @@ import org.jetbrains.annotations.Nullable;
  * <p>
  * After the first mutation the {@link #tuple} becomes a full copy of {@link #row},
  * all data access methods delegate to a {@link #tuple}, and the {@link #row} one is no longer useful.
- * The adapter acts as simple schema-less tuple {@link TupleImpl} and {@link #schema()} return null.
+ * The adapter acts as simple schema-less tuple {@link Tuple} and {@link #schema()} return null.
  * <p>
  * Serialization.
  * Row access methods implicitly require a context (schema) for a binary data reading, The context may be huge
  * comparing to a row data, and its serialization is unwanted.
  * So, Row firstly is converted to Tuple.
  * <p>
- * Because of after that the adapter will act as underlying tuple {@link TupleImpl},
+ * Because of after that the adapter will act as underlying tuple {@link Tuple},
  * the adapter will be substituted unconditionally with the tuple itself during deserialization.
  *
- * @see TupleImpl
+ * @see Tuple
  * @see #unmarshalRow()
  * @see #writeReplace()
  */
@@ -64,7 +63,7 @@ public class MutableRowTupleAdapter extends AbstractRowTupleAdapter implements S
     // this object never get serialized, it's unconditionally substituted during serialization.
 
     /** Tuple with overwritten data. */
-    protected TupleImpl tuple;
+    protected Tuple tuple;
 
     /**
      * Creates mutable wrapper over row.
@@ -269,7 +268,7 @@ public class MutableRowTupleAdapter extends AbstractRowTupleAdapter implements S
      */
     private void unmarshalRow() {
         if (tuple == null) {
-            tuple = new TupleImpl(this);
+            tuple = Tuple.create(this);
 
             row = null;
         }

--- a/modules/table/src/test/java/org/apache/ignite/internal/benchmarks/TupleMarshallerFixlenOnlyBenchmark.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/benchmarks/TupleMarshallerFixlenOnlyBenchmark.java
@@ -29,7 +29,6 @@ import org.apache.ignite.internal.schema.registry.SchemaRegistryImpl;
 import org.apache.ignite.internal.schema.row.Row;
 import org.apache.ignite.internal.table.TupleMarshallerImpl;
 import org.apache.ignite.table.Tuple;
-import org.apache.ignite.table.TupleImpl;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -134,12 +133,12 @@ public class TupleMarshallerFixlenOnlyBenchmark {
     public void measureTupleBuildAndMarshallerCost(Blackhole bh) {
         final Columns cols = schema.valueColumns();
 
-        final TupleImpl valBld = new TupleImpl();
+        final Tuple valBld = Tuple.create(cols.length());
 
         for (int i = 0; i < cols.length(); i++)
             valBld.set(cols.column(i).name(), vals[i]);
 
-        Tuple keyTuple = new TupleImpl().set("key", rnd.nextLong());
+        Tuple keyTuple = Tuple.create(1).set("key", rnd.nextLong());
 
         final Row row = marshaller.marshal(keyTuple, valBld);
 

--- a/modules/table/src/test/java/org/apache/ignite/internal/benchmarks/TupleMarshallerVarlenOnlyBenchmark.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/benchmarks/TupleMarshallerVarlenOnlyBenchmark.java
@@ -30,7 +30,6 @@ import org.apache.ignite.internal.schema.registry.SchemaRegistryImpl;
 import org.apache.ignite.internal.schema.row.Row;
 import org.apache.ignite.internal.table.TupleMarshallerImpl;
 import org.apache.ignite.table.Tuple;
-import org.apache.ignite.table.TupleImpl;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -154,12 +153,12 @@ public class TupleMarshallerVarlenOnlyBenchmark {
     public void measureTupleBuildAndMarshallerCost(Blackhole bh) {
         final Columns cols = schema.valueColumns();
 
-        final TupleImpl valBld = new TupleImpl();
+        final Tuple valBld = Tuple.create(cols.length());
 
         for (int i = 0; i < cols.length(); i++)
             valBld.set(cols.column(i).name(), val);
 
-        Tuple keyTuple = new TupleImpl().set("key", rnd.nextLong());
+        Tuple keyTuple = Tuple.create(1).set("key", rnd.nextLong());
 
         final Row row = marshaller.marshal(keyTuple, valBld);
 

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/MutableRowTupleAdapterTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/MutableRowTupleAdapterTest.java
@@ -42,7 +42,6 @@ import org.apache.ignite.internal.table.impl.DummySchemaManagerImpl;
 import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.schema.SchemaMode;
 import org.apache.ignite.table.Tuple;
-import org.apache.ignite.table.TupleImpl;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -188,7 +187,7 @@ public class MutableRowTupleAdapterTest {
             }
         );
 
-        Tuple original = new TupleImpl()
+        Tuple original = Tuple.create()
                              .set("id", 3L)
                              .set("name", "Shirt")
                              .set("price", 5.99d);
@@ -221,7 +220,7 @@ public class MutableRowTupleAdapterTest {
     public void testRowTupleMutability() {
         TupleMarshaller marshaller = new TupleMarshallerImpl(null, tbl, new DummySchemaManagerImpl(schema));
 
-        Row row = new Row(schema, new ByteBufferRow(marshaller.marshal(new TupleImpl().set("id", 1L).set("name", "Shirt")).bytes()));
+        Row row = new Row(schema, new ByteBufferRow(marshaller.marshal(Tuple.create().set("id", 1L).set("name", "Shirt")).bytes()));
 
         Tuple tuple = TableRow.tuple(row);
         Tuple key = TableRow.keyTuple(row);
@@ -248,7 +247,7 @@ public class MutableRowTupleAdapterTest {
     public void testKeyValueTupleMutability() {
         TupleMarshaller marshaller = new TupleMarshallerImpl(null, tbl, new DummySchemaManagerImpl(schema));
 
-        Row row = new Row(schema, new ByteBufferRow(marshaller.marshal(new TupleImpl().set("id", 1L).set("name", "Shirt")).bytes()));
+        Row row = new Row(schema, new ByteBufferRow(marshaller.marshal(Tuple.create().set("id", 1L).set("name", "Shirt")).bytes()));
 
         Tuple tuple = TableRow.tuple(row);
         Tuple key = TableRow.keyTuple(row);
@@ -277,7 +276,7 @@ public class MutableRowTupleAdapterTest {
     public void testRowTupleSchemaAwareness() {
         TupleMarshaller marshaller = new TupleMarshallerImpl(null, tbl, new DummySchemaManagerImpl(schema));
 
-        Row row = new Row(schema, new ByteBufferRow(marshaller.marshal(new TupleImpl().set("id", 1L).set("name", "Shirt")).bytes()));
+        Row row = new Row(schema, new ByteBufferRow(marshaller.marshal(Tuple.create().set("id", 1L).set("name", "Shirt")).bytes()));
 
         Tuple tuple = TableRow.tuple(row);
         Tuple key = TableRow.keyTuple(row);
@@ -300,7 +299,7 @@ public class MutableRowTupleAdapterTest {
     public void testKeyValueTupleSchemaAwareness() {
         TupleMarshaller marshaller = new TupleMarshallerImpl(null, tbl, new DummySchemaManagerImpl(schema));
 
-        Row row = new Row(schema, new ByteBufferRow(marshaller.marshal(new TupleImpl().set("id", 1L).set("name", "Shirt")).bytes()));
+        Row row = new Row(schema, new ByteBufferRow(marshaller.marshal(Tuple.create().set("id", 1L).set("name", "Shirt")).bytes()));
 
         Tuple tuple = TableRow.tuple(row);
         Tuple key = TableRow.keyTuple(row);
@@ -348,7 +347,7 @@ public class MutableRowTupleAdapterTest {
 
         TupleMarshaller marshaller = new TupleMarshallerImpl(null, tbl, new DummySchemaManagerImpl(schema));
 
-        Tuple tuple = new TupleImpl()
+        Tuple tuple = Tuple.create()
                           .set("valByteCol", (byte)1)
                           .set("valShortCol", (short)2)
                           .set("valIntCol", 3)
@@ -400,7 +399,7 @@ public class MutableRowTupleAdapterTest {
             }
         );
 
-        Tuple tup1 = new TupleImpl()
+        Tuple tup1 = Tuple.create()
                          .set("valByteCol", (byte)1)
                          .set("valShortCol", (short)2)
                          .set("valIntCol", 3)
@@ -452,8 +451,8 @@ public class MutableRowTupleAdapterTest {
             }
         );
 
-        Tuple key1 = new TupleImpl().set("keyUuidCol", UUID.randomUUID());
-        Tuple val1 = new TupleImpl()
+        Tuple key1 = Tuple.create().set("keyUuidCol", UUID.randomUUID());
+        Tuple val1 = Tuple.create()
                          .set("valByteCol", (byte)1)
                          .set("valShortCol", (short)2)
                          .set("valIntCol", 3)
@@ -556,7 +555,7 @@ public class MutableRowTupleAdapterTest {
     }
 
     private Tuple getTuple() {
-        Tuple original = new TupleImpl()
+        Tuple original = Tuple.create()
                              .set("id", 3L)
                              .set("name", "Shirt");
 

--- a/modules/table/src/test/java/org/apache/ignite/table/TupleImplTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/table/TupleImplTest.java
@@ -30,6 +30,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -285,6 +286,18 @@ public class TupleImplTest {
         }
 
         assertEquals(tup1, tup2);
+    }
+
+    @Test
+    void testTupleFactoryMethods() {
+        assertEquals(Tuple.create(), Tuple.create(10));
+        assertEquals(Tuple.create().set("id", 42L), Tuple.create(10).set("id", 42L));
+
+        assertEquals(Tuple.create().set("id", 42L).set("name", "universe"),
+            Tuple.create(Map.of("id", 42L, "name", "universe")));
+
+        assertEquals(Tuple.create().set("id", 42L).set("name", "universe"),
+            Tuple.create(Tuple.create().set("id", 42L).set("name", "universe")));
     }
 
     private static TupleImpl createTuple() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-15382

Finnaly, TupleImpl was made a package-private to restrict user access.
TupleImpl left in ignite-api module and can be reused in table and/or client module via using public factory methods.