### PR TITLE
IGNITE-16382 .NET: Speed up tests by reusing server node

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -83,7 +83,7 @@ namespace Apache.Ignite.Tests
         [TearDown]
         public async Task TearDown()
         {
-            await TupleView.DeleteAllAsync(null, Enumerable.Range(1, 10).Select(x => GetTuple(x)));
+            await TupleView.DeleteAllAsync(null, Enumerable.Range(-5, 15).Select(x => GetTuple(x)));
 
             Assert.AreEqual(_eventListener.BuffersReturned, _eventListener.BuffersRented);
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -82,7 +82,7 @@ namespace Apache.Ignite.Tests
         [TearDown]
         public async Task TearDown()
         {
-            await TupleView.DeleteAllAsync(null, Enumerable.Range(-5, 15).Select(x => GetTuple(x)));
+            await TupleView.DeleteAllAsync(null, Enumerable.Range(-5, 20).Select(x => GetTuple(x)));
 
             Assert.AreEqual(_eventListener.BuffersReturned, _eventListener.BuffersRented);
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -35,18 +35,18 @@ namespace Apache.Ignite.Tests
 
         protected const string ValCol = "val";
 
-        private static JavaServer _serverNode;
+        private static readonly JavaServer ServerNode;
 
         private TestEventListener _eventListener = null!;
 
         static IgniteTestsBase()
         {
-            _serverNode = JavaServer.StartAsync().GetAwaiter().GetResult();
+            ServerNode = JavaServer.StartAsync().GetAwaiter().GetResult();
 
-            AppDomain.CurrentDomain.ProcessExit += (_, _) => _serverNode.Dispose();
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => ServerNode.Dispose();
         }
 
-        protected static int ServerPort => _serverNode.Port;
+        protected static int ServerPort => ServerNode.Port;
 
         protected IIgniteClient Client { get; private set; } = null!;
 
@@ -61,7 +61,6 @@ namespace Apache.Ignite.Tests
         {
             _eventListener = new TestEventListener();
 
-            _serverNode = await JavaServer.StartAsync();
             Client = await IgniteClient.StartAsync(GetConfig());
 
             Table = (await Client.Tables.GetTableAsync(TableName))!;
@@ -95,7 +94,7 @@ namespace Apache.Ignite.Tests
 
         protected static IgniteClientConfiguration GetConfig() => new()
         {
-            Endpoints = { "127.0.0.1:" + _serverNode.Port }
+            Endpoints = { "127.0.0.1:" + ServerNode.Port }
         };
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -121,6 +121,7 @@ namespace Apache.Ignite.Tests
         {
             _process?.Kill();
             _process?.Dispose();
+            Log(">>> Java server stopped.");
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/RawSocketConnectionTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/RawSocketConnectionTests.cs
@@ -120,7 +120,7 @@ namespace Apache.Ignite.Tests
             stream.Write(bufferWriter.WrittenSpan);
         }
 
-        private async Task<NetworkStream> Connect()
+        private static async Task<NetworkStream> Connect()
         {
             Socket socket = new(SocketType.Stream, ProtocolType.Tcp)
             {

--- a/modules/platforms/dotnet/DEVNOTES.md
+++ b/modules/platforms/dotnet/DEVNOTES.md
@@ -10,7 +10,8 @@ In repo root: `mvn clean install -DskipTests`
 In this dir: `dotnet build`
 
 ## Run Tests
-In this dir: `dotnet test`
+In this dir: `dotnet test --logger "console;verbosity=normal"`
+Specific test: `dotnet test --logger "console;verbosity=normal" --filter ClientSocketTests`
 
 ## Start a Test Node
 * cd `modules/runner`


### PR DESCRIPTION
Do not start/stop a new node for every test class, use one for everything, stop on test process exit.