### PR TITLE
IGNITE-16734 Java thin: Add Compute

### DIFF
--- a/modules/api/src/main/java/org/apache/ignite/Ignite.java
+++ b/modules/api/src/main/java/org/apache/ignite/Ignite.java
@@ -26,7 +26,7 @@ import org.apache.ignite.tx.IgniteTransactions;
 import org.jetbrains.annotations.ApiStatus.Experimental;
 
 /**
- * Ignite node interface. Main entry-point for all Ignite APIs.
+ * Ignite API entry point.
  */
 public interface Ignite extends AutoCloseable {
     /**

--- a/modules/api/src/main/java/org/apache/ignite/Ignite.java
+++ b/modules/api/src/main/java/org/apache/ignite/Ignite.java
@@ -17,10 +17,13 @@
 
 package org.apache.ignite;
 
+import java.util.Collection;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.compute.ComputeJob;
 import org.apache.ignite.compute.IgniteCompute;
 import org.apache.ignite.lang.IgniteException;
+import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.table.manager.IgniteTables;
 import org.apache.ignite.tx.IgniteTransactions;
 import org.jetbrains.annotations.ApiStatus.Experimental;
@@ -79,4 +82,20 @@ public interface Ignite extends AutoCloseable {
      * @see ComputeJob
      */
     IgniteCompute compute();
+
+    /**
+     * Gets the cluster nodes.
+     * NOTE: Temporary API to enable Compute until we have proper Cluster API.
+     *
+     * @return Collection of cluster nodes.
+     */
+    Collection<ClusterNode> clusterNodes();
+
+    /**
+     * Gets the cluster nodes.
+     * NOTE: Temporary API to enable Compute until we have proper Cluster API.
+     *
+     * @return Collection of cluster nodes.
+     */
+    CompletableFuture<Collection<ClusterNode>> clusterNodesAsync();
 }

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
@@ -785,6 +785,84 @@ public class ClientMessagePacker implements AutoCloseable {
     }
 
     /**
+     * Packs object type ({@link ClientDataType}) and value.
+     *
+     * @param obj Object.
+     */
+    public void packObjectWithType(Object obj) {
+        if (obj == null) {
+            packNil();
+
+            return;
+        }
+
+        Class<?> cls = obj.getClass();
+
+        if (cls == Boolean.class) {
+            packInt(ClientDataType.BOOLEAN);
+            packBoolean((Boolean) obj);
+        } else if (cls == Byte.class) {
+            packInt(ClientDataType.INT8);
+            packByte((Byte) obj);
+        } else if (cls == Short.class) {
+            packInt(ClientDataType.INT16);
+            packShort((Short) obj);
+        } else if (cls == Integer.class) {
+            packInt(ClientDataType.INT32);
+            packInt((Integer) obj);
+        } else if (cls == Long.class) {
+            packInt(ClientDataType.INT64);
+            packLong((Long) obj);
+        } else if (cls == Float.class) {
+            packInt(ClientDataType.FLOAT);
+            packFloat((Float) obj);
+        } else if (cls == Double.class) {
+            packInt(ClientDataType.DOUBLE);
+            packDouble((Double) obj);
+        } else if (cls == String.class) {
+            packInt(ClientDataType.STRING);
+            packString((String) obj);
+        } else if (cls == UUID.class) {
+            packInt(ClientDataType.UUID);
+            packUuid((UUID) obj);
+        } else if (cls == LocalDate.class) {
+            packInt(ClientDataType.DATE);
+            packDate((LocalDate) obj);
+        } else if (cls == LocalTime.class) {
+            packInt(ClientDataType.TIME);
+            packTime((LocalTime) obj);
+        } else if (cls == LocalDateTime.class) {
+            packInt(ClientDataType.DATETIME);
+            packDateTime((LocalDateTime) obj);
+        } else if (cls == Instant.class) {
+            packInt(ClientDataType.TIMESTAMP);
+            packTimestamp((Instant) obj);
+        } else if (cls == byte[].class) {
+            packInt(ClientDataType.BYTES);
+
+            packBinaryHeader(((byte[]) obj).length);
+            writePayload((byte[]) obj);
+        } else if (cls == Date.class) {
+            packInt(ClientDataType.DATE);
+            packDate(((Date) obj).toLocalDate());
+        } else if (cls == Time.class) {
+            packInt(ClientDataType.TIME);
+            packTime(((Time) obj).toLocalTime());
+        } else if (cls == Timestamp.class) {
+            packInt(ClientDataType.TIMESTAMP);
+            packTimestamp(((java.util.Date) obj).toInstant());
+        } else if (cls == BigDecimal.class) {
+            packInt(ClientDataType.DECIMAL);
+            packDecimal(((BigDecimal) obj));
+        } else if (cls == BigInteger.class) {
+            packInt(ClientDataType.BIGINTEGER);
+            packBigInteger(((BigInteger) obj));
+        } else {
+            throw new UnsupportedOperationException("Custom objects are not supported");
+        }
+    }
+
+    /**
      * Packs an array of different objects.
      *
      * @param args Object array.
@@ -802,76 +880,7 @@ public class ClientMessagePacker implements AutoCloseable {
         packArrayHeader(args.length);
 
         for (Object arg : args) {
-            if (arg == null) {
-                packNil();
-
-                continue;
-            }
-
-            Class<?> cls = arg.getClass();
-
-            if (cls == Boolean.class) {
-                packInt(ClientDataType.BOOLEAN);
-                packBoolean((Boolean) arg);
-            } else if (cls == Byte.class) {
-                packInt(ClientDataType.INT8);
-                packByte((Byte) arg);
-            } else if (cls == Short.class) {
-                packInt(ClientDataType.INT16);
-                packShort((Short) arg);
-            } else if (cls == Integer.class) {
-                packInt(ClientDataType.INT32);
-                packInt((Integer) arg);
-            } else if (cls == Long.class) {
-                packInt(ClientDataType.INT64);
-                packLong((Long) arg);
-            } else if (cls == Float.class) {
-                packInt(ClientDataType.FLOAT);
-                packFloat((Float) arg);
-            } else if (cls == Double.class) {
-                packInt(ClientDataType.DOUBLE);
-                packDouble((Double) arg);
-            } else if (cls == String.class) {
-                packInt(ClientDataType.STRING);
-                packString((String) arg);
-            } else if (cls == UUID.class) {
-                packInt(ClientDataType.UUID);
-                packUuid((UUID) arg);
-            } else if (cls == LocalDate.class) {
-                packInt(ClientDataType.DATE);
-                packDate((LocalDate) arg);
-            } else if (cls == LocalTime.class) {
-                packInt(ClientDataType.TIME);
-                packTime((LocalTime) arg);
-            } else if (cls == LocalDateTime.class) {
-                packInt(ClientDataType.DATETIME);
-                packDateTime((LocalDateTime) arg);
-            } else if (cls == Instant.class) {
-                packInt(ClientDataType.TIMESTAMP);
-                packTimestamp((Instant) arg);
-            } else if (cls == byte[].class) {
-                packInt(ClientDataType.BYTES);
-
-                packBinaryHeader(((byte[]) arg).length);
-                writePayload((byte[]) arg);
-            } else if (cls == Date.class) {
-                packInt(ClientDataType.DATE);
-                packDate(((Date) arg).toLocalDate());
-            } else if (cls == Time.class) {
-                packInt(ClientDataType.TIME);
-                packTime(((Time) arg).toLocalTime());
-            } else if (cls == Timestamp.class) {
-                packInt(ClientDataType.TIMESTAMP);
-                packTimestamp(((java.util.Date) arg).toInstant());
-            } else if (cls == BigDecimal.class) {
-                packInt(ClientDataType.DECIMAL);
-                packDecimal(((BigDecimal) arg));
-            } else if (cls == BigInteger.class) {
-                packInt(ClientDataType.BIGINTEGER);
-                packBigInteger(((BigInteger) arg));
-            } else {
-                throw new UnsupportedOperationException("Custom objects are not supported");
-            }
+            packObjectWithType(arg);
         }
     }
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
@@ -859,7 +859,7 @@ public class ClientMessagePacker implements AutoCloseable {
             packBigInteger(((BigInteger) obj));
         } else if (cls == BitSet.class) {
             packInt(ClientDataType.BITMASK);
-            packBitSet((BitSet)obj);
+            packBitSet((BitSet) obj);
         } else {
             throw new UnsupportedOperationException("Custom objects are not supported");
         }

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
@@ -857,6 +857,9 @@ public class ClientMessagePacker implements AutoCloseable {
         } else if (cls == BigInteger.class) {
             packInt(ClientDataType.BIGINTEGER);
             packBigInteger(((BigInteger) obj));
+        } else if (cls == BitSet.class) {
+            packInt(ClientDataType.BITMASK);
+            packBitSet((BitSet)obj);
         } else {
             throw new UnsupportedOperationException("Custom objects are not supported");
         }

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
@@ -938,6 +938,19 @@ public class ClientMessageUnpacker implements AutoCloseable {
     }
 
     /**
+     * Unpacks object type ({@link ClientDataType}) and value.
+     *
+     * @return Object value.
+     */
+    public Object unpackObjectWithType() {
+        if (tryUnpackNil()) {
+            return null;
+        }
+
+        return unpackObject(unpackInt());
+    }
+
+    /**
      * Unpacks an object based on the specified type.
      *
      * @param dataType Data type code.

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientOp.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientOp.java
@@ -128,4 +128,7 @@ public class ClientOp {
 
     /** Broadcast compute job. */
     public static final int COMPUTE_BROADCAST = 48;
