### PR TITLE
IGNITE-15456 Integrate RocksDBKeyValueStorage into the production code

### DIFF
--- a/modules/metastorage-client/src/integrationTest/java/org/apache/ignite/internal/metastorage/client/ITMetaStorageServiceTest.java
+++ b/modules/metastorage-client/src/integrationTest/java/org/apache/ignite/internal/metastorage/client/ITMetaStorageServiceTest.java
@@ -27,12 +27,11 @@ import java.util.NavigableMap;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.ignite.internal.metastorage.common.OperationType;
+import org.apache.ignite.internal.metastorage.server.EntryEvent;
 import org.apache.ignite.internal.metastorage.server.KeyValueStorage;
 import org.apache.ignite.internal.metastorage.server.raft.MetaStorageListener;
 import org.apache.ignite.internal.raft.server.RaftServer;
@@ -55,29 +54,35 @@ import org.apache.ignite.raft.client.service.RaftGroupService;
 import org.apache.ignite.raft.client.service.impl.RaftGroupServiceImpl;
 import org.apache.ignite.utils.ClusterServiceTestUtils;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Meta storage client tests.
  */
-@SuppressWarnings("WeakerAccess")
 @ExtendWith(WorkDirectoryExtension.class)
+@ExtendWith(MockitoExtension.class)
 public class ITMetaStorageServiceTest {
     /** The logger. */
     private static final IgniteLogger LOG = IgniteLogger.forClass(ITMetaStorageServiceTest.class);
@@ -102,38 +107,53 @@ public class ITMetaStorageServiceTest {
 
     /**  Expected server result entry. */
     private static final org.apache.ignite.internal.metastorage.server.Entry EXPECTED_SRV_RESULT_ENTRY =
-            new org.apache.ignite.internal.metastorage.server.Entry(
-                    new byte[] {1},
-                    new byte[] {2},
-                    10,
-                    2
-            );
+        new org.apache.ignite.internal.metastorage.server.Entry(
+            new byte[] {1},
+            new byte[] {2},
+            10,
+            2
+        );
 
-    /**  Expected server result entry. */
+    /**
+     * Expected server result entry.
+     */
     private static final EntryImpl EXPECTED_RESULT_ENTRY =
-            new EntryImpl(
-                    new ByteArray(new byte[] {1}),
-                    new byte[] {2},
-                    10,
-                    2
-            );
+        new EntryImpl(
+            new ByteArray(new byte[] {1}),
+            new byte[] {2},
+            10,
+            2
+        );
 
-    /** Expected result map. */
+    /**
+     * Expected result map.
+     */
     private static final NavigableMap<ByteArray, Entry> EXPECTED_RESULT_MAP;
 
+    /** Expected server result collection. */
     private static final Collection<org.apache.ignite.internal.metastorage.server.Entry> EXPECTED_SRV_RESULT_COLL;
 
     /** Node 0 id. */
-    public static final String NODE_ID_0 = "node-id-0";
+    private static final String NODE_ID_0 = "node-id-0";
 
     /** Node 1 id. */
-    public static final String NODE_ID_1 = "node-id-1";
+    private static final String NODE_ID_1 = "node-id-1";
 
     /** Cluster. */
-    private ArrayList<ClusterService> cluster = new ArrayList<>();
+    private final ArrayList<ClusterService> cluster = new ArrayList<>();
 
-    /**  Meta storage raft server. */
+    /** Meta storage raft server. */
     private RaftServer metaStorageRaftSrv;
+
+    /** Raft group service. */
+    private RaftGroupService metaStorageRaftGrpSvc;
+
+    /** Mock Metastorage storage. */
+    @Mock
+    private KeyValueStorage mockStorage;
+
+    /** Metastorage service. */
+    private MetaStorageService metaStorageSvc;
 
     /** */
     @WorkDirectory
@@ -143,39 +163,38 @@ public class ITMetaStorageServiceTest {
         EXPECTED_RESULT_MAP = new TreeMap<>();
 
         EntryImpl entry1 = new EntryImpl(
-                new ByteArray(new byte[]{1}),
-                new byte[]{2},
-                10,
-                2
+            new ByteArray(new byte[] {1}),
+            new byte[] {2},
+            10,
+            2
         );
 
         EXPECTED_RESULT_MAP.put(entry1.key(), entry1);
 
         EntryImpl entry2 = new EntryImpl(
-                new ByteArray(new byte[]{3}),
-                new byte[]{4},
-                10,
-                3
+            new ByteArray(new byte[] {3}),
+            new byte[] {4},
+            10,
+            3
         );
 
         EXPECTED_RESULT_MAP.put(entry2.key(), entry2);
 
-        EXPECTED_SRV_RESULT_COLL = new ArrayList<>();
-
-        EXPECTED_SRV_RESULT_COLL.add(new org.apache.ignite.internal.metastorage.server.Entry(
+        EXPECTED_SRV_RESULT_COLL = List.of(
+            new org.apache.ignite.internal.metastorage.server.Entry(
                 entry1.key().bytes(), entry1.value(), entry1.revision(), entry1.updateCounter()
-        ));
-
-        EXPECTED_SRV_RESULT_COLL.add(new org.apache.ignite.internal.metastorage.server.Entry(
+            ),
+            new org.apache.ignite.internal.metastorage.server.Entry(
                 entry2.key().bytes(), entry2.value(), entry2.revision(), entry2.updateCounter()
-        ));
+            )
+        );
     }
 
     /**
      * Run {@code NODES} cluster nodes.
      */
     @BeforeEach
-    public void beforeTest() {
+    public void beforeTest() throws Exception {
         var nodeFinder = new LocalPortRangeNodeFinder(NODE_PORT_BASE, NODE_PORT_BASE + NODES);
 
         nodeFinder.findNodes().stream()
@@ -197,6 +216,8 @@ public class ITMetaStorageServiceTest {
             assertTrue(waitForTopology(node, NODES, 1000));
 
         LOG.info("Cluster started.");
+
+        metaStorageSvc = prepareMetaStorage();
     }
 
     /**
@@ -207,6 +228,7 @@ public class ITMetaStorageServiceTest {
     @AfterEach
     public void afterTest() throws Exception {
         metaStorageRaftSrv.stop();
+        metaStorageRaftGrpSvc.shutdown();
 
         for (ClusterService node : cluster)
             node.stop();
@@ -219,12 +241,7 @@ public class ITMetaStorageServiceTest {
      */
     @Test
     public void testGet() throws Exception {
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public @NotNull org.apache.ignite.internal.metastorage.server.Entry get(byte[] key) {
-                        return EXPECTED_SRV_RESULT_ENTRY;
-                    }
-                });
+        when(mockStorage.get(EXPECTED_RESULT_ENTRY.key().bytes())).thenReturn(EXPECTED_SRV_RESULT_ENTRY);
 
         assertEquals(EXPECTED_RESULT_ENTRY, metaStorageSvc.get(EXPECTED_RESULT_ENTRY.key()).get());
     }
@@ -236,16 +253,12 @@ public class ITMetaStorageServiceTest {
      */
     @Test
     public void testGetWithUpperBoundRevision() throws Exception {
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public @NotNull org.apache.ignite.internal.metastorage.server.Entry get(byte[] key, long rev) {
-                        return EXPECTED_SRV_RESULT_ENTRY;
-                    }
-                });
+        when(mockStorage.get(EXPECTED_RESULT_ENTRY.key().bytes(), EXPECTED_RESULT_ENTRY.revision()))
+            .thenReturn(EXPECTED_SRV_RESULT_ENTRY);
 
         assertEquals(
-                EXPECTED_RESULT_ENTRY,
-                metaStorageSvc.get(EXPECTED_RESULT_ENTRY.key(), EXPECTED_RESULT_ENTRY.revision()).get()
+            EXPECTED_RESULT_ENTRY,
+            metaStorageSvc.get(EXPECTED_RESULT_ENTRY.key(), EXPECTED_RESULT_ENTRY.revision()).get()
         );
     }
 
@@ -256,12 +269,7 @@ public class ITMetaStorageServiceTest {
      */
     @Test
     public void testGetAll() throws Exception {
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public @NotNull List<org.apache.ignite.internal.metastorage.server.Entry> getAll(List<byte[]> keys) {
-                        return new ArrayList<>(EXPECTED_SRV_RESULT_COLL);
-                    }
-                });
+        when(mockStorage.getAll(anyList())).thenReturn(EXPECTED_SRV_RESULT_COLL);
 
         assertEquals(EXPECTED_RESULT_MAP, metaStorageSvc.getAll(EXPECTED_RESULT_MAP.keySet()).get());
     }
@@ -273,16 +281,11 @@ public class ITMetaStorageServiceTest {
      */
     @Test
     public void testGetAllWithUpperBoundRevision() throws Exception {
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public @NotNull List<org.apache.ignite.internal.metastorage.server.Entry> getAll(List<byte[]> keys, long revUpperBound) {
-                        return new ArrayList<>(EXPECTED_SRV_RESULT_COLL);
-                    }
-                });
+        when(mockStorage.getAll(anyList(), eq(10L))).thenReturn(EXPECTED_SRV_RESULT_COLL);
 
         assertEquals(
-                EXPECTED_RESULT_MAP,
-                metaStorageSvc.getAll(EXPECTED_RESULT_MAP.keySet(), 10).get()
+            EXPECTED_RESULT_MAP,
+            metaStorageSvc.getAll(EXPECTED_RESULT_MAP.keySet(), 10).get()
         );
     }
 
@@ -293,19 +296,11 @@ public class ITMetaStorageServiceTest {
      */
     @Test
     public void testPut() throws Exception {
-        ByteArray expKey = new ByteArray(new byte[]{1});
+        ByteArray expKey = new ByteArray(new byte[] {1});
 
-        byte[] expVal = new byte[]{2};
+        byte[] expVal = {2};
 
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @SuppressWarnings("JavaAbbreviationUsage")
-                    @Override public void put(byte[] key, byte[] value) {
-                        assertArrayEquals(expKey.bytes(), key);
-
-                        assertArrayEquals(expVal, value);
-                    }
-                });
+        doNothing().when(mockStorage).put(expKey.bytes(), expVal);
 
         metaStorageSvc.put(expKey, expVal).get();
     }
@@ -317,23 +312,13 @@ public class ITMetaStorageServiceTest {
      */
     @Test
     public void testGetAndPut() throws Exception {
-        byte[] expVal = new byte[]{2};
+        byte[] expVal = {2};
 
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @SuppressWarnings("JavaAbbreviationUsage")
-                    @Override public @NotNull org.apache.ignite.internal.metastorage.server.Entry getAndPut(byte[] key, byte[] value) {
-                        assertArrayEquals(EXPECTED_RESULT_ENTRY.key().bytes(), key);
-
-                        assertArrayEquals(expVal, value);
-
-                        return EXPECTED_SRV_RESULT_ENTRY;
-                    }
-                });
+        when(mockStorage.getAndPut(EXPECTED_RESULT_ENTRY.key().bytes(), expVal)).thenReturn(EXPECTED_SRV_RESULT_ENTRY);
 
         assertEquals(
-                EXPECTED_RESULT_ENTRY,
-                metaStorageSvc.getAndPut(EXPECTED_RESULT_ENTRY.key(), expVal).get()
+            EXPECTED_RESULT_ENTRY,
+            metaStorageSvc.getAndPut(EXPECTED_RESULT_ENTRY.key(), expVal).get()
         );
     }
 
@@ -344,36 +329,36 @@ public class ITMetaStorageServiceTest {
      */
     @Test
     public void testPutAll() throws Exception {
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public void putAll(List<byte[]> keys, List<byte[]> values) {
-                        // Assert keys equality.
-                        assertEquals(EXPECTED_RESULT_MAP.keySet().size(), keys.size());
-
-                        List<byte[]> expKeys = EXPECTED_RESULT_MAP.keySet().stream().
-                                map(ByteArray::bytes).collect(toList());
-
-                        for (int i = 0; i < expKeys.size(); i++)
-                            assertArrayEquals(expKeys.get(i), keys.get(i));
-
-                        // Assert values equality.
-                        assertEquals(EXPECTED_RESULT_MAP.values().size(), values.size());
-
-                        List<byte[]> expVals = EXPECTED_RESULT_MAP.values().stream().
-                                map(Entry::value).collect(toList());
-
-                        for (int i = 0; i < expKeys.size(); i++)
-                            assertArrayEquals(expVals.get(i), values.get(i));
-                    }
-                });
-
         metaStorageSvc.putAll(
-                EXPECTED_RESULT_MAP.entrySet().stream()
-                        .collect(Collectors.toMap(
-                                Map.Entry::getKey,
-                                e -> e.getValue().value())
-                        )
+            EXPECTED_RESULT_MAP.entrySet().stream()
+                .collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    e -> e.getValue().value())
+                )
         ).get();
+
+        ArgumentCaptor<List<byte[]>> keysCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<byte[]>> valuesCaptor = ArgumentCaptor.forClass(List.class);
+
+        verify(mockStorage).putAll(keysCaptor.capture(), valuesCaptor.capture());
+
+        // Assert keys equality.
+        assertEquals(EXPECTED_RESULT_MAP.keySet().size(), keysCaptor.getValue().size());
+
+        List<byte[]> expKeys = EXPECTED_RESULT_MAP.keySet().stream().
+            map(ByteArray::bytes).collect(toList());
+
+        for (int i = 0; i < expKeys.size(); i++)
+            assertArrayEquals(expKeys.get(i), keysCaptor.getValue().get(i));
+
+        // Assert values equality.
+        assertEquals(EXPECTED_RESULT_MAP.values().size(), valuesCaptor.getValue().size());
+
+        List<byte[]> expVals = EXPECTED_RESULT_MAP.values().stream().
+            map(Entry::value).collect(toList());
+
+        for (int i = 0; i < expKeys.size(); i++)
+            assertArrayEquals(expVals.get(i), valuesCaptor.getValue().get(i));
     }
 
     /**
@@ -383,40 +368,40 @@ public class ITMetaStorageServiceTest {
      */
     @Test
     public void testGetAndPutAll() throws Exception {
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public @NotNull List<org.apache.ignite.internal.metastorage.server.Entry> getAndPutAll(List<byte[]> keys, List<byte[]> values) {
-                        // Assert keys equality.
-                        assertEquals(EXPECTED_RESULT_MAP.keySet().size(), keys.size());
-
-                        List<byte[]> expKeys = EXPECTED_RESULT_MAP.keySet().stream().
-                                map(ByteArray::bytes).collect(toList());
-
-                        for (int i = 0; i < expKeys.size(); i++)
-                            assertArrayEquals(expKeys.get(i), keys.get(i));
-
-                        // Assert values equality.
-                        assertEquals(EXPECTED_RESULT_MAP.values().size(), values.size());
-
-                        List<byte[]> expVals = EXPECTED_RESULT_MAP.values().stream().
-                                map(Entry::value).collect(toList());
-
-                        for (int i = 0; i < expKeys.size(); i++)
-                            assertArrayEquals(expVals.get(i), values.get(i));
-
-                        return new ArrayList<>(EXPECTED_SRV_RESULT_COLL);
-                    }
-                });
+        when(mockStorage.getAndPutAll(anyList(), anyList())).thenReturn(EXPECTED_SRV_RESULT_COLL);
 
         Map<ByteArray, Entry> gotRes = metaStorageSvc.getAndPutAll(
-                EXPECTED_RESULT_MAP.entrySet().stream()
-                        .collect(Collectors.toMap(
-                                Map.Entry::getKey,
-                                e -> e.getValue().value())
-                        )
+            EXPECTED_RESULT_MAP.entrySet().stream()
+                .collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    e -> e.getValue().value())
+                )
         ).get();
 
         assertEquals(EXPECTED_RESULT_MAP, gotRes);
+
+        ArgumentCaptor<List<byte[]>> keysCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<byte[]>> valuesCaptor = ArgumentCaptor.forClass(List.class);
+
+        verify(mockStorage).getAndPutAll(keysCaptor.capture(), valuesCaptor.capture());
+
+        // Assert keys equality.
+        assertEquals(EXPECTED_RESULT_MAP.keySet().size(), keysCaptor.getValue().size());
+
+        List<byte[]> expKeys = EXPECTED_RESULT_MAP.keySet().stream().
+            map(ByteArray::bytes).collect(toList());
+
+        for (int i = 0; i < expKeys.size(); i++)
+            assertArrayEquals(expKeys.get(i), keysCaptor.getValue().get(i));
+
+        // Assert values equality.
+        assertEquals(EXPECTED_RESULT_MAP.values().size(), valuesCaptor.getValue().size());
+
+        List<byte[]> expVals = EXPECTED_RESULT_MAP.values().stream().
+            map(Entry::value).collect(toList());
+
+        for (int i = 0; i < expKeys.size(); i++)
+            assertArrayEquals(expVals.get(i), valuesCaptor.getValue().get(i));
     }
 
     /**
@@ -426,14 +411,9 @@ public class ITMetaStorageServiceTest {
      */
     @Test
     public void testRemove() throws Exception {
-        ByteArray expKey = new ByteArray(new byte[]{1});
+        ByteArray expKey = new ByteArray(new byte[] {1});
 
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public void remove(byte[] key) {
-                        assertArrayEquals(expKey.bytes(), key);
-                    }
-                });
+        doNothing().when(mockStorage).remove(expKey.bytes());
 
         metaStorageSvc.remove(expKey).get();
     }
@@ -446,25 +426,20 @@ public class ITMetaStorageServiceTest {
     @Test
     public void testGetAndRemove() throws Exception {
         EntryImpl expRes = new EntryImpl(
-                new ByteArray(new byte[]{1}),
-                new byte[]{3},
-                10,
-                2
+            new ByteArray(new byte[] {1}),
+            new byte[] {3},
+            10,
+            2
         );
 
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public @NotNull org.apache.ignite.internal.metastorage.server.Entry getAndRemove(byte[] key) {
-                        assertArrayEquals(expRes.key().bytes(), key);
-
-                        return new org.apache.ignite.internal.metastorage.server.Entry(
-                                expRes.key().bytes(),
-                                expRes.value(),
-                                expRes.revision(),
-                                expRes.updateCounter()
-                        );
-                    }
-                });
+        when(mockStorage.getAndRemove(expRes.key().bytes())).thenReturn(
+            new org.apache.ignite.internal.metastorage.server.Entry(
+                expRes.key().bytes(),
+                expRes.value(),
+                expRes.revision(),
+                expRes.updateCounter()
+            )
+        );
 
         assertEquals(expRes, metaStorageSvc.getAndRemove(expRes.key()).get());
     }
@@ -476,20 +451,21 @@ public class ITMetaStorageServiceTest {
      */
     @Test
     public void testRemoveAll() throws Exception {
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public void removeAll(List<byte[]> keys) {
-                        assertEquals(EXPECTED_RESULT_MAP.keySet().size(), keys.size());
-
-                        List<byte[]> expKeys = EXPECTED_RESULT_MAP.keySet().stream().
-                                map(ByteArray::bytes).collect(toList());
-
-                        for (int i = 0; i < expKeys.size(); i++)
-                            assertArrayEquals(expKeys.get(i), keys.get(i));
-                    }
-                });
+        doNothing().when(mockStorage).removeAll(anyList());
 
         metaStorageSvc.removeAll(EXPECTED_RESULT_MAP.keySet()).get();
+
+        List<byte[]> expKeys = EXPECTED_RESULT_MAP.keySet().stream().
+            map(ByteArray::bytes).collect(toList());
+
+        ArgumentCaptor<List<byte[]>> keysCaptor = ArgumentCaptor.forClass(List.class);
+
+        verify(mockStorage).removeAll(keysCaptor.capture());
+
+        assertEquals(EXPECTED_RESULT_MAP.keySet().size(), keysCaptor.getValue().size());
+
+        for (int i = 0; i < expKeys.size(); i++)
+            assertArrayEquals(expKeys.get(i), keysCaptor.getValue().get(i));
     }
 
     /**
@@ -499,77 +475,41 @@ public class ITMetaStorageServiceTest {
      */
     @Test
     public void testGetAndRemoveAll() throws Exception {
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public @NotNull List<org.apache.ignite.internal.metastorage.server.Entry> getAndRemoveAll(List<byte[]> keys) {
-                        // Assert keys equality.
-                        assertEquals(EXPECTED_RESULT_MAP.keySet().size(), keys.size());
-
-                        List<byte[]> expKeys = EXPECTED_RESULT_MAP.keySet().stream().
-                                map(ByteArray::bytes).collect(toList());
-
-                        for (int i = 0; i < expKeys.size(); i++)
-                            assertArrayEquals(expKeys.get(i), keys.get(i));
-
-                        return new ArrayList<>(EXPECTED_SRV_RESULT_COLL);
-                    }
-                });
+        when(mockStorage.getAndRemoveAll(anyList())).thenReturn(EXPECTED_SRV_RESULT_COLL);
 
         Map<ByteArray, Entry> gotRes = metaStorageSvc.getAndRemoveAll(EXPECTED_RESULT_MAP.keySet()).get();
 
         assertEquals(EXPECTED_RESULT_MAP, gotRes);
+
+        ArgumentCaptor<List<byte[]>> keysCaptor = ArgumentCaptor.forClass(List.class);
+
+        verify(mockStorage).getAndRemoveAll(keysCaptor.capture());
+
+        // Assert keys equality.
+        assertEquals(EXPECTED_RESULT_MAP.keySet().size(), keysCaptor.getValue().size());
+
+        List<byte[]> expKeys = EXPECTED_RESULT_MAP.keySet().stream().
+            map(ByteArray::bytes).collect(toList());
+
+        for (int i = 0; i < expKeys.size(); i++)
+            assertArrayEquals(expKeys.get(i), keysCaptor.getValue().get(i));
     }
 
     /**
-     * Tests {@link MetaStorageService#range(ByteArray, ByteArray, long)}} with not null keyTo and explicit revUpperBound.
+     * Tests {@link MetaStorageService#range(ByteArray, ByteArray, long)}} with not null keyTo and explicit
+     * revUpperBound.
      *
      * @throws Exception If failed.
      */
     @Test
     public void testRangeWitKeyToAndUpperBound() throws Exception {
-        ByteArray expKeyFrom = new ByteArray(new byte[]{1});
+        ByteArray expKeyFrom = new ByteArray(new byte[] {1});
 
-        ByteArray expKeyTo = new ByteArray(new byte[]{3});
+        ByteArray expKeyTo = new ByteArray(new byte[] {3});
 
         long expRevUpperBound = 10;
 
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public Cursor<org.apache.ignite.internal.metastorage.server.Entry> range(byte[] keyFrom, byte[] keyTo, long revUpperBound) {
-                        assertArrayEquals(expKeyFrom.bytes(), keyFrom);
-
-                        assertArrayEquals(expKeyTo.bytes(), keyTo);
-
-                        assertEquals(expRevUpperBound, revUpperBound);
-
-                        return new Cursor<>() {
-                            private final Iterator<org.apache.ignite.internal.metastorage.server.Entry> it = new Iterator<>() {
-                                @Override public boolean hasNext() {
-                                    return false;
-                                }
-
-                                @Override public org.apache.ignite.internal.metastorage.server.Entry next() {
-                                    return null;
-                                }
-                            };
-
-                            @Override public void close() throws Exception {
-                            }
-
-                            @NotNull @Override public Iterator<org.apache.ignite.internal.metastorage.server.Entry> iterator() {
-                                return it;
-                            }
-
-                            @Override public boolean hasNext() {
-                                return it.hasNext();
-                            }
-
-                            @Override public org.apache.ignite.internal.metastorage.server.Entry next() {
-                                return it.next();
-                            }
-                        };
-                    }
-                });
+        when(mockStorage.range(expKeyFrom.bytes(), expKeyTo.bytes(), expRevUpperBound)).thenReturn(mock(Cursor.class));
 
         metaStorageSvc.range(expKeyFrom, expKeyTo, expRevUpperBound).close();
     }
@@ -581,45 +521,11 @@ public class ITMetaStorageServiceTest {
      */
     @Test
     public void testRangeWitKeyTo() throws Exception {
-        ByteArray expKeyFrom = new ByteArray(new byte[]{1});
+        ByteArray expKeyFrom = new ByteArray(new byte[] {1});
 
-        ByteArray expKeyTo = new ByteArray(new byte[]{3});
+        ByteArray expKeyTo = new ByteArray(new byte[] {3});
 
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public Cursor<org.apache.ignite.internal.metastorage.server.Entry> range(byte[] keyFrom, byte[] keyTo) {
-                        assertArrayEquals(expKeyFrom.bytes(), keyFrom);
-
-                        assertArrayEquals(expKeyTo.bytes(), keyTo);
-
-                        return new Cursor<>() {
-                            private final Iterator<org.apache.ignite.internal.metastorage.server.Entry> it = new Iterator<>() {
-                                @Override public boolean hasNext() {
-                                    return false;
-                                }
-
-                                @Override public org.apache.ignite.internal.metastorage.server.Entry next() {
-                                    return null;
-                                }
-                            };
-
-                            @Override public void close() throws Exception {
-                            }
-
-                            @NotNull @Override public Iterator<org.apache.ignite.internal.metastorage.server.Entry> iterator() {
-                                return it;
-                            }
-
-                            @Override public boolean hasNext() {
-                                return it.hasNext();
-                            }
-
-                            @Override public org.apache.ignite.internal.metastorage.server.Entry next() {
-                                return it.next();
-                            }
-                        };
-                    }
-                });
+        when(mockStorage.range(expKeyFrom.bytes(), expKeyTo.bytes())).thenReturn(mock(Cursor.class));
 
         metaStorageSvc.range(expKeyFrom, expKeyTo).close();
     }
@@ -631,87 +537,27 @@ public class ITMetaStorageServiceTest {
      */
     @Test
     public void testRangeWitNullAsKeyTo() throws Exception {
-        ByteArray expKeyFrom = new ByteArray(new byte[]{1});
+        ByteArray expKeyFrom = new ByteArray(new byte[] {1});
 
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public Cursor<org.apache.ignite.internal.metastorage.server.Entry> range(byte[] keyFrom, byte[] keyTo) {
-                        assertArrayEquals(expKeyFrom.bytes(), keyFrom);
-
-                        assertNull(keyTo);
-
-                        return new Cursor<>() {
-                            private final Iterator<org.apache.ignite.internal.metastorage.server.Entry> it = new Iterator<>() {
-                                @Override public boolean hasNext() {
-                                    return false;
-                                }
-
-                                @Override public org.apache.ignite.internal.metastorage.server.Entry next() {
-                                    return null;
-                                }
-                            };
-
-                            @Override public void close() throws Exception {
-                            }
-
-                            @NotNull @Override public Iterator<org.apache.ignite.internal.metastorage.server.Entry> iterator() {
-                                return it;
-                            }
-
-                            @Override public boolean hasNext() {
-                                return it.hasNext();
-                            }
-
-                            @Override public org.apache.ignite.internal.metastorage.server.Entry next() {
-                                return it.next();
-                            }
-                        };
-                    }
-                });
+        when(mockStorage.range(expKeyFrom.bytes(), null)).thenReturn(mock(Cursor.class));
 
         metaStorageSvc.range(expKeyFrom, null).close();
     }
 
     /**
      * Tests {@link MetaStorageService#range(ByteArray, ByteArray, long)}} hasNext.
-     *
-     * @throws Exception If failed.
      */
     @Test
-    public void testRangeHasNext() throws Exception {
-        ByteArray expKeyFrom = new ByteArray(new byte[]{1});
+    public void testRangeHasNext() {
+        ByteArray expKeyFrom = new ByteArray(new byte[] {1});
 
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public Cursor<org.apache.ignite.internal.metastorage.server.Entry> range(byte[] keyFrom, byte[] keyTo) {
-                        return new Cursor<>() {
-                            private final Iterator<org.apache.ignite.internal.metastorage.server.Entry> it = new Iterator<>() {
-                                @Override public boolean hasNext() {
-                                    return true;
-                                }
+        when(mockStorage.range(expKeyFrom.bytes(), null)).thenAnswer(invocation -> {
+            var cursor = mock(Cursor.class);
 
-                                @Override public org.apache.ignite.internal.metastorage.server.Entry next() {
-                                    return null;
-                                }
-                            };
+            when(cursor.hasNext()).thenReturn(true);
 
-                            @Override public void close() throws Exception {
-                            }
-
-                            @NotNull @Override public Iterator<org.apache.ignite.internal.metastorage.server.Entry> iterator() {
-                                return it;
-                            }
-
-                            @Override public boolean hasNext() {
-                                return it.hasNext();
-                            }
-
-                            @Override public org.apache.ignite.internal.metastorage.server.Entry next() {
-                                return it.next();
-                            }
-                        };
-                    }
-                });
+            return cursor;
+        });
 
         Cursor<Entry> cursor = metaStorageSvc.range(expKeyFrom, null);
 
@@ -721,47 +567,21 @@ public class ITMetaStorageServiceTest {
     /**
      * Tests {@link MetaStorageService#range(ByteArray, ByteArray, long)}} next.
      *
-     * @throws Exception If failed.
      */
     @Test
-    public void testRangeNext() throws Exception {
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public Cursor<org.apache.ignite.internal.metastorage.server.Entry> range(byte[] keyFrom, byte[] keyTo) {
-                        return new Cursor<>() {
-                            private final Iterator<org.apache.ignite.internal.metastorage.server.Entry> it = new Iterator<>() {
-                                @Override public boolean hasNext() {
-                                    return true;
-                                }
+    public void testRangeNext() {
+        when(mockStorage.range(EXPECTED_RESULT_ENTRY.key().bytes(), null)).thenAnswer(invocation -> {
+            var cursor = mock(Cursor.class);
 
-                                @Override public org.apache.ignite.internal.metastorage.server.Entry next() {
-                                    return EXPECTED_SRV_RESULT_ENTRY;
-                                }
-                            };
+            when(cursor.hasNext()).thenReturn(true);
+            when(cursor.next()).thenReturn(EXPECTED_SRV_RESULT_ENTRY);
 
-                            @Override public void close() throws Exception {
-
-                            }
-
-                            @NotNull @Override public Iterator<org.apache.ignite.internal.metastorage.server.Entry> iterator() {
-                                return it;
-                            }
-
-                            @Override public boolean hasNext() {
-                                return it.hasNext();
-                            }
-
-                            @Override
-                            public org.apache.ignite.internal.metastorage.server.Entry next() {
-                                return it.next();
-                            }
-                        };
-                    }
-                });
+            return cursor;
+        });
 
         Cursor<Entry> cursor = metaStorageSvc.range(EXPECTED_RESULT_ENTRY.key(), null);
 
-        assertEquals(EXPECTED_RESULT_ENTRY, (cursor.iterator().next()));
+        assertEquals(EXPECTED_RESULT_ENTRY, cursor.iterator().next());
     }
 
     /**
@@ -771,16 +591,11 @@ public class ITMetaStorageServiceTest {
      */
     @Test
     public void testRangeClose() throws Exception {
-        ByteArray expKeyFrom = new ByteArray(new byte[]{1});
+        ByteArray expKeyFrom = new ByteArray(new byte[] {1});
 
         Cursor cursorMock = mock(Cursor.class);
 
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public Cursor<org.apache.ignite.internal.metastorage.server.Entry> range(byte[] keyFrom, byte[] keyTo) {
-                        return cursorMock;
-                    }
-                });
+        when(mockStorage.range(expKeyFrom.bytes(), null)).thenReturn(cursorMock);
 
         Cursor<Entry> cursor = metaStorageSvc.range(expKeyFrom, null);
 
@@ -791,112 +606,88 @@ public class ITMetaStorageServiceTest {
 
     @Test
     public void testWatchOnUpdate() throws Exception {
-        org.apache.ignite.internal.metastorage.server.WatchEvent returnedWatchEvents = new org.apache.ignite.internal.metastorage.server.WatchEvent(List.of(
+        org.apache.ignite.internal.metastorage.server.WatchEvent expectedEvent =
+            new org.apache.ignite.internal.metastorage.server.WatchEvent(List.of(
                 new org.apache.ignite.internal.metastorage.server.EntryEvent(
-                        new org.apache.ignite.internal.metastorage.server.Entry(
-                                new byte[]{2},
-                                new byte[]{20},
-                                1,
-                                1
-                        ),
-                        new org.apache.ignite.internal.metastorage.server.Entry(
-                                new byte[]{2},
-                                new byte[]{21},
-                                2,
-                                4
-                        )
+                    new org.apache.ignite.internal.metastorage.server.Entry(
+                        new byte[] {2},
+                        new byte[] {20},
+                        1,
+                        1
+                    ),
+                    new org.apache.ignite.internal.metastorage.server.Entry(
+                        new byte[] {2},
+                        new byte[] {21},
+                        2,
+                        4
+                    )
                 ),
                 new org.apache.ignite.internal.metastorage.server.EntryEvent(
-                        new org.apache.ignite.internal.metastorage.server.Entry(
-                                new byte[] {3},
-                                new byte[] {20},
-                                1,
-                                2
-                        ),
-                        new org.apache.ignite.internal.metastorage.server.Entry(
-                                new byte[] {3},
-                                new byte[]{},
-                                2,
-                                5
-                        )
+                    new org.apache.ignite.internal.metastorage.server.Entry(
+                        new byte[] {3},
+                        new byte[] {20},
+                        1,
+                        2
+                    ),
+                    new org.apache.ignite.internal.metastorage.server.Entry(
+                        new byte[] {3},
+                        new byte[] {},
+                        2,
+                        5
+                    )
                 ),
                 new org.apache.ignite.internal.metastorage.server.EntryEvent(
-                        new org.apache.ignite.internal.metastorage.server.Entry(
-                                new byte[] {4},
-                                new byte[] {20},
-                                1,
-                                3
-                        ),
-                        new org.apache.ignite.internal.metastorage.server.Entry(
-                                new byte[] {4},
-                                new byte[] {},
-                                3,
-                                6
-                        )
+                    new org.apache.ignite.internal.metastorage.server.Entry(
+                        new byte[] {4},
+                        new byte[] {20},
+                        1,
+                        3
+                    ),
+                    new org.apache.ignite.internal.metastorage.server.Entry(
+                        new byte[] {4},
+                        new byte[] {},
+                        3,
+                        6
+                    )
                 )
-        ));
+            ));
 
-        ByteArray keyFrom = new ByteArray(new byte[]{1});
+        ByteArray keyFrom = new ByteArray(new byte[] {1});
 
-        ByteArray keyTo = new ByteArray(new byte[]{10});
+        ByteArray keyTo = new ByteArray(new byte[] {10});
 
         long rev = 2;
 
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public Cursor<org.apache.ignite.internal.metastorage.server.WatchEvent> watch(byte[] keyFrom, byte @Nullable [] keyTo, long rev) {
-                        return new Cursor<>() {
-                            private final Iterator<org.apache.ignite.internal.metastorage.server.WatchEvent> it = new Iterator<>() {
-                                @Override public boolean hasNext() {
+        when(mockStorage.watch(keyFrom.bytes(), keyTo.bytes(), rev)).thenAnswer(invocation -> {
+            var cursor = mock(Cursor.class);
 
-                                    return retirevedItemCnt.get() < returnedWatchEvents.entryEvents().size();
-                                }
+            when(cursor.hasNext()).thenReturn(true);
+            when(cursor.next()).thenReturn(expectedEvent);
 
-                                @Override public org.apache.ignite.internal.metastorage.server.WatchEvent next() {
-                                    return returnedWatchEvents;
-                                }
-                            };
-
-                            AtomicInteger retirevedItemCnt = new AtomicInteger(0);
-
-                            @Override public void close() throws Exception {
-                                // No-op.
-                            }
-
-                            @NotNull @Override public Iterator<org.apache.ignite.internal.metastorage.server.WatchEvent> iterator() {
-                                return it;
-                            }
-
-                            @Override public boolean hasNext() {
-                                return it.hasNext();
-                            }
-
-                            @Override
-                            public org.apache.ignite.internal.metastorage.server.WatchEvent next() {
-                                return it.next();
-                            }
-                        };
-                    }
-                });
+            return cursor;
+        });
 
         CountDownLatch latch = new CountDownLatch(1);
 
         IgniteUuid watchId = metaStorageSvc.watch(keyFrom, keyTo, rev, new WatchListener() {
-            @Override public boolean onUpdate(@NotNull WatchEvent events) {
-                List gotEvents = new ArrayList();
+            @Override public boolean onUpdate(@NotNull WatchEvent event) {
+                Collection<EntryEvent> expectedEvents = expectedEvent.entryEvents();
+                Collection<org.apache.ignite.internal.metastorage.client.EntryEvent> actualEvents = event.entryEvents();
 
-                List returnedWatchEvents = new ArrayList(events.entryEvents());
+                assertEquals(expectedEvents.size(), actualEvents.size());
 
-                Iterator<EntryEvent> iter = events.entryEvents().iterator();
+                Iterator<EntryEvent> expectedIterator = expectedEvents.iterator();
+                Iterator<org.apache.ignite.internal.metastorage.client.EntryEvent> actualIterator = actualEvents.iterator();
 
-                while (iter.hasNext())
-                    gotEvents.add(iter.next());
+                while (expectedIterator.hasNext() && actualIterator.hasNext()) {
+                    org.apache.ignite.internal.metastorage.server.EntryEvent expectedEntryEvent = expectedIterator.next();
+                    org.apache.ignite.internal.metastorage.client.EntryEvent actualEntryEvent = actualIterator.next();
 
-                assertEquals(3, gotEvents.size());
-
-                assertTrue(gotEvents.contains(returnedWatchEvents.get(0)));
-
-                assertTrue(gotEvents.contains(returnedWatchEvents.get(1)));
+                    assertArrayEquals(expectedEntryEvent.oldEntry().key(), actualEntryEvent.oldEntry().key().bytes());
+                    assertArrayEquals(expectedEntryEvent.oldEntry().value(), actualEntryEvent.oldEntry().value());
+                    assertArrayEquals(expectedEntryEvent.entry().key(), actualEntryEvent.newEntry().key().bytes());
+                    assertArrayEquals(expectedEntryEvent.entry().value(), actualEntryEvent.newEntry().value());
+                }
 
                 latch.countDown();
 
@@ -916,9 +707,11 @@ public class ITMetaStorageServiceTest {
 
     @Test
     public void testInvoke() throws Exception {
-        ByteArray expKey = new ByteArray(new byte[]{1});
+        ByteArray expKey = new ByteArray(new byte[] {1});
 
-        byte[] expVal = new byte[]{2};
+        byte[] expVal = {2};
+
+        when(mockStorage.invoke(any(), any(), any())).thenReturn(true);
 
         Condition condition = Conditions.notExists(expKey);
 
@@ -926,24 +719,24 @@ public class ITMetaStorageServiceTest {
 
         Operation failure = Operations.noop();
 
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public boolean invoke(
-                            org.apache.ignite.internal.metastorage.server.Condition cond,
-                            Collection<org.apache.ignite.internal.metastorage.server.Operation> success,
-                            Collection<org.apache.ignite.internal.metastorage.server.Operation> failure) {
-                        assertArrayEquals(expKey.bytes(), cond.key());
-
-                        assertArrayEquals(expKey.bytes(), success.iterator().next().key());
-                        assertArrayEquals(expVal, success.iterator().next().value());
-
-                        assertEquals(OperationType.NO_OP, failure.iterator().next().type());
-
-                        return true;
-                    }
-                });
-
         assertTrue(metaStorageSvc.invoke(condition, success, failure).get());
+
+        var conditionCaptor = ArgumentCaptor.forClass(org.apache.ignite.internal.metastorage.server.Condition.class);
+
+        ArgumentCaptor<Collection<org.apache.ignite.internal.metastorage.server.Operation>> successCaptor =
+            ArgumentCaptor.forClass(Collection.class);
+
+        ArgumentCaptor<Collection<org.apache.ignite.internal.metastorage.server.Operation>> failureCaptor =
+            ArgumentCaptor.forClass(Collection.class);
+
+        verify(mockStorage).invoke(conditionCaptor.capture(), successCaptor.capture(), failureCaptor.capture());
+
+        assertArrayEquals(expKey.bytes(), conditionCaptor.getValue().key());
+
+        assertArrayEquals(expKey.bytes(), successCaptor.getValue().iterator().next().key());
+        assertArrayEquals(expVal, successCaptor.getValue().iterator().next().value());
+
+        assertEquals(OperationType.NO_OP, failureCaptor.getValue().iterator().next().type());
     }
 
     // TODO: IGNITE-14693 Add tests for exception handling logic: onError,
@@ -951,36 +744,23 @@ public class ITMetaStorageServiceTest {
 
     /**
      * Tests {@link MetaStorageService#get(ByteArray)}.
-     *
-     * @throws Exception If failed.
      */
     @Disabled // TODO: IGNITE-14693 Add tests for exception handling logic.
     @Test
-    public void testGetThatThrowsCompactedException() throws Exception {
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public @NotNull org.apache.ignite.internal.metastorage.server.Entry get(byte[] key) {
-                        throw new org.apache.ignite.internal.metastorage.server.CompactedException();
-                    }
-                });
+    public void testGetThatThrowsCompactedException() {
+        when(mockStorage.get(EXPECTED_RESULT_ENTRY.key().bytes()))
+            .thenThrow(new org.apache.ignite.internal.metastorage.server.CompactedException());
 
         assertThrows(CompactedException.class, () -> metaStorageSvc.get(EXPECTED_RESULT_ENTRY.key()).get());
     }
 
     /**
      * Tests {@link MetaStorageService#get(ByteArray)}.
-     *
-     * @throws Exception If failed.
      */
     @Disabled // TODO: IGNITE-14693 Add tests for exception handling logic.
     @Test
-    public void testGetThatThrowsOperationTimeoutException() throws Exception {
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-                new AbstractKeyValueStorage() {
-                    @Override public @NotNull org.apache.ignite.internal.metastorage.server.Entry get(byte[] key) {
-                        throw new OperationTimeoutException();
-                    }
-                });
+    public void testGetThatThrowsOperationTimeoutException() {
+        when(mockStorage.get(EXPECTED_RESULT_ENTRY.key().bytes())).thenThrow(new OperationTimeoutException());
 
         assertThrows(OperationTimeoutException.class, () -> metaStorageSvc.get(EXPECTED_RESULT_ENTRY.key()).get());
     }
@@ -992,39 +772,14 @@ public class ITMetaStorageServiceTest {
      */
     @Test
     public void testCursorsCleanup() throws Exception {
-        MetaStorageService metaStorageSvc = prepareMetaStorage(
-            new AbstractKeyValueStorage() {
-                @Override public Cursor<org.apache.ignite.internal.metastorage.server.Entry> range(byte[] keyFrom, byte[] keyTo) {
-                    return new Cursor<>() {
-                        private final Iterator<org.apache.ignite.internal.metastorage.server.Entry> it = new Iterator<>() {
-                            @Override public boolean hasNext() {
-                                return true;
-                            }
+        when(mockStorage.range(EXPECTED_RESULT_ENTRY.key().bytes(), null)).thenAnswer(invocation -> {
+            var cursor = mock(Cursor.class);
 
-                            @Override public org.apache.ignite.internal.metastorage.server.Entry next() {
-                                return EXPECTED_SRV_RESULT_ENTRY;
-                            }
-                        };
+            when(cursor.hasNext()).thenReturn(true);
+            when(cursor.next()).thenReturn(EXPECTED_SRV_RESULT_ENTRY);
 
-                        @Override public void close() throws Exception {
-
-                        }
-
-                        @NotNull @Override public Iterator<org.apache.ignite.internal.metastorage.server.Entry> iterator() {
-                            return it;
-                        }
-
-                        @Override public boolean hasNext() {
-                            return it.hasNext();
-                        }
-
-                        @Override
-                        public org.apache.ignite.internal.metastorage.server.Entry next() {
-                            return it.next();
-                        }
-                    };
-                }
-            });
+            return cursor;
+        });
 
         List<Peer> peers = List.of(new Peer(cluster.get(0).topologyService().localMember().address()));
 
@@ -1038,31 +793,36 @@ public class ITMetaStorageServiceTest {
             200
         ).get(3, TimeUnit.SECONDS);
 
-        MetaStorageService metaStorageSvc2 = new MetaStorageServiceImpl(metaStorageRaftGrpSvc, NODE_ID_1);
+        try {
+            MetaStorageService metaStorageSvc2 = new MetaStorageServiceImpl(metaStorageRaftGrpSvc, NODE_ID_1);
 
-        Cursor<Entry> cursorNode0 = metaStorageSvc.range(EXPECTED_RESULT_ENTRY.key(), null);
+            Cursor<Entry> cursorNode0 = metaStorageSvc.range(EXPECTED_RESULT_ENTRY.key(), null);
 
-        Cursor<Entry> cursor2Node0 = metaStorageSvc.range(EXPECTED_RESULT_ENTRY.key(), null);
+            Cursor<Entry> cursor2Node0 = metaStorageSvc.range(EXPECTED_RESULT_ENTRY.key(), null);
 
-        Cursor<Entry> cursorNode1 = metaStorageSvc2.range(EXPECTED_RESULT_ENTRY.key(), null);
+            Cursor<Entry> cursorNode1 = metaStorageSvc2.range(EXPECTED_RESULT_ENTRY.key(), null);
 
-        metaStorageSvc.closeCursors(NODE_ID_0).get();
+            metaStorageSvc.closeCursors(NODE_ID_0).get();
 
-        assertThrows(NoSuchElementException.class, () -> cursorNode0.iterator().next());
+            assertThrows(NoSuchElementException.class, () -> cursorNode0.iterator().next());
 
-        assertThrows(NoSuchElementException.class, () -> cursor2Node0.iterator().next());
+            assertThrows(NoSuchElementException.class, () -> cursor2Node0.iterator().next());
 
-        assertEquals(EXPECTED_RESULT_ENTRY, (cursorNode1.iterator().next()));
+            assertEquals(EXPECTED_RESULT_ENTRY, (cursorNode1.iterator().next()));
+        }
+        finally {
+            metaStorageRaftGrpSvc.shutdown();
+        }
     }
 
     /**
      * @param cluster The cluster.
-     * @param exp Expected count.
+     * @param exp     Expected count.
      * @param timeout The timeout in millis.
      * @return {@code True} if topology size is equal to expected.
      */
     @SuppressWarnings("SameParameterValue")
-    private boolean waitForTopology(ClusterService cluster, int exp, int timeout) {
+    private static boolean waitForTopology(ClusterService cluster, int exp, int timeout) {
         long stop = System.currentTimeMillis() + timeout;
 
         while (System.currentTimeMillis() < stop) {
@@ -1081,23 +841,21 @@ public class ITMetaStorageServiceTest {
     }
 
     /**
-     * Prepares meta storage by instantiating corresponding raft server with {@link MetaStorageListener} and
-     * {@link MetaStorageServiceImpl}.
+     * Prepares meta storage by instantiating corresponding raft server with {@link MetaStorageListener} and {@link
+     * MetaStorageServiceImpl}.
      *
-     * @param keyValStorageMock {@link KeyValueStorage} mock.
      * @return {@link MetaStorageService} instance.
      */
-    private MetaStorageService prepareMetaStorage(KeyValueStorage keyValStorageMock) throws Exception {
+    private MetaStorageService prepareMetaStorage() throws Exception {
         List<Peer> peers = List.of(new Peer(cluster.get(0).topologyService().localMember().address()));
 
         metaStorageRaftSrv = new RaftServerImpl(cluster.get(0), FACTORY);
 
         metaStorageRaftSrv.start();
 
-        metaStorageRaftSrv.
-            startRaftGroup(METASTORAGE_RAFT_GROUP_NAME, new MetaStorageListener(keyValStorageMock), peers);
+        metaStorageRaftSrv.startRaftGroup(METASTORAGE_RAFT_GROUP_NAME, new MetaStorageListener(mockStorage), peers);
 
-        RaftGroupService metaStorageRaftGrpSvc = RaftGroupServiceImpl.start(
+        metaStorageRaftGrpSvc = RaftGroupServiceImpl.start(
             METASTORAGE_RAFT_GROUP_NAME,
             cluster.get(1),
             FACTORY,
@@ -1108,166 +866,5 @@ public class ITMetaStorageServiceTest {
         ).get(3, TimeUnit.SECONDS);
 
         return new MetaStorageServiceImpl(metaStorageRaftGrpSvc, NODE_ID_0);
-    }
-
-    /**
-     * Abstract {@link KeyValueStorage}. Used for tests purposes.
-     */
-    @SuppressWarnings("JavaAbbreviationUsage")
-    private abstract class AbstractKeyValueStorage implements KeyValueStorage {
-        /** {@inheritDoc} */
-        @Override public long revision() {
-            return 0;
-        }
-
-        /** {@inheritDoc} */
-        @Override public long updateCounter() {
-            return 0;
-        }
-
-        /** {@inheritDoc} */
-        @Override public @NotNull org.apache.ignite.internal.metastorage.server.Entry get(byte[] key) {
-            fail();
-
-            return null;
-        }
-
-        /** {@inheritDoc} */
-        @Override public @NotNull org.apache.ignite.internal.metastorage.server.Entry get(byte[] key, long rev) {
-            fail();
-
-            return null;
-        }
-
-        /** {@inheritDoc} */
-        @Override public @NotNull Collection<org.apache.ignite.internal.metastorage.server.Entry> getAll(List<byte[]> keys) {
-            fail();
-
-            return null;
-        }
-
-        /** {@inheritDoc} */
-        @Override public @NotNull Collection<org.apache.ignite.internal.metastorage.server.Entry> getAll(List<byte[]> keys, long revUpperBound) {
-            fail();
-
-            return null;
-        }
-
-        /** {@inheritDoc} */
-        @Override public void put(byte[] key, byte[] value) {
-            fail();
-        }
-
-        /** {@inheritDoc} */
-        @Override public @NotNull org.apache.ignite.internal.metastorage.server.Entry getAndPut(byte[] key, byte[] value) {
-            fail();
-
-            return null;
-        }
-
-        /** {@inheritDoc} */
-        @Override public void putAll(List<byte[]> keys, List<byte[]> values) {
-            fail();
-        }
-
-        /** {@inheritDoc} */
-        @Override public @NotNull Collection<org.apache.ignite.internal.metastorage.server.Entry> getAndPutAll(List<byte[]> keys, List<byte[]> values) {
-            fail();
-
-            return null;
-        }
-
-        /** {@inheritDoc} */
-        @Override public void remove(byte[] key) {
-            fail();
-        }
-
-        /** {@inheritDoc} */
-        @Override public @NotNull org.apache.ignite.internal.metastorage.server.Entry getAndRemove(byte[] key) {
-            fail();
-
-            return null;
-        }
-
-        /** {@inheritDoc} */
-        @Override public void removeAll(List<byte[]> keys) {
-            fail();
-        }
-
-        /** {@inheritDoc} */
-        @Override public @NotNull Collection<org.apache.ignite.internal.metastorage.server.Entry> getAndRemoveAll(List<byte[]> keys) {
-            fail();
-
-            return null;
-        }
-
-        /** {@inheritDoc} */
-        @Override public boolean invoke(
-                org.apache.ignite.internal.metastorage.server.Condition condition,
-                Collection<org.apache.ignite.internal.metastorage.server.Operation> success,
-                Collection<org.apache.ignite.internal.metastorage.server.Operation> failure
-        ) {
-            fail();
-
-            return false;
-        }
-
-        /** {@inheritDoc} */
-        @Override public Cursor<org.apache.ignite.internal.metastorage.server.Entry> range(byte[] keyFrom, byte[] keyTo) {
-            fail();
-
-            return null;
-        }
-
-        /** {@inheritDoc} */
-        @Override public Cursor<org.apache.ignite.internal.metastorage.server.Entry> range(byte[] keyFrom, byte[] keyTo, long revUpperBound) {
-            fail();
-
-            return null;
-        }
-
-        /** {@inheritDoc} */
-        @Override public Cursor<org.apache.ignite.internal.metastorage.server.WatchEvent> watch(byte[] keyFrom, byte @Nullable [] keyTo, long rev) {
-            fail();
-
-            return null;
-        }
-
-        /** {@inheritDoc} */
-        @Override public Cursor<org.apache.ignite.internal.metastorage.server.WatchEvent> watch(byte[] key, long rev) {
-            fail();
-
-            return null;
-        }
-
-        /** {@inheritDoc} */
-        @Override public Cursor<org.apache.ignite.internal.metastorage.server.WatchEvent> watch(Collection<byte[]> keys, long rev) {
-            fail();
-
-            return null;
-        }
-
-        /** {@inheritDoc} */
-        @Override public void compact() {
-            fail();
-        }
-
-        /** {@inheritDoc} */
-        @Override public void close() {
-            fail();
-        }
-
-        /** {@inheritDoc} */
-        @NotNull
-        @Override public CompletableFuture<Void> snapshot(Path snapshotPath) {
-            fail();
-
-            return null;
-        }
-
-        /** {@inheritDoc} */
-        @Override public void restoreSnapshot(Path snapshotPath) {
-            fail();
-        }
     }
 }

--- a/modules/metastorage-server/pom.xml
+++ b/modules/metastorage-server/pom.xml
@@ -73,4 +73,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testJar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/modules/metastorage-server/src/main/java/org/apache/ignite/internal/metastorage/server/KeyValueStorage.java
+++ b/modules/metastorage-server/src/main/java/org/apache/ignite/internal/metastorage/server/KeyValueStorage.java
@@ -30,6 +30,11 @@ import org.jetbrains.annotations.Nullable;
  */
 public interface KeyValueStorage extends AutoCloseable {
     /**
+     * Starts the given storage, allocating the necessary resources.
+     */
+    void start();
+
+    /**
      * Returns storage revision.
      *
      * @return Storage revision.
@@ -83,7 +88,7 @@ public interface KeyValueStorage extends AutoCloseable {
      * @param key The key.
      * @param value The value.
      */
-    void put(@NotNull byte[] key, @NotNull byte[] value);
+    void put(byte[] key, byte[] value);
 
     /**
      * Inserts an entry with the given key and given value and returns previous entry.
@@ -159,7 +164,7 @@ public interface KeyValueStorage extends AutoCloseable {
      * @param keyTo Last key of range (exclusive).
      * @return Cursor by entries which correspond to the given keys range.
      */
-    Cursor<Entry> range(byte[] keyFrom, byte[] keyTo);
+    Cursor<Entry> range(byte[] keyFrom, byte @Nullable [] keyTo);
 
     /**
      * Returns cursor by entries which correspond to the given keys range and bounded by revision number..

--- a/modules/metastorage-server/src/test/java/org/apache/ignite/internal/metastorage/server/AbstractKeyValueStorageTest.java
+++ b/modules/metastorage-server/src/test/java/org/apache/ignite/internal/metastorage/server/AbstractKeyValueStorageTest.java
@@ -49,6 +49,8 @@ public abstract class AbstractKeyValueStorageTest {
     @BeforeEach
     public void setUp() {
         storage = storage();
+
+        storage.start();
     }
 
     @AfterEach

--- a/modules/metastorage-server/src/test/java/org/apache/ignite/internal/metastorage/server/SimpleInMemoryKeyValueStorage.java
+++ b/modules/metastorage-server/src/test/java/org/apache/ignite/internal/metastorage/server/SimpleInMemoryKeyValueStorage.java
@@ -39,8 +39,6 @@ import static org.apache.ignite.internal.metastorage.server.Value.TOMBSTONE;
 
 /**
  * Simple in-memory key/value storage.
- *
- * WARNING: Only for test purposes.
  */
 public class SimpleInMemoryKeyValueStorage implements KeyValueStorage {
     /** Lexicographical comparator. */
@@ -68,13 +66,22 @@ public class SimpleInMemoryKeyValueStorage implements KeyValueStorage {
     private final Object mux = new Object();
 
     /** {@inheritDoc} */
+    @Override public void start() {
+        // no-op
+    }
+
+    /** {@inheritDoc} */
     @Override public long revision() {
-        return rev;
+        synchronized (mux) {
+            return rev;
+        }
     }
 
     /** {@inheritDoc} */
     @Override public long updateCounter() {
-        return updCntr;
+        synchronized (mux) {
+            return updCntr;
+        }
     }
 
     /** {@inheritDoc} */
@@ -278,7 +285,9 @@ public class SimpleInMemoryKeyValueStorage implements KeyValueStorage {
 
     /** {@inheritDoc} */
     @Override public Cursor<Entry> range(byte[] keyFrom, byte[] keyTo) {
-        return new RangeCursor(keyFrom, keyTo, rev);
+        synchronized (mux) {
+            return new RangeCursor(keyFrom, keyTo, rev);
+        }
     }
 
     /** {@inheritDoc} */

--- a/modules/runner/pom.xml
+++ b/modules/runner/pom.xml
@@ -145,6 +145,13 @@
             <artifactId>ignite-client</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-metastorage-server</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/storage/ITDistributedConfigurationStorageTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/storage/ITDistributedConfigurationStorageTest.java
@@ -29,6 +29,7 @@ import org.apache.ignite.internal.configuration.ConfigurationManager;
 import org.apache.ignite.internal.configuration.storage.Data;
 import org.apache.ignite.internal.manager.IgniteComponent;
 import org.apache.ignite.internal.metastorage.MetaStorageManager;
+import org.apache.ignite.internal.metastorage.server.SimpleInMemoryKeyValueStorage;
 import org.apache.ignite.internal.raft.Loza;
 import org.apache.ignite.internal.testframework.WorkDirectory;
 import org.apache.ignite.internal.testframework.WorkDirectoryExtension;
@@ -109,7 +110,8 @@ public class ITDistributedConfigurationStorageTest {
                 vaultManager,
                 cfgManager,
                 clusterService,
-                raftManager
+                raftManager,
+                new SimpleInMemoryKeyValueStorage()
             );
 
             cfgStorage = new DistributedConfigurationStorage(metaStorageManager, vaultManager);

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
@@ -43,6 +43,7 @@ import org.apache.ignite.internal.configuration.ConfigurationManager;
 import org.apache.ignite.internal.configuration.ConfigurationRegistry;
 import org.apache.ignite.internal.manager.IgniteComponent;
 import org.apache.ignite.internal.metastorage.MetaStorageManager;
+import org.apache.ignite.internal.metastorage.server.persistence.RocksDBKeyValueStorage;
 import org.apache.ignite.internal.processors.query.calcite.SqlQueryProcessor;
 import org.apache.ignite.internal.raft.Loza;
 import org.apache.ignite.internal.schema.SchemaManager;
@@ -50,6 +51,7 @@ import org.apache.ignite.internal.storage.DistributedConfigurationStorage;
 import org.apache.ignite.internal.storage.LocalConfigurationStorage;
 import org.apache.ignite.internal.table.distributed.TableManager;
 import org.apache.ignite.internal.vault.VaultManager;
+import org.apache.ignite.internal.vault.VaultService;
 import org.apache.ignite.internal.vault.persistence.PersistentVaultService;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.lang.IgniteInternalException;
@@ -74,9 +76,14 @@ public class IgniteImpl implements Ignite {
     private static final IgniteLogger LOG = IgniteLogger.forClass(IgniteImpl.class);
 
     /**
-     * Path to the persistent storage used by the {@link org.apache.ignite.internal.vault.VaultService} component.
+     * Path to the persistent storage used by the {@link VaultService} component.
      */
     private static final Path VAULT_DB_PATH = Paths.get("vault");
+
+    /**
+     * Path to the persistent storage used by the {@link MetaStorageManager} component.
+     */
+    private static final Path METASTORAGE_DB_PATH = Paths.get("metastorage");
 
     /**
      * Path for the partitions persistent storage.
@@ -170,7 +177,8 @@ public class IgniteImpl implements Ignite {
             vaultMgr,
             nodeCfgMgr,
             clusterSvc,
-            raftMgr
+            raftMgr,
+            new RocksDBKeyValueStorage(workDir.resolve(METASTORAGE_DB_PATH))
         );
 
         clusterCfgMgr = new ConfigurationManager(

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -457,6 +457,13 @@
 
             <dependency>
                 <groupId>org.apache.ignite</groupId>
+                <artifactId>ignite-metastorage-server</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.ignite</groupId>
                 <artifactId>ignite-network</artifactId>
                 <version>${project.version}</version>
                 <type>test-jar</type>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-15456

1. `SimpleKeyValueStorage` is moved to the `test` folder.
2. `RocksDbKeyValuesStorage` is used when creating `IgniteImpl` instances.