### PR TITLE
IGNITE-16311 Removed redundant mentions of closed tasks in code. 

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/jdbc/ItJdbcConnectionSelfTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/jdbc/ItJdbcConnectionSelfTest.java
@@ -754,6 +754,8 @@ public class ItJdbcConnectionSelfTest extends AbstractJdbcSelfTest {
     }
 
     /**
+     * Get-set holdability test.
+     *
      * @throws Exception If failed.
      */
     @Test

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/jdbc/ItJdbcConnectionSelfTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/jdbc/ItJdbcConnectionSelfTest.java
@@ -754,8 +754,6 @@ public class ItJdbcConnectionSelfTest extends AbstractJdbcSelfTest {
     }
 
     /**
-     * TODO  IGNITE-15188.
-     *
      * @throws Exception If failed.
      */
     @Test

--- a/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItInternalTableScanTest.java
+++ b/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItInternalTableScanTest.java
@@ -26,13 +26,13 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -186,7 +186,7 @@ public class ItInternalTableScanTest {
         internalTbl = new InternalTableImpl(
                 TEST_TABLE_NAME,
                 tblId,
-                Map.of(0, raftGrpSvc),
+                Int2ObjectMaps.singleton(0, raftGrpSvc),
                 1,
                 NetworkAddress::toString,
                 txManager,

--- a/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItTablePersistenceTest.java
+++ b/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItTablePersistenceTest.java
@@ -20,6 +20,8 @@ package org.apache.ignite.distributed;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -97,10 +99,14 @@ public class ItTablePersistenceTest extends ItAbstractListenerSnapshotTest<Parti
 
         txManager.start();
 
+        Int2ObjectOpenHashMap<RaftGroupService> map = new Int2ObjectOpenHashMap<>();
+
+        map.put(0, service);
+
         var table = new InternalTableImpl(
                 "table",
                 new IgniteUuid(UUID.randomUUID(), 0),
-                Map.of(0, service),
+                map,
                 1,
                 NetworkAddress::toString,
                 txManager,
@@ -122,7 +128,7 @@ public class ItTablePersistenceTest extends ItAbstractListenerSnapshotTest<Parti
         var table = new InternalTableImpl(
                 "table",
                 new IgniteUuid(UUID.randomUUID(), 0),
-                Map.of(0, service),
+                Int2ObjectMaps.singleton(0, service),
                 1,
                 NetworkAddress::toString,
                 txManager,
@@ -147,10 +153,13 @@ public class ItTablePersistenceTest extends ItAbstractListenerSnapshotTest<Parti
 
         txManager.start();
 
+        Int2ObjectOpenHashMap<RaftGroupService> map = new Int2ObjectOpenHashMap<>();
+        map.put(0, service);
+
         var table = new InternalTableImpl(
                 "table",
                 new IgniteUuid(UUID.randomUUID(), 0),
-                Map.of(0, service),
+                map,
                 1,
                 NetworkAddress::toString,
                 txManager,

--- a/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItTablePersistenceTest.java
+++ b/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItTablePersistenceTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -99,14 +98,10 @@ public class ItTablePersistenceTest extends ItAbstractListenerSnapshotTest<Parti
 
         txManager.start();
 
-        Int2ObjectOpenHashMap<RaftGroupService> map = new Int2ObjectOpenHashMap<>();
-
-        map.put(0, service);
-
         var table = new InternalTableImpl(
                 "table",
                 new IgniteUuid(UUID.randomUUID(), 0),
-                map,
+                Int2ObjectMaps.singleton(0, service),
                 1,
                 NetworkAddress::toString,
                 txManager,
@@ -153,13 +148,10 @@ public class ItTablePersistenceTest extends ItAbstractListenerSnapshotTest<Parti
 
         txManager.start();
 
-        Int2ObjectOpenHashMap<RaftGroupService> map = new Int2ObjectOpenHashMap<>();
-        map.put(0, service);
-
         var table = new InternalTableImpl(
                 "table",
                 new IgniteUuid(UUID.randomUUID(), 0),
-                map,
+                Int2ObjectMaps.singleton(0, service),
                 1,
                 NetworkAddress::toString,
                 txManager,

--- a/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItTxDistributedTestSingleNode.java
+++ b/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItTxDistributedTestSingleNode.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -85,9 +86,9 @@ public class ItTxDistributedTestSingleNode extends TxAbstractTest {
 
     protected Map<ClusterNode, TxManager> txManagers;
 
-    protected Map<Integer, RaftGroupService> accRaftClients;
+    protected Int2ObjectOpenHashMap<RaftGroupService> accRaftClients;
 
-    protected Map<Integer, RaftGroupService> custRaftClients;
+    protected Int2ObjectOpenHashMap<RaftGroupService> custRaftClients;
 
     protected List<ClusterService> cluster = new CopyOnWriteArrayList<>();
 
@@ -245,7 +246,7 @@ public class ItTxDistributedTestSingleNode extends TxAbstractTest {
      * @param tblId Table id.
      * @return Groups map.
      */
-    protected Map<Integer, RaftGroupService> startTable(String name, IgniteUuid tblId)
+    protected Int2ObjectOpenHashMap<RaftGroupService> startTable(String name, IgniteUuid tblId)
             throws Exception {
         List<List<ClusterNode>> assignment = RendezvousAffinityFunction.assignPartitions(
                 cluster.stream().map(node -> node.topologyService().localMember())
@@ -256,7 +257,8 @@ public class ItTxDistributedTestSingleNode extends TxAbstractTest {
                 null
         );
 
-        Map<Integer, RaftGroupService> clients = new HashMap<>();
+
+        Int2ObjectOpenHashMap<RaftGroupService> clients = new Int2ObjectOpenHashMap<>();
 
         for (int p = 0; p < assignment.size(); p++) {
             List<ClusterNode> partNodes = assignment.get(p);
@@ -388,7 +390,7 @@ public class ItTxDistributedTestSingleNode extends TxAbstractTest {
     /** {@inheritDoc} */
     @Override
     protected TxManager txManager(Table t) {
-        Map<Integer, RaftGroupService> clients = null;
+        Int2ObjectOpenHashMap<RaftGroupService> clients = null;
 
         if (t == accounts) {
             clients = accRaftClients;

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
@@ -20,11 +20,11 @@ package org.apache.ignite.internal.table.distributed;
 import static org.apache.ignite.configuration.schemas.store.DataStorageConfigurationSchema.DEFAULT_DATA_REGION_NAME;
 import static org.apache.ignite.internal.configuration.util.ConfigurationUtil.directProxy;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -507,7 +507,7 @@ public class TableManager extends Producer<TableEvent, TableEventParameters> imp
 
         CompletableFuture.allOf(partitionsGroupsFutures.toArray(CompletableFuture[]::new)).thenRun(() -> {
             try {
-                HashMap<Integer, RaftGroupService> partitionMap = new HashMap<>(partitions);
+                Int2ObjectOpenHashMap<RaftGroupService> partitionMap = new Int2ObjectOpenHashMap<>(partitions);
 
                 for (int p = 0; p < partitions; p++) {
                     CompletableFuture<RaftGroupService> future = partitionsGroupsFutures.get(p);

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/impl/DummyInternalTableImpl.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/impl/DummyInternalTableImpl.java
@@ -21,9 +21,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import java.io.Serializable;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
@@ -67,7 +67,8 @@ public class DummyInternalTableImpl extends InternalTableImpl {
      * @param txManager Transaction manager.
      */
     public DummyInternalTableImpl(VersionedRowStore store, TxManager txManager) {
-        super("test", new IgniteUuid(UUID.randomUUID(), 0), Map.of(0, mock(RaftGroupService.class)),
+        super("test", new IgniteUuid(UUID.randomUUID(), 0),
+                Int2ObjectMaps.singleton(0, mock(RaftGroupService.class)),
                 1, null, txManager, mock(TableStorage.class));
 
         RaftGroupService svc = partitionMap.get(0);


### PR DESCRIPTION
1. TODO "IGNITE-15188" was just not deleted after the task was closed. So simply remove it.
2. TODO "IGNITE-15443" meant having to replace HashMap implementations with primitive IntMap in Table module. Since the task was not finished, this feed contains the corresponding edits to the module.