### PR TITLE
IGNITE-16093 Thin client: Handle absent and null values differently

### DIFF
--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageCommon.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageCommon.java
@@ -26,4 +26,7 @@ public class ClientMessageCommon {
 
     /** Magic bytes before handshake. */
     public static final byte[] MAGIC_BYTES = new byte[]{0x49, 0x47, 0x4E, 0x49}; // IGNI
+
+    /** Special "no value" object. */
+    public static final Object NO_VALUE = new Object();
 }

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.client.proto;
 
 import static org.apache.ignite.internal.client.proto.ClientMessageCommon.HEADER_SIZE;
+import static org.apache.ignite.internal.client.proto.ClientMessageCommon.NO_VALUE;
 import static org.msgpack.core.MessagePack.Code;
 
 import io.netty.buffer.ByteBuf;
@@ -655,6 +656,12 @@ public class ClientMessagePacker implements AutoCloseable {
     public void packObject(Object val) {
         if (val == null) {
             packNil();
+
+            return;
+        }
+
+        if (val == NO_VALUE) {
+            packNoValue();
 
             return;
         }

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
@@ -82,6 +82,17 @@ public class ClientMessagePacker implements AutoCloseable {
     }
 
     /**
+     * Writes a "no value" value.
+     */
+    public void packNoValue() {
+        assert !closed : "Packer is closed";
+
+        buf.writeByte(Code.FIXEXT1);
+        buf.writeByte(ClientMsgPackType.NO_VALUE);
+        buf.writeByte(0);
+    }
+
+    /**
      * Writes a boolean value.
      *
      * @param b the value to be written.

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
@@ -548,6 +548,29 @@ public class ClientMessageUnpacker implements AutoCloseable {
     }
 
     /**
+     * Tries to read a "no value" value.
+     *
+     * @return True when there was a "no value" value, false otherwise.
+     */
+    public boolean tryUnpackNoValue() {
+        assert refCnt > 0 : "Unpacker is closed";
+
+        int idx = buf.readerIndex();
+        byte code = buf.getByte(idx);
+
+        if (code == Code.FIXEXT1) {
+            byte extCode = buf.getByte(idx + 1);
+
+            if (extCode == ClientMsgPackType.NO_VALUE) {
+                buf.readerIndex(idx + 3);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Reads a payload.
      *
      * @param length Payload size.

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMsgPackType.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMsgPackType.java
@@ -47,4 +47,7 @@ public class ClientMsgPackType {
 
     /** Ignite UUID. */
     public static final byte IGNITE_UUID = 9;
+
+    /** Absent value for a column. */
+    public static final byte NO_VALUE = 10;
 }

--- a/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerUnpackerTest.java
+++ b/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerUnpackerTest.java
@@ -329,6 +329,7 @@ public class ClientMessagePackerUnpackerTest {
         try (var packer = new ClientMessagePacker(PooledByteBufAllocator.DEFAULT.directBuffer())) {
             packer.packInt(1);
             packer.packNoValue();
+            packer.packString("s");
 
             var buf = packer.getBuffer();
 
@@ -341,6 +342,7 @@ public class ClientMessagePackerUnpackerTest {
                 assertFalse(unpacker.tryUnpackNoValue());
                 assertEquals(1, unpacker.unpackInt());
                 assertTrue(unpacker.tryUnpackNoValue());
+                assertEquals("s", unpacker.unpackString());
             }
         }
     }

--- a/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerUnpackerTest.java
+++ b/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerUnpackerTest.java
@@ -20,6 +20,7 @@ package org.apache.ignite.internal.client.proto;
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.randomBytes;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
@@ -318,6 +319,24 @@ public class ClientMessagePackerUnpackerTest {
                 Object[] res = unpacker.unpackObjectArray();
 
                 assertEquals(16L, (Long) res[0]);
+            }
+        }
+    }
+
+    @Test
+    public void testNoValue() {
+        try (var packer = new ClientMessagePacker(PooledByteBufAllocator.DEFAULT.directBuffer())) {
+            packer.packNoValue();
+
+            var buf = packer.getBuffer();
+
+            byte[] data = new byte[buf.readableBytes()];
+            buf.readBytes(data);
+
+            try (var unpacker = new ClientMessageUnpacker(Unpooled.wrappedBuffer(data))) {
+                unpacker.skipValues(4);
+
+                assertTrue(unpacker.tryUnpackNoValue());
             }
         }
     }

--- a/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerUnpackerTest.java
+++ b/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerUnpackerTest.java
@@ -20,6 +20,7 @@ package org.apache.ignite.internal.client.proto;
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.randomBytes;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.netty.buffer.PooledByteBufAllocator;
@@ -326,6 +327,7 @@ public class ClientMessagePackerUnpackerTest {
     @Test
     public void testNoValue() {
         try (var packer = new ClientMessagePacker(PooledByteBufAllocator.DEFAULT.directBuffer())) {
+            packer.packInt(1);
             packer.packNoValue();
 
             var buf = packer.getBuffer();
@@ -336,6 +338,8 @@ public class ClientMessagePackerUnpackerTest {
             try (var unpacker = new ClientMessageUnpacker(Unpooled.wrappedBuffer(data))) {
                 unpacker.skipValues(4);
 
+                assertFalse(unpacker.tryUnpackNoValue());
+                assertEquals(1, unpacker.unpackInt());
                 assertTrue(unpacker.tryUnpackNoValue());
             }
         }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTableCommon.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTableCommon.java
@@ -313,7 +313,7 @@ class ClientTableCommon {
         var tuple = Tuple.create(cnt);
 
         for (int i = 0; i < cnt; i++) {
-            if (unpacker.tryUnpackNil()) {
+            if (unpacker.tryUnpackNoValue()) {
                 continue;
             }
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTableCommon.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTableCommon.java
@@ -17,6 +17,8 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
+import static org.apache.ignite.internal.client.proto.ClientMessageCommon.NO_VALUE;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
@@ -49,8 +51,6 @@ import org.jetbrains.annotations.NotNull;
  * Common table functionality.
  */
 class ClientTableCommon {
-    private static final Object NO_VALUE = new Object();
-
     /**
      * Writes a schema.
      *

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTableCommon.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTableCommon.java
@@ -49,6 +49,8 @@ import org.jetbrains.annotations.NotNull;
  * Common table functionality.
  */
 class ClientTableCommon {
+    private static final Object NO_VALUE = new Object();
+
     /**
      * Writes a schema.
      *
@@ -437,10 +439,15 @@ class ClientTableCommon {
     }
 
     private static void writeColumnValue(ClientMessagePacker packer, Tuple tuple, Column col) {
-        var val = tuple.valueOrDefault(col.name(), null);
+        var val = tuple.valueOrDefault(col.name(), NO_VALUE);
 
         if (val == null) {
             packer.packNil();
+            return;
+        }
+
+        if (val == NO_VALUE) {
+            packer.packNoValue();
             return;
         }
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -251,8 +251,6 @@ public class ClientTable implements Table {
             boolean keyOnly,
             boolean skipHeader
     ) {
-        // TODO: Special case for ClientTupleBuilder - it has columns in order
-        // TODO: Optimize (IGNITE-16082).
         if (!skipHeader) {
             out.packIgniteUuid(id);
             out.packInt(schema.version());

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -257,8 +257,9 @@ public class ClientTable implements Table {
         }
 
         var columns = schema.columns();
+        var count = keyOnly ? schema.keyColumnCount() : columns.length;
 
-        for (var i = 0; i < columns.length; i++) {
+        for (var i = 0; i < count; i++) {
             var col = columns[i];
 
             Object v = tuple.valueOrDefault(col.name(), NO_VALUE);
@@ -295,7 +296,9 @@ public class ClientTable implements Table {
 
             Object v = col.key()
                     ? key.valueOrDefault(col.name(), NO_VALUE)
-                    : val.valueOrDefault(col.name(), NO_VALUE);
+                    : val != null
+                            ? val.valueOrDefault(col.name(), NO_VALUE)
+                            : NO_VALUE;
 
             out.packObject(v);
         }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -253,27 +253,19 @@ public class ClientTable implements Table {
     ) {
         // TODO: Special case for ClientTupleBuilder - it has columns in order
         // TODO: Optimize (IGNITE-16082).
-        var vals = new Object[keyOnly ? schema.keyColumnCount() : schema.columns().length];
-        var tupleSize = tuple.columnCount();
-
-        for (var i = 0; i < tupleSize; i++) {
-            var colName = tuple.columnName(i);
-            var col = schema.column(colName);
-
-            if (keyOnly && !col.key()) {
-                continue;
-            }
-
-            vals[col.schemaIndex()] = tuple.value(i);
-        }
-
         if (!skipHeader) {
             out.packIgniteUuid(id);
             out.packInt(schema.version());
         }
 
-        for (var val : vals) {
-            out.packObject(val);
+        var columns = schema.columns();
+
+        for (var i = 0; i < columns.length; i++) {
+            var col = columns[i];
+
+            Object v = tuple.valueOrDefault(col.name(), NO_VALUE);
+
+            out.packObject(v);
         }
     }
 

--- a/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTableTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTableTest.java
@@ -19,6 +19,7 @@ package org.apache.ignite.client;
 
 import static org.apache.ignite.client.fakes.FakeIgniteTables.TABLE_ALL_COLUMNS;
 import static org.apache.ignite.client.fakes.FakeIgniteTables.TABLE_ONE_COLUMN;
+import static org.apache.ignite.client.fakes.FakeIgniteTables.TABLE_WITH_DEFAULT_VALUES;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -91,6 +92,12 @@ public class AbstractClientTableTest extends AbstractClientTest {
         server.tables().createTableIfNotExists(DEFAULT_TABLE, tbl -> tbl.changeReplicas(1));
 
         return client.tables().table(DEFAULT_TABLE);
+    }
+
+    protected Table tableWithDefaultValues() {
+        server.tables().createTableIfNotExists(TABLE_WITH_DEFAULT_VALUES, tbl -> tbl.changeReplicas(1));
+
+        return client.tables().table(TABLE_WITH_DEFAULT_VALUES);
     }
 
     protected static Tuple allClumnsTableKey(long id) {

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientTableTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientTableTest.java
@@ -329,4 +329,24 @@ public class ClientTableTest extends AbstractClientTableTest {
         assertEquals(3L, skippedTuples[1].longValue("id"));
         assertEquals("z", skippedTuples[1].stringValue("name"));
     }
+
+    @Test
+    public void testNullableColumnWithDefaultValueSetNullResultNull() {
+        // TODO
+    }
+
+    @Test
+    public void testNullableColumnWithDefaultValueNotSetResultDefault() {
+        // TODO
+    }
+
+    @Test
+    public void testNonNullableColumnWithDefaultValueSetNullResultException() {
+        // TODO
+    }
+
+    @Test
+    public void testNonNullableColumnWithDefaultValueNotSetResultDefault() {
+        // TODO
+    }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientTableTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientTableTest.java
@@ -332,7 +332,17 @@ public class ClientTableTest extends AbstractClientTableTest {
 
     @Test
     public void testNullableColumnWithDefaultValueSetNullResultNull() {
-        // TODO
+        RecordView<Tuple> table = tableWithDefaultValues().recordView();
+
+        var tuple = Tuple.create()
+                .set("id", 1)
+                .set("str", null);
+
+        table.upsert(tuple);
+
+        var res = table.get(tuple);
+
+        assertNull(res.stringValue("str"));
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientTableTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientTableTest.java
@@ -331,7 +331,22 @@ public class ClientTableTest extends AbstractClientTableTest {
     }
 
     @Test
-    public void testNullableColumnWithDefaultValueSetNullResultNull() {
+    public void testColumnWithDefaultValueNotSetReturnsDefault() {
+        RecordView<Tuple> table = tableWithDefaultValues().recordView();
+
+        var tuple = Tuple.create()
+                .set("id", 1);
+
+        table.upsert(tuple);
+
+        var res = table.get(tuple);
+
+        assertEquals("def_str", res.stringValue("str"));
+        assertEquals("def_str2", res.stringValue("str_non_null"));
+    }
+
+    @Test
+    public void testNullableColumnWithDefaultValueSetNullReturnsNull() {
         RecordView<Tuple> table = tableWithDefaultValues().recordView();
 
         var tuple = Tuple.create()
@@ -346,17 +361,15 @@ public class ClientTableTest extends AbstractClientTableTest {
     }
 
     @Test
-    public void testNullableColumnWithDefaultValueNotSetResultDefault() {
-        // TODO
-    }
+    public void testNonNullableColumnWithDefaultValueSetNullThrowsException() {
+        RecordView<Tuple> table = tableWithDefaultValues().recordView();
 
-    @Test
-    public void testNonNullableColumnWithDefaultValueSetNullResultException() {
-        // TODO
-    }
+        var tuple = Tuple.create()
+                .set("id", 1)
+                .set("str_non_null", null);
 
-    @Test
-    public void testNonNullableColumnWithDefaultValueNotSetResultDefault() {
-        // TODO
+        var ex = assertThrows(CompletionException.class, () -> table.upsert(tuple));
+
+        assertTrue(ex.getMessage().contains("null was passed, but column is not nullable"), ex.getMessage());
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgniteTables.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgniteTables.java
@@ -262,7 +262,7 @@ public class FakeIgniteTables implements IgniteTables, IgniteTablesInternal {
                         new Column("id", NativeTypes.INT32, false)
                 },
                 new Column[]{
-                        new Column("num", NativeTypes.INT8, true, () -> (byte)42),
+                        new Column("num", NativeTypes.INT8, true, () -> (byte) 42),
                         new Column("str", NativeTypes.STRING, true, () -> "def_str"),
                         new Column("str_non_null", NativeTypes.STRING, false, () -> "def_str2"),
                 });

--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgniteTables.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgniteTables.java
@@ -46,6 +46,8 @@ public class FakeIgniteTables implements IgniteTables, IgniteTablesInternal {
 
     public static final String TABLE_ONE_COLUMN = "one-column";
 
+    public static final String TABLE_WITH_DEFAULT_VALUES = "default-columns";
+
     private final ConcurrentHashMap<String, TableImpl> tables = new ConcurrentHashMap<>();
 
     private final ConcurrentHashMap<IgniteUuid, TableImpl> tablesById = new ConcurrentHashMap<>();
@@ -172,6 +174,10 @@ public class FakeIgniteTables implements IgniteTables, IgniteTablesInternal {
                 history = this::getOneColumnSchema;
                 break;
 
+            case TABLE_WITH_DEFAULT_VALUES:
+                history = this::getDefaultColumnValuesSchema;
+                break;
+
             default:
                 history = this::getSchema;
                 break;
@@ -240,6 +246,24 @@ public class FakeIgniteTables implements IgniteTables, IgniteTablesInternal {
                         new Column("zbitmask", NativeTypes.bitmaskOf(16), true),
                         new Column("zdecimal", NativeTypes.decimalOf(20, 3), true),
                         new Column("znumber", NativeTypes.numberOf(24), true),
+                });
+    }
+
+    /**
+     * Gets the schema.
+     *
+     * @param v Version.
+     * @return Schema descriptor.
+     */
+    private SchemaDescriptor getDefaultColumnValuesSchema(Integer v) {
+        return new SchemaDescriptor(
+                v,
+                new Column[]{
+                        new Column("id", NativeTypes.INT32, false)
+                },
+                new Column[]{
+                        new Column("zbyte", NativeTypes.INT8, true, () -> (byte)42),
+                        new Column("zstring", NativeTypes.STRING, true, () -> "def_str"),
                 });
     }
 

--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgniteTables.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgniteTables.java
@@ -262,8 +262,9 @@ public class FakeIgniteTables implements IgniteTables, IgniteTablesInternal {
                         new Column("id", NativeTypes.INT32, false)
                 },
                 new Column[]{
-                        new Column("zbyte", NativeTypes.INT8, true, () -> (byte)42),
-                        new Column("zstring", NativeTypes.STRING, true, () -> "def_str"),
+                        new Column("num", NativeTypes.INT8, true, () -> (byte)42),
+                        new Column("str", NativeTypes.STRING, true, () -> "def_str"),
+                        new Column("str_non_null", NativeTypes.STRING, false, () -> "def_str2"),
                 });
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/MessagePackExtensionsTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/MessagePackExtensionsTest.cs
@@ -122,6 +122,43 @@ namespace Apache.Ignite.Tests.Proto
             CollectionAssert.AreEqual(JavaUuidBytes, bytes);
         }
 
+        [Test]
+        public void TestNoValue()
+        {
+            var res1 = WriteRead(
+                buf =>
+                {
+                    var w = buf.GetMessageWriter();
+
+                    w.WriteNoValue();
+                    w.Flush();
+                },
+                m =>
+                {
+                    var r = new MessagePackReader(m);
+
+                    return r.TryReadNoValue();
+                });
+
+            var res2 = WriteRead(
+                buf =>
+                {
+                    var w = buf.GetMessageWriter();
+
+                    w.WriteNil();
+                    w.Flush();
+                },
+                m =>
+                {
+                    var r = new MessagePackReader(m);
+
+                    return r.TryReadNoValue();
+                });
+
+            Assert.IsTrue(res1);
+            Assert.IsFalse(res2);
+        }
+
         private static T WriteRead<T>(Action<PooledArrayBufferWriter> write, Func<ReadOnlyMemory<byte>, T> read)
         {
             var bufferWriter = new PooledArrayBufferWriter();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/MessagePackExtensionsTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/MessagePackExtensionsTest.cs
@@ -130,33 +130,23 @@ namespace Apache.Ignite.Tests.Proto
                 {
                     var w = buf.GetMessageWriter();
 
+                    w.Write(3);
                     w.WriteNoValue();
+                    w.Write("abc");
+
                     w.Flush();
                 },
                 m =>
                 {
                     var r = new MessagePackReader(m);
 
-                    return r.TryReadNoValue();
+                    return (r.TryReadNoValue(), r.ReadInt32(), r.TryReadNoValue(), r.ReadString());
                 });
 
-            var res2 = WriteRead(
-                buf =>
-                {
-                    var w = buf.GetMessageWriter();
-
-                    w.WriteNil();
-                    w.Flush();
-                },
-                m =>
-                {
-                    var r = new MessagePackReader(m);
-
-                    return r.TryReadNoValue();
-                });
-
-            Assert.IsTrue(res1);
-            Assert.IsFalse(res2);
+            Assert.IsFalse(res1.Item1);
+            Assert.AreEqual(3, res1.Item2);
+            Assert.IsTrue(res1.Item3);
+            Assert.AreEqual("abc", res1.Item4);
         }
 
         private static T WriteRead<T>(Action<PooledArrayBufferWriter> write, Func<ReadOnlyMemory<byte>, T> read)

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientMessagePackType.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientMessagePackType.cs
@@ -65,6 +65,11 @@ namespace Apache.Ignite.Internal.Proto
         /// <summary>
         /// Ignite UUID.
         /// </summary>
-        IgniteUuid = 9
+        IgniteUuid = 9,
+
+        /// <summary>
+        /// Absent value for a column.
+        /// </summary>
+        NoValue = 10
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackReaderExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackReaderExtensions.cs
@@ -143,6 +143,30 @@ namespace Apache.Ignite.Internal.Proto
             return res;
         }
 
+        /// <summary>
+        /// Reads <see cref="ClientMessagePackType.NoValue"/> if it is the next token.
+        /// </summary>
+        /// <param name="reader">Reader.</param>
+        /// <returns><c>true</c> if the next token was NoValue; <c>false</c> otherwise.</returns>
+        public static bool TryReadNoValue(this ref MessagePackReader reader)
+        {
+            if (reader.NextCode != MessagePackCode.FixExt1)
+            {
+                return false;
+            }
+
+            var header = reader.CreatePeekReader().ReadExtensionFormatHeader();
+
+            if (header.TypeCode != (sbyte)ClientMessagePackType.NoValue)
+            {
+                return false;
+            }
+
+            reader.ReadRaw(3);
+
+            return true;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void ValidateExtensionType(
             ref MessagePackReader reader,

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackWriterExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackWriterExtensions.cs
@@ -83,6 +83,18 @@ namespace Apache.Ignite.Internal.Proto
         }
 
         /// <summary>
+        /// Writes Ignite UUID.
+        /// </summary>
+        /// <param name="writer">Writer.</param>
+        public static void WriteNoValue(this ref MessagePackWriter writer)
+        {
+            writer.WriteExtensionFormatHeader(
+                new ExtensionHeader((sbyte)ClientMessagePackType.NoValue, 1));
+
+            writer.Advance(1);
+        }
+
+        /// <summary>
         /// Writes an object.
         /// </summary>
         /// <param name="writer">Writer.</param>
@@ -94,6 +106,10 @@ namespace Apache.Ignite.Internal.Proto
             {
                 case null:
                     writer.WriteNil();
+                    return;
+
+                case var o when o == ProtoCommon.NoValue:
+                    writer.WriteNoValue();
                     return;
 
                 case string str:

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackWriterExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackWriterExtensions.cs
@@ -108,10 +108,6 @@ namespace Apache.Ignite.Internal.Proto
                     writer.WriteNil();
                     return;
 
-                case var o when o == ProtoCommon.NoValue:
-                    writer.WriteNoValue();
-                    return;
-
                 case string str:
                     writer.Write(str);
                     return;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ProtoCommon.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ProtoCommon.cs
@@ -33,5 +33,10 @@ namespace Apache.Ignite.Internal.Proto
         /// String encoding.
         /// </summary>
         public static readonly Encoding Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+        /// <summary>
+        /// Special "no value" object.
+        /// </summary>
+        public static readonly object NoValue = new object();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ProtoCommon.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ProtoCommon.cs
@@ -17,8 +17,6 @@
 
 namespace Apache.Ignite.Internal.Proto
 {
-    using System.Text;
-
     /// <summary>
     /// Common protocol data.
     /// </summary>
@@ -28,15 +26,5 @@ namespace Apache.Ignite.Internal.Proto
         /// Magic bytes.
         /// </summary>
         public static readonly byte[] MagicBytes = { (byte)'I', (byte)'G', (byte)'N', (byte)'I' };
-
-        /// <summary>
-        /// String encoding.
-        /// </summary>
-        public static readonly Encoding Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-
-        /// <summary>
-        /// Special "no value" object.
-        /// </summary>
-        public static readonly object NoValue = new object();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -443,7 +443,7 @@ namespace Apache.Ignite.Internal.Table
 
                 if (colIdx < 0)
                 {
-                    w.WriteNil();
+                    w.WriteNoValue();
                 }
                 else
                 {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -352,6 +352,11 @@ namespace Apache.Ignite.Internal.Table
                 }
                 else
                 {
+                    if (r.TryReadNoValue())
+                    {
+                        continue;
+                    }
+
                     tuple[column.Name] = r.ReadObject(column.Type);
                 }
             }
@@ -367,6 +372,11 @@ namespace Apache.Ignite.Internal.Table
 
             for (var index = 0; index < count; index++)
             {
+                if (r.TryReadNoValue())
+                {
+                    continue;
+                }
+
                 var column = columns[index];
                 tuple[column.Name] = r.ReadObject(column.Type);
             }


### PR DESCRIPTION
Ignite Table API handles "column set to null" (1) and "column not set" (2) differently.
* Non-nullable column does not allow (1), but allows (2) as long as there is a default value.
* Nullable column will be set to null in (1) and to default value in (2).

Add a new data type `NO_VALUE` to the protocol to reflect this distinction.