+
+    /** Get cluster nodes. */
+    public static final int CLUSTER_GET_NODES = 49;
 }

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientOp.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientOp.java
@@ -122,4 +122,10 @@ public class ClientOp {
 
     /** Execute prepared statement batch query. */
     public static final int SQL_EXEC_PS_BATCH = 46;
+
+    /** Execute compute job. */
+    public static final int COMPUTE_EXECUTE = 47;
+
+    /** Broadcast compute job. */
+    public static final int COMPUTE_BROADCAST = 48;
 }

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientOp.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientOp.java
@@ -126,9 +126,6 @@ public class ClientOp {
     /** Execute compute job. */
     public static final int COMPUTE_EXECUTE = 47;
 
-    /** Broadcast compute job. */
-    public static final int COMPUTE_BROADCAST = 48;
-
     /** Get cluster nodes. */
-    public static final int CLUSTER_GET_NODES = 49;
+    public static final int CLUSTER_GET_NODES = 48;
 }

--- a/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerTest.java
+++ b/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerTest.java
@@ -30,11 +30,13 @@ import java.net.Socket;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.apache.ignite.compute.IgniteCompute;
 import org.apache.ignite.configuration.schemas.clientconnector.ClientConnectorConfiguration;
 import org.apache.ignite.configuration.schemas.network.NetworkConfiguration;
 import org.apache.ignite.internal.configuration.ConfigurationManager;
 import org.apache.ignite.internal.configuration.storage.TestConfigurationStorage;
 import org.apache.ignite.internal.sql.engine.QueryProcessor;
+import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.network.NettyBootstrapFactory;
 import org.apache.ignite.table.manager.IgniteTables;
 import org.apache.ignite.tx.IgniteTransactions;
@@ -206,7 +208,7 @@ public class ItClientHandlerTest {
         bootstrapFactory.start();
 
         var module = new ClientHandlerModule(mock(QueryProcessor.class), mock(IgniteTables.class), mock(IgniteTransactions.class), registry,
-                compute, clusterService, bootstrapFactory);
+                mock(IgniteCompute.class), mock(ClusterService.class), bootstrapFactory);
 
         module.start();
 

