### PR TITLE
IGNITE-15670 .NET: Fix ClientSocketTests flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -39,7 +39,7 @@ namespace Apache.Ignite.Tests
         private const string MavenCommandExec = "exec:java@platform-test-node-runner";
 
         /** Maven arg to perform a dry run to ensure that code is compiled and all artifacts are downloaded. */
-        private const string MavenCommandDryRunArg = "-Dexec.args=dry-run";
+        private const string MavenCommandDryRunArg = " -Dexec.args=dry-run";
 
         /** Full path to Maven binary. */
         private static readonly string MavenPath = GetMaven();
@@ -155,7 +155,8 @@ namespace Apache.Ignite.Tests
             process.BeginErrorReadLine();
             process.BeginOutputReadLine();
 
-            if (!process.WaitForExit(300_000))
+            // 5 min timeout for the build process (may take time to download artifacts on slow networks).
+            if (!process.WaitForExit(5 * 60_000))
             {
                 process.Kill();
                 throw new Exception("Failed to wait for Maven exec dry run.");

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -38,7 +38,7 @@ namespace Apache.Ignite.Tests
         /** Maven command to execute the main class. */
         private const string MavenCommandExec = "exec:java@platform-test-node-runner";
 
-        /** Maven arg to perform a dry run to ensure that code is compiled. */
+        /** Maven arg to perform a dry run to ensure that code is compiled and all artifacts are downloaded. */
         private const string MavenCommandDryRunArg = "-Dexec.args=dry-run";
 
         /** Full path to Maven binary. */

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -33,6 +33,8 @@ namespace Apache.Ignite.Tests
     {
         private const int DefaultClientPort = 10942;
 
+        private const int ConnectTimeoutSeconds = 20;
+
         /** Maven command to execute the main class. */
         private const string MavenCommandExec = "exec:java@platform-test-node-runner";
 
@@ -115,7 +117,7 @@ namespace Apache.Ignite.Tests
 
             var port = ports?.FirstOrDefault() ?? DefaultClientPort;
 
-            if (!evt.Wait(TimeSpan.FromSeconds(15)) || !WaitForServer(port))
+            if (!evt.Wait(TimeSpan.FromSeconds(ConnectTimeoutSeconds)) || !WaitForServer(port))
             {
                 process.Kill(true);
 
@@ -148,7 +150,7 @@ namespace Apache.Ignite.Tests
 
             try
             {
-                return TryConnectForever(port, cts.Token).Wait(TimeSpan.FromSeconds(15));
+                return TryConnectForever(port, cts.Token).Wait(TimeSpan.FromSeconds(ConnectTimeoutSeconds));
             }
             finally
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -72,6 +72,7 @@ namespace Apache.Ignite.Tests
 
             Log(">>> Java server is not detected, starting...");
 
+            EnsureBuild();
             var process = CreateProcess();
 
             var evt = new ManualResetEventSlim(false);
@@ -122,7 +123,11 @@ namespace Apache.Ignite.Tests
             _process?.Dispose();
         }
 
-        private static void ExecDryRun()
+        /// <summary>
+        /// Performs a dry run of the Maven executable to ensure that code is compiled and all artifacts are downloaded.
+        /// Does not start the actual node.
+        /// </summary>
+        private static void EnsureBuild()
         {
             if (_dryRunComplete)
             {

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -48,6 +48,9 @@ public class PlatformTestNodeRunner {
     /** */
     private static final String TABLE_NAME = "tbl1";
 
+    /** Time to keep the node alive. */
+    private static final int RUN_TIME_MINUTES = 30;
+
     /** Nodes bootstrap configuration. */
     private static final Map<String, String> nodesBootstrapCfg = new LinkedHashMap<>() {{
         put(NODE_NAME, "{\n" +
@@ -70,6 +73,12 @@ public class PlatformTestNodeRunner {
      * @param args Args.
      */
     public static void main(String[] args) throws Exception {
+        System.out.println("Starting test node runner...");
+
+        for (int i = 0; i < args.length; i++) {
+            System.out.println("Arg " + i + ": " + args[i]);
+        }
+
         if (args.length > 0 && "dry-run".equals(args[0]))
         {
             System.out.println("Dry run succeeded.");
@@ -105,7 +114,9 @@ public class PlatformTestNodeRunner {
 
         System.out.println("THIN_CLIENT_PORTS=" + ports);
 
-        Thread.sleep(Long.MAX_VALUE);
+        Thread.sleep(RUN_TIME_MINUTES * 60_000);
+
+        System.out.println("Exiting after " + RUN_TIME_MINUTES + " minutes.");
     }
 
     /**

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -70,6 +70,12 @@ public class PlatformTestNodeRunner {
      * @param args Args.
      */
     public static void main(String[] args) throws Exception {
+        if (args.length > 0 && "dry-run".equals(args[0]))
+        {
+            System.out.println("Dry run succeeded.");
+            return;
+        }
+
         IgniteUtils.deleteIfExists(BASE_PATH);
         Files.createDirectories(BASE_PATH);
 


### PR DESCRIPTION
`mvn exec` downloads artifacts on the first run, which may cause node start timeout when the network is slow. Perform a separate, dry run of the command with a bigger timeout to download artifacts and compile the code with a bigger timeout (5 minutes). Then start the node with a smaller timeout.