### PR TITLE
IGNITE-15352 Thin client: Use varint for decimal scale and IgniteUuid localId

### DIFF
--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
@@ -528,7 +528,7 @@ public class ClientMessagePacker implements AutoCloseable {
         // Pack scale as varint.
         // TODO: Proper varint with all variants?
         boolean oneByteScale = val.scale() < (1 << 7);
-        int payloadLen = (oneByteScale ? 1 : 4) + unscaledValue.length;
+        int payloadLen = (oneByteScale ? 1 : 5) + unscaledValue.length;
 
         packExtensionTypeHeader(ClientMsgPackType.DECIMAL, payloadLen);
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
@@ -507,7 +507,6 @@ public class ClientMessagePacker implements AutoCloseable {
     public void packIgniteUuid(IgniteUuid val) {
         assert !closed : "Packer is closed";
 
-        packExtensionTypeHeader(ClientMsgPackType.IGNITE_UUID, 24);
         buf.writeByte(Code.EXT8);
 
         // Reserve space for varint payload length.

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
@@ -507,12 +507,15 @@ public class ClientMessagePacker implements AutoCloseable {
     public void packIgniteUuid(IgniteUuid val) {
         assert !closed : "Packer is closed";
 
+        // TODO: always ext8, simplify.
         packExtensionTypeHeader(ClientMsgPackType.IGNITE_UUID, 24);
 
         UUID globalId = val.globalId();
 
         buf.writeLong(globalId.getMostSignificantBits());
         buf.writeLong(globalId.getLeastSignificantBits());
+
+        // TODO: Pack varint.
         buf.writeLong(val.localId());
     }
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
@@ -157,7 +157,7 @@ public class ClientMessagePacker implements AutoCloseable {
         assert !closed : "Packer is closed";
 
         if (i < -(1 << 5)) {
-            if (i < -(1 << 15)) { // TODO: Is this correct? How do we pack -1, -2?
+            if (i < -(1 << 15)) {
                 buf.writeByte(Code.INT32);
                 buf.writeInt(i);
             } else if (i < -(1 << 7)) {
@@ -168,6 +168,7 @@ public class ClientMessagePacker implements AutoCloseable {
                 buf.writeByte(i);
             }
         } else if (i < (1 << 7)) {
+            // Includes negative fixint.
             buf.writeByte(i);
         } else {
             if (i < (1 << 8)) {

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
@@ -782,8 +782,11 @@ public class ClientMessageUnpacker implements AutoCloseable {
             throw new MessageTypeException("Expected DECIMAL extension (2), but got " + type);
         }
 
-        int scale = buf.readInt();
-        var bytes = readPayload(len - 4);
+        int pos = buf.readerIndex();
+        int scale = unpackInt();
+        int scaleSize = buf.readerIndex() - pos;
+
+        var bytes = readPayload(len - scaleSize);
 
         return new BigDecimal(new BigInteger(bytes), scale);
     }

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
@@ -754,7 +754,6 @@ public class ClientMessageUnpacker implements AutoCloseable {
 
         var hdr = unpackExtensionTypeHeader();
         var type = hdr.getType();
-        var len = hdr.getLength();
 
         if (type != ClientMsgPackType.IGNITE_UUID) {
             throw new MessageTypeException("Expected Ignite UUID extension (1), but got " + type);

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
@@ -758,10 +758,6 @@ public class ClientMessageUnpacker implements AutoCloseable {
             throw new MessageTypeException("Expected Ignite UUID extension (1), but got " + type);
         }
 
-        if (len != 24) {
-            throw new MessageSizeException("Expected 24 bytes for UUID extension, but got " + len, len);
-        }
-
         return new IgniteUuid(new UUID(buf.readLong(), buf.readLong()), unpackLong());
     }
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
@@ -762,7 +762,7 @@ public class ClientMessageUnpacker implements AutoCloseable {
             throw new MessageSizeException("Expected 24 bytes for UUID extension, but got " + len, len);
         }
 
-        return new IgniteUuid(new UUID(buf.readLong(), buf.readLong()), buf.readLong());
+        return new IgniteUuid(new UUID(buf.readLong(), buf.readLong()), unpackLong());
     }
 
     /**

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
@@ -126,10 +126,14 @@ public class ClientMessageUnpacker implements AutoCloseable {
 
         switch (code) {
             case Code.UINT8:
+                return buf.readUnsignedByte();
+
             case Code.INT8:
                 return buf.readByte();
 
             case Code.UINT16:
+                return buf.readUnsignedShort();
+
             case Code.INT16:
                 return buf.readShort();
 
@@ -245,8 +249,6 @@ public class ClientMessageUnpacker implements AutoCloseable {
                 return buf.readByte();
 
             case Code.UINT16:
-                return (short) buf.readUnsignedShort();
-
             case Code.INT16:
                 return buf.readShort();
 

--- a/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerTest.java
+++ b/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerTest.java
@@ -142,11 +142,13 @@ public class ClientMessagePackerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {126, 127, 128, 255, 256, 65535, 65536})
+    @ValueSource(ints = {30, 31, 32, 126, 127, 128, 255, 256, 65535, 65536})
     public void testPackLongString(int length) {
-        String s = "x".repeat(length);
-
+        String s = "x".repeat(length / 3);
         testPacker(p -> p.packString(s), p -> p.packString(s));
+
+        String s2 = "x".repeat(length);
+        testPacker(p -> p.packString(s2), p -> p.packString(s2));
     }
 
     @ParameterizedTest

--- a/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerTest.java
+++ b/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerTest.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.client.proto;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.netty.buffer.ByteBuf;
@@ -145,10 +146,15 @@ public class ClientMessagePackerTest {
     @ValueSource(ints = {30, 31, 32, 126, 127, 128, 255, 256, 65535, 65536})
     public void testPackLongString(int length) {
         String s = "x".repeat(length / 3);
-        testPacker(p -> p.packString(s), p -> p.packString(s));
+        byte[] packed = packIgnite(p -> p.packString(s));
 
-        String s2 = "x".repeat(length);
-        testPacker(p -> p.packString(s2), p -> p.packString(s2));
+        try (var unpacker = MessagePack.newDefaultUnpacker(packed)) {
+            String res = unpacker.unpackString();
+
+            assertEquals(s, res);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @ParameterizedTest

--- a/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerTest.java
+++ b/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerTest.java
@@ -142,6 +142,14 @@ public class ClientMessagePackerTest {
     }
 
     @ParameterizedTest
+    @ValueSource(ints = {126, 127, 128, 255, 256, 65535, 65536})
+    public void testPackLongString(int length) {
+        String s = "x".repeat(length);
+
+        testPacker(p -> p.packString(s), p -> p.packString(s));
+    }
+
+    @ParameterizedTest
     @ValueSource(ints = {0, 1, 255, 256, 65535, 65536, Integer.MAX_VALUE})
     public void testPackArrayHeader(int i) {
         testPacker(p -> p.packArrayHeader(i), p -> p.packArrayHeader(i));

--- a/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessageUnpackerTest.java
+++ b/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessageUnpackerTest.java
@@ -195,11 +195,12 @@ public class ClientMessageUnpackerTest {
             p.packInt(123456);
             p.packBoolean(false);
 
-            p.packMapHeader(2);
+            p.packMapHeader(3);
             p.packString("x");
             p.packNil();
             p.packUuid(UUID.randomUUID());
             p.packIgniteUuid(new IgniteUuid(UUID.randomUUID(), 123));
+            p.packUuid(UUID.randomUUID());
             p.packIgniteUuid(new IgniteUuid(UUID.randomUUID(), UUID.randomUUID().getLeastSignificantBits()));
 
             p.packDouble(1.1);

--- a/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessageUnpackerTest.java
+++ b/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessageUnpackerTest.java
@@ -192,6 +192,7 @@ public class ClientMessageUnpackerTest {
             p.packNil();
             p.packUuid(UUID.randomUUID());
             p.packIgniteUuid(new IgniteUuid(UUID.randomUUID(), 123));
+            p.packIgniteUuid(new IgniteUuid(UUID.randomUUID(), UUID.randomUUID().getLeastSignificantBits()));
 
             p.packDouble(1.1);
             p.packDouble(2.2);

--- a/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessageUnpackerTest.java
+++ b/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessageUnpackerTest.java
@@ -133,6 +133,16 @@ public class ClientMessageUnpackerTest {
     }
 
     @ParameterizedTest
+    @ValueSource(ints = {30, 31, 32, 126, 127, 128, 255, 256, 65535, 65536})
+    public void testUnpackLongString(int length) {
+        String s = "x".repeat(length / 3);
+        testUnpacker(p -> p.packString(s), ClientMessageUnpacker::unpackString, s);
+
+        String s2 = "x".repeat(length);
+        testUnpacker(p -> p.packString(s2), ClientMessageUnpacker::unpackString, s2);
+    }
+
+    @ParameterizedTest
     @ValueSource(ints = {0, 1, 255, 256, 65535, 65536, Integer.MAX_VALUE})
     public void testUnpackArrayHeader(int i) {
         testUnpacker(p -> p.packArrayHeader(i), ClientMessageUnpacker::unpackArrayHeader, i);

--- a/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessageUnpackerTest.java
+++ b/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessageUnpackerTest.java
@@ -181,6 +181,14 @@ public class ClientMessageUnpackerTest {
         testUnpacker(p -> p.writePayload(b, 1, 1), p -> p.readPayload(1), new byte[]{5});
     }
 
+    @ParameterizedTest
+    @ValueSource(longs = {0, 1, 255, 256, 65535, 65536, Integer.MAX_VALUE, Long.MAX_VALUE, Long.MIN_VALUE, Integer.MIN_VALUE})
+    public void testUnpackIgniteUuid(long l) {
+        IgniteUuid id = new IgniteUuid(UUID.randomUUID(), l);
+
+        testUnpacker(p -> p.packIgniteUuid(id), ClientMessageUnpacker::unpackIgniteUuid, id);
+    }
+
     @Test
     public void testSkipValues() {
         testUnpacker(p -> {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/IgniteUuid.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/IgniteUuid.cs
@@ -26,9 +26,9 @@ namespace Apache.Ignite.Internal.Proto
     internal unsafe struct IgniteUuid
     {
         /// <summary>
-        /// Struct size.
+        /// Struct max size.
         /// </summary>
-        public const int Size = 24;
+        public const int MaxSize = 24;
 
         /// <summary>
         /// IgniteUuid bytes.
@@ -36,6 +36,11 @@ namespace Apache.Ignite.Internal.Proto
         /// We could deserialize the data into <see cref="Guid"/> and <see cref="long"/>, but there is no need to deal
         /// with the parts separately on the client.
         /// </summary>
-        public fixed byte Bytes[Size];
+        public fixed byte Bytes[MaxSize];
+
+        /// <summary>
+        /// Struct size.
+        /// </summary>
+        public byte Size;
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackWriterExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackWriterExtensions.cs
@@ -77,9 +77,9 @@ namespace Apache.Ignite.Internal.Proto
         public static unsafe void Write(this ref MessagePackWriter writer, IgniteUuid igniteUuid)
         {
             writer.WriteExtensionFormatHeader(
-                new ExtensionHeader((sbyte)ClientMessagePackType.IgniteUuid, IgniteUuid.Size));
+                new ExtensionHeader((sbyte)ClientMessagePackType.IgniteUuid, igniteUuid.Size));
 
-            writer.WriteRaw(new Span<byte>(igniteUuid.Bytes, IgniteUuid.Size));
+            writer.WriteRaw(new Span<byte>(igniteUuid.Bytes, igniteUuid.Size));
         }
 
         /// <summary>


### PR DESCRIPTION
* `BigDecimal#scale` is usually small and will use 1 byte instead of 4.
* `IgniteUuid.localId` can use 1-5 bytes instead of 8 for small values.