--- a/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerTest.java
+++ b/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerTest.java
@@ -206,7 +206,7 @@ public class ItClientHandlerTest {
         bootstrapFactory.start();
 
         var module = new ClientHandlerModule(mock(QueryProcessor.class), mock(IgniteTables.class), mock(IgniteTransactions.class), registry,
-                bootstrapFactory);
+                compute, clusterService, bootstrapFactory);
 
         module.start();
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientHandlerModule.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientHandlerModule.java
@@ -77,6 +77,7 @@ public class ClientHandlerModule implements IgniteComponent {
 
     /**
      * Constructor.
+     *
      * @param queryProcessor     Sql query processor.
      * @param igniteTables       Ignite.
      * @param igniteTransactions Transactions.

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientHandlerModule.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientHandlerModule.java
@@ -77,7 +77,7 @@ public class ClientHandlerModule implements IgniteComponent {
 
     /**
      * Constructor.
-     *  @param queryProcessor    Sql query processor.
+     * @param queryProcessor     Sql query processor.
      * @param igniteTables       Ignite.
      * @param igniteTransactions Transactions.
      * @param registry           Configuration registry.

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientHandlerModule.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientHandlerModule.java
@@ -30,6 +30,7 @@ import io.netty.handler.timeout.IdleStateHandler;
 import java.net.BindException;
 import java.net.SocketAddress;
 import java.util.concurrent.TimeUnit;
+import org.apache.ignite.compute.IgniteCompute;
 import org.apache.ignite.configuration.schemas.clientconnector.ClientConnectorConfiguration;
 import org.apache.ignite.internal.client.proto.ClientMessageDecoder;
 import org.apache.ignite.internal.configuration.ConfigurationRegistry;
@@ -37,6 +38,7 @@ import org.apache.ignite.internal.manager.IgniteComponent;
 import org.apache.ignite.internal.sql.engine.QueryProcessor;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.lang.IgniteLogger;
+import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.network.NettyBootstrapFactory;
 import org.apache.ignite.table.manager.IgniteTables;
 import org.apache.ignite.tx.IgniteTransactions;
@@ -64,16 +66,23 @@ public class ClientHandlerModule implements IgniteComponent {
     /** Processor. */
     private final QueryProcessor queryProcessor;
 
+    /** Compute. */
+    private final IgniteCompute igniteCompute;
+
+    /** Cluster. */
+    private final ClusterService clusterService;
+
     /** Netty bootstrap factory. */
     private final NettyBootstrapFactory bootstrapFactory;
 
     /**
      * Constructor.
-     *
-     * @param queryProcessor     Sql query processor.
+     *  @param queryProcessor    Sql query processor.
      * @param igniteTables       Ignite.
      * @param igniteTransactions Transactions.
      * @param registry           Configuration registry.
+     * @param igniteCompute      Compute.
+     * @param clusterService     Cluster.
      * @param bootstrapFactory   Bootstrap factory.
      */
     public ClientHandlerModule(
@@ -81,15 +90,21 @@ public class ClientHandlerModule implements IgniteComponent {
             IgniteTables igniteTables,
             IgniteTransactions igniteTransactions,
             ConfigurationRegistry registry,
+            IgniteCompute igniteCompute,
+            ClusterService clusterService,
             NettyBootstrapFactory bootstrapFactory) {
         assert igniteTables != null;
         assert registry != null;
         assert queryProcessor != null;
+        assert igniteCompute != null;
+        assert clusterService != null;
         assert bootstrapFactory != null;
 
         this.queryProcessor = queryProcessor;
         this.igniteTables = igniteTables;
         this.igniteTransactions = igniteTransactions;
+        this.igniteCompute = igniteCompute;
+        this.clusterService = clusterService;
         this.registry = registry;
         this.bootstrapFactory = bootstrapFactory;
     }
@@ -159,7 +174,13 @@ public class ClientHandlerModule implements IgniteComponent {
 
                         ch.pipeline().addLast(
                                 new ClientMessageDecoder(),
-                                new ClientInboundMessageHandler(igniteTables, igniteTransactions, queryProcessor, configuration));
+                                new ClientInboundMessageHandler(
+                                        igniteTables,
+                                        igniteTransactions,
+                                        queryProcessor,
+                                        configuration,
+                                        igniteCompute,
+                                        clusterService));
                     }
                 })
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, configuration.connectTimeout());

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -413,10 +413,6 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter {
             case ClientOp.COMPUTE_EXECUTE:
                 return ClientComputeExecuteRequest.process(in, out, compute, clusterService);
 
-            case ClientOp.COMPUTE_BROADCAST:
-                // TODO
-                return null;
-
             case ClientOp.CLUSTER_GET_NODES:
                 return ClientClusterGetNodesRequest.process(out, clusterService);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -60,6 +60,7 @@ import org.apache.ignite.client.handler.requests.tx.ClientTransactionBeginReques
 import org.apache.ignite.client.handler.requests.tx.ClientTransactionCommitRequest;
 import org.apache.ignite.client.handler.requests.tx.ClientTransactionRollbackRequest;
 import org.apache.ignite.client.proto.query.JdbcQueryEventHandler;
+import org.apache.ignite.compute.IgniteCompute;
 import org.apache.ignite.configuration.schemas.clientconnector.ClientConnectorView;
 import org.apache.ignite.internal.client.proto.ClientErrorCode;
 import org.apache.ignite.internal.client.proto.ClientMessageCommon;
@@ -71,6 +72,7 @@ import org.apache.ignite.internal.client.proto.ServerMessageType;
 import org.apache.ignite.internal.sql.engine.QueryProcessor;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.lang.IgniteLogger;
+import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.table.manager.IgniteTables;
 import org.apache.ignite.tx.IgniteTransactions;
 
@@ -97,30 +99,43 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter {
     /** Configuration. */
     private final ClientConnectorView configuration;
 
+    /** Compute. */
+    private final IgniteCompute compute;
+
+    /** Cluster. */
+    private final ClusterService clusterService;
+
     /** Context. */
     private ClientContext clientContext;
 
     /**
      * Constructor.
-     *
-     * @param igniteTables      Ignite tables API entry point.
+     *  @param igniteTables      Ignite tables API entry point.
      * @param igniteTransactions Transactions API.
      * @param processor          Sql query processor.
      * @param configuration      Configuration.
+     * @param compute            Compute.
+     * @param clusterService     Cluster.
      */
     public ClientInboundMessageHandler(
             IgniteTables igniteTables,
             IgniteTransactions igniteTransactions,
             QueryProcessor processor,
-            ClientConnectorView configuration) {
+            ClientConnectorView configuration,
+            IgniteCompute compute,
+            ClusterService clusterService) {
         assert igniteTables != null;
         assert igniteTransactions != null;
         assert processor != null;
         assert configuration != null;
+        assert compute != null;
+        assert clusterService != null;
 
         this.igniteTables = igniteTables;
         this.igniteTransactions = igniteTransactions;
         this.configuration = configuration;
+        this.compute = compute;
+        this.clusterService = clusterService;
 
         this.jdbcQueryEventHandler = new JdbcQueryEventHandlerImpl(processor, new JdbcMetadataCatalog(igniteTables));
     }
@@ -393,7 +408,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter {
                 return ClientTransactionRollbackRequest.process(in, resources);
 
             case ClientOp.COMPUTE_EXECUTE:
-                return ClientComputeExecuteRequest.process(in, out);
+                return ClientComputeExecuteRequest.process(in, out, compute, clusterService);
 
             case ClientOp.COMPUTE_BROADCAST:
                 // TODO

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -111,7 +111,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter {
 
     /**
      * Constructor.
-     *  @param igniteTables      Ignite tables API entry point.
+     * @param igniteTables       Ignite tables API entry point.
      * @param igniteTransactions Transactions API.
      * @param processor          Sql query processor.
      * @param configuration      Configuration.

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import java.util.BitSet;
 import java.util.concurrent.CompletableFuture;
+import org.apache.ignite.client.handler.requests.compute.ClientComputeExecuteRequest;
 import org.apache.ignite.client.handler.requests.sql.ClientSqlCloseRequest;
 import org.apache.ignite.client.handler.requests.sql.ClientSqlColumnMetadataRequest;
 import org.apache.ignite.client.handler.requests.sql.ClientSqlExecuteBatchRequest;
@@ -390,6 +391,13 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter {
 
             case ClientOp.TX_ROLLBACK:
                 return ClientTransactionRollbackRequest.process(in, resources);
+
+            case ClientOp.COMPUTE_EXECUTE:
+                return ClientComputeExecuteRequest.process(in, out);
+
+            case ClientOp.COMPUTE_BROADCAST:
+                // TODO
+                return null;
 
             default:
                 throw new IgniteException("Unexpected operation code: " + opCode);

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -111,6 +111,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter {
 
     /**
      * Constructor.
+     *
      * @param igniteTables       Ignite tables API entry point.
      * @param igniteTransactions Transactions API.
      * @param processor          Sql query processor.

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import java.util.BitSet;
 import java.util.concurrent.CompletableFuture;
+import org.apache.ignite.client.handler.requests.cluster.ClientClusterGetNodesRequest;
 import org.apache.ignite.client.handler.requests.compute.ClientComputeExecuteRequest;
 import org.apache.ignite.client.handler.requests.sql.ClientSqlCloseRequest;
 import org.apache.ignite.client.handler.requests.sql.ClientSqlColumnMetadataRequest;
@@ -413,6 +414,9 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter {
             case ClientOp.COMPUTE_BROADCAST:
                 // TODO
                 return null;
+
+            case ClientOp.CLUSTER_GET_NODES:
+                return ClientClusterGetNodesRequest.process(out, clusterService);
 
             default:
                 throw new IgniteException("Unexpected operation code: " + opCode);

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -232,6 +232,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter {
     }
 
     private void writeError(long requestId, Throwable err, ChannelHandlerContext ctx) {
+        LOG.error("Error processing client request", err);
+
         var packer = getPacker(ctx.alloc());
 
         try {

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/cluster/ClientClusterGetNodesRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/cluster/ClientClusterGetNodesRequest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client.handler.requests.cluster;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import org.apache.ignite.internal.client.proto.ClientMessagePacker;
+import org.apache.ignite.network.ClusterNode;
+import org.apache.ignite.network.ClusterService;
+
+/**
+ * Cluster nodes request.
+ */
+public class ClientClusterGetNodesRequest {
+    /**
+     * Processes the request.
+     *
+     * @param out            Packer.
+     * @param clusterService Cluster.
+     * @return Future.
+     */
+    public static CompletableFuture<Void> process(
+            ClientMessagePacker out,
+            ClusterService clusterService) {
+        Collection<ClusterNode> nodes = clusterService.topologyService().allMembers();
+
+        out.packArrayHeader(nodes.size());
+
+        for (ClusterNode node : nodes) {
+            out.packString(node.id());
+            out.packString(node.name());
+            out.packString(node.address().host());
+            out.packInt(node.address().port());
+        }
+
+        // Null future indicates synchronous completion.
+        return null;
+    }
+}

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client.handler.requests.compute;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.ignite.compute.IgniteCompute;
+import org.apache.ignite.internal.client.proto.ClientMessagePacker;
+import org.apache.ignite.internal.client.proto.ClientMessageUnpacker;
+import org.apache.ignite.network.ClusterService;
+
+/**
+ * Compute execute request.
+ */
+public class ClientComputeExecuteRequest {
+    /**
+     * Processes the request.
+     *
+     * @param in        Unpacker.
+     * @param out       Packer.
+     * @param compute   Compute.
+     * @param cluster   Cluster.
+     * @return Future.
+     */
+    public static CompletableFuture<Void> process(
+            ClientMessageUnpacker in,
+            ClientMessagePacker out,
+            IgniteCompute compute,
+            ClusterService cluster) {
+        return null;
+    }
+}

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteRequest.java
@@ -50,7 +50,7 @@ public class ClientComputeExecuteRequest {
         var nodes = new HashSet<ClusterNode>(nodeCnt);
 
         for (int i = 0; i < nodeCnt; i++) {
-            var node = new ClusterNode(in.unpackString(), in.unpackString(), new NetworkAddress(in.unpackString(), in.unpackInt()));
+            var node = new ClusterNode(in.unpackString(), null, null);
             nodes.add(node);
         }
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteRequest.java
@@ -50,7 +50,7 @@ public class ClientComputeExecuteRequest {
         var nodes = new HashSet<ClusterNode>(nodeCnt);
 
         for (int i = 0; i < nodeCnt; i++) {
-            var node = new ClusterNode(in.unpackString(), null, null);
+            var node = new ClusterNode(in.unpackString(), in.unpackString(), new NetworkAddress(in.unpackString(), in.unpackInt()));
             nodes.add(node);
         }
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpIgniteClient.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpIgniteClient.java
@@ -25,6 +25,7 @@ import org.apache.ignite.client.IgniteClientConfiguration;
 import org.apache.ignite.client.IgniteClientException;
 import org.apache.ignite.client.proto.query.ClientMessage;
 import org.apache.ignite.compute.IgniteCompute;
+import org.apache.ignite.internal.client.compute.ClientCompute;
 import org.apache.ignite.internal.client.io.ClientConnectionMultiplexer;
 import org.apache.ignite.internal.client.table.ClientTables;
 import org.apache.ignite.internal.client.tx.ClientTransactions;
@@ -46,6 +47,9 @@ public class TcpIgniteClient implements IgniteClient {
 
     /** Transactions. */
     private final ClientTransactions transactions;
+
+    /** Transactions. */
+    private final ClientCompute compute;
 
     /**
      * Constructor.
@@ -74,6 +78,7 @@ public class TcpIgniteClient implements IgniteClient {
         ch = new ReliableChannel(chFactory, cfg);
         tables = new ClientTables(ch);
         transactions = new ClientTransactions(ch);
+        compute = new ClientCompute(ch);
     }
 
     /**
@@ -119,7 +124,7 @@ public class TcpIgniteClient implements IgniteClient {
     /** {@inheritDoc} */
     @Override
     public IgniteCompute compute() {
-        throw new UnsupportedOperationException("Not implemented yet");
+        return compute;
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpIgniteClient.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpIgniteClient.java
@@ -56,7 +56,7 @@ public class TcpIgniteClient implements IgniteClient {
     /** Transactions. */
     private final ClientTransactions transactions;
 
-    /** Transactions. */
+    /** Compute. */
     private final ClientCompute compute;
 
     /**

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -81,7 +81,7 @@ public class ClientCompute implements IgniteCompute {
         Objects.requireNonNull(nodes);
         Objects.requireNonNull(jobClassName);
 
-        Map<ClusterNode, CompletableFuture<R>> map = new HashMap<>();
+        Map<ClusterNode, CompletableFuture<R>> map = new HashMap<>(nodes.size());
 
         for (ClusterNode node : nodes) {
             if (map.put(node, executeOnOneNode(node, jobClassName, args)) != null) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -56,6 +56,9 @@ public class ClientCompute implements IgniteCompute {
 
             for (var n : nodes) {
                 w.out().packString(n.id());
+                w.out().packString(n.name());
+                w.out().packString(n.address().host());
+                w.out().packInt(n.address().port());
             }
 
             w.out().packString(jobClassName);

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -61,7 +61,7 @@ public class ClientCompute implements IgniteCompute {
             w.out().packString(jobClassName);
             w.out().packArrayHeader(args.length);
             w.out().packObjectArray(args);
-        }, r -> (R)r.in().unpackObject(r.in().unpackInt()));
+        }, r -> (R)r.in().unpackObjectWithType());
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -29,28 +29,38 @@ import org.apache.ignite.network.ClusterNode;
  * Client compute implementation.
  */
 public class ClientCompute implements IgniteCompute {
+    /** Channel. */
     private final ReliableChannel ch;
 
+    /**
+     * Constructor.
+     *
+     * @param ch Channel.
+     */
     public ClientCompute(ReliableChannel ch) {
         this.ch = ch;
     }
 
+    /** {@inheritDoc} */
     @Override
     public <R> CompletableFuture<R> execute(Set<ClusterNode> nodes, Class<? extends ComputeJob<R>> jobClass, Object... args) {
         return null;
     }
 
+    /** {@inheritDoc} */
     @Override
     public <R> CompletableFuture<R> execute(Set<ClusterNode> nodes, String jobClassName, Object... args) {
         return null;
     }
 
+    /** {@inheritDoc} */
     @Override
     public <R> Map<ClusterNode, CompletableFuture<R>> broadcast(Set<ClusterNode> nodes, Class<? extends ComputeJob<R>> jobClass,
             Object... args) {
         return null;
     }
 
+    /** {@inheritDoc} */
     @Override
     public <R> Map<ClusterNode, CompletableFuture<R>> broadcast(Set<ClusterNode> nodes, String jobClassName, Object... args) {
         return null;

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -44,6 +44,7 @@ public class ClientCompute implements IgniteCompute {
     /** {@inheritDoc} */
     @Override
     public <R> CompletableFuture<R> execute(Set<ClusterNode> nodes, Class<? extends ComputeJob<R>> jobClass, Object... args) {
+        // TODO There is no public API to get cluster nodes, so we ignore that part for now.
         return null;
     }
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.client.compute;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.apache.ignite.compute.ComputeJob;
+import org.apache.ignite.compute.IgniteCompute;
+import org.apache.ignite.internal.client.ReliableChannel;
+import org.apache.ignite.network.ClusterNode;
+
+/**
+ * Client compute implementation.
+ */
+public class ClientCompute implements IgniteCompute {
+    private final ReliableChannel ch;
+
+    public ClientCompute(ReliableChannel ch) {
+        this.ch = ch;
+    }
+
+    @Override
+    public <R> CompletableFuture<R> execute(Set<ClusterNode> nodes, Class<? extends ComputeJob<R>> jobClass, Object... args) {
+        return null;
+    }
+
+    @Override
+    public <R> CompletableFuture<R> execute(Set<ClusterNode> nodes, String jobClassName, Object... args) {
+        return null;
+    }
+
+    @Override
+    public <R> Map<ClusterNode, CompletableFuture<R>> broadcast(Set<ClusterNode> nodes, Class<? extends ComputeJob<R>> jobClass,
+            Object... args) {
+        return null;
+    }
+
+    @Override
+    public <R> Map<ClusterNode, CompletableFuture<R>> broadcast(Set<ClusterNode> nodes, String jobClassName, Object... args) {
+        return null;
+    }
+}

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -62,7 +62,6 @@ public class ClientCompute implements IgniteCompute {
             }
 
             w.out().packString(jobClassName);
-            w.out().packArrayHeader(args.length);
             w.out().packObjectArray(args);
         }, r -> (R)r.in().unpackObjectWithType());
     }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -45,13 +45,12 @@ public class ClientCompute implements IgniteCompute {
     /** {@inheritDoc} */
     @Override
     public <R> CompletableFuture<R> execute(Set<ClusterNode> nodes, Class<? extends ComputeJob<R>> jobClass, Object... args) {
-        return null;
+        return execute(nodes, jobClass.getName(), args);
     }
 
     /** {@inheritDoc} */
     @Override
     public <R> CompletableFuture<R> execute(Set<ClusterNode> nodes, String jobClassName, Object... args) {
-        // TODO Add simple public API to retrieve cluster nodes.
         return ch.serviceAsync(ClientOp.COMPUTE_EXECUTE, w -> {
             w.out().packArrayHeader(nodes.size());
 

--- a/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
@@ -77,7 +77,7 @@ public class TestServer implements AutoCloseable {
                 ignite.tables(),
                 ignite.transactions(),
                 cfg,
-                bootstrapFactory
+                compute, clusterService, bootstrapFactory
         );
 
         module.start();

--- a/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
@@ -18,16 +18,19 @@
 package org.apache.ignite.client;
 
 import static org.apache.ignite.configuration.annotation.ConfigurationType.LOCAL;
+import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import java.util.Map;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.client.fakes.FakeIgnite;
 import org.apache.ignite.client.handler.ClientHandlerModule;
+import org.apache.ignite.compute.IgniteCompute;
 import org.apache.ignite.configuration.schemas.clientconnector.ClientConnectorConfiguration;
 import org.apache.ignite.configuration.schemas.network.NetworkConfiguration;
 import org.apache.ignite.internal.configuration.ConfigurationRegistry;
 import org.apache.ignite.internal.configuration.storage.TestConfigurationStorage;
+import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.network.NettyBootstrapFactory;
 
 /**
@@ -77,7 +80,9 @@ public class TestServer implements AutoCloseable {
                 ignite.tables(),
                 ignite.transactions(),
                 cfg,
-                compute, clusterService, bootstrapFactory
+                mock(IgniteCompute.class),
+                mock(ClusterService.class),
+                bootstrapFactory
         );
 
         module.start();

--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgnite.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgnite.java
@@ -93,6 +93,12 @@ public class FakeIgnite implements Ignite {
 
     /** {@inheritDoc} */
     @Override
+    public CompletableFuture<Collection<ClusterNode>> clusterNodesAsync() {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void close() {
         // No-op.
     }

--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgnite.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgnite.java
@@ -17,11 +17,13 @@
 
 package org.apache.ignite.client.fakes;
 
+import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.compute.IgniteCompute;
 import org.apache.ignite.internal.sql.engine.QueryProcessor;
+import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.table.manager.IgniteTables;
 import org.apache.ignite.tx.IgniteTransactions;
 import org.apache.ignite.tx.Transaction;
@@ -80,6 +82,12 @@ public class FakeIgnite implements Ignite {
     /** {@inheritDoc} */
     @Override
     public IgniteCompute compute() {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Collection<ClusterNode> clusterNodes() {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeImpl.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeImpl.java
@@ -21,6 +21,7 @@ import static java.util.stream.Collectors.toUnmodifiableMap;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
@@ -46,12 +47,26 @@ public class IgniteComputeImpl implements IgniteCompute {
     /** {@inheritDoc} */
     @Override
     public <R> CompletableFuture<R> execute(Set<ClusterNode> nodes, Class<? extends ComputeJob<R>> jobClass, Object... args) {
+        Objects.requireNonNull(nodes);
+        Objects.requireNonNull(jobClass);
+
+        if (nodes.isEmpty()) {
+            throw new IllegalArgumentException("nodes must not be empty.");
+        }
+
         return executeOnOneNode(randomNode(nodes), jobClass, args);
     }
 
     /** {@inheritDoc} */
     @Override
     public <R> CompletableFuture<R> execute(Set<ClusterNode> nodes, String jobClassName, Object... args) {
+        Objects.requireNonNull(nodes);
+        Objects.requireNonNull(jobClassName);
+
+        if (nodes.isEmpty()) {
+            throw new IllegalArgumentException("nodes must not be empty.");
+        }
+
         return executeOnOneNode(randomNode(nodes), jobClassName, args);
     }
 
@@ -93,6 +108,9 @@ public class IgniteComputeImpl implements IgniteCompute {
             Class<? extends ComputeJob<R>> jobClass,
             Object... args
     ) {
+        Objects.requireNonNull(nodes);
+        Objects.requireNonNull(jobClass);
+
         return nodes.stream()
                 .collect(toUnmodifiableMap(node -> node, node -> executeOnOneNode(node, jobClass, args)));
     }
@@ -100,6 +118,9 @@ public class IgniteComputeImpl implements IgniteCompute {
     /** {@inheritDoc} */
     @Override
     public <R> Map<ClusterNode, CompletableFuture<R>> broadcast(Set<ClusterNode> nodes, String jobClassName, Object... args) {
+        Objects.requireNonNull(nodes);
+        Objects.requireNonNull(jobClassName);
+
         return nodes.stream()
                 .collect(toUnmodifiableMap(node -> node, node -> executeOnOneNode(node, jobClassName, args)));
     }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
@@ -128,6 +129,15 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
     @Test
     void testAllSupportedArgTypes() {
         // TODO: Test all types and arrays of them.
+        testEchoArg(1);
+        testEchoArg("1");
+        testEchoArg(UUID.randomUUID());
+    }
+
+    private void testEchoArg(Object arg) {
+        Object res = client().compute().execute(Set.of(node(0)), EchoJob.class, arg).join();
+
+        assertEquals(arg, res);
     }
 
     private ClusterNode node(int idx) {
@@ -158,6 +168,13 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
         @Override
         public String execute(JobExecutionContext context, Object... args) {
             throw new TransactionException("Custom job error");
+        }
+    }
+
+    private static class EchoJob implements ComputeJob<Object> {
+        @Override
+        public Object execute(JobExecutionContext context, Object... args) {
+            return args[0];
         }
     }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -21,8 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.ignite.compute.ComputeJob;
+import org.apache.ignite.compute.JobExecutionContext;
 import org.apache.ignite.network.ClusterNode;
 import org.junit.jupiter.api.Test;
 
@@ -45,5 +48,36 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
         assertEquals("ItThinClientComputeTest_null_3345", nodes.get(1).name());
         assertEquals(3345, nodes.get(1).address().port());
         assertTrue(nodes.get(1).id().length() > 10);
+    }
+
+    @Test
+    void testExecute() {
+        var nodes = new HashSet<>(client().clusterNodes());
+        String res = client().compute().execute(nodes, NodeNameJob.class).join();
+
+        assertEquals("ItThinClientComputeTest_null_334", res);
+    }
+
+    @Test
+    void testExecuteWithArgs() {
+        var nodes = new HashSet<>(client().clusterNodes());
+        String res = client().compute().execute(nodes, ConcatJob.class, 1, "2", 3.3).join();
+
+        assertEquals("1_2_3.3", res);
+    }
+
+    private static class NodeNameJob implements ComputeJob<String> {
+        @Override
+        public String execute(JobExecutionContext context, Object... args) {
+            return context.ignite().name();
+        }
+    }
+
+    private static class ConcatJob implements ComputeJob<String> {
+        @Override
+        public String execute(JobExecutionContext context, Object... args) {
+            // TODO: Concat args.
+            return null;
+        }
     }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -19,11 +19,19 @@ package org.apache.ignite.internal.runner.app.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -128,16 +136,33 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
 
     @Test
     void testAllSupportedArgTypes() {
-        // TODO: Test all types and arrays of them.
-        testEchoArg(1);
-        testEchoArg("1");
+        testEchoArg(Byte.MAX_VALUE);
+        testEchoArg(Short.MAX_VALUE);
+        testEchoArg(Integer.MAX_VALUE);
+        testEchoArg(Long.MAX_VALUE);
+        testEchoArg(Float.MAX_VALUE);
+        testEchoArg(Double.MAX_VALUE);
+        testEchoArg(BigDecimal.TEN);
         testEchoArg(UUID.randomUUID());
+        testEchoArg("string");
+        testEchoArg(new byte[] {1,2,3});
+        testEchoArg(new BitSet(10));
+        testEchoArg(LocalDate.now());
+        testEchoArg(LocalTime.now());
+        testEchoArg(LocalDateTime.now());
+        testEchoArg(Instant.now());
+        testEchoArg(BigInteger.TEN);
+        testEchoArg(true);
     }
 
     private void testEchoArg(Object arg) {
         Object res = client().compute().execute(Set.of(node(0)), EchoJob.class, arg).join();
 
-        assertEquals(arg, res);
+        if (arg instanceof byte[]) {
+            assertArrayEquals((byte[])arg, (byte[])res);
+        } else {
+            assertEquals(arg, res);
+        }
     }
 
     private ClusterNode node(int idx) {

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -59,7 +59,7 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
     }
 
     @Test
-    void testExecute() {
+    void testExecuteOnSpecificNode() {
         String res1 = client().compute().execute(Set.of(node(0)), NodeNameJob.class).join();
         String res2 = client().compute().execute(Set.of(node(1)), NodeNameJob.class).join();
 
@@ -68,12 +68,36 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
     }
 
     @Test
-    void testBroadcast() {
+    void testExecuteOnRandomNode() {
+        String res = client().compute().execute(new HashSet<>(sortedNodes()), NodeNameJob.class).join();
+
+        assertTrue(Set.of("ItThinClientComputeTest_null_3344", "ItThinClientComputeTest_null_3345").contains(res));
+    }
+
+    @Test
+    void testBroadcastOneNode() {
+        Map<ClusterNode, CompletableFuture<String>> futuresPerNode = client().compute().broadcast(
+                Set.of(node(1)),
+                NodeNameJob.class,
+                "_",
+                123);
+
+        assertEquals(1, futuresPerNode.size());
+
+        String res = futuresPerNode.get(node(1)).join();
+
+        assertEquals("ItThinClientComputeTest_null_3345__123", res);
+    }
+
+    @Test
+    void testBroadcastAllNodes() {
         Map<ClusterNode, CompletableFuture<String>> futuresPerNode = client().compute().broadcast(
                 new HashSet<>(sortedNodes()),
                 NodeNameJob.class,
                 "_",
                 123);
+
+        assertEquals(2, futuresPerNode.size());
 
         String res1 = futuresPerNode.get(node(0)).join();
         String res2 = futuresPerNode.get(node(1)).join();

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.ignite.compute.ComputeJob;
 import org.apache.ignite.compute.JobExecutionContext;
@@ -36,9 +37,7 @@ import org.junit.jupiter.api.Test;
 public class ItThinClientComputeTest extends ItAbstractThinClientTest {
     @Test
     void testClusterNodes() {
-        List<ClusterNode> nodes = client().clusterNodes().stream()
-                .sorted(Comparator.comparing(ClusterNode::name))
-                .collect(Collectors.toList());
+        List<ClusterNode> nodes = sortedNodes();
 
         assertEquals(2, nodes.size());
 
@@ -53,10 +52,9 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
 
     @Test
     void testExecute() {
-        var nodes = new HashSet<>(client().clusterNodes());
-        String res = client().compute().execute(nodes, NodeNameJob.class).join();
+        String res = client().compute().execute(Set.of(node(0)), NodeNameJob.class).join();
 
-        assertEquals("ItThinClientComputeTest_null_334", res);
+        assertEquals("ItThinClientComputeTest_null_3344", res);
     }
 
     @Test
@@ -65,6 +63,16 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
         String res = client().compute().execute(nodes, ConcatJob.class, 1, "2", 3.3).join();
 
         assertEquals("1_2_3.3", res);
+    }
+
+    private ClusterNode node(int idx) {
+        return sortedNodes().get(idx);
+    }
+
+    private List<ClusterNode> sortedNodes() {
+        return client().clusterNodes().stream()
+                .sorted(Comparator.comparing(ClusterNode::name))
+                .collect(Collectors.toList());
     }
 
     private static class NodeNameJob implements ComputeJob<String> {

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -20,6 +20,7 @@ package org.apache.ignite.internal.runner.app.client;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -76,8 +77,7 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
     private static class ConcatJob implements ComputeJob<String> {
         @Override
         public String execute(JobExecutionContext context, Object... args) {
-            // TODO: Concat args.
-            return null;
+            return Arrays.stream(args).map(Object::toString).collect(Collectors.joining("_"));
         }
     }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.runner.app.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collection;
+import org.apache.ignite.network.ClusterNode;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Thin client compute integration test.
+ */
+public class ItThinClientComputeTest extends ItAbstractThinClientTest {
+    @Test
+    void testClusterNodes() {
+        Collection<ClusterNode> nodes = client().clusterNodes();
+
+        assertEquals(2, nodes.size());
+    }
+}

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -82,6 +82,11 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
         assertThat(cause.getMessage(), containsString("TransactionException: Custom job error"));
     }
 
+    @Test
+    void testAllSupportedArgTypes() {
+        // TODO: Test all types and arrays of them.
+    }
+
     private ClusterNode node(int idx) {
         return sortedNodes().get(idx);
     }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -18,8 +18,11 @@
 package org.apache.ignite.internal.runner.app.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.ignite.network.ClusterNode;
 import org.junit.jupiter.api.Test;
 
@@ -29,8 +32,18 @@ import org.junit.jupiter.api.Test;
 public class ItThinClientComputeTest extends ItAbstractThinClientTest {
     @Test
     void testClusterNodes() {
-        Collection<ClusterNode> nodes = client().clusterNodes();
+        List<ClusterNode> nodes = client().clusterNodes().stream()
+                .sorted(Comparator.comparing(ClusterNode::name))
+                .collect(Collectors.toList());
 
         assertEquals(2, nodes.size());
+
+        assertEquals("ItThinClientComputeTest_null_3344", nodes.get(0).name());
+        assertEquals(3344, nodes.get(0).address().port());
+        assertTrue(nodes.get(0).id().length() > 10);
+
+        assertEquals("ItThinClientComputeTest_null_3345", nodes.get(1).name());
+        assertEquals(3345, nodes.get(1).address().port());
+        assertTrue(nodes.get(1).id().length() > 10);
     }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -144,7 +144,7 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
         testEchoArg(BigDecimal.TEN);
         testEchoArg(UUID.randomUUID());
         testEchoArg("string");
-        testEchoArg(new byte[] {1,2,3});
+        testEchoArg(new byte[] {1, 2, 3});
         testEchoArg(new BitSet(10));
         testEchoArg(LocalDate.now());
         testEchoArg(LocalTime.now());
@@ -160,7 +160,7 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
         Object res = client().compute().execute(Set.of(node(0)), EchoJob.class, arg).join();
 
         if (arg instanceof byte[]) {
-            assertArrayEquals((byte[])arg, (byte[])res);
+            assertArrayEquals((byte[]) arg, (byte[]) res);
         } else {
             assertEquals(arg, res);
         }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -151,8 +150,10 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
         testEchoArg(LocalTime.now());
         testEchoArg(LocalDateTime.now());
         testEchoArg(Instant.now());
-        testEchoArg(BigInteger.TEN);
         testEchoArg(true);
+
+        // TODO IGNITE-16772
+        // testEchoArg(BigInteger.TEN);
     }
 
     private void testEchoArg(Object arg) {

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
@@ -272,7 +272,9 @@ public class IgniteImpl implements Ignite {
                 distributedTblMgr,
                 new IgniteTransactionsImpl(txManager),
                 nodeCfgMgr.configurationRegistry(),
-                compute, clusterService, nettyBootstrapFactory
+                compute,
+                clusterSvc,
+                nettyBootstrapFactory
         );
 
         longJvmPauseDetector = new LongJvmPauseDetector(name);

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
@@ -272,7 +272,7 @@ public class IgniteImpl implements Ignite {
                 distributedTblMgr,
                 new IgniteTransactionsImpl(txManager),
                 nodeCfgMgr.configurationRegistry(),
-                nettyBootstrapFactory
+                compute, clusterService, nettyBootstrapFactory
         );
 
         longJvmPauseDetector = new LongJvmPauseDetector(name);

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
@@ -448,6 +449,12 @@ public class IgniteImpl implements Ignite {
             compute = new IgniteComputeImpl(clusterSvc.topologyService(), computeComponent);
         }
         return compute;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Collection<ClusterNode> clusterNodes() {
+        return clusterSvc.topologyService().allMembers();
     }
 
     /**

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
@@ -457,6 +457,12 @@ public class IgniteImpl implements Ignite {
         return clusterSvc.topologyService().allMembers();
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public CompletableFuture<Collection<ClusterNode>> clusterNodesAsync() {
+        return CompletableFuture.completedFuture(clusterNodes());
+    }
+
     /**
      * Returns node configuration.
      */

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
@@ -155,8 +155,7 @@ public class IgniteImpl implements Ignite {
     /** Node status. Adds ability to stop currently starting node. */
     private final AtomicReference<Status> status = new AtomicReference<>(Status.STARTING);
 
-    @Nullable
-    private transient IgniteCompute compute;
+    private final IgniteCompute compute;
 
     /** JVM pause detector. */
     private final LongJvmPauseDetector longJvmPauseDetector;
@@ -266,6 +265,8 @@ public class IgniteImpl implements Ignite {
                 clusterSvc,
                 distributedTblMgr
         );
+
+        compute = new IgniteComputeImpl(clusterSvc.topologyService(), computeComponent);
 
         clientHandlerModule = new ClientHandlerModule(
                 qryEngine,
@@ -447,9 +448,6 @@ public class IgniteImpl implements Ignite {
     /** {@inheritDoc} */
     @Override
     public IgniteCompute compute() {
-        if (compute == null) {
-            compute = new IgniteComputeImpl(clusterSvc.topologyService(), computeComponent);
-        }
         return compute;
     }
 


### PR DESCRIPTION
* Implement `IgniteCompute` interface.
    * `execute` and `broadcast` use the same `ClientOp#COMPUTE_EXECUTE`.
    * For now all operations go through the default node; cluster awareness to be implemented separately (IGNITE-16771).
* Add temporary `Ignite#clusterNodes` to enable Compute usage while Cluster API is not available.