### PR TITLE
IGNITE-16531 .NET: Thin client: add heartbeats

### DIFF
--- a/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
@@ -63,4 +63,22 @@ public class HeartbeatTest {
             }
         }
     }
+
+    @Test
+    public void testInvalidHeartbeatIntervalThrows() throws Exception {
+        try (var srv = new TestServer(10800, 10, 300, new FakeIgnite())) {
+
+            Builder builder = IgniteClient.builder()
+                    .addresses("127.0.0.1:" + getPort(srv.module()))
+                    .heartbeatInterval(-50);
+
+            Throwable ex = assertThrows(IgniteClientException.class, builder::build);
+
+            while (ex.getCause() != null) {
+                ex = ex.getCause();
+            }
+
+            assertEquals("Negative delay.", ex.getMessage());
+        }
+    }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests.ruleset
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests.ruleset
@@ -49,5 +49,8 @@
 
     <!-- DoNotCatchGeneralExceptionTypes -->
     <Rule Id="CA1031" Action="None" />
+
+    <!-- UnusedParameters -->
+    <Rule Id="CA1801" Action="None" />
   </Rules>
 </RuleSet>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ClientSocketTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ClientSocketTests.cs
@@ -35,7 +35,7 @@ namespace Apache.Ignite.Tests
         [Test]
         public async Task TestConnectAndSendRequestReturnsResponse()
         {
-            using var socket = await ClientSocket.ConnectAsync(new IPEndPoint(IPAddress.Loopback, ServerPort));
+            using var socket = await ClientSocket.ConnectAsync(new IPEndPoint(IPAddress.Loopback, ServerPort), new());
 
             using var requestWriter = new PooledArrayBufferWriter();
 
@@ -54,7 +54,7 @@ namespace Apache.Ignite.Tests
         [Test]
         public async Task TestConnectAndSendRequestWithInvalidOpCodeThrowsError()
         {
-            using var socket = await ClientSocket.ConnectAsync(new IPEndPoint(IPAddress.Loopback, ServerPort));
+            using var socket = await ClientSocket.ConnectAsync(new IPEndPoint(IPAddress.Loopback, ServerPort), new());
 
             using var requestWriter = new PooledArrayBufferWriter();
             requestWriter.GetMessageWriter().Write(123);
@@ -68,7 +68,7 @@ namespace Apache.Ignite.Tests
         [Test]
         public async Task TestDisposedSocketThrowsExceptionOnSend()
         {
-            var socket = await ClientSocket.ConnectAsync(new IPEndPoint(IPAddress.Loopback, ServerPort));
+            var socket = await ClientSocket.ConnectAsync(new IPEndPoint(IPAddress.Loopback, ServerPort), new());
 
             socket.Dispose();
 
@@ -85,7 +85,7 @@ namespace Apache.Ignite.Tests
         [Test]
         public void TestConnectWithoutServerThrowsException()
         {
-            Assert.CatchAsync(async () => await ClientSocket.ConnectAsync(new IPEndPoint(IPAddress.Loopback, 569)));
+            Assert.CatchAsync(async () => await ClientSocket.ConnectAsync(new IPEndPoint(IPAddress.Loopback, 569), new()));
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Tests
 {
+    using System.Linq;
     using System.Threading.Tasks;
     using NUnit.Framework;
 
@@ -28,12 +29,17 @@ namespace Apache.Ignite.Tests
         [Test]
         public async Task TestServerDoesNotDisconnectIdleClientWithHeartbeats()
         {
-            // TODO: Check logger messages.
-            Assert.DoesNotThrowAsync(async () => await Client.Tables.GetTablesAsync());
+            var logger = new ListLogger();
+
+            var cfg = new IgniteClientConfiguration(GetConfig()) { Logger = logger };
+            using var client = await IgniteClient.StartAsync(cfg);
+
+            logger.Clear();
 
             await Task.Delay(ServerIdleTimeout * 3);
 
-            Assert.DoesNotThrowAsync(async () => await Client.Tables.GetTablesAsync());
+            Assert.DoesNotThrowAsync(async () => await client.Tables.GetTablesAsync());
+            Assert.IsEmpty(string.Join(", ", logger.Entries.Select(e => e.Message)));
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
@@ -29,7 +29,9 @@ namespace Apache.Ignite.Tests
         public async Task TestServerDoesNotDisconnectIdleClientWithHeartbeats()
         {
             // TODO: Check logger messages.
-            await Task.Delay(ServerIdleTimeout * 2);
+            Assert.DoesNotThrowAsync(async () => await Client.Tables.GetTablesAsync());
+
+            await Task.Delay(ServerIdleTimeout * 3);
 
             Assert.DoesNotThrowAsync(async () => await Client.Tables.GetTablesAsync());
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests
+{
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests client heartbeat functionality (<see cref="IgniteClientConfiguration.HeartbeatInterval"/>).
+    /// </summary>
+    public class HeartbeatTests : IgniteTestsBase
+    {
+        [Test]
+        public async Task TestServerDoesNotDisconnectIdleClientWithHeartbeats()
+        {
+            // TODO: Check logger messages.
+            await Task.Delay(ServerIdleTimeout * 2);
+
+            Assert.DoesNotThrowAsync(async () => await Client.Tables.GetTablesAsync());
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
@@ -55,28 +55,26 @@ namespace Apache.Ignite.Tests
         }
 
         [Test]
-        public void TestCustomHeartbeatIntervalOverridesCalculatedFromIdleTimeout()
+        public async Task TestCustomHeartbeatIntervalOverridesCalculatedFromIdleTimeout()
         {
-            // using var client = GetClient(enableHeartbeats: true, heartbeatInterval: 300);
-            //
-            // Assert.AreEqual(TimeSpan.FromMilliseconds(300), client.GetConfiguration().HeartbeatInterval);
-            //
-            // StringAssert.Contains("Server-side IdleTimeout is 2000ms, using configured IgniteClientConfiguration." +
-            //                       "HeartbeatInterval: 00:00:00.3000000", GetLogString(client));
+            var log = await ConnectAndGetLog(TimeSpan.FromMilliseconds(50));
+
+            StringAssert.Contains(
+                "ClientSocket [Info] Server-side IdleTimeout is 00:00:00.5000000, " +
+                "using configured IgniteClientConfiguration.HeartbeatInterval: 00:00:00.0500000",
+                log);
         }
 
         [Test]
-        public void TestCustomHeartbeatIntervalLongerThanRecommendedDoesNotOverrideCalculatedFromIdleTimeout()
+        public async Task TestCustomHeartbeatIntervalLongerThanRecommendedDoesNotOverrideCalculatedFromIdleTimeout()
         {
-            // using var client = GetClient(enableHeartbeats: true, heartbeatInterval: 3000);
-            //
-            // Assert.AreEqual(TimeSpan.FromMilliseconds(3000), client.GetConfiguration().HeartbeatInterval);
-            //
-            // StringAssert.Contains(
-            //     "Server-side IdleTimeout is 2000ms, configured IgniteClientConfiguration.HeartbeatInterval is " +
-            //     "00:00:03, which is longer than recommended IdleTimeout / 3. " +
-            //     "Overriding heartbeat interval with IdleTimeout / 3: 00:00:00.6660000",
-            //     GetLogString(client));
+            var log = await ConnectAndGetLog(TimeSpan.FromSeconds(4));
+
+            StringAssert.Contains(
+                "ClientSocket [Warn] Server-side IdleTimeout is 00:00:00.5000000, " +
+                "configured IgniteClientConfiguration.HeartbeatInterval is 00:00:04, which is longer than recommended IdleTimeout / 3. " +
+                "Overriding heartbeat interval with IdleTimeout / 3: 00:00:00.5000000",
+                log);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
@@ -48,9 +48,9 @@ namespace Apache.Ignite.Tests
             var log = await ConnectAndGetLog(IgniteClientConfiguration.DefaultHeartbeatInterval);
 
             StringAssert.Contains(
-                "ClientSocket [Warn] Server-side IdleTimeout is 00:00:00.5000000, " +
+                "ClientSocket [Warn] Server-side IdleTimeout is 00:00:01, " +
                 "configured IgniteClientConfiguration.HeartbeatInterval is 00:00:30, which is longer than recommended IdleTimeout / 3. " +
-                "Overriding heartbeat interval with IdleTimeout / 3: 00:00:00.5000000",
+                "Overriding heartbeat interval with max(IdleTimeout / 3, 500ms): 00:00:00.5000000",
                 log);
         }
 
@@ -60,7 +60,7 @@ namespace Apache.Ignite.Tests
             var log = await ConnectAndGetLog(TimeSpan.FromMilliseconds(50));
 
             StringAssert.Contains(
-                "ClientSocket [Info] Server-side IdleTimeout is 00:00:00.5000000, " +
+                "ClientSocket [Info] Server-side IdleTimeout is 00:00:01, " +
                 "using configured IgniteClientConfiguration.HeartbeatInterval: 00:00:00.0500000",
                 log);
         }
@@ -71,9 +71,9 @@ namespace Apache.Ignite.Tests
             var log = await ConnectAndGetLog(TimeSpan.FromSeconds(4));
 
             StringAssert.Contains(
-                "ClientSocket [Warn] Server-side IdleTimeout is 00:00:00.5000000, " +
+                "ClientSocket [Warn] Server-side IdleTimeout is 00:00:01, " +
                 "configured IgniteClientConfiguration.HeartbeatInterval is 00:00:04, which is longer than recommended IdleTimeout / 3. " +
-                "Overriding heartbeat interval with IdleTimeout / 3: 00:00:00.5000000",
+                "Overriding heartbeat interval with max(IdleTimeout / 3, 500ms): 00:00:00.5000000",
                 log);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
@@ -17,7 +17,6 @@
 
 namespace Apache.Ignite.Tests
 {
-    using System.Linq;
     using System.Threading.Tasks;
     using NUnit.Framework;
 
@@ -39,7 +38,7 @@ namespace Apache.Ignite.Tests
             await Task.Delay(ServerIdleTimeout * 3);
 
             Assert.DoesNotThrowAsync(async () => await client.Tables.GetTablesAsync());
-            Assert.IsEmpty(string.Join(", ", logger.Entries.Select(e => e.Message)));
+            Assert.IsEmpty(logger.GetLogString(), "No disconnects or reconnects should be logged.");
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -36,7 +36,7 @@ namespace Apache.Ignite.Tests
 
         protected const string ValCol = "val";
 
-        protected static readonly TimeSpan ServerIdleTimeout = TimeSpan.FromMilliseconds(500); // See PlatformTestNodeRunner.
+        protected static readonly TimeSpan ServerIdleTimeout = TimeSpan.FromMilliseconds(1000); // See PlatformTestNodeRunner.
 
         private static readonly JavaServer ServerNode;
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -21,6 +21,7 @@ namespace Apache.Ignite.Tests
     using System.Linq;
     using System.Threading.Tasks;
     using Ignite.Table;
+    using Log;
     using NUnit.Framework;
     using Table;
 
@@ -34,6 +35,8 @@ namespace Apache.Ignite.Tests
         protected const string KeyCol = "key";
 
         protected const string ValCol = "val";
+
+        protected static readonly TimeSpan ServerIdleTimeout = TimeSpan.FromMilliseconds(500); // See PlatformTestNodeRunner.
 
         private static readonly JavaServer ServerNode;
 
@@ -94,7 +97,8 @@ namespace Apache.Ignite.Tests
 
         protected static IgniteClientConfiguration GetConfig() => new()
         {
-            Endpoints = { "127.0.0.1:" + ServerNode.Port }
+            Endpoints = { "127.0.0.1:" + ServerNode.Port },
+            Logger = new ConsoleLogger { MinLevel = LogLevel.Trace }
         };
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ListLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ListLogger.cs
@@ -106,10 +106,7 @@ namespace Apache.Ignite.Tests
                 return;
             }
 
-            if (_wrappedLogger != null)
-            {
-                _wrappedLogger.Log(level, message, args, formatProvider, category, nativeErrorInfo, ex);
-            }
+            _wrappedLogger?.Log(level, message, args, formatProvider, category, nativeErrorInfo, ex);
 
             lock (_lock)
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ListLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ListLogger.cs
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+    using Log;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Stores log entries in a list.
+    /// </summary>
+    public class ListLogger : IIgniteLogger
+    {
+        [SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible", Justification = "Tests.")]
+        public record Entry(string Message, LogLevel Level, string? Category);
+
+        /** */
+        private readonly List<Entry> _entries = new();
+
+        /** */
+        private readonly object _lock = new();
+
+        /** */
+        private readonly IIgniteLogger? _wrappedLogger;
+
+        public ListLogger(IIgniteLogger? wrappedLogger = null)
+        {
+            _wrappedLogger = wrappedLogger;
+            EnabledLevels = new() { LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error };
+        }
+
+        /// <summary>
+        /// Gets enabled levels.
+        /// </summary>
+        public List<LogLevel> EnabledLevels { get; }
+
+        /// <summary>
+        /// Gets the entries.
+        /// </summary>
+        public List<Entry> Entries
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _entries.ToList();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clears the entries.
+        /// </summary>
+        public void Clear()
+        {
+            lock (_lock)
+            {
+                _entries.Clear();
+            }
+        }
+
+        /** <inheritdoc /> */
+        public void Log(
+            LogLevel level,
+            string message,
+            object[]? args,
+            IFormatProvider? formatProvider,
+            string? category,
+            string? nativeErrorInfo,
+            Exception? ex)
+        {
+            Assert.NotNull(message);
+
+            if (!IsEnabled(level))
+            {
+                return;
+            }
+
+            if (_wrappedLogger != null)
+            {
+                _wrappedLogger.Log(level, message, args, formatProvider, category, nativeErrorInfo, ex);
+            }
+
+            lock (_lock)
+            {
+                if (args != null)
+                {
+                    message = string.Format(formatProvider, message, args);
+                }
+
+                if (ex != null)
+                {
+                    message += Environment.NewLine + ex;
+                }
+
+                _entries.Add(new Entry(message, level, category));
+            }
+        }
+
+        /** <inheritdoc /> */
+        public bool IsEnabled(LogLevel level)
+        {
+            return EnabledLevels.Contains(level);
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ListLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ListLogger.cs
@@ -67,6 +67,18 @@ namespace Apache.Ignite.Tests
         }
 
         /// <summary>
+        /// Gets the log as a string.
+        /// </summary>
+        /// <returns>Log string.</returns>
+        public string GetLogString()
+        {
+            lock (_lock)
+            {
+                return string.Join(", ", _entries.Select(e => $"{e.Category} [{e.Level}] {e.Message}"));
+            }
+        }
+
+        /// <summary>
         /// Clears the entries.
         /// </summary>
         public void Clear()

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/RawSocketConnectionTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/RawSocketConnectionTests.cs
@@ -83,7 +83,7 @@ namespace Apache.Ignite.Tests
 
             var str = Encoding.UTF8.GetString(msg);
 
-            Assert.AreEqual(8, msgSize, str);
+            Assert.AreEqual(10, msgSize, str);
 
             // Protocol version.
             Assert.AreEqual(3, msg[0]);

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
@@ -40,6 +40,11 @@ namespace Apache.Ignite
         public static readonly TimeSpan DefaultSocketTimeout = TimeSpan.FromSeconds(5);
 
         /// <summary>
+        /// Default heartbeat interval.
+        /// </summary>
+        public static readonly TimeSpan DefaultHeartbeatInterval = TimeSpan.FromSeconds(30);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="IgniteClientConfiguration"/> class.
         /// </summary>
         public IgniteClientConfiguration()
@@ -74,6 +79,7 @@ namespace Apache.Ignite
             SocketTimeout = other.SocketTimeout;
             Endpoints = other.Endpoints.ToList();
             RetryPolicy = other.RetryPolicy;
+            HeartbeatInterval = other.HeartbeatInterval;
         }
 
         /// <summary>
@@ -109,5 +115,19 @@ namespace Apache.Ignite
         /// <see cref="RetryLimitPolicy.RetryLimit"/>.
         /// </summary>
         public IRetryPolicy RetryPolicy { get; set; } = RetryNonePolicy.Instance;
+
+        /// <summary>
+        /// Gets or sets the heartbeat message interval.
+        /// <para />
+        /// Default is <see cref="DefaultHeartbeatInterval"/>.
+        /// <para />
+        /// When server-side idle timeout is not zero, effective heartbeat
+        /// interval is set to <c>Min(HeartbeatInterval, IdleTimeout / 3)</c>.
+        /// <para />
+        /// When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
+        /// to keep the connection alive and detect potential half-open state.
+        /// </summary>
+        [DefaultValue(typeof(TimeSpan), "00:00:30")]
+        public TimeSpan HeartbeatInterval { get; set; } = DefaultHeartbeatInterval;
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -216,7 +216,7 @@ namespace Apache.Ignite.Internal
         /// </summary>
         private async Task<ClientSocket> ConnectAsync(SocketEndpoint endPoint)
         {
-            var socket = await ClientSocket.ConnectAsync(endPoint.EndPoint, _logger).ConfigureAwait(false);
+            var socket = await ClientSocket.ConnectAsync(endPoint.EndPoint, Configuration).ConfigureAwait(false);
 
             endPoint.Socket = socket;
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -155,6 +155,11 @@ namespace Apache.Ignite.Internal
 
                 if (_socket == null || _socket.IsDisposed)
                 {
+                    if (_socket?.IsDisposed == true)
+                    {
+                        _logger?.Info("Primary socket connection lost, reconnecting.");
+                    }
+
                     _socket = await GetNextSocketAsync().ConfigureAwait(false);
                 }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -70,7 +70,7 @@ namespace Apache.Ignite.Internal
                     $"{nameof(IgniteClientConfiguration.Endpoints)} is empty. Nowhere to connect.");
             }
 
-            _logger = configuration.Logger;
+            _logger = configuration.Logger.GetLogger(GetType());
             _endPoints = GetIpEndPoints(configuration).ToList();
 
             Configuration = new(configuration); // Defensive copy.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -402,6 +402,13 @@ namespace Apache.Ignite.Internal
 
         private static TimeSpan GetHeartbeatInterval(TimeSpan configuredInterval, TimeSpan serverIdleTimeout, IIgniteLogger? logger)
         {
+            if (configuredInterval <= TimeSpan.Zero)
+            {
+                throw new IgniteClientException(
+                    $"{nameof(IgniteClientConfiguration)}.{nameof(IgniteClientConfiguration.HeartbeatInterval)} " +
+                    "should be greater than zero.");
+            }
+
             if (serverIdleTimeout <= TimeSpan.Zero)
             {
                 logger?.Info(

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -429,6 +429,7 @@ namespace Apache.Ignite.Internal
                 return configuredInterval;
             }
 
+            // TODO: Explain MinRecommendedHeartbeatInterval behavior in the message.
             logger?.Warn(
                 $"Server-side IdleTimeout is {serverIdleTimeout}, configured " +
                 $"{nameof(IgniteClientConfiguration)}.{nameof(IgniteClientConfiguration.HeartbeatInterval)} " +

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -441,7 +441,7 @@ namespace Apache.Ignite.Internal
                 $"Server-side IdleTimeout is {serverIdleTimeout}, configured " +
                 $"{nameof(IgniteClientConfiguration)}.{nameof(IgniteClientConfiguration.HeartbeatInterval)} " +
                 $"is {configuredInterval}, which is longer than recommended IdleTimeout / 3. " +
-                $"Overriding heartbeat interval with IdleTimeout / 3: {recommendedHeartbeatInterval}");
+                $"Overriding heartbeat interval with max(IdleTimeout / 3, 500ms): {recommendedHeartbeatInterval}");
 
             return recommendedHeartbeatInterval;
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -436,7 +436,6 @@ namespace Apache.Ignite.Internal
                 return configuredInterval;
             }
 
-            // TODO: Explain MinRecommendedHeartbeatInterval behavior in the message.
             logger?.Warn(
                 $"Server-side IdleTimeout is {serverIdleTimeout}, configured " +
                 $"{nameof(IgniteClientConfiguration)}.{nameof(IgniteClientConfiguration.HeartbeatInterval)} " +

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -572,8 +572,7 @@ namespace Apache.Ignite.Internal
             }
             catch (Exception e)
             {
-                _exception = e;
-                Dispose();
+                Dispose(e);
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -96,6 +96,9 @@ namespace Apache.Ignite.Internal
             _configuration = configuration;
             _context = context;
 
+            // TODO: Init heartbeats
+            // TODO: Validate config.
+
             // Because this call is not awaited, execution of the current method continues before the call is completed.
             // Receive loop runs in the background and should not be awaited.
 #pragma warning disable 4014

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientOp.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientOp.cs
@@ -22,6 +22,9 @@ namespace Apache.Ignite.Internal.Proto
     /// </summary>
     internal enum ClientOp
     {
+        /** Heartbeat. */
+        Heartbeat = 1,
+
         /** Get tables. */
         TablesGet = 3,
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientOpExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientOpExtensions.cs
@@ -54,6 +54,9 @@ namespace Apache.Ignite.Internal.Proto
                 ClientOp.TxBegin => null,
                 ClientOp.TxCommit => null,
                 ClientOp.TxRollback => null,
+                ClientOp.Heartbeat => null,
+
+                // Do not return null from default arm intentionally so we don't forget to update this when new ClientOp values are added.
                 _ => throw new ArgumentOutOfRangeException(nameof(op), op, message: null)
             };
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Log/LoggerExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Log/LoggerExtensions.cs
@@ -323,12 +323,11 @@ namespace Apache.Ignite.Log
         /// <param name="logger">The logger.</param>
         /// <param name="category">The category as a type.</param>
         /// <returns>Logger that uses specified category when no other category is provided.</returns>
-        public static IIgniteLogger GetLogger(this IIgniteLogger logger, Type category)
+        public static IIgniteLogger? GetLogger(this IIgniteLogger? logger, Type category)
         {
-            IgniteArgumentCheck.NotNull(logger, "logger");
             IgniteArgumentCheck.NotNull(category, "category");
 
-            return new CategoryLogger(logger, category.Name);
+            return logger == null ? null : new CategoryLogger(logger, category.Name);
         }
     }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -55,7 +55,7 @@ public class PlatformTestNodeRunner {
                     + "  \"node\": {\n"
                     + "    \"metastorageNodes\":[ \"" + NODE_NAME + "\" ]\n"
                     + "  },\n"
-                    + "  \"clientConnector\":{\"port\": 10942,\"portRange\":10,\"idleTimeout\":300},"
+                    + "  \"clientConnector\":{\"port\": 10942,\"portRange\":10,\"idleTimeout\":500},"
                     + "  \"network\": {\n"
                     + "    \"port\":3344,\n"
                     + "    \"nodeFinder\": {\n"

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -55,7 +55,7 @@ public class PlatformTestNodeRunner {
                     + "  \"node\": {\n"
                     + "    \"metastorageNodes\":[ \"" + NODE_NAME + "\" ]\n"
                     + "  },\n"
-                    + "  \"clientConnector\":{\"port\": 10942,\"portRange\":10},"
+                    + "  \"clientConnector\":{\"port\": 10942,\"portRange\":10,\"idleTimeout\":300},"
                     + "  \"network\": {\n"
                     + "    \"port\":3344,\n"
                     + "    \"nodeFinder\": {\n"

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -55,7 +55,7 @@ public class PlatformTestNodeRunner {
                     + "  \"node\": {\n"
                     + "    \"metastorageNodes\":[ \"" + NODE_NAME + "\" ]\n"
                     + "  },\n"
-                    + "  \"clientConnector\":{\"port\": 10942,\"portRange\":10,\"idleTimeout\":500},"
+                    + "  \"clientConnector\":{\"port\": 10942,\"portRange\":10,\"idleTimeout\":1000},"
                     + "  \"network\": {\n"
                     + "    \"port\":3344,\n"
                     + "    \"nodeFinder\": {\n"


### PR DESCRIPTION
Implement keepalive in .NET client: https://cwiki.apache.org/confluence/display/IGNITE/IEP-83+Thin+Client+Keepalive

* Add `IgniteClientConfiguration.HeartbeatInterval`, default 30 seconds. Heartbeats are always enabled (no need to disable like in 2.x).
* Set effective heartbeat interval to `Math.Min(HeartbeatInterval, IdleTimeout / 3)`. Log warning when user-defined value is overridden.