### PR TITLE
IGNITE-15027 provide human-readable error when start single-node cluster without hosting meta storage

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/testframework/IgniteTestUtils.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/testframework/IgniteTestUtils.java
@@ -160,7 +160,7 @@ public final class IgniteTestUtils {
      * @return {@code True} if one of the causing exception is an instance of passed in classes,
      *      {@code false} otherwise.
      */
-    private static boolean hasCause(
+    public static boolean hasCause(
         @NotNull Throwable t,
         @NotNull Class<?> cls,
         @Nullable String msg

--- a/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/MetaStorageManager.java
+++ b/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/MetaStorageManager.java
@@ -52,6 +52,7 @@ import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.vault.VaultManager;
 import org.apache.ignite.lang.ByteArray;
 import org.apache.ignite.lang.IgniteBiTuple;
+import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.lang.IgniteInternalException;
 import org.apache.ignite.lang.IgniteLogger;
 import org.apache.ignite.lang.IgniteUuid;
@@ -175,6 +176,12 @@ public class MetaStorageManager implements IgniteComponent {
             List<ClusterNode> metaStorageMembers = clusterNetSvc.topologyService().allMembers().stream()
                 .filter(metaStorageNodesContainsLocPred)
                 .collect(Collectors.toList());
+
+            // TODO: This is temporary solution for providing human-readable error when you try to start single-node cluster
+            // without hosting metastorage, this will be rewritten in init phase https://issues.apache.org/jira/browse/IGNITE-14414
+            if (metaStorageMembers.isEmpty())
+                throw new IgniteException(
+                    "Cannot start meta storage manager because there is no node in the cluster that hosts meta storage.");
 
             storage.start();
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ITIgnitionTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ITIgnitionTest.java
@@ -25,9 +25,11 @@ import java.util.Map;
 import com.google.common.collect.Lists;
 import org.apache.ignite.app.Ignite;
 import org.apache.ignite.app.IgnitionManager;
+import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.internal.testframework.WorkDirectory;
 import org.apache.ignite.internal.testframework.WorkDirectoryExtension;
 import org.apache.ignite.internal.util.IgniteUtils;
+import org.apache.ignite.lang.IgniteException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +38,8 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.testNodeName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Ignition interface tests.
@@ -124,5 +128,89 @@ class ITIgnitionTest {
         startedNodes.add(IgnitionManager.start(testNodeName(testInfo, 47500), null, workDir));
 
         Assertions.assertNotNull(startedNodes.get(0));
+    }
+
+    /**
+     * Tests scenario when we try to start cluster with single node, but without any node, that hosts metastorage.
+     */
+    @Test
+    void testErrorWhenStartSingleNodeClusterWithoutMetastorage() throws Exception {
+        Ignite ig = null;
+
+        try {
+        ig = IgnitionManager.start("other-name", "{\n" +
+            "    \"node\": {\n" +
+            "        \"metastorageNodes\": [\n" +
+            "            \"node-0\", \"node-1\", \"node-2\"\n" +
+            "        ]\n" +
+            "    },\n" +
+            "    \"network\": {\n" +
+            "        \"port\": 3344,\n" +
+            "        \"netClusterNodes\": [\n" +
+            "            \"localhost:3344\"\n" +
+            "        ]\n" +
+            "    }\n" +
+            "}", workDir.resolve("other-name"));
+        }
+        catch (Throwable th) {
+            assertTrue(IgniteTestUtils.hasCause(th,
+                IgniteException.class,
+                "Cannot start meta storage manager because there is no node in the cluster that hosts meta storage."
+            ));
+        }
+        finally {
+            if (ig != null)
+                IgniteUtils.closeAll(ig);
+        }
+    }
+
+    /**
+     * Tests scenario when we try to start node that doesn't host metastorage in cluster with node, that hosts
+     * metastorage.
+     */
+    @Test
+    void testStartNodeClusterWithoutMetastorage() throws Exception {
+        Ignite ig1 = null;
+
+        Ignite ig2 = null;
+
+        try {
+            ig1 = IgnitionManager.start("node-0", "{\n" +
+                "    \"node\": {\n" +
+                "        \"metastorageNodes\": [\n" +
+                "            \"node-0\", \"node-1\", \"node-2\"\n" +
+                "        ]\n" +
+                "    },\n" +
+                "    \"network\": {\n" +
+                "        \"port\": 3344,\n" +
+                "        \"netClusterNodes\": [\n" +
+                "            \"localhost:3344\"\n" +
+                "        ]\n" +
+                "    }\n" +
+                "}", workDir.resolve("node-0"));
+
+            ig2 = IgnitionManager.start("other-name", "{\n" +
+                "    \"node\": {\n" +
+                "        \"metastorageNodes\": [\n" +
+                "            \"node-0\", \"node-1\", \"node-2\"\n" +
+                "        ]\n" +
+                "    },\n" +
+                "    \"network\": {\n" +
+                "        \"port\": 3344,\n" +
+                "        \"netClusterNodes\": [\n" +
+                "            \"localhost:3344\"\n" +
+                "        ]\n" +
+                "    }\n" +
+                "}", workDir.resolve("other-name"));
+
+            assertEquals(ig2.name(), "other-name");
+        }
+        finally {
+            if (ig1 != null)
+                IgniteUtils.closeAll(ig1);
+
+            if (ig2 != null)
+                IgniteUtils.closeAll(ig2);
+        }
     }
 }

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/IgnitionImpl.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/IgnitionImpl.java
@@ -138,7 +138,14 @@ public class IgnitionImpl implements Ignition {
 
         ackBanner();
 
-        nodeToStart.start(cfgContent);
+        try {
+            nodeToStart.start(cfgContent);
+        }
+        catch (Exception e) {
+            nodes.remove(nodeName);
+
+            throw new IgniteException(e);
+        }
 
         ackSuccessStart();
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-15027