### PR TITLE
IGNITE-15430 .NET: Add Table API

### DIFF
--- a/modules/api/src/main/java/org/apache/ignite/table/KeyValueView.java
+++ b/modules/api/src/main/java/org/apache/ignite/table/KeyValueView.java
@@ -208,7 +208,7 @@ public interface KeyValueView<K, V> {
      *
      * @param keys Keys which mapping is to be removed from the table.
      * The keys cannot be {@code null}.
-     * @return Keys whose values were not existed.
+     * @return Keys which did not exist.
      */
     Collection<K> removeAll(@NotNull Collection<K> keys);
 

--- a/modules/api/src/main/java/org/apache/ignite/table/TableView.java
+++ b/modules/api/src/main/java/org/apache/ignite/table/TableView.java
@@ -276,7 +276,7 @@ public interface TableView<R> {
      *
      * @param recs Records with key columns set.
      * The records cannot be {@code null}.
-     * @return Records with key columns set that were not exists.
+     * @return Records with key columns set that did not exist.
      */
     Collection<R> deleteAll(@NotNull Collection<R> recs);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Program.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Program.cs
@@ -1,17 +1,19 @@
-﻿// Licensed to the Apache Software Foundation (ASF) under one or more
-// contributor license agreements. See the NOTICE file distributed with
-// this work for additional information regarding copyright ownership.
-// The ASF licenses this file to You under the Apache License, Version 2.0
-// (the "License"); you may not use this file except in compliance with
-// the License. You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 namespace Apache.Ignite.Benchmarks
 {

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Proto/WriteGuidBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Proto/WriteGuidBenchmarks.cs
@@ -1,17 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more
-// contributor license agreements. See the NOTICE file distributed with
-// this work for additional information regarding copyright ownership.
-// The ASF licenses this file to You under the Apache License, Version 2.0
-// (the "License"); you may not use this file except in compliance with
-// the License. You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 namespace Apache.Ignite.Benchmarks.Proto
 {

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TupleGetBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TupleGetBenchmarks.cs
@@ -1,17 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more
-// contributor license agreements. See the NOTICE file distributed with
-// this work for additional information regarding copyright ownership.
-// The ASF licenses this file to You under the Apache License, Version 2.0
-// (the "License"); you may not use this file except in compliance with
-// the License. You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 namespace Apache.Ignite.Benchmarks.Table
 {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Tests
 {
     using System.Threading.Tasks;
+    using Ignite.Table;
     using NUnit.Framework;
 
     /// <summary>
@@ -25,19 +26,33 @@ namespace Apache.Ignite.Tests
     /// </summary>
     public class IgniteTestsBase
     {
+        protected const string TableName = "PUB.tbl1";
+
+        protected const string KeyCol = "key";
+
+        protected const string ValCol = "val";
+
         private JavaServer? _serverNode;
 
         protected int ServerPort => _serverNode?.Port ?? 0;
+
+        protected IIgniteClient Client { get; private set; } = null!;
+
+        protected ITable Table { get; private set; } = null!;
 
         [OneTimeSetUp]
         public async Task OneTimeSetUp()
         {
             _serverNode = await JavaServer.StartAsync();
+            Client = await IgniteClient.StartAsync(GetConfig());
+            Table = (await Client.Tables.GetTableAsync(TableName))!;
         }
 
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
+            // ReSharper disable once ConstantConditionalAccessQualifier
+            Client?.Dispose();
             _serverNode?.Dispose();
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/CustomTestIgniteTuple.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/CustomTestIgniteTuple.cs
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests.Table
+{
+    using Ignite.Table;
+
+    /// <summary>
+    /// Custom tuple implementation for tests.
+    /// </summary>
+    public class CustomTestIgniteTuple : IIgniteTuple
+    {
+        public const int Key = 42;
+
+        public const string Value = "Val1";
+
+        public int FieldCount => 2;
+
+        public object? this[int ordinal]
+        {
+            get => ordinal switch { 0 => Key, _ => Value };
+            set => throw new System.NotImplementedException();
+        }
+
+        public object? this[string name]
+        {
+            get => name switch { "key" => Key, _ => Value };
+            set => throw new System.NotImplementedException();
+        }
+
+        public string GetName(int ordinal) => ordinal switch { 0 => "key", _ => "val" };
+
+        public int GetOrdinal(string name) => name switch { "key" => 0, _ => 1 };
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
@@ -59,5 +59,30 @@ namespace Apache.Ignite.Tests.Table
             Assert.AreEqual("x", tuple[1]);
             Assert.IsNull(tuple[2]);
         }
+
+        [Test]
+        public void TestToStringEmpty()
+        {
+            Assert.AreEqual("IgniteTuple []", new IgniteTuple().ToString());
+        }
+
+        [Test]
+        public void TestToStringOneField()
+        {
+            var tuple = new IgniteTuple { ["foo"] = 1 };
+            Assert.AreEqual("IgniteTuple [foo=1]", tuple.ToString());
+        }
+
+        [Test]
+        public void TestToStringTwoFields()
+        {
+            var tuple = new IgniteTuple
+            {
+                ["foo"] = 1,
+                ["b"] = "abcd"
+            };
+
+            Assert.AreEqual("IgniteTuple [foo=1, b=abcd]", tuple.ToString());
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -197,6 +197,36 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
+        public async Task TestReplaceExistingRecordReturnsTrueOverwrites()
+        {
+            await Table.UpsertAsync(GetTuple(1, "1"));
+            bool res = await Table.ReplaceAsync(GetTuple(1, "2"));
+
+            Assert.IsTrue(res);
+            Assert.AreEqual("2", (await Table.GetAsync(GetTuple(1)))![1]);
+        }
+
+        [Test]
+        public async Task TestGetAndReplaceNonExistentRecordReturnsNullDoesNotCreateRecord()
+        {
+            IIgniteTuple? res = await Table.GetAndReplaceAsync(GetTuple(1, "1"));
+
+            Assert.IsNull(res);
+            Assert.IsNull(await Table.GetAsync(GetTuple(1)));
+        }
+
+        [Test]
+        public async Task TestGetAndReplaceExistingRecordReturnsOldOverwrites()
+        {
+            await Table.UpsertAsync(GetTuple(1, "1"));
+            IIgniteTuple? res = await Table.GetAndReplaceAsync(GetTuple(1, "2"));
+
+            Assert.IsNotNull(res);
+            Assert.AreEqual("1", res![1]);
+            Assert.AreEqual("2", (await Table.GetAsync(GetTuple(1)))![1]);
+        }
+
+        [Test]
         public async Task TestReplaceExactNonExistentRecordReturnsFalseDoesNotCreateRecord()
         {
             bool res = await Table.ReplaceAsync(GetTuple(1, "1"), GetTuple(1, "2"));
@@ -223,16 +253,6 @@ namespace Apache.Ignite.Tests.Table
 
             Assert.IsTrue(res);
             Assert.AreEqual("22", (await Table.GetAsync(GetTuple(1)))![1]);
-        }
-
-        [Test]
-        public async Task TestReplaceExistingRecordReturnsTrueOverwrites()
-        {
-            await Table.UpsertAsync(GetTuple(1, "1"));
-            bool res = await Table.ReplaceAsync(GetTuple(1, "2"));
-
-            Assert.IsTrue(res);
-            Assert.AreEqual("2", (await Table.GetAsync(GetTuple(1)))![1]);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -87,7 +87,7 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
-        public async Task TestGetAndUpsertReturnsNullForNonExistingRecord()
+        public async Task TestGetAndUpsertReturnsNullForNonExistentRecord()
         {
             IIgniteTuple? res = await Table.GetAndUpsertAsync(GetTuple(2, "2"));
 
@@ -108,7 +108,7 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
-        public async Task TestInsertNonExistingKeyCreatesRecordReturnsTrue()
+        public async Task TestInsertNonExistentKeyCreatesRecordReturnsTrue()
         {
             var res = await Table.InsertAsync(GetTuple(1, "1"));
 
@@ -150,7 +150,7 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
-        public async Task TestReplaceNonExistingRecordReturnsFalseDoesNotCreateRecord()
+        public async Task TestReplaceNonExistentRecordReturnsFalseDoesNotCreateRecord()
         {
             bool res = await Table.ReplaceAsync(GetTuple(1, "1"));
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -176,6 +176,35 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
+        public async Task TestReplaceExactNonExistentRecordReturnsFalseDoesNotCreateRecord()
+        {
+            bool res = await Table.ReplaceAsync(GetTuple(1, "1"), GetTuple(1, "2"));
+
+            Assert.IsFalse(res);
+            Assert.IsNull(await Table.GetAsync(GetTuple(1)));
+        }
+
+        [Test]
+        public async Task TestReplaceExactExistingRecordWithDifferentValueReturnsFalseDoesNotReplace()
+        {
+            await Table.UpsertAsync(GetTuple(1, "1"));
+            bool res = await Table.ReplaceAsync(GetTuple(1, "11"), GetTuple(1, "22"));
+
+            Assert.IsFalse(res);
+            Assert.AreEqual("1", (await Table.GetAsync(GetTuple(1)))![1]);
+        }
+
+        [Test]
+        public async Task TestReplaceExactExistingRecordWithSameValueReturnsTrueReplacesOld()
+        {
+            await Table.UpsertAsync(GetTuple(1, "1"));
+            bool res = await Table.ReplaceAsync(GetTuple(1, "1"), GetTuple(1, "22"));
+
+            Assert.IsTrue(res);
+            Assert.AreEqual("22", (await Table.GetAsync(GetTuple(1)))![1]);
+        }
+
+        [Test]
         public async Task TestReplaceExistingRecordReturnsTrueOverwrites()
         {
             await Table.UpsertAsync(GetTuple(1, "1"));

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -393,6 +393,29 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
+        public async Task TestDeleteAllExistingKeysReturnsEmptyListRemovesRecords()
+        {
+            await Table.UpsertAllAsync(new[] { GetTuple(1, "1"), GetTuple(2, "2") });
+            var skipped = await Table.DeleteAllAsync(new[] { GetTuple(1), GetTuple(2) });
+
+            Assert.AreEqual(0, skipped.Count);
+            Assert.IsNull(await Table.GetAsync(GetTuple(1)));
+            Assert.IsNull(await Table.GetAsync(GetTuple(2)));
+        }
+
+        [Test]
+        public async Task TestDeleteAllRemovesExistingRecordsReturnsNonExistentKeys()
+        {
+            await Table.UpsertAllAsync(new[] { GetTuple(1, "1"), GetTuple(2, "2"), GetTuple(3, "3") });
+            var skipped = await Table.DeleteAllAsync(new[] { GetTuple(1), GetTuple(2) });
+
+            Assert.AreEqual(1, skipped.Count);
+            Assert.IsNull(await Table.GetAsync(GetTuple(1)));
+            Assert.IsNull(await Table.GetAsync(GetTuple(2)));
+            Assert.IsNotNull(await Table.GetAsync(GetTuple(3)));
+        }
+
+        [Test]
         public void TestUpsertAllThrowsArgumentExceptionOnNullCollectionElement()
         {
             var ex = Assert.ThrowsAsync<ArgumentException>(

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -64,7 +64,7 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
-        public async Task TestUpsertCustomTuple()
+        public async Task TestUpsertAllowsCustomTupleImplementation()
         {
             await Table.UpsertAsync(new CustomTestIgniteTuple());
 
@@ -186,7 +186,7 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
-        public async Task TestUpsertAll()
+        public async Task TestUpsertAllCreatesRecords()
         {
             var ids = Enumerable.Range(1, 10).ToList();
             var records = ids.Select(x => GetTuple(x, x.ToString(CultureInfo.InvariantCulture)));
@@ -219,7 +219,7 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
-        public async Task TestInsertAll()
+        public async Task TestInsertAllCreatesRecords()
         {
             var ids = Enumerable.Range(1, 10).ToList();
             var records = ids.Select(x => GetTuple(x, x.ToString(CultureInfo.InvariantCulture)));
@@ -270,7 +270,7 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
-        public async Task TestGetAll()
+        public async Task TestGetAllReturnsRecordsForExistingKeys()
         {
             var records = Enumerable
                 .Range(1, 10)

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -340,6 +340,19 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
+        public async Task TestInsertAllEmptyCollectionDoesNothingReturnsEmptyList()
+        {
+            var res = await Table.InsertAllAsync(Array.Empty<IIgniteTuple>());
+            CollectionAssert.IsEmpty(res);
+        }
+
+        [Test]
+        public async Task TestUpsertAllEmptyCollectionDoesNothing()
+        {
+            await Table.UpsertAllAsync(Array.Empty<IIgniteTuple>());
+        }
+
+        [Test]
         public async Task TestGetAllReturnsRecordsForExistingKeys()
         {
             var records = Enumerable

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Tests.Table
 {
+    using System;
     using System.Globalization;
     using System.Linq;
     using System.Threading.Tasks;
@@ -103,17 +104,12 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
-        public async Task TestUpsertAllLazyCollection()
+        public void TestUpsertAllThrowsArgumentExceptionOnNullCollectionElement()
         {
-            // TODO
-            await Task.Yield();
-        }
+            var ex = Assert.ThrowsAsync<ArgumentException>(
+                async () => await Table.UpsertAllAsync(new[] { GetTuple(1, "1"), null! }));
 
-        [Test]
-        public async Task TestUpsertAllThrowsOnNullCollectionElement()
-        {
-            // TODO
-            await Task.Yield();
+            Assert.AreEqual("Tuple collection can't contain null elements.", ex!.Message);
         }
 
         private static IIgniteTuple GetTuple(int id, string? val = null) =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -49,10 +49,15 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
-        public async Task TestUpsertEmptyTupleThrowsException()
+        public void TestUpsertEmptyTupleThrowsException()
         {
-            await Task.Yield();
-            throw new NotImplementedException();
+            var ex = Assert.ThrowsAsync<IgniteClientException>(async () => await Table.UpsertAsync(new IgniteTuple()));
+
+            Assert.AreEqual(
+                "Failed to set column (null was passed, but column is not nullable):" +
+                " [col=Column [schemaIndex=0, name=key, type=NativeType [name=INT32, sizeInBytes=4, fixed=true]," +
+                " nullable=false]]",
+                ex!.Message);
         }
 
         private static IIgniteTuple GetTuple(int id, string? val = null) =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -116,6 +116,19 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
+        public async Task TestDeleteExact()
+        {
+            await Table.UpsertAsync(GetTuple(1, "1"));
+
+            Assert.IsFalse(await Table.DeleteExactAsync(GetTuple(-1)));
+            Assert.IsFalse(await Table.DeleteExactAsync(GetTuple(1)));
+            Assert.IsNotNull(await Table.GetAsync(GetTuple(1)));
+
+            Assert.IsTrue(await Table.DeleteExactAsync(GetTuple(1, "1")));
+            Assert.IsNull(await Table.GetAsync(GetTuple(1)));
+        }
+
+        [Test]
         public async Task TestUpsertAll()
         {
             var ids = Enumerable.Range(1, 10).ToList();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -127,23 +127,40 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
-        public async Task TestDelete()
+        public async Task TestDeleteNonExistentRecordReturnFalse()
+        {
+            Assert.IsFalse(await Table.DeleteAsync(GetTuple(-1)));
+        }
+
+        [Test]
+        public async Task TestDeleteExistingRecordReturnsTrue()
         {
             await Table.UpsertAsync(GetTuple(1, "1"));
 
-            Assert.IsFalse(await Table.DeleteAsync(GetTuple(-1)));
             Assert.IsTrue(await Table.DeleteAsync(GetTuple(1)));
             Assert.IsNull(await Table.GetAsync(GetTuple(1)));
         }
 
         [Test]
-        public async Task TestDeleteExact()
+        public async Task TestDeleteExactNonExistentRecordReturnsFalse()
+        {
+            Assert.IsFalse(await Table.DeleteExactAsync(GetTuple(-1)));
+        }
+
+        [Test]
+        public async Task TestDeleteExactExistingKeyDifferentValueReturnsFalseDoesNotDelete()
         {
             await Table.UpsertAsync(GetTuple(1, "1"));
 
-            Assert.IsFalse(await Table.DeleteExactAsync(GetTuple(-1)));
             Assert.IsFalse(await Table.DeleteExactAsync(GetTuple(1)));
+            Assert.IsFalse(await Table.DeleteExactAsync(GetTuple(1, "2")));
             Assert.IsNotNull(await Table.GetAsync(GetTuple(1)));
+        }
+
+        [Test]
+        public async Task TestDeleteExactSameKeyAndValueReturnsTrueDeletesRecord()
+        {
+            await Table.UpsertAsync(GetTuple(1, "1"));
 
             Assert.IsTrue(await Table.DeleteExactAsync(GetTuple(1, "1")));
             Assert.IsNull(await Table.GetAsync(GetTuple(1)));

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Tests.Table
 {
+    using System;
     using System.Threading.Tasks;
     using Ignite.Table;
     using NUnit.Framework;
@@ -26,27 +27,32 @@ namespace Apache.Ignite.Tests.Table
     /// </summary>
     public class TableTests : IgniteTestsBase
     {
-        private const string TableName = "PUB.tbl1";
-
-        private const string KeyCol = "key";
-
-        private const string ValCol = "val";
-
         [Test]
         public async Task TestUpsertGet()
         {
-            using var client = await IgniteClient.StartAsync(GetConfig());
-            var table = (await client.Tables.GetTableAsync(TableName))!;
+            await Table.UpsertAsync(GetTuple(1, "foo"));
 
-            await table.UpsertAsync(GetTuple(1, "foo"));
-
-            var keyTuple = new IgniteTuple { ["key"] = 1 };
-            var resTuple = (await table.GetAsync(keyTuple))!;
+            var keyTuple = GetTuple(1);
+            var resTuple = (await Table.GetAsync(keyTuple))!;
 
             Assert.IsNotNull(resTuple);
             Assert.AreEqual(2, resTuple.FieldCount);
             Assert.AreEqual(1L, resTuple["key"]);
             Assert.AreEqual("foo", resTuple["val"]);
+        }
+
+        [Test]
+        public async Task TestUpsertCustomTuple()
+        {
+            await Task.Yield();
+            throw new NotImplementedException();
+        }
+
+        [Test]
+        public async Task TestUpsertEmptyTupleThrowsException()
+        {
+            await Task.Yield();
+            throw new NotImplementedException();
         }
 
         private static IIgniteTuple GetTuple(int id, string? val = null) =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -130,6 +130,24 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
+        public async Task TestUpsertAllOverwritesExistingData()
+        {
+            await Table.InsertAsync(GetTuple(2, "x"));
+            await Table.InsertAsync(GetTuple(4, "y"));
+
+            var ids = Enumerable.Range(1, 10).ToList();
+            var records = ids.Select(x => GetTuple(x, x.ToString(CultureInfo.InvariantCulture)));
+
+            await Table.UpsertAllAsync(records);
+
+            foreach (var id in ids)
+            {
+                var res = await Table.GetAsync(GetTuple(id));
+                Assert.AreEqual(id.ToString(CultureInfo.InvariantCulture), res![1]);
+            }
+        }
+
+        [Test]
         public async Task TestGetAll()
         {
             var records = Enumerable

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -377,6 +377,22 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
+        public async Task TestDeleteAllEmptyKeysReturnsEmptyList()
+        {
+            var skipped = await Table.DeleteAllAsync(Array.Empty<IIgniteTuple>());
+
+            Assert.AreEqual(0, skipped.Count);
+        }
+
+        [Test]
+        public async Task TestDeleteAllNonExistentKeysReturnsAllKeys()
+        {
+            var skipped = await Table.DeleteAllAsync(new[] { GetTuple(1), GetTuple(2) });
+
+            Assert.AreEqual(2, skipped.Count);
+        }
+
+        [Test]
         public void TestUpsertAllThrowsArgumentExceptionOnNullCollectionElement()
         {
             var ex = Assert.ThrowsAsync<ArgumentException>(

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -18,7 +18,6 @@
 namespace Apache.Ignite.Tests.Table
 {
     using System;
-    using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
     using System.Threading.Tasks;
@@ -30,6 +29,13 @@ namespace Apache.Ignite.Tests.Table
     /// </summary>
     public class TableTests : IgniteTestsBase
     {
+        [SetUp]
+        public async Task SetUp()
+        {
+            // Clean up test data.
+            await Table.DeleteAllAsync(Enumerable.Range(0, 100).Select(x => GetTuple(x)));
+        }
+
         [Test]
         public async Task TestUpsertGet()
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -85,6 +85,27 @@ namespace Apache.Ignite.Tests.Table
             Assert.IsNull(await Table.GetAsync(GetTuple(1)));
         }
 
+        [Test]
+        public async Task TestUpsertAll()
+        {
+            // TODO
+            await Task.Yield();
+        }
+
+        [Test]
+        public async Task TestUpsertAllLazyCollection()
+        {
+            // TODO
+            await Task.Yield();
+        }
+
+        [Test]
+        public async Task TestUpsertAllThrowsOnNullCollectionElement()
+        {
+            // TODO
+            await Task.Yield();
+        }
+
         private static IIgniteTuple GetTuple(int id, string? val = null) =>
             new IgniteTuple { [KeyCol] = id, [ValCol] = val };
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -87,7 +87,7 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
-        public async Task TestGetAndUpsertReturnsNullForNonExistentRecord()
+        public async Task TestGetAndUpsertNonExistentRecordReturnsNull()
         {
             IIgniteTuple? res = await Table.GetAndUpsertAsync(GetTuple(2, "2"));
 
@@ -96,7 +96,7 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
-        public async Task TestGetAndUpsertOverwritesAndReturnsExistingRecord()
+        public async Task TestGetAndUpsertExistingRecordOverwritesAndReturns()
         {
             await Table.UpsertAsync(GetTuple(2, "2"));
             IIgniteTuple? res = await Table.GetAndUpsertAsync(GetTuple(2, "22"));
@@ -105,6 +105,27 @@ namespace Apache.Ignite.Tests.Table
             Assert.AreEqual(2, res![0]);
             Assert.AreEqual("2", res[1]);
             Assert.AreEqual("22", (await Table.GetAsync(GetTuple(2)))![1]);
+        }
+
+        [Test]
+        public async Task TestGetAndDeleteNonExistentRecordReturnsNull()
+        {
+            IIgniteTuple? res = await Table.GetAndDeleteAsync(GetTuple(2, "2"));
+
+            Assert.IsNull(res);
+            Assert.IsNull(await Table.GetAsync(GetTuple(2)));
+        }
+
+        [Test]
+        public async Task TestGetAndDeleteExistingRecordRemovesAndReturns()
+        {
+            await Table.UpsertAsync(GetTuple(2, "2"));
+            IIgniteTuple? res = await Table.GetAndDeleteAsync(GetTuple(2));
+
+            Assert.IsNotNull(res);
+            Assert.AreEqual(2, res![0]);
+            Assert.AreEqual("2", res[1]);
+            Assert.IsNull(await Table.GetAsync(GetTuple(2)));
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -385,6 +385,24 @@ namespace Apache.Ignite.Tests.Table
             Assert.AreEqual("Tuple collection can't contain null elements.", ex!.Message);
         }
 
+        [Test]
+        public void TestGetAllThrowsArgumentExceptionOnNullCollectionElement()
+        {
+            var ex = Assert.ThrowsAsync<ArgumentException>(
+                async () => await Table.GetAllAsync(new[] { GetTuple(1, "1"), null! }));
+
+            Assert.AreEqual("Tuple collection can't contain null elements.", ex!.Message);
+        }
+
+        [Test]
+        public void TestDeleteAllThrowsArgumentExceptionOnNullCollectionElement()
+        {
+            var ex = Assert.ThrowsAsync<ArgumentException>(
+                async () => await Table.DeleteAllAsync(new[] { GetTuple(1, "1"), null! }));
+
+            Assert.AreEqual("Tuple collection can't contain null elements.", ex!.Message);
+        }
+
         private static IIgniteTuple GetTuple(int id, string? val = null) =>
             new IgniteTuple { [KeyCol] = id, [ValCol] = val };
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -86,6 +86,25 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
+        public async Task TestInsertNonExistingKeyCreatesRecordReturnsTrue()
+        {
+            var res = await Table.InsertAsync(GetTuple(1, "1"));
+
+            Assert.IsTrue(res);
+            Assert.IsTrue(await Table.GetAsync(GetTuple(1)) != null);
+        }
+
+        [Test]
+        public async Task TestInsertExistingKeyDoesNotOverwriteReturnsFalse()
+        {
+            await Table.UpsertAsync(GetTuple(1, "1"));
+            var res = await Table.InsertAsync(GetTuple(1, "2"));
+
+            Assert.IsFalse(res);
+            Assert.AreEqual("1", (await Table.GetAsync(GetTuple(1)))![1]);
+        }
+
+        [Test]
         public async Task TestDelete()
         {
             await Table.UpsertAsync(GetTuple(1, "1"));

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -418,10 +418,10 @@ namespace Apache.Ignite.Tests.Table
         [Test]
         public async Task TestDeleteAllExactNonExistentKeysReturnsAllKeys()
         {
-            var skipped = await Table.DeleteAllExactAsync(new[] { GetTuple(1), GetTuple(2) });
+            var skipped = await Table.DeleteAllExactAsync(new[] { GetTuple(1, "1"), GetTuple(2, "2") });
 
             Assert.AreEqual(2, skipped.Count);
-            CollectionAssert.AreEquivalent(new[] { 1, 2 }, skipped.Select(x => (int)x[1]!).ToArray());
+            CollectionAssert.AreEquivalent(new[] { 1, 2 }, skipped.Select(x => (int)x[0]!).ToArray());
         }
 
         [Test]
@@ -437,7 +437,7 @@ namespace Apache.Ignite.Tests.Table
         public async Task TestDeleteAllExactExistingKeysReturnsEmptyListRemovesRecords()
         {
             await Table.UpsertAllAsync(new[] { GetTuple(1, "1"), GetTuple(2, "2") });
-            var skipped = await Table.DeleteAllExactAsync(new[] { GetTuple(1), GetTuple(2) });
+            var skipped = await Table.DeleteAllExactAsync(new[] { GetTuple(1, "1"), GetTuple(2, "2") });
 
             Assert.AreEqual(0, skipped.Count);
             Assert.IsNull(await Table.GetAsync(GetTuple(1)));
@@ -448,7 +448,7 @@ namespace Apache.Ignite.Tests.Table
         public async Task TestDeleteAllExactRemovesExistingRecordsReturnsNonExistentKeys()
         {
             await Table.UpsertAllAsync(new[] { GetTuple(1, "1"), GetTuple(2, "2"), GetTuple(3, "3") });
-            var skipped = await Table.DeleteAllExactAsync(new[] { GetTuple(1), GetTuple(2) });
+            var skipped = await Table.DeleteAllExactAsync(new[] { GetTuple(1, "1"), GetTuple(2, "22") });
 
             Assert.AreEqual(1, skipped.Count);
             Assert.IsNull(await Table.GetAsync(GetTuple(1)));

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -150,6 +150,25 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
+        public async Task TestReplaceNonExistingRecordReturnsFalseDoesNotCreateRecord()
+        {
+            bool res = await Table.ReplaceAsync(GetTuple(1, "1"));
+
+            Assert.IsFalse(res);
+            Assert.IsNull(await Table.GetAsync(GetTuple(1)));
+        }
+
+        [Test]
+        public async Task TestReplaceExistingRecordReturnsTrueOverwrites()
+        {
+            await Table.UpsertAsync(GetTuple(1, "1"));
+            bool res = await Table.ReplaceAsync(GetTuple(1, "2"));
+
+            Assert.IsTrue(res);
+            Assert.AreEqual("2", (await Table.GetAsync(GetTuple(1)))![1]);
+        }
+
+        [Test]
         public async Task TestUpsertAll()
         {
             var ids = Enumerable.Range(1, 10).ToList();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -17,6 +17,8 @@
 
 namespace Apache.Ignite.Tests.Table
 {
+    using System.Globalization;
+    using System.Linq;
     using System.Threading.Tasks;
     using Ignite.Table;
     using NUnit.Framework;
@@ -88,8 +90,16 @@ namespace Apache.Ignite.Tests.Table
         [Test]
         public async Task TestUpsertAll()
         {
-            // TODO
-            await Task.Yield();
+            var ids = Enumerable.Range(1, 10).ToList();
+            var records = ids.Select(x => GetTuple(x, x.ToString(CultureInfo.InvariantCulture)));
+
+            await Table.UpsertAllAsync(records);
+
+            foreach (var id in ids)
+            {
+                var res = await Table.GetAsync(GetTuple(id));
+                Assert.AreEqual(id.ToString(CultureInfo.InvariantCulture), res![1]);
+            }
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -26,6 +26,14 @@ namespace Apache.Ignite.Tests.Table
     /// </summary>
     public class TableTests : IgniteTestsBase
     {
+        // [SetUp]
+        // public async Task SetUp()
+        // {
+        //     for (var i = 0; i < 10; i++)
+        //     {
+        //         await Table.DeleteAsync(GetTuple(i));
+        //     }
+        // }
         [Test]
         public async Task TestUpsertGet()
         {
@@ -73,6 +81,16 @@ namespace Apache.Ignite.Tests.Table
                 " [col=Column [schemaIndex=0, name=key, type=NativeType [name=INT32, sizeInBytes=4, fixed=true]," +
                 " nullable=false]]",
                 ex!.Message);
+        }
+
+        [Test]
+        public async Task TestDelete()
+        {
+            await Table.UpsertAsync(GetTuple(1, "1"));
+
+            Assert.IsFalse(await Table.DeleteAsync(GetTuple(-1)));
+            Assert.IsTrue(await Table.DeleteAsync(GetTuple(1)));
+            Assert.IsNull(await Table.GetAsync(GetTuple(1)));
         }
 
         private static IIgniteTuple GetTuple(int id, string? val = null) =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -407,9 +407,10 @@ namespace Apache.Ignite.Tests.Table
         public async Task TestDeleteAllRemovesExistingRecordsReturnsNonExistentKeys()
         {
             await Table.UpsertAllAsync(new[] { GetTuple(1, "1"), GetTuple(2, "2"), GetTuple(3, "3") });
-            var skipped = await Table.DeleteAllAsync(new[] { GetTuple(1), GetTuple(2) });
+            var skipped = await Table.DeleteAllAsync(new[] { GetTuple(1), GetTuple(2), GetTuple(4) });
 
             Assert.AreEqual(1, skipped.Count);
+            Assert.AreEqual(4, skipped[0][0]);
             Assert.IsNull(await Table.GetAsync(GetTuple(1)));
             Assert.IsNull(await Table.GetAsync(GetTuple(2)));
             Assert.IsNotNull(await Table.GetAsync(GetTuple(3)));
@@ -452,7 +453,7 @@ namespace Apache.Ignite.Tests.Table
 
             Assert.AreEqual(1, skipped.Count);
             Assert.IsNull(await Table.GetAsync(GetTuple(1)));
-            Assert.IsNull(await Table.GetAsync(GetTuple(2)));
+            Assert.IsNotNull(await Table.GetAsync(GetTuple(2)));
             Assert.IsNotNull(await Table.GetAsync(GetTuple(3)));
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -26,25 +26,21 @@ namespace Apache.Ignite.Tests.Table
     /// </summary>
     public class TableTests : IgniteTestsBase
     {
+        private const string TableName = "PUB.tbl1";
+
+        private const string KeyCol = "key";
+
+        private const string ValCol = "val";
+
         [Test]
         public async Task TestUpsertGet()
         {
             using var client = await IgniteClient.StartAsync(GetConfig());
-            var table = (await client.Tables.GetTableAsync("PUB.tbl1"))!;
+            var table = (await client.Tables.GetTableAsync(TableName))!;
 
-            var tuple = new IgniteTuple
-            {
-                ["key"] = 1,
-                ["val"] = "foo"
-            };
+            await table.UpsertAsync(GetTuple(1, "foo"));
 
-            await table.UpsertAsync(tuple);
-
-            var keyTuple = new IgniteTuple
-            {
-                ["key"] = 1
-            };
-
+            var keyTuple = new IgniteTuple { ["key"] = 1 };
             var resTuple = (await table.GetAsync(keyTuple))!;
 
             Assert.IsNotNull(resTuple);
@@ -52,5 +48,8 @@ namespace Apache.Ignite.Tests.Table
             Assert.AreEqual(1L, resTuple["key"]);
             Assert.AreEqual("foo", resTuple["val"]);
         }
+
+        private static IIgniteTuple GetTuple(int id, string? val = null) =>
+            new IgniteTuple { [KeyCol] = id, [ValCol] = val };
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -44,8 +44,12 @@ namespace Apache.Ignite.Tests.Table
         [Test]
         public async Task TestUpsertCustomTuple()
         {
-            await Task.Yield();
-            throw new NotImplementedException();
+            await Table.UpsertAsync(new CustomTestIgniteTuple());
+
+            var res = await Table.GetAsync(GetTuple(CustomTestIgniteTuple.Key));
+
+            Assert.IsNotNull(res);
+            Assert.AreEqual(CustomTestIgniteTuple.Value, res![1]);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -114,8 +114,15 @@ namespace Apache.Ignite.Tests.Table
             await Table.UpsertAllAsync(records);
 
             var res = await Table.GetAllAsync(Enumerable.Range(9, 4).Select(x => GetTuple(x)));
+            var resArr = res.OrderBy(x => x[0]).ToArray();
 
             Assert.AreEqual(2, res.Count);
+
+            Assert.AreEqual(9, resArr[0][0]);
+            Assert.AreEqual("9", resArr[0][1]);
+
+            Assert.AreEqual(10, resArr[1][0]);
+            Assert.AreEqual("10", resArr[1][1]);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Tests.Table
 {
     using System;
+    using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
     using System.Threading.Tasks;
@@ -101,6 +102,36 @@ namespace Apache.Ignite.Tests.Table
                 var res = await Table.GetAsync(GetTuple(id));
                 Assert.AreEqual(id.ToString(CultureInfo.InvariantCulture), res![1]);
             }
+        }
+
+        [Test]
+        public async Task TestGetAll()
+        {
+            var records = Enumerable
+                .Range(1, 10)
+                .Select(x => GetTuple(x, x.ToString(CultureInfo.InvariantCulture)));
+
+            await Table.UpsertAllAsync(records);
+
+            var res = await Table.GetAllAsync(Enumerable.Range(9, 4).Select(x => GetTuple(x)));
+
+            Assert.AreEqual(2, res.Count);
+        }
+
+        [Test]
+        public async Task TestGetAllNonExistentKeysReturnsEmptyList()
+        {
+            var res = await Table.GetAllAsync(new[] { GetTuple(-100) });
+
+            Assert.AreEqual(0, res.Count);
+        }
+
+        [Test]
+        public async Task TestGetAllEmptyKeysReturnsEmptyList()
+        {
+            var res = await Table.GetAllAsync(Array.Empty<IIgniteTuple>());
+
+            Assert.AreEqual(0, res.Count);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -17,7 +17,6 @@
 
 namespace Apache.Ignite.Tests.Table
 {
-    using System;
     using System.Threading.Tasks;
     using Ignite.Table;
     using NUnit.Framework;
@@ -39,6 +38,18 @@ namespace Apache.Ignite.Tests.Table
             Assert.AreEqual(2, resTuple.FieldCount);
             Assert.AreEqual(1L, resTuple["key"]);
             Assert.AreEqual("foo", resTuple["val"]);
+        }
+
+        [Test]
+        public async Task TestUpsertOverridesPreviousValue()
+        {
+            var key = GetTuple(1);
+
+            await Table.UpsertAsync(GetTuple(1, "foo"));
+            Assert.AreEqual("foo", (await Table.GetAsync(key))![1]);
+
+            await Table.UpsertAsync(GetTuple(1, "bar"));
+            Assert.AreEqual("bar", (await Table.GetAsync(key))![1]);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -87,6 +87,27 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
+        public async Task TestGetAndUpsertReturnsNullForNonExistingRecord()
+        {
+            IIgniteTuple? res = await Table.GetAndUpsertAsync(GetTuple(2, "2"));
+
+            Assert.IsNull(res);
+            Assert.AreEqual("2", (await Table.GetAsync(GetTuple(2)))![1]);
+        }
+
+        [Test]
+        public async Task TestGetAndUpsertOverwritesAndReturnsExistingRecord()
+        {
+            await Table.UpsertAsync(GetTuple(2, "2"));
+            IIgniteTuple? res = await Table.GetAndUpsertAsync(GetTuple(2, "22"));
+
+            Assert.IsNotNull(res);
+            Assert.AreEqual(2, res![0]);
+            Assert.AreEqual("2", res[1]);
+            Assert.AreEqual("22", (await Table.GetAsync(GetTuple(2)))![1]);
+        }
+
+        [Test]
         public async Task TestInsertNonExistingKeyCreatesRecordReturnsTrue()
         {
             var res = await Table.InsertAsync(GetTuple(1, "1"));

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TableTests.cs
@@ -26,14 +26,6 @@ namespace Apache.Ignite.Tests.Table
     /// </summary>
     public class TableTests : IgniteTestsBase
     {
-        // [SetUp]
-        // public async Task SetUp()
-        // {
-        //     for (var i = 0; i < 10; i++)
-        //     {
-        //         await Table.DeleteAsync(GetTuple(i));
-        //     }
-        // }
         [Test]
         public async Task TestUpsertGet()
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TablesTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TablesTests.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Tests.Table
 {
+    using System;
     using System.Threading.Tasks;
     using Ignite.Table;
     using NUnit.Framework;
@@ -27,29 +28,29 @@ namespace Apache.Ignite.Tests.Table
     public class TablesTests : IgniteTestsBase
     {
         [Test]
-        public async Task TestGetTablesAsync()
+        public async Task TestGetTables()
         {
-            using var client = await IgniteClient.StartAsync(GetConfig());
-
-            Assert.IsNotNull(client);
-
-            var tables = await client.Tables.GetTablesAsync();
+            var tables = await Client.Tables.GetTablesAsync();
 
             Assert.AreEqual(1, tables.Count);
             Assert.AreEqual("PUB.tbl1", tables[0].Name);
         }
 
         [Test]
-        public async Task TestGetTableAsync()
+        public async Task TestGetExistingTable()
         {
-            using var client = await IgniteClient.StartAsync(GetConfig());
-
-            Assert.IsNotNull(client);
-
-            var table = await client.Tables.GetTableAsync("PUB.tbl1");
+            var table = await Client.Tables.GetTableAsync(TableName);
 
             Assert.IsNotNull(table);
             Assert.AreEqual("PUB.tbl1", table!.Name);
+        }
+
+        [Test]
+        public async Task TestGetNonExistentTableReturnsNull()
+        {
+            var table = await Client.Tables.GetTableAsync(Guid.NewGuid().ToString());
+
+            Assert.IsNull(table);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBufferWriter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBufferWriter.cs
@@ -155,7 +155,7 @@ namespace Apache.Ignite.Internal.Buffers
         }
 
         /// <summary>
-        /// Reserves space for an int32 value and returns it's position.
+        /// Reserves space for an int32 value and returns its position.
         /// </summary>
         /// <returns>Reserved int position. To be used with <see cref="WriteInt32"/>.</returns>
         public int ReserveInt32()

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBufferWriter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBufferWriter.cs
@@ -154,6 +154,34 @@ namespace Apache.Ignite.Internal.Buffers
             return new(this);
         }
 
+        /// <summary>
+        /// Reserves space for an int32 value and returns it's position.
+        /// </summary>
+        /// <returns>Reserved int position. To be used with <see cref="WriteInt32"/>.</returns>
+        public int ReserveInt32()
+        {
+            var pos = _index;
+
+            Advance(5);
+
+            return pos;
+        }
+
+        /// <summary>
+        /// Writes an int32 value at the given position. Intended to be used with <see cref="ReserveInt32"/>.
+        /// </summary>
+        /// <param name="position">Position.</param>
+        /// <param name="value">Value.</param>
+        public unsafe void WriteInt32(int position, int value)
+        {
+            fixed (byte* ptr = &_buffer[position + 1])
+            {
+                 *(int*)ptr = IPAddress.HostToNetworkOrder(value);
+            }
+
+            _buffer[position] = MessagePackCode.Int32;
+        }
+
         /// <inheritdoc />
         public void Dispose()
         {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackReaderExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackReaderExtensions.cs
@@ -73,8 +73,11 @@ namespace Apache.Ignite.Internal.Proto
         /// </summary>
         /// <param name="reader">Reader.</param>
         /// <returns>Nullable int.</returns>
-        public static int? ReadInt32Nullable(this ref MessagePackReader reader) =>
-            reader.IsNil ? (int?)null : reader.ReadInt32();
+        public static int? ReadInt32Nullable(this ref MessagePackReader reader)
+        {
+            // ReSharper disable RedundantCast (does not build on older SDKs)
+            return reader.IsNil ? (int?)null : reader.ReadInt32();
+        }
 
         /// <summary>
         /// Skips multiple elements.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackReaderExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackReaderExtensions.cs
@@ -74,7 +74,7 @@ namespace Apache.Ignite.Internal.Proto
         /// <param name="reader">Reader.</param>
         /// <returns>Nullable int.</returns>
         public static int? ReadInt32Nullable(this ref MessagePackReader reader) =>
-            reader.IsNil ? null : reader.ReadInt32();
+            reader.IsNil ? (int?)null : reader.ReadInt32();
 
         /// <summary>
         /// Skips multiple elements.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -104,8 +104,14 @@ namespace Apache.Ignite.Internal.Table
         /// <inheritdoc/>
         public async Task UpsertAllAsync(IEnumerable<IIgniteTuple> records)
         {
-            await Task.Yield();
-            throw new NotImplementedException();
+            IgniteArgumentCheck.NotNull(records, nameof(records));
+
+            var schema = await GetLatestSchemaAsync().ConfigureAwait(false);
+
+            using var writer = new PooledArrayBufferWriter();
+            WriteTuples(writer, schema, records);
+
+            using var resBuf = await _socket.DoOutInOpAsync(ClientOp.TupleUpsert, writer).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -211,7 +211,7 @@ namespace Apache.Ignite.Internal.Table
             using var resBuf = await _socket.DoOutInOpAsync(ClientOp.TupleGetAndReplace, writer).ConfigureAwait(false);
             var resSchema = await ReadSchemaAsync(resBuf, schema).ConfigureAwait(false);
 
-            return ReadTuple(resBuf, resSchema);
+            return ReadValueTuple(resBuf, resSchema, record);
         }
 
         /// <inheritdoc/>
@@ -319,21 +319,6 @@ namespace Apache.Ignite.Internal.Table
             }
 
             return tuple;
-        }
-
-        private static IIgniteTuple? ReadTuple(PooledBuffer buf, Schema? schema)
-        {
-            if (schema == null)
-            {
-                return null;
-            }
-
-            var r = buf.GetReader();
-
-            // Skip schema version.
-            r.Skip();
-
-            return ReadTuple(ref r, schema);
         }
 
         private static IIgniteTuple ReadTuple(ref MessagePackReader r, Schema schema, bool keyOnly = false)

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -479,6 +479,11 @@ namespace Apache.Ignite.Internal.Table
 
             foreach (var tuple in tuples)
             {
+                if (tuple == null)
+                {
+                    throw new ArgumentException("Tuple collection can't contain null elements.");
+                }
+
                 WriteTuple(ref w, schema, tuple, keyOnly);
                 count++;
             }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -90,7 +90,12 @@ namespace Apache.Ignite.Internal.Table
             var schema = await GetLatestSchemaAsync().ConfigureAwait(false);
 
             using var writer = new PooledArrayBufferWriter();
-            WriteTuples(writer, schema, keys, keyOnly: true);
+            var count = WriteTuples(writer, schema, keys, keyOnly: true);
+
+            if (count == 0)
+            {
+                return Array.Empty<IIgniteTuple>();
+            }
 
             using var resBuf = await _socket.DoOutInOpAsync(ClientOp.TupleGetAll, writer).ConfigureAwait(false);
             var resSchema = await ReadSchemaAsync(resBuf, schema).ConfigureAwait(false);
@@ -119,7 +124,12 @@ namespace Apache.Ignite.Internal.Table
             var schema = await GetLatestSchemaAsync().ConfigureAwait(false);
 
             using var writer = new PooledArrayBufferWriter();
-            WriteTuples(writer, schema, records);
+            var count = WriteTuples(writer, schema, records);
+
+            if (count == 0)
+            {
+                return;
+            }
 
             using var resBuf = await _socket.DoOutInOpAsync(ClientOp.TupleUpsertAll, writer).ConfigureAwait(false);
         }
@@ -162,7 +172,12 @@ namespace Apache.Ignite.Internal.Table
             var schema = await GetLatestSchemaAsync().ConfigureAwait(false);
 
             using var writer = new PooledArrayBufferWriter();
-            WriteTuples(writer, schema, records);
+            var count = WriteTuples(writer, schema, records);
+
+            if (count == 0)
+            {
+                return Array.Empty<IIgniteTuple>();
+            }
 
             using var resBuf = await _socket.DoOutInOpAsync(ClientOp.TupleInsertAll, writer).ConfigureAwait(false);
             var resSchema = await ReadSchemaAsync(resBuf, schema).ConfigureAwait(false);
@@ -266,7 +281,12 @@ namespace Apache.Ignite.Internal.Table
             var schema = await GetLatestSchemaAsync().ConfigureAwait(false);
 
             using var writer = new PooledArrayBufferWriter();
-            WriteTuples(writer, schema, keys, keyOnly: true);
+            var count = WriteTuples(writer, schema, keys, keyOnly: true);
+
+            if (count == 0)
+            {
+                return Array.Empty<IIgniteTuple>();
+            }
 
             using var resBuf = await _socket.DoOutInOpAsync(ClientOp.TupleDeleteAll, writer).ConfigureAwait(false);
             var resSchema = await ReadSchemaAsync(resBuf, schema).ConfigureAwait(false);
@@ -282,7 +302,12 @@ namespace Apache.Ignite.Internal.Table
             var schema = await GetLatestSchemaAsync().ConfigureAwait(false);
 
             using var writer = new PooledArrayBufferWriter();
-            WriteTuples(writer, schema, records);
+            var count = WriteTuples(writer, schema, records);
+
+            if (count == 0)
+            {
+                return Array.Empty<IIgniteTuple>();
+            }
 
             using var resBuf = await _socket.DoOutInOpAsync(ClientOp.TupleDeleteAllExact, writer).ConfigureAwait(false);
             var resSchema = await ReadSchemaAsync(resBuf, schema).ConfigureAwait(false);
@@ -544,7 +569,7 @@ namespace Apache.Ignite.Internal.Table
             w.Flush();
         }
 
-        private void WriteTuples(
+        private int WriteTuples(
             PooledArrayBufferWriter buf,
             Schema schema,
             IEnumerable<IIgniteTuple> tuples,
@@ -573,6 +598,8 @@ namespace Apache.Ignite.Internal.Table
             buf.WriteInt32(countPos, count);
 
             w.Flush();
+
+            return count;
         }
 
         private void WriteTupleWithHeader(

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -554,7 +554,7 @@ namespace Apache.Ignite.Internal.Table
             var w = buf.GetMessageWriter();
 
             WriteTupleWithHeader(ref w, schema, t, keyOnly);
-            WriteTupleWithHeader(ref w, schema, t2, keyOnly);
+            WriteTuple(ref w, schema, t2, keyOnly);
 
             w.Flush();
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -134,7 +134,7 @@ namespace Apache.Ignite.Internal.Table
             using var writer = new PooledArrayBufferWriter();
             WriteTuple(writer, schema, record);
 
-            using var resBuf = await _socket.DoOutInOpAsync(ClientOp.TupleUpsert, writer).ConfigureAwait(false);
+            using var resBuf = await _socket.DoOutInOpAsync(ClientOp.TupleGetAndUpsert, writer).ConfigureAwait(false);
             var resSchema = await ReadSchemaAsync(resBuf, schema).ConfigureAwait(false);
 
             return ReadValueTuple(resBuf, resSchema, record);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -255,7 +255,7 @@ namespace Apache.Ignite.Internal.Table
             using var resBuf = await _socket.DoOutInOpAsync(ClientOp.TupleGetAndDelete, writer).ConfigureAwait(false);
             var resSchema = await ReadSchemaAsync(resBuf, schema).ConfigureAwait(false);
 
-            return ReadTuple(resBuf, resSchema);
+            return ReadValueTuple(resBuf, resSchema, key);
         }
 
         /// <inheritdoc/>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -127,6 +127,12 @@ namespace Apache.Ignite.Internal.Table
         }
 
         /// <inheritdoc/>
+        public Task<IList<IIgniteTuple>> GetAllAsync(IEnumerable<IIgniteTuple> keys)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
         public async Task UpsertAsync(IIgniteTuple record)
         {
             IgniteArgumentCheck.NotNull(record, nameof(record));
@@ -159,6 +165,78 @@ namespace Apache.Ignite.Internal.Table
 
                 w.Flush();
             }
+        }
+
+        /// <inheritdoc/>
+        public Task UpsertAllAsync(IEnumerable<IIgniteTuple> records)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public Task<IIgniteTuple?> GetAndUpsertAsync(IIgniteTuple record)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> InsertAsync(IIgniteTuple record)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public Task<IList<IIgniteTuple>> InsertAllAsync(IEnumerable<IIgniteTuple> records)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> ReplaceAsync(IIgniteTuple oldRecord)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> ReplaceAsync(IIgniteTuple oldRecord, IIgniteTuple newRecord)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public Task<IIgniteTuple?> GetAndReplaceAsync(IIgniteTuple record)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> DeleteAsync(IIgniteTuple key)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> DeleteExactAsync(IIgniteTuple record)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public Task<IIgniteTuple?> GetAndDeleteAsync(IIgniteTuple key)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public Task<IList<IIgniteTuple>> DeleteAllAsync(IEnumerable<IIgniteTuple> keys)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public Task<IList<IIgniteTuple>> DeleteAllExactAsync(IEnumerable<IIgniteTuple> records)
+        {
+            throw new NotImplementedException();
         }
 
         private static int? ReadSchemaVersion(PooledBuffer buf)

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -133,12 +133,7 @@ namespace Apache.Ignite.Internal.Table
             var schema = await GetLatestSchemaAsync().ConfigureAwait(false);
 
             using var writer = new PooledArrayBufferWriter();
-            var count = WriteTuples(writer, schema, iterator);
-
-            if (count == 0)
-            {
-                return;
-            }
+            WriteTuples(writer, schema, iterator);
 
             using var resBuf = await _socket.DoOutInOpAsync(ClientOp.TupleUpsertAll, writer).ConfigureAwait(false);
         }
@@ -584,7 +579,7 @@ namespace Apache.Ignite.Internal.Table
             w.Flush();
         }
 
-        private int WriteTuples(
+        private void WriteTuples(
             PooledArrayBufferWriter buf,
             Schema schema,
             IEnumerator<IIgniteTuple> tuples,
@@ -616,8 +611,6 @@ namespace Apache.Ignite.Internal.Table
             buf.WriteInt32(countPos, count);
 
             w.Flush();
-
-            return count;
         }
 
         private void WriteTupleWithHeader(

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -539,7 +539,7 @@ namespace Apache.Ignite.Internal.Table
         {
             var w = buf.GetMessageWriter();
 
-            WriteTupleWithSchema(ref w, schema, tuple, keyOnly);
+            WriteTupleWithHeader(ref w, schema, tuple, keyOnly);
 
             w.Flush();
         }
@@ -553,8 +553,8 @@ namespace Apache.Ignite.Internal.Table
         {
             var w = buf.GetMessageWriter();
 
-            WriteTupleWithSchema(ref w, schema, t, keyOnly);
-            WriteTupleWithSchema(ref w, schema, t2, keyOnly);
+            WriteTupleWithHeader(ref w, schema, t, keyOnly);
+            WriteTupleWithHeader(ref w, schema, t2, keyOnly);
 
             w.Flush();
         }
@@ -590,7 +590,7 @@ namespace Apache.Ignite.Internal.Table
             w.Flush();
         }
 
-        private void WriteTupleWithSchema(
+        private void WriteTupleWithHeader(
             ref MessagePackWriter w,
             Schema schema,
             IIgniteTuple tuple,

--- a/modules/platforms/dotnet/Apache.Ignite/Table/ITableView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/ITableView.cs
@@ -97,24 +97,24 @@ namespace Apache.Ignite.Table
         /// <summary>
         /// Replaces a record with the same key columns if it exists.
         /// </summary>
-        /// <param name="oldRecord">Record to insert.</param>
+        /// <param name="record">Record to insert.</param>
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation.
         /// The task result contains a value indicating whether a record with the specified key was replaced.
         /// </returns>
-        Task<bool> ReplaceAsync(T oldRecord);
+        Task<bool> ReplaceAsync(T record);
 
         /// <summary>
         /// Replaces a record with a new one only if all existing columns have the same values
-        /// as the specified <paramref name="oldRecord"/>.
+        /// as the specified <paramref name="record"/>.
         /// </summary>
-        /// <param name="oldRecord">Record to replace.</param>
+        /// <param name="record">Record to replace.</param>
         /// <param name="newRecord">Record to replace with.</param>
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation.
         /// The task result contains a value indicating whether a record was replaced.
         /// </returns>
-        Task<bool> ReplaceAsync(T oldRecord, T newRecord);
+        Task<bool> ReplaceAsync(T record, T newRecord);
 
         /// <summary>
         /// Replaces a record with the same key columns if it exists.

--- a/modules/platforms/dotnet/Apache.Ignite/Table/ITableView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/ITableView.cs
@@ -106,7 +106,7 @@ namespace Apache.Ignite.Table
 
         /// <summary>
         /// Replaces a record with a new one only if all existing columns have the same values
-        /// as the specified <see cref="oldRecord"/>.
+        /// as the specified <paramref name="oldRecord"/>.
         /// </summary>
         /// <param name="oldRecord">Record to replace.</param>
         /// <param name="newRecord">Record to replace with.</param>
@@ -137,7 +137,7 @@ namespace Apache.Ignite.Table
         Task<bool> DeleteAsync(T key);
 
         /// <summary>
-        /// Deletes a record only if all existing columns have the same values as the specified <see cref="record"/>.
+        /// Deletes a record only if all existing columns have the same values as the specified <paramref name="record"/>.
         /// </summary>
         /// <param name="record">A record with all columns set.</param>
         /// <returns>
@@ -162,7 +162,7 @@ namespace Apache.Ignite.Table
         /// <param name="keys">Record keys to delete.</param>
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation.
-        /// The task result contains records from <see cref="keys"/> that did not exist.
+        /// The task result contains records from <paramref name="keys"/> that did not exist.
         /// </returns>
         Task<IList<T>> DeleteAllAsync(IEnumerable<T> keys);
 
@@ -172,7 +172,7 @@ namespace Apache.Ignite.Table
         /// <param name="records">Records to delete.</param>
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation.
-        /// The task result contains records from <see cref="records"/> that did not exist.
+        /// The task result contains records from <paramref name="records"/> that did not exist.
         /// </returns>
         Task<IList<T>> DeleteAllExactAsync(IEnumerable<T> records);
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Table/ITableView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/ITableView.cs
@@ -95,7 +95,7 @@ namespace Apache.Ignite.Table
         Task<IList<T>> InsertAllAsync(IEnumerable<T> records);
 
         /// <summary>
-        /// Replaces a record with the same key columns if it exists.
+        /// Replaces a record with the same key columns if it exists, otherwise does nothing.
         /// </summary>
         /// <param name="record">Record to insert.</param>
         /// <returns>
@@ -157,7 +157,7 @@ namespace Apache.Ignite.Table
         Task<T?> GetAndDeleteAsync(T key);
 
         /// <summary>
-        /// Deletes multiple records.
+        /// Deletes multiple records. If one or more keys do not exist, other records are still deleted.
         /// </summary>
         /// <param name="keys">Record keys to delete.</param>
         /// <returns>
@@ -167,7 +167,8 @@ namespace Apache.Ignite.Table
         Task<IList<T>> DeleteAllAsync(IEnumerable<T> keys);
 
         /// <summary>
-        /// Deletes multiple exactly matching records.
+        /// Deletes multiple exactly matching records.  If one or more records do not exist,
+        /// other records are still deleted.
         /// </summary>
         /// <param name="records">Records to delete.</param>
         /// <returns>

--- a/modules/platforms/dotnet/Apache.Ignite/Table/ITableView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/ITableView.cs
@@ -97,12 +97,24 @@ namespace Apache.Ignite.Table
         /// <summary>
         /// Replaces a record with the same key columns if it exists.
         /// </summary>
-        /// <param name="record">Record to insert.</param>
+        /// <param name="oldRecord">Record to insert.</param>
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation.
         /// The task result contains a value indicating whether a record with the specified key was replaced.
         /// </returns>
-        Task<bool> ReplaceAsync(T record);
+        Task<bool> ReplaceAsync(T oldRecord);
+
+        /// <summary>
+        /// Replaces a record with a new one only if all existing columns have the same values
+        /// as the specified <see cref="oldRecord"/>.
+        /// </summary>
+        /// <param name="oldRecord">Record to replace.</param>
+        /// <param name="newRecord">Record to replace with.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// The task result contains a value indicating whether a record was replaced.
+        /// </returns>
+        Task<bool> ReplaceAsync(T oldRecord, T newRecord);
 
         /// <summary>
         /// Replaces a record with the same key columns if it exists.
@@ -123,5 +135,15 @@ namespace Apache.Ignite.Table
         /// The task result contains a value indicating whether a record with the specified key was deleted.
         /// </returns>
         Task<bool> DeleteAsync(T key);
+
+        /// <summary>
+        /// Deletes a record only if all existing columns have the same values as the specified <see cref="record"/>.
+        /// </summary>
+        /// <param name="record">A record with all columns set.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// The task result contains a value indicating whether a record was deleted.
+        /// </returns>
+        Task<bool> DeleteExactAsync(T record);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Table/ITableView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/ITableView.cs
@@ -165,5 +165,15 @@ namespace Apache.Ignite.Table
         /// The task result contains records from <see cref="keys"/> that did not exist.
         /// </returns>
         Task<IList<T>> DeleteAllAsync(IEnumerable<T> keys);
+
+        /// <summary>
+        /// Deletes multiple exactly matching records.
+        /// </summary>
+        /// <param name="records">Records to delete.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// The task result contains records from <see cref="records"/> that did not exist.
+        /// </returns>
+        Task<IList<T>> DeleteAllExactAsync(IEnumerable<T> records);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Table/ITableView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/ITableView.cs
@@ -145,5 +145,25 @@ namespace Apache.Ignite.Table
         /// The task result contains a value indicating whether a record was deleted.
         /// </returns>
         Task<bool> DeleteExactAsync(T record);
+
+        /// <summary>
+        /// Gets and deletes a record with the specified key.
+        /// </summary>
+        /// <param name="key">A record with key columns set.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// The task result contains deleted record or <c>null</c> if it did not exist.
+        /// </returns>
+        Task<T?> GetAndDeleteAsync(T key);
+
+        /// <summary>
+        /// Deletes multiple records.
+        /// </summary>
+        /// <param name="keys">Record keys to delete.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// The task result contains records from <see cref="keys"/> that did not exist.
+        /// </returns>
+        Task<IList<T>> DeleteAllAsync(IEnumerable<T> keys);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Table
 {
     using System.Collections.Generic;
+    using System.Text;
 
     /// <summary>
     /// Ignite tuple.
@@ -76,5 +77,27 @@ namespace Apache.Ignite.Table
 
         /// <inheritdoc/>
         public int GetOrdinal(string name) => _indexes.TryGetValue(name, out var index) ? index : -1;
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+
+            sb.Append(nameof(IgniteTuple)).Append(" [");
+
+            for (var i = 0; i < FieldCount; i++)
+            {
+                if (i > 0)
+                {
+                    sb.Append(", ");
+                }
+
+                sb.Append(GetName(i)).Append('=').Append(this[i]);
+            }
+
+            sb.Append(']');
+
+            return sb.ToString();
+        }
     }
 }

--- a/modules/storage-api/src/main/java/org/apache/ignite/internal/storage/Storage.java
+++ b/modules/storage-api/src/main/java/org/apache/ignite/internal/storage/Storage.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.storage;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import org.apache.ignite.internal.util.Cursor;
@@ -48,7 +49,7 @@ public interface Storage extends AutoCloseable {
      * @return Data rows.
      * @throws StorageException If failed to read the data or the storage is already stopped.
      */
-    public Collection<DataRow> readAll(Collection<? extends SearchRow> keys);
+    public Collection<DataRow> readAll(List<? extends SearchRow> keys);
 
     /**
      * Writes a DataRow into the storage.
@@ -64,7 +65,7 @@ public interface Storage extends AutoCloseable {
      * @param rows Data rows.
      * @throws StorageException If failed to write the data or the storage is already stopped.
      */
-    public void writeAll(Collection<? extends DataRow> rows) throws StorageException;
+    public void writeAll(List<? extends DataRow> rows) throws StorageException;
 
     /**
      * Inserts a collection of {@link DataRow}s into the storage and returns a collection of rows that
@@ -74,7 +75,7 @@ public interface Storage extends AutoCloseable {
      * @return Collection of rows that could not be inserted.
      * @throws StorageException If failed to write the data or the storage is already stopped.
      */
-    public Collection<DataRow> insertAll(Collection<? extends DataRow> rows) throws StorageException;
+    public Collection<DataRow> insertAll(List<? extends DataRow> rows) throws StorageException;
 
     /**
      * Removes a DataRow associated with a given Key.
@@ -91,7 +92,7 @@ public interface Storage extends AutoCloseable {
      * @return List of skipped data rows.
      * @throws StorageException If failed to remove the data or the storage is already stopped.
      */
-    public Collection<DataRow> removeAll(Collection<? extends SearchRow> keys);
+    public Collection<SearchRow> removeAll(List<? extends SearchRow> keys);
 
     /**
      * Removes {@link DataRow}s mapped by given keys and containing given values.
@@ -100,7 +101,7 @@ public interface Storage extends AutoCloseable {
      * @return List of skipped data rows.
      * @throws StorageException If failed to remove the data or the storage is already stopped.
      */
-    public Collection<DataRow> removeAllExact(Collection<? extends DataRow> keyValues);
+    public Collection<DataRow> removeAllExact(List<? extends DataRow> keyValues);
 
     /**
      * Executes an update with custom logic implemented by storage.UpdateClosure interface.

--- a/modules/storage-api/src/main/java/org/apache/ignite/internal/storage/Storage.java
+++ b/modules/storage-api/src/main/java/org/apache/ignite/internal/storage/Storage.java
@@ -88,7 +88,7 @@ public interface Storage extends AutoCloseable {
      * Removes {@link DataRow}s mapped by given keys.
      *
      * @param keys Search rows.
-     * @return List of removed data rows.
+     * @return List of skipped data rows.
      * @throws StorageException If failed to remove the data or the storage is already stopped.
      */
     public Collection<DataRow> removeAll(Collection<? extends SearchRow> keys);
@@ -97,7 +97,7 @@ public interface Storage extends AutoCloseable {
      * Removes {@link DataRow}s mapped by given keys and containing given values.
      *
      * @param keyValues Data rows.
-     * @return List of removed data rows.
+     * @return List of skipped data rows.
      * @throws StorageException If failed to remove the data or the storage is already stopped.
      */
     public Collection<DataRow> removeAllExact(Collection<? extends DataRow> keyValues);

--- a/modules/storage-api/src/main/java/org/apache/ignite/internal/storage/basic/ConcurrentHashMapStorage.java
+++ b/modules/storage-api/src/main/java/org/apache/ignite/internal/storage/basic/ConcurrentHashMapStorage.java
@@ -87,37 +87,36 @@ public class ConcurrentHashMapStorage implements Storage {
 
     /** {@inheritDoc} */
     @Override public Collection<DataRow> removeAll(Collection<? extends SearchRow> keys) {
-        var deletedRows = new ArrayList<DataRow>(keys.size());
+        var skippedRows = new ArrayList<DataRow>(keys.size());
 
         for (SearchRow key : keys) {
             byte[] keyBytes = key.keyBytes();
 
             byte[] removedValueBytes = map.remove(new ByteArray(keyBytes));
 
-            if (removedValueBytes != null)
-                deletedRows.add(new SimpleDataRow(keyBytes, removedValueBytes));
+            if (removedValueBytes == null)
+                skippedRows.add(new SimpleDataRow(keyBytes, removedValueBytes));
         }
 
-        return deletedRows;
+        return skippedRows;
     }
 
     /** {@inheritDoc} */
     @Override public Collection<DataRow> removeAllExact(Collection<? extends DataRow> keyValues) {
-        var deletedRows = new ArrayList<DataRow>(keyValues.size());
+        var skippedRows = new ArrayList<DataRow>(keyValues.size());
 
         for (DataRow row : keyValues) {
             var key = new ByteArray(row.keyBytes());
 
             byte[] existingValueBytes = map.get(key);
 
-            if (Arrays.equals(existingValueBytes, row.valueBytes())) {
+            if (Arrays.equals(existingValueBytes, row.valueBytes()))
                 map.remove(key);
-
-                deletedRows.add(row);
-            }
+            else
+                skippedRows.add(row);
         }
 
-        return deletedRows;
+        return skippedRows;
     }
 
     /** {@inheritDoc} */

--- a/modules/storage-api/src/main/java/org/apache/ignite/internal/storage/basic/ConcurrentHashMapStorage.java
+++ b/modules/storage-api/src/main/java/org/apache/ignite/internal/storage/basic/ConcurrentHashMapStorage.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -55,7 +56,7 @@ public class ConcurrentHashMapStorage implements Storage {
     }
 
     /** {@inheritDoc} */
-    @Override public Collection<DataRow> readAll(Collection<? extends SearchRow> keys) {
+    @Override public Collection<DataRow> readAll(List<? extends SearchRow> keys) {
         return keys.stream()
             .map(this::read)
             .filter(Objects::nonNull)
@@ -68,12 +69,12 @@ public class ConcurrentHashMapStorage implements Storage {
     }
 
     /** {@inheritDoc} */
-    @Override public void writeAll(Collection<? extends DataRow> rows) throws StorageException {
+    @Override public void writeAll(List<? extends DataRow> rows) throws StorageException {
         rows.forEach(this::write);
     }
 
     /** {@inheritDoc} */
-    @Override public Collection<DataRow> insertAll(Collection<? extends DataRow> rows) throws StorageException {
+    @Override public Collection<DataRow> insertAll(List<? extends DataRow> rows) throws StorageException {
         return rows.stream()
             .map(row -> map.putIfAbsent(new ByteArray(row.keyBytes()), row.valueBytes()) == null ? null : row)
             .filter(Objects::nonNull)
@@ -86,8 +87,8 @@ public class ConcurrentHashMapStorage implements Storage {
     }
 
     /** {@inheritDoc} */
-    @Override public Collection<DataRow> removeAll(Collection<? extends SearchRow> keys) {
-        var skippedRows = new ArrayList<DataRow>(keys.size());
+    @Override public Collection<SearchRow> removeAll(List<? extends SearchRow> keys) {
+        var skippedRows = new ArrayList<SearchRow>(keys.size());
 
         for (SearchRow key : keys) {
             byte[] keyBytes = key.keyBytes();
@@ -95,14 +96,14 @@ public class ConcurrentHashMapStorage implements Storage {
             byte[] removedValueBytes = map.remove(new ByteArray(keyBytes));
 
             if (removedValueBytes == null)
-                skippedRows.add(new SimpleDataRow(keyBytes, removedValueBytes));
+                skippedRows.add(key);
         }
 
         return skippedRows;
     }
 
     /** {@inheritDoc} */
-    @Override public Collection<DataRow> removeAllExact(Collection<? extends DataRow> keyValues) {
+    @Override public Collection<DataRow> removeAllExact(List<? extends DataRow> keyValues) {
         var skippedRows = new ArrayList<DataRow>(keyValues.size());
 
         for (DataRow row : keyValues) {

--- a/modules/storage-api/src/test/java/org/apache/ignite/internal/storage/AbstractStorageTest.java
+++ b/modules/storage-api/src/test/java/org/apache/ignite/internal/storage/AbstractStorageTest.java
@@ -459,7 +459,7 @@ public abstract class AbstractStorageTest {
     }
 
     /**
-     * Tests the {@link Storage#readAll(Collection)} operation successfully reads data rows from the storage.
+     * Tests the {@link Storage#readAll(List)} operation successfully reads data rows from the storage.
      */
     @Test
     public void testReadAll() {
@@ -477,7 +477,7 @@ public abstract class AbstractStorageTest {
     }
 
     /**
-     * Tests that {@link Storage#writeAll(Collection)} operation successfully writes a collection of data rows into the
+     * Tests that {@link Storage#writeAll(List)} operation successfully writes a collection of data rows into the
      * storage.
      */
     @Test
@@ -491,7 +491,7 @@ public abstract class AbstractStorageTest {
     }
 
     /**
-     * Tests that {@link Storage#insertAll(Collection)} operation doesn't insert data rows which keys
+     * Tests that {@link Storage#insertAll(List)} operation doesn't insert data rows which keys
      * are already present in the storage. This operation must also return the list of such data rows.
      */
     @Test
@@ -511,16 +511,16 @@ public abstract class AbstractStorageTest {
     }
 
     /**
-     * Tests that {@link Storage#removeAll(Collection)} operation successfully retrieves and removes a collection of
+     * Tests that {@link Storage#removeAll(List)} operation successfully retrieves and removes a collection of
      * {@link SearchRow}s.
      */
     @Test
     public void testRemoveAll() throws Exception {
         List<DataRow> rows = insertBulk(100);
 
-        Collection<DataRow> removed = storage.removeAll(rows);
+        Collection<SearchRow> skipped = storage.removeAll(rows);
 
-        assertEquals(rows, removed);
+        assertEquals(0, skipped.size());
 
         Cursor<DataRow> scan = storage.scan(row -> true);
 
@@ -531,24 +531,26 @@ public abstract class AbstractStorageTest {
 
     @Test
     public void testRemoveAllKeyNotExists() {
-        Collection<DataRow> removed = storage.removeAll(Collections.singleton(searchRow(KEY)));
+        SearchRow row = searchRow(KEY);
+        Collection<SearchRow> skipped = storage.removeAll(Collections.singletonList(row));
 
-        assertNotNull(removed);
+        assertNotNull(skipped);
 
-        assertTrue(removed.isEmpty());
+        assertEquals(1, skipped.size());
+        assertEquals(row, skipped.iterator().next());
     }
 
     /**
-     * Tests that {@link Storage#removeAllExact(Collection)} operation successfully removes and retrieves a collection
+     * Tests that {@link Storage#removeAllExact(List)} operation successfully removes and retrieves a collection
      * of data rows with the given exact keys and values from the storage.
      */
     @Test
     public void testRemoveAllExact() throws Exception {
         List<DataRow> rows = insertBulk(100);
 
-        Collection<DataRow> removed = storage.removeAllExact(rows);
+        Collection<DataRow> skipped = storage.removeAllExact(rows);
 
-        assertEquals(rows, removed);
+        assertEquals(0, skipped.size());
 
         Cursor<DataRow> scan = storage.scan(row -> true);
 
@@ -558,7 +560,7 @@ public abstract class AbstractStorageTest {
     }
 
     /**
-     * Tests that {@link Storage#removeAllExact(Collection)} operation doesn't remove and retrieve a collection
+     * Tests that {@link Storage#removeAllExact(List)} operation doesn't remove and retrieve a collection
      * of data rows with the given exact keys and values from the storage if the value in the storage doesn't match
      * the given value.
      */
@@ -570,9 +572,9 @@ public abstract class AbstractStorageTest {
             .mapToObj(i -> dataRow(KEY + i, VALUE + (i + 1)))
             .collect(Collectors.toList());
 
-        Collection<DataRow> removed = storage.removeAllExact(notExactRows);
+        Collection<DataRow> skipped = storage.removeAllExact(notExactRows);
 
-        assertEquals(0, removed.size());
+        assertEquals(notExactRows, skipped);
 
         rows.forEach(this::checkHasSameEntry);
     }

--- a/modules/storage-rocksdb/src/main/java/org/apache/ignite/internal/storage/rocksdb/RocksDbStorage.java
+++ b/modules/storage-rocksdb/src/main/java/org/apache/ignite/internal/storage/rocksdb/RocksDbStorage.java
@@ -264,7 +264,7 @@ public class RocksDbStorage implements Storage {
     }
 
     /** {@inheritDoc} */
-    @Override public List<SearchRow> removeAll(List<? extends SearchRow> keys) {
+    @Override public Collection<SearchRow> removeAll(List<? extends SearchRow> keys) {
         List<SearchRow> skippedRows = new ArrayList<>();
 
         try (WriteBatch batch = new WriteBatch();

--- a/modules/storage-rocksdb/src/main/java/org/apache/ignite/internal/storage/rocksdb/RocksDbStorage.java
+++ b/modules/storage-rocksdb/src/main/java/org/apache/ignite/internal/storage/rocksdb/RocksDbStorage.java
@@ -267,7 +267,7 @@ public class RocksDbStorage implements Storage {
 
     /** {@inheritDoc} */
     @Override public Collection<DataRow> removeAll(Collection<? extends SearchRow> keys) {
-        List<DataRow> res = new ArrayList<>();
+        List<DataRow> skippedRows = new ArrayList<>();
 
         try (WriteBatch batch = new WriteBatch();
              WriteOptions opts = new WriteOptions()) {
@@ -277,11 +277,10 @@ public class RocksDbStorage implements Storage {
 
                 byte[] value = data.get(keyBytes);
 
-                if (value != null) {
-                    res.add(new SimpleDataRow(keyBytes, value));
-
+                if (value != null)
                     data.delete(batch, keyBytes);
-                }
+                else
+                    skippedRows.add(new SimpleDataRow(keyBytes, value));
             }
 
             db.write(opts, batch);
@@ -290,12 +289,12 @@ public class RocksDbStorage implements Storage {
             throw new StorageException("Failed to remove data from the storage", e);
         }
 
-        return res;
+        return skippedRows;
     }
 
     /** {@inheritDoc} */
     @Override public Collection<DataRow> removeAllExact(Collection<? extends DataRow> keyValues) {
-        List<DataRow> res = new ArrayList<>();
+        List<DataRow> skippedRows = new ArrayList<>();
 
         try (WriteBatch batch = new WriteBatch();
              WriteOptions opts = new WriteOptions()) {
@@ -320,11 +319,10 @@ public class RocksDbStorage implements Storage {
                 byte[] expectedValue = expectedValues.get(i);
                 byte[] value = values.get(i);
 
-                if (Arrays.equals(value, expectedValue)) {
-                    res.add(new SimpleDataRow(key, value));
-
+                if (Arrays.equals(value, expectedValue))
                     data.delete(batch, key);
-                }
+                else
+                    skippedRows.add(new SimpleDataRow(key, value));
             }
 
             db.write(opts, batch);
@@ -333,7 +331,7 @@ public class RocksDbStorage implements Storage {
             throw new StorageException("Failed to remove data from the storage", e);
         }
 
-        return res;
+        return skippedRows;
     }
 
     /** {@inheritDoc} */

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/raft/PartitionListener.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/raft/PartitionListener.java
@@ -283,7 +283,7 @@ public class PartitionListener implements RaftGroupListener {
             .collect(Collectors.toList());
 
         List<BinaryRow> res = storage.removeAll(keys).stream()
-            .map(skipped -> new ByteBufferRow(skipped.keyBytes()))
+            .map(skipped -> ((BinarySearchRow)skipped).sourceRow)
             .collect(Collectors.toList());
 
         clo.result(new MultiRowsResponse(res));
@@ -461,12 +461,16 @@ public class PartitionListener implements RaftGroupListener {
         /** Search key. */
         private final byte[] keyBytes;
 
+        /** Source row. */
+        private final BinaryRow sourceRow;
+
         /**
          * Constructor.
          *
          * @param row Row to search for.
          */
         BinarySearchRow(BinaryRow row) {
+            sourceRow = row;
             keyBytes = new byte[row.keySlice().capacity()];
 
             row.keySlice().get(keyBytes);

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/raft/PartitionListener.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/raft/PartitionListener.java
@@ -283,7 +283,7 @@ public class PartitionListener implements RaftGroupListener {
             .collect(Collectors.toList());
 
         List<BinaryRow> res = storage.removeAll(keys).stream()
-            .map(skipped -> new ByteBufferRow(skipped.valueBytes()))
+            .map(skipped -> new ByteBufferRow(skipped.keyBytes()))
             .collect(Collectors.toList());
 
         clo.result(new MultiRowsResponse(res));

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/raft/PartitionListener.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/raft/PartitionListener.java
@@ -243,7 +243,7 @@ public class PartitionListener implements RaftGroupListener {
             .collect(Collectors.toList());
 
         List<BinaryRow> res = storage.insertAll(keyValues).stream()
-            .map(inserted -> new ByteBufferRow(inserted.valueBytes()))
+            .map(skipped -> new ByteBufferRow(skipped.valueBytes()))
             .collect(Collectors.toList());
 
         clo.result(new MultiRowsResponse(res));
@@ -283,7 +283,7 @@ public class PartitionListener implements RaftGroupListener {
             .collect(Collectors.toList());
 
         List<BinaryRow> res = storage.removeAll(keys).stream()
-            .map(removed -> new ByteBufferRow(removed.valueBytes()))
+            .map(skipped -> new ByteBufferRow(skipped.valueBytes()))
             .collect(Collectors.toList());
 
         clo.result(new MultiRowsResponse(res));
@@ -323,7 +323,7 @@ public class PartitionListener implements RaftGroupListener {
             .collect(Collectors.toList());
 
         List<BinaryRow> res = storage.removeAllExact(keyValues).stream()
-            .map(inserted -> new ByteBufferRow(inserted.valueBytes()))
+            .map(skipped -> new ByteBufferRow(skipped.valueBytes()))
             .collect(Collectors.toList());
 
         clo.result(new MultiRowsResponse(res));

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/storage/InternalTableImpl.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/storage/InternalTableImpl.java
@@ -17,10 +17,12 @@
 
 package org.apache.ignite.internal.table.distributed.storage;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -134,11 +136,18 @@ public class InternalTableImpl implements InternalTable {
         }
 
         return CompletableFuture.allOf(futures)
-            .thenApply(response -> Arrays.stream(futures)
-                .map(CompletableFuture::join)
-                .map(MultiRowsResponse::getValues)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList()));
+            .thenApply(response -> {
+                List<BinaryRow> list = new ArrayList<>(futures.length);
+
+                for (CompletableFuture<MultiRowsResponse> future : futures) {
+                    Collection<BinaryRow> values = future.join().getValues();
+
+                    if (values != null)
+                        list.addAll(values);
+                }
+
+                return list;
+            });
     }
 
     /** {@inheritDoc} */

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/storage/InternalTableImpl.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/storage/InternalTableImpl.java
@@ -34,6 +34,7 @@ import org.apache.ignite.internal.table.distributed.command.DeleteExactAllComman
 import org.apache.ignite.internal.table.distributed.command.DeleteExactCommand;
 import org.apache.ignite.internal.table.distributed.command.GetAllCommand;
 import org.apache.ignite.internal.table.distributed.command.GetAndDeleteCommand;
+import org.apache.ignite.internal.table.distributed.command.GetAndReplaceCommand;
 import org.apache.ignite.internal.table.distributed.command.GetAndUpsertCommand;
 import org.apache.ignite.internal.table.distributed.command.GetCommand;
 import org.apache.ignite.internal.table.distributed.command.InsertAllCommand;
@@ -210,7 +211,7 @@ public class InternalTableImpl implements InternalTable {
 
     /** {@inheritDoc} */
     @Override public CompletableFuture<BinaryRow> getAndReplace(BinaryRow row, Transaction tx) {
-        return partitionMap.get(partId(row)).<SingleRowResponse>run(new ReplaceIfExistCommand(row))
+        return partitionMap.get(partId(row)).<SingleRowResponse>run(new GetAndReplaceCommand(row))
             .thenApply(SingleRowResponse::getValue);
     }
 

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/raft/PartitionCommandListenerTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/raft/PartitionCommandListenerTest.java
@@ -362,7 +362,7 @@ public class PartitionCommandListenerTest {
             doAnswer(invocation -> {
                 MultiRowsResponse resp = invocation.getArgument(0);
 
-                if (existed) {
+                if (!existed) {
                     assertEquals(KEY_COUNT, resp.getValues().size());
 
                     for (BinaryRow binaryRow : resp.getValues()) {
@@ -371,7 +371,6 @@ public class PartitionCommandListenerTest {
                         int keyVal = row.intValue(0);
 
                         assertTrue(keyVal < KEY_COUNT);
-                        assertEquals(keyVal, row.intValue(1));
                     }
                 }
                 else
@@ -524,7 +523,7 @@ public class PartitionCommandListenerTest {
             doAnswer(invocation -> {
                 MultiRowsResponse resp = invocation.getArgument(0);
 
-                if (existed) {
+                if (!existed) {
                     assertEquals(KEY_COUNT, resp.getValues().size());
 
                     for (BinaryRow binaryRow : resp.getValues()) {


### PR DESCRIPTION
* Add and implement all known methods in `ITableView`.
* Fix NPE in `InternalTableImpl`: `getAll`, `insertAll`, `deleteAll`. Reuse multirow processing logic.
* Invert `Storage#removeAll` and `removeAllExact` logic: return skipped rows so that `deleteAll`/`deleteAllExact` public API works as specified in the Javadoc.
* Refactor `Storage` to accept `List` instead of `Collection` to simplify implementation and reduce allocations.