### PR TITLE
IGNITE-16735 .NET: Add Compute

### DIFF
--- a/modules/api/src/main/java/org/apache/ignite/Ignite.java
+++ b/modules/api/src/main/java/org/apache/ignite/Ignite.java
@@ -93,8 +93,7 @@ public interface Ignite extends AutoCloseable {
 
     /**
      * Gets the cluster nodes.
-     * NOTE: Temporary API to enable Compute until we have proper Cluster API.
-     *
+c     *
      * @return Collection of cluster nodes.
      */
     CompletableFuture<Collection<ClusterNode>> clusterNodesAsync();

--- a/modules/api/src/main/java/org/apache/ignite/Ignite.java
+++ b/modules/api/src/main/java/org/apache/ignite/Ignite.java
@@ -93,7 +93,8 @@ public interface Ignite extends AutoCloseable {
 
     /**
      * Gets the cluster nodes.
-c     *
+     * NOTE: Temporary API to enable Compute until we have proper Cluster API.
+     *
      * @return Collection of cluster nodes.
      */
     CompletableFuture<Collection<ClusterNode>> clusterNodesAsync();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -25,7 +25,6 @@ namespace Apache.Ignite.Tests.Compute
     using Ignite.Compute;
     using Network;
     using NUnit.Framework;
-    using NUnit.Framework.Internal;
 
     /// <summary>
     /// Tests <see cref="ICompute"/>.

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -18,8 +18,11 @@
 namespace Apache.Ignite.Tests.Compute
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
+    using Network;
     using NUnit.Framework;
 
     /// <summary>
@@ -46,12 +49,11 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestExecuteOnSpecificNode()
         {
-            // TODO: Start two nodes.
-            // TODO: Test type mismatch.
-            var nodes = await Client.GetClusterNodesAsync();
-            var res = await Client.Compute.ExecuteAsync<string>(nodes, NodeNameJob);
+            var res1 = await Client.Compute.ExecuteAsync<string>(await GetNode(0), NodeNameJob);
+            var res2 = await Client.Compute.ExecuteAsync<string>(await GetNode(1), NodeNameJob);
 
-            Assert.AreEqual(PlatformTestNodeRunner, res);
+            Assert.AreEqual(PlatformTestNodeRunner, res1);
+            Assert.AreEqual(PlatformTestNodeRunner + "_2", res2);
         }
 
         [Test]
@@ -60,5 +62,8 @@ namespace Apache.Ignite.Tests.Compute
             Assert.ThrowsAsync<InvalidCastException>(async () =>
                 await Client.Compute.ExecuteAsync<Guid>(await Client.GetClusterNodesAsync(), NodeNameJob));
         }
+
+        private async Task<IEnumerable<IClusterNode>> GetNode(int index) =>
+            (await Client.GetClusterNodesAsync()).OrderBy(n => n.Name).Skip(index).Take(1);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -126,8 +126,30 @@ namespace Apache.Ignite.Tests.Compute
             Assert.AreEqual("class org.apache.ignite.tx.TransactionException: Custom job error", ex!.Message);
         }
 
+        // TODO: Support all types (IGNITE-15431).
         [Test]
-        public async Task TestAllSupportedArgTypes([Values(byte.MaxValue, short.MinValue)] object val) // TODO: all types
+        public async Task TestAllSupportedArgTypes([Values(
+            byte.MinValue,
+            byte.MaxValue,
+            sbyte.MinValue,
+            sbyte.MaxValue,
+            short.MinValue,
+            short.MaxValue,
+            ushort.MinValue,
+            ushort.MaxValue,
+            int.MinValue,
+            int.MaxValue,
+            uint.MinValue,
+            uint.MaxValue,
+            long.MinValue,
+            long.MaxValue,
+            ulong.MinValue,
+            ulong.MaxValue,
+            float.MinValue,
+            float.MaxValue,
+            double.MinValue,
+            double.MaxValue,
+            "Ignite 🔥")] object val)
         {
             var res = await Client.Compute.ExecuteAsync<object>(await Client.GetClusterNodesAsync(), EchoJob, val);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -132,21 +132,21 @@ namespace Apache.Ignite.Tests.Compute
         public async Task TestAllSupportedArgTypes()
         {
             await Test(byte.MinValue);
-            await Test(byte.MaxValue);
+            await Test(byte.MaxValue, -1);
             await Test(sbyte.MinValue);
             await Test(sbyte.MaxValue);
             await Test(short.MinValue);
             await Test(short.MaxValue);
             await Test(ushort.MinValue);
-            await Test(ushort.MaxValue);
+            await Test(ushort.MaxValue, -1);
             await Test(int.MinValue);
             await Test(int.MaxValue);
             await Test(uint.MinValue);
-            await Test(uint.MaxValue);
+            await Test(uint.MaxValue, -1);
             await Test(long.MinValue);
             await Test(long.MaxValue);
             await Test(ulong.MinValue);
-            await Test(ulong.MaxValue);
+            await Test(ulong.MaxValue, -1);
             await Test(float.MinValue);
             await Test(float.MaxValue);
             await Test(double.MinValue);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests.Compute
+{
+    using System.Net;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// TODO.
+    /// </summary>
+    public class ComputeTests : IgniteTestsBase
+    {
+        [Test]
+        public async Task TestGetClusterNodes()
+        {
+            var res = await Client.GetClusterNodesAsync();
+
+            Assert.AreEqual(1, res.Count);
+            Assert.AreEqual("org.apache.ignite.internal.runner.app.PlatformTestNodeRunner", res[0].Name);
+            Assert.IsNotEmpty(res[0].Id);
+            Assert.AreEqual(3344, res[0].Address.Port);
+            Assert.IsTrue(IPAddress.IsLoopback(res[0].Address.Address), res[0].Address.ToString());
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -78,11 +78,14 @@ namespace Apache.Ignite.Tests.Compute
         public async Task TestBroadcastOneNode()
         {
             var nodes = await GetNodeAsync(0);
-            IDictionary<IClusterNode, Task<string>> taskMap = Client.Compute.BroadcastAsync<string>(nodes, NodeNameJob);
 
-            // TODO:
+            IDictionary<IClusterNode, Task<string>> taskMap = Client.Compute.BroadcastAsync<string>(nodes, NodeNameJob, "123");
+            var res = await taskMap[nodes[0]];
+
             Assert.AreEqual(1, taskMap.Count);
             Assert.AreSame(nodes[0], taskMap.Keys.Single());
+
+            Assert.AreEqual(PlatformTestNodeRunner + "123", res);
         }
 
         private async Task<List<IClusterNode>> GetNodeAsync(int index) =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -22,11 +22,12 @@ namespace Apache.Ignite.Tests.Compute
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
+    using Ignite.Compute;
     using Network;
     using NUnit.Framework;
 
     /// <summary>
-    /// TODO.
+    /// Tests <see cref="ICompute"/>.
     /// </summary>
     public class ComputeTests : IgniteTestsBase
     {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -52,11 +52,11 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestExecuteOnSpecificNode()
         {
-            var res1 = await Client.Compute.ExecuteAsync<string>(await GetNodeAsync(0), NodeNameJob);
-            var res2 = await Client.Compute.ExecuteAsync<string>(await GetNodeAsync(1), NodeNameJob);
+            var res1 = await Client.Compute.ExecuteAsync<string>(await GetNodeAsync(0), NodeNameJob, "-", 11);
+            var res2 = await Client.Compute.ExecuteAsync<string>(await GetNodeAsync(1), NodeNameJob, ":", 22);
 
-            Assert.AreEqual(PlatformTestNodeRunner, res1);
-            Assert.AreEqual(PlatformTestNodeRunner + "_2", res2);
+            Assert.AreEqual(PlatformTestNodeRunner + "-_11", res1);
+            Assert.AreEqual(PlatformTestNodeRunner + "_2:_22", res2);
         }
 
         [Test]
@@ -72,6 +72,12 @@ namespace Apache.Ignite.Tests.Compute
         {
             Assert.ThrowsAsync<InvalidCastException>(async () =>
                 await Client.Compute.ExecuteAsync<Guid>(await Client.GetClusterNodesAsync(), NodeNameJob));
+        }
+
+        [Test]
+        public async Task TestBroadcastOneNode()
+        {
+            IDictionary<IClusterNode, Task<string>> taskMap = Client.Compute.BroadcastAsync<string>(await GetNodeAsync(0), NodeNameJob);
         }
 
         private async Task<IEnumerable<IClusterNode>> GetNodeAsync(int index) =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -44,15 +44,19 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestGetClusterNodes()
         {
-            var res = await Client.GetClusterNodesAsync();
+            var res = (await Client.GetClusterNodesAsync()).OrderBy(x => x.Name).ToList();
 
             Assert.AreEqual(2, res.Count);
 
-            var firstNode = res.Single(x => x.Name == PlatformTestNodeRunner);
+            Assert.IsNotEmpty(res[0].Id);
+            Assert.IsNotEmpty(res[1].Id);
 
-            Assert.IsNotEmpty(firstNode.Id);
-            Assert.AreEqual(3344, firstNode.Address.Port);
-            Assert.IsTrue(IPAddress.IsLoopback(firstNode.Address.Address), firstNode.Address.ToString());
+            Assert.AreEqual(3344, res[0].Address.Port);
+            Assert.AreEqual(3345, res[1].Address.Port);
+
+            Assert.AreNotEqual(IPAddress.None, res[0].Address.Address);
+            Assert.AreNotEqual(IPAddress.None, res[1].Address.Address);
+            Assert.AreEqual(res[0].Address.Address, res[1].Address.Address);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Tests.Compute
 {
+    using System;
     using System.Net;
     using System.Threading.Tasks;
     using NUnit.Framework;
@@ -28,13 +29,15 @@ namespace Apache.Ignite.Tests.Compute
     {
         private const string NodeNameJob = "org.apache.ignite.internal.runner.app.client.ItThinClientComputeTest$NodeNameJob";
 
+        private const string PlatformTestNodeRunner = "org.apache.ignite.internal.runner.app.PlatformTestNodeRunner";
+
         [Test]
         public async Task TestGetClusterNodes()
         {
             var res = await Client.GetClusterNodesAsync();
 
             Assert.AreEqual(1, res.Count);
-            Assert.AreEqual("org.apache.ignite.internal.runner.app.PlatformTestNodeRunner", res[0].Name);
+            Assert.AreEqual(PlatformTestNodeRunner, res[0].Name);
             Assert.IsNotEmpty(res[0].Id);
             Assert.AreEqual(3344, res[0].Address.Port);
             Assert.IsTrue(IPAddress.IsLoopback(res[0].Address.Address), res[0].Address.ToString());
@@ -46,7 +49,16 @@ namespace Apache.Ignite.Tests.Compute
             // TODO: Start two nodes.
             // TODO: Test type mismatch.
             var nodes = await Client.GetClusterNodesAsync();
-            await Client.Compute.ExecuteAsync<string>(nodes, NodeNameJob);
+            var res = await Client.Compute.ExecuteAsync<string>(nodes, NodeNameJob);
+
+            Assert.AreEqual(PlatformTestNodeRunner, res);
+        }
+
+        [Test]
+        public void TestExecuteResultTypeMismatchThrowsInvalidCastException()
+        {
+            Assert.ThrowsAsync<InvalidCastException>(async () =>
+                await Client.Compute.ExecuteAsync<Guid>(await Client.GetClusterNodesAsync(), NodeNameJob));
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -52,11 +52,19 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestExecuteOnSpecificNode()
         {
-            var res1 = await Client.Compute.ExecuteAsync<string>(await GetNode(0), NodeNameJob);
-            var res2 = await Client.Compute.ExecuteAsync<string>(await GetNode(1), NodeNameJob);
+            var res1 = await Client.Compute.ExecuteAsync<string>(await GetNodeAsync(0), NodeNameJob);
+            var res2 = await Client.Compute.ExecuteAsync<string>(await GetNodeAsync(1), NodeNameJob);
 
             Assert.AreEqual(PlatformTestNodeRunner, res1);
             Assert.AreEqual(PlatformTestNodeRunner + "_2", res2);
+        }
+
+        [Test]
+        public async Task TestExecuteOnRandomNode()
+        {
+            var res = await Client.Compute.ExecuteAsync<string>(await Client.GetClusterNodesAsync(), NodeNameJob);
+
+            CollectionAssert.Contains(new[] { PlatformTestNodeRunner, PlatformTestNodeRunner + "_2" }, res);
         }
 
         [Test]
@@ -66,7 +74,7 @@ namespace Apache.Ignite.Tests.Compute
                 await Client.Compute.ExecuteAsync<Guid>(await Client.GetClusterNodesAsync(), NodeNameJob));
         }
 
-        private async Task<IEnumerable<IClusterNode>> GetNode(int index) =>
+        private async Task<IEnumerable<IClusterNode>> GetNodeAsync(int index) =>
             (await Client.GetClusterNodesAsync()).OrderBy(n => n.Name).Skip(index).Take(1);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -77,10 +77,15 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestBroadcastOneNode()
         {
-            IDictionary<IClusterNode, Task<string>> taskMap = Client.Compute.BroadcastAsync<string>(await GetNodeAsync(0), NodeNameJob);
+            var nodes = await GetNodeAsync(0);
+            IDictionary<IClusterNode, Task<string>> taskMap = Client.Compute.BroadcastAsync<string>(nodes, NodeNameJob);
+
+            // TODO:
+            Assert.AreEqual(1, taskMap.Count);
+            Assert.AreSame(nodes[0], taskMap.Keys.Single());
         }
 
-        private async Task<IEnumerable<IClusterNode>> GetNodeAsync(int index) =>
-            (await Client.GetClusterNodesAsync()).OrderBy(n => n.Name).Skip(index).Take(1);
+        private async Task<List<IClusterNode>> GetNodeAsync(int index) =>
+            (await Client.GetClusterNodesAsync()).OrderBy(n => n.Name).Skip(index).Take(1).ToList();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -39,11 +39,13 @@ namespace Apache.Ignite.Tests.Compute
         {
             var res = await Client.GetClusterNodesAsync();
 
-            Assert.AreEqual(1, res.Count);
-            Assert.AreEqual(PlatformTestNodeRunner, res[0].Name);
-            Assert.IsNotEmpty(res[0].Id);
-            Assert.AreEqual(3344, res[0].Address.Port);
-            Assert.IsTrue(IPAddress.IsLoopback(res[0].Address.Address), res[0].Address.ToString());
+            Assert.AreEqual(2, res.Count);
+
+            var firstNode = res.Single(x => x.Name == PlatformTestNodeRunner);
+
+            Assert.IsNotEmpty(firstNode.Id);
+            Assert.AreEqual(3344, firstNode.Address.Port);
+            Assert.IsTrue(IPAddress.IsLoopback(firstNode.Address.Address), firstNode.Address.ToString());
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -26,6 +26,8 @@ namespace Apache.Ignite.Tests.Compute
     /// </summary>
     public class ComputeTests : IgniteTestsBase
     {
+        private const string NodeNameJob = "org.apache.ignite.internal.runner.app.client.ItThinClientComputeTest$NodeNameJob";
+
         [Test]
         public async Task TestGetClusterNodes()
         {
@@ -36,6 +38,15 @@ namespace Apache.Ignite.Tests.Compute
             Assert.IsNotEmpty(res[0].Id);
             Assert.AreEqual(3344, res[0].Address.Port);
             Assert.IsTrue(IPAddress.IsLoopback(res[0].Address.Address), res[0].Address.ToString());
+        }
+
+        [Test]
+        public async Task TestExecuteOnSpecificNode()
+        {
+            // TODO: Start two nodes.
+            // TODO: Test type mismatch.
+            var nodes = await Client.GetClusterNodesAsync();
+            await Client.Compute.ExecuteAsync<string>(nodes, NodeNameJob);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -88,6 +88,21 @@ namespace Apache.Ignite.Tests.Compute
             Assert.AreEqual(PlatformTestNodeRunner + "123", res);
         }
 
+        [Test]
+        public async Task TestBroadcastAllNodes()
+        {
+            var nodes = await Client.GetClusterNodesAsync();
+
+            IDictionary<IClusterNode, Task<string>> taskMap = Client.Compute.BroadcastAsync<string>(nodes, NodeNameJob, "123");
+            var res1 = await taskMap[nodes[0]];
+            var res2 = await taskMap[nodes[1]];
+
+            Assert.AreEqual(2, taskMap.Count);
+
+            Assert.AreEqual(nodes[0].Name + "123", res1);
+            Assert.AreEqual(nodes[1].Name + "123", res2);
+        }
+
         private async Task<List<IClusterNode>> GetNodeAsync(int index) =>
             (await Client.GetClusterNodesAsync()).OrderBy(n => n.Name).Skip(index).Take(1).ToList();
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -25,6 +25,7 @@ namespace Apache.Ignite.Tests.Compute
     using Ignite.Compute;
     using Network;
     using NUnit.Framework;
+    using NUnit.Framework.Internal;
 
     /// <summary>
     /// Tests <see cref="ICompute"/>.
@@ -128,32 +129,37 @@ namespace Apache.Ignite.Tests.Compute
 
         // TODO: Support all types (IGNITE-15431).
         [Test]
-        public async Task TestAllSupportedArgTypes([Values(
-            byte.MinValue,
-            byte.MaxValue,
-            sbyte.MinValue,
-            sbyte.MaxValue,
-            short.MinValue,
-            short.MaxValue,
-            ushort.MinValue,
-            ushort.MaxValue,
-            int.MinValue,
-            int.MaxValue,
-            uint.MinValue,
-            uint.MaxValue,
-            long.MinValue,
-            long.MaxValue,
-            ulong.MinValue,
-            ulong.MaxValue,
-            float.MinValue,
-            float.MaxValue,
-            double.MinValue,
-            double.MaxValue,
-            "Ignite 🔥")] object val)
+        public async Task TestAllSupportedArgTypes()
         {
-            var res = await Client.Compute.ExecuteAsync<object>(await Client.GetClusterNodesAsync(), EchoJob, val);
+            await Test(byte.MinValue);
+            await Test(byte.MaxValue);
+            await Test(sbyte.MinValue);
+            await Test(sbyte.MaxValue);
+            await Test(short.MinValue);
+            await Test(short.MaxValue);
+            await Test(ushort.MinValue);
+            await Test(ushort.MaxValue);
+            await Test(int.MinValue);
+            await Test(int.MaxValue);
+            await Test(uint.MinValue);
+            await Test(uint.MaxValue);
+            await Test(long.MinValue);
+            await Test(long.MaxValue);
+            await Test(ulong.MinValue);
+            await Test(ulong.MaxValue);
+            await Test(float.MinValue);
+            await Test(float.MaxValue);
+            await Test(double.MinValue);
+            await Test(double.MaxValue);
+            await Test("Ignite 🔥");
+            await Test(Guid.NewGuid());
 
-            Assert.AreEqual(val, res);
+            async Task Test(object val, object? expected = null)
+            {
+                var res = await Client.Compute.ExecuteAsync<object>(await Client.GetClusterNodesAsync(), EchoJob, val);
+
+                Assert.AreEqual(expected ?? val, res);
+            }
         }
 
         private async Task<List<IClusterNode>> GetNodeAsync(int index) =>

--- a/modules/platforms/dotnet/Apache.Ignite/ClientOperationType.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/ClientOperationType.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite
 {
+    using Compute;
     using Table;
 
     /// <summary>
@@ -107,6 +108,11 @@ namespace Apache.Ignite
         /// <summary>
         /// Get and Delete (<see cref="IRecordView{T}.GetAndDeleteAsync"/>).
         /// </summary>
-        TupleGetAndDelete
+        TupleGetAndDelete,
+
+        /// <summary>
+        /// Compute (<see cref="ICompute.ExecuteAsync{T}"/>, <see cref="ICompute.BroadcastAsync{T}"/>).
+        /// </summary>
+        ComputeExecute,
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Compute/ICompute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Compute/ICompute.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -15,43 +15,25 @@
  * limitations under the License.
  */
 
-namespace Apache.Ignite
+namespace Apache.Ignite.Compute
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using Compute;
     using Network;
-    using Table;
-    using Transactions;
 
     /// <summary>
-    /// Ignite API entry point.
-    /// <para />
-    /// Implementation can be a thin client (see <see cref="IIgniteClient"/> and <see cref="IgniteClient.StartAsync"/>),
-    /// or a direct IPC connection for server-side functionality like compute.
+    /// Ignite Compute API provides distributed job execution functionality.
     /// </summary>
-    public interface IIgnite
+    public interface ICompute
     {
         /// <summary>
-        /// Gets the tables API.
+        /// Executes a compute job represented by the given class on one of the specified nodes.
         /// </summary>
-        ITables Tables { get; }
-
-        /// <summary>
-        /// Gets the transactions API.
-        /// </summary>
-        ITransactions Transactions { get; }
-
-        /// <summary>
-        /// Gets the compute API.
-        /// </summary>
-        ICompute Compute { get; }
-
-        /// <summary>
-        /// Gets the cluster nodes.
-        /// NOTE: Temporary API to enable Compute until we have proper Cluster API.
-        /// </summary>
+        /// <param name="nodes">Nodes to use for the job execution.</param>
+        /// <param name="jobClassName">Java class name of the job to execute.</param>
+        /// <param name="args">Job arguments.</param>
+        /// <typeparam name="T">Job result type.</typeparam>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task<IList<IClusterNode>> GetClusterNodesAsync();
+        Task<T> ExecuteAsync<T>(IEnumerable<IClusterNode> nodes, string jobClassName, params object[] args);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Compute/ICompute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Compute/ICompute.cs
@@ -35,5 +35,15 @@ namespace Apache.Ignite.Compute
         /// <typeparam name="T">Job result type.</typeparam>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task<T> ExecuteAsync<T>(IEnumerable<IClusterNode> nodes, string jobClassName, params object[] args);
+
+        /// <summary>
+        /// Executes a compute job represented by the given class on all of the specified nodes.
+        /// </summary>
+        /// <param name="nodes">Nodes to use for the job execution.</param>
+        /// <param name="jobClassName">Java class name of the job to execute.</param>
+        /// <param name="args">Job arguments.</param>
+        /// <typeparam name="T">Job result type.</typeparam>
+        /// <returns>A map of <see cref="Task"/> representing the asynchronous operation for every node.</returns>
+        IDictionary<IClusterNode, Task<T>> BroadcastAsync<T>(IEnumerable<IClusterNode> nodes, string jobClassName, params object[] args);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/IIgnite.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IIgnite.cs
@@ -17,6 +17,9 @@
 
 namespace Apache.Ignite
 {
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Network;
     using Table;
     using Transactions;
 
@@ -37,5 +40,12 @@ namespace Apache.Ignite
         /// Gets the transactions API.
         /// </summary>
         ITransactions Transactions { get; }
+
+        /// <summary>
+        /// Gets the cluster nodes.
+        /// NOTE: Temporary API to enable Compute until we have proper Cluster API.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task<IList<IClusterNode>> GetClusterNodesAsync();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/ThreadLocalRandom.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/ThreadLocalRandom.cs
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Internal.Common
+{
+    using System;
+    using System.Threading;
+
+    /// <summary>
+    /// Thread-local random.
+    /// </summary>
+    internal static class ThreadLocalRandom
+    {
+        private static readonly ThreadLocal<Random> TlRandom = new(() => new Random());
+
+        /// <summary>
+        /// Gets the <see cref="Random"/> instance for the current thread.
+        /// </summary>
+        public static Random Instance => TlRandom.Value;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -49,6 +49,7 @@ namespace Apache.Ignite.Internal.Compute
             IgniteArgumentCheck.NotNull(nodes, nameof(nodes));
             IgniteArgumentCheck.NotNull(jobClassName, nameof(jobClassName));
 
+            // TODO: Cluster awareness (IGNITE-16823): match specified nodes to known connections.
             return await ExecuteOnOneNode<T>(GetRandomNode(nodes), jobClassName, args).ConfigureAwait(false);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -105,7 +105,7 @@ namespace Apache.Ignite.Internal.Compute
                 w.Write(node.Address.Port);
 
                 w.Write(jobClassName);
-                w.WriteObjectArray(args);
+                w.WriteObjectArrayWithTypes(args);
 
                 w.Flush();
             }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -70,6 +70,8 @@ namespace Apache.Ignite.Internal.Compute
 
                 w.Write(jobClassName);
                 w.WriteObjectArray(args);
+
+                w.Flush();
             }
 
             T Read()

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -86,6 +86,8 @@ namespace Apache.Ignite.Internal.Compute
 
         private async Task<T> ExecuteOnOneNode<T>(IClusterNode node, string jobClassName, object[] args)
         {
+            IgniteArgumentCheck.NotNull(node, nameof(node));
+
             using var writer = new PooledArrayBufferWriter();
             Write();
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -52,6 +52,24 @@ namespace Apache.Ignite.Internal.Compute
             return await ExecuteOnOneNode<T>(GetRandomNode(nodes), jobClassName, args).ConfigureAwait(false);
         }
 
+        /// <inheritdoc/>
+        public IDictionary<IClusterNode, Task<T>> BroadcastAsync<T>(IEnumerable<IClusterNode> nodes, string jobClassName, params object[] args)
+        {
+            IgniteArgumentCheck.NotNull(nodes, nameof(nodes));
+            IgniteArgumentCheck.NotNull(jobClassName, nameof(jobClassName));
+
+            var res = new Dictionary<IClusterNode, Task<T>>();
+
+            foreach (var node in nodes)
+            {
+                var task = ExecuteOnOneNode<T>(node, jobClassName, args);
+
+                res[node] = task;
+            }
+
+            return res;
+        }
+
         private static IClusterNode GetRandomNode(IEnumerable<IClusterNode> nodes)
         {
             var nodesCol = GetNodesCollection(nodes);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Internal.Compute
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Ignite.Compute;
+    using Ignite.Network;
+    using Proto;
+
+    /// <summary>
+    /// Compute API.
+    /// </summary>
+    internal sealed class Compute : ICompute
+    {
+        /** Socket. */
+        private readonly ClientFailoverSocket _socket;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Compute"/> class.
+        /// </summary>
+        /// <param name="socket">Socket.</param>
+        public Compute(ClientFailoverSocket socket)
+        {
+            _socket = socket;
+        }
+
+        /// <inheritdoc/>
+        public async Task<T> ExecuteAsync<T>(IEnumerable<IClusterNode> nodes, string jobClassName, params object[] args)
+        {
+            // TODO: ser/de
+            using var resBuf = await _socket.DoOutInOpAsync(ClientOp.ComputeExecute).ConfigureAwait(false);
+
+            return default!;
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Internal.Compute
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using Ignite.Compute;
     using Ignite.Network;
@@ -42,6 +43,13 @@ namespace Apache.Ignite.Internal.Compute
 
         /// <inheritdoc/>
         public async Task<T> ExecuteAsync<T>(IEnumerable<IClusterNode> nodes, string jobClassName, params object[] args)
+        {
+            // TODO: Random node.
+            // TODO: Validate args.
+            return await ExecuteOnOneNode<T>(nodes.First(), jobClassName, args).ConfigureAwait(false);
+        }
+
+        private async Task<T> ExecuteOnOneNode<T>(IClusterNode node, string jobClassName, object[] args)
         {
             // TODO: ser/de
             using var resBuf = await _socket.DoOutInOpAsync(ClientOp.ComputeExecute).ConfigureAwait(false);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Internal
     using System.Collections.Generic;
     using System.Net;
     using System.Threading.Tasks;
+    using Ignite.Compute;
     using Ignite.Network;
     using Ignite.Table;
     using Ignite.Transactions;
@@ -44,6 +45,7 @@ namespace Apache.Ignite.Internal
             _socket = socket;
             Tables = new Tables(socket);
             Transactions = new Transactions.Transactions(socket);
+            Compute = new Compute.Compute(socket);
         }
 
         /// <inheritdoc/>
@@ -55,6 +57,9 @@ namespace Apache.Ignite.Internal
 
         /// <inheritdoc/>
         public ITransactions Transactions { get; }
+
+        /// <inheritdoc/>
+        public ICompute Compute { get; }
 
         /// <inheritdoc/>
         public async Task<IList<IClusterNode>> GetClusterNodesAsync()

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
@@ -77,9 +77,9 @@ namespace Apache.Ignite.Internal
                 for (var i = 0; i < count; i++)
                 {
                     res.Add(new ClusterNode(
-                        id: r.ReadString(),
-                        name: r.ReadString(),
-                        address: new IPEndPoint(IPAddress.Parse(r.ReadString()), r.ReadInt32())));
+                        Id: r.ReadString(),
+                        Name: r.ReadString(),
+                        Address: new IPEndPoint(IPAddress.Parse(r.ReadString()), r.ReadInt32())));
                 }
 
                 return res;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
@@ -66,7 +66,7 @@ namespace Apache.Ignite.Internal
             IList<IClusterNode> Read()
             {
                 var r = resBuf.GetReader();
-                var count = r.ReadInt32();
+                var count = r.ReadArrayHeader();
                 var res = new List<IClusterNode>(count);
 
                 for (var i = 0; i < count; i++)

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Network/ClusterNode.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Network/ClusterNode.cs
@@ -23,28 +23,5 @@ namespace Apache.Ignite.Internal.Network
     /// <summary>
     /// Cluster node.
     /// </summary>
-    internal sealed class ClusterNode : IClusterNode
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ClusterNode"/> class.
-        /// </summary>
-        /// <param name="id">Id.</param>
-        /// <param name="name">Name.</param>
-        /// <param name="address">Address.</param>
-        public ClusterNode(string id, string name, IPEndPoint address)
-        {
-            Id = id;
-            Name = name;
-            Address = address;
-        }
-
-        /// <inheritdoc/>
-        public string Id { get; }
-
-        /// <inheritdoc/>
-        public string Name { get; }
-
-        /// <inheritdoc/>
-        public IPEndPoint Address { get; }
-    }
+    internal sealed record ClusterNode(string Id, string Name, IPEndPoint Address) : IClusterNode;
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Network/ClusterNode.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Network/ClusterNode.cs
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Internal.Network
+{
+    using System.Net;
+    using Ignite.Network;
+
+    /// <summary>
+    /// Cluster node.
+    /// </summary>
+    internal sealed class ClusterNode : IClusterNode
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClusterNode"/> class.
+        /// </summary>
+        /// <param name="id">Id.</param>
+        /// <param name="name">Name.</param>
+        /// <param name="address">Address.</param>
+        public ClusterNode(string id, string name, IPEndPoint address)
+        {
+            Id = id;
+            Name = name;
+            Address = address;
+        }
+
+        /// <inheritdoc/>
+        public string Id { get; }
+
+        /// <inheritdoc/>
+        public string Name { get; }
+
+        /// <inheritdoc/>
+        public IPEndPoint Address { get; }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientOp.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientOp.cs
@@ -86,6 +86,12 @@ namespace Apache.Ignite.Internal.Proto
         TxCommit = 44,
 
         /** Rollback transaction. */
-        TxRollback = 45
+        TxRollback = 45,
+
+        /** Execute compute job. */
+        ComputeExecute = 47,
+
+        /** Get cluster nodes. */
+        ClusterGetNodes = 48
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientOpExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientOpExtensions.cs
@@ -51,10 +51,12 @@ namespace Apache.Ignite.Internal.Proto
                 ClientOp.TupleDeleteExact => ClientOperationType.TupleDeleteExact,
                 ClientOp.TupleDeleteAllExact => ClientOperationType.TupleDeleteAllExact,
                 ClientOp.TupleGetAndDelete => ClientOperationType.TupleGetAndDelete,
+                ClientOp.ComputeExecute => ClientOperationType.ComputeExecute,
                 ClientOp.TxBegin => null,
                 ClientOp.TxCommit => null,
                 ClientOp.TxRollback => null,
                 ClientOp.Heartbeat => null,
+                ClientOp.ClusterGetNodes => null,
 
                 // Do not return null from default arm intentionally so we don't forget to update this when new ClientOp values are added.
                 _ => throw new ArgumentOutOfRangeException(nameof(op), op, message: null)

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackReaderExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackReaderExtensions.cs
@@ -40,7 +40,7 @@ namespace Apache.Ignite.Internal.Proto
             switch (type)
             {
                 case ClientDataType.Int8:
-                    return reader.ReadByte();
+                    return reader.ReadSByte();
 
                 case ClientDataType.Int16:
                     return reader.ReadInt16();

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackReaderExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackReaderExtensions.cs
@@ -69,6 +69,21 @@ namespace Apache.Ignite.Internal.Proto
         }
 
         /// <summary>
+        /// Reads <see cref="ClientDataType"/> and value.
+        /// </summary>
+        /// <param name="reader">Reader.</param>
+        /// <returns>Value.</returns>
+        public static object? ReadObjectWithType(this ref MessagePackReader reader)
+        {
+            if (reader.TryReadNil())
+            {
+                return null;
+            }
+
+            return ReadObject(ref reader, (ClientDataType)reader.ReadInt32());
+        }
+
+        /// <summary>
         /// Reads nullable integer.
         /// </summary>
         /// <param name="reader">Reader.</param>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackWriterExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackWriterExtensions.cs
@@ -234,7 +234,7 @@ namespace Apache.Ignite.Internal.Proto
         /// </summary>
         /// <param name="writer">Writer.</param>
         /// <param name="arr">Array.</param>
-        public static void WriteObjectArray(this ref MessagePackWriter writer, object[]? arr)
+        public static void WriteObjectArrayWithTypes(this ref MessagePackWriter writer, object[]? arr)
         {
             if (arr == null)
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackWriterExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MessagePackWriterExtensions.cs
@@ -150,5 +150,105 @@ namespace Apache.Ignite.Internal.Proto
 
             throw new IgniteClientException("Unsupported type: " + obj.GetType());
         }
+
+        /// <summary>
+        /// Writes an object with type code.
+        /// </summary>
+        /// <param name="writer">Writer.</param>
+        /// <param name="obj">Object.</param>
+        public static void WriteObjectWithType(this ref MessagePackWriter writer, object? obj)
+        {
+            // TODO: Support all types (IGNITE-15431).
+            switch (obj)
+            {
+                case null:
+                    writer.WriteNil();
+                    return;
+
+                case string str:
+                    writer.Write((int)ClientDataType.String);
+                    writer.Write(str);
+                    return;
+
+                case Guid g:
+                    writer.Write((int)ClientDataType.Uuid);
+                    writer.Write(g);
+                    return;
+
+                case byte b:
+                    writer.Write((int)ClientDataType.Int8);
+                    writer.Write(b);
+                    return;
+
+                case sbyte sb:
+                    writer.Write((int)ClientDataType.Int8);
+                    writer.Write(sb);
+                    return;
+
+                case short s:
+                    writer.Write((int)ClientDataType.Int16);
+                    writer.Write(s);
+                    return;
+
+                case ushort us:
+                    writer.Write((int)ClientDataType.Int16);
+                    writer.Write(us);
+                    return;
+
+                case int i:
+                    writer.Write((int)ClientDataType.Int32);
+                    writer.Write(i);
+                    return;
+
+                case uint ui:
+                    writer.Write((int)ClientDataType.Int32);
+                    writer.Write(ui);
+                    return;
+
+                case long l:
+                    writer.Write((int)ClientDataType.Int64);
+                    writer.Write(l);
+                    return;
+
+                case ulong ul:
+                    writer.Write((int)ClientDataType.Int64);
+                    writer.Write(ul);
+                    return;
+
+                case float f:
+                    writer.Write((int)ClientDataType.Float);
+                    writer.Write(f);
+                    return;
+
+                case double d:
+                    writer.Write((int)ClientDataType.Double);
+                    writer.Write(d);
+                    return;
+            }
+
+            throw new IgniteClientException("Unsupported type: " + obj.GetType());
+        }
+
+        /// <summary>
+        /// Writes an array of objects with type codes.
+        /// </summary>
+        /// <param name="writer">Writer.</param>
+        /// <param name="arr">Array.</param>
+        public static void WriteObjectArray(this ref MessagePackWriter writer, object[]? arr)
+        {
+            if (arr == null)
+            {
+                writer.WriteNil();
+
+                return;
+            }
+
+            writer.WriteArrayHeader(arr.Length);
+
+            foreach (var obj in arr)
+            {
+                writer.WriteObjectWithType(obj);
+            }
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Network/IClusterNode.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Network/IClusterNode.cs
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Network
+{
+    using System.Net;
+
+    /// <summary>
+    /// Ignite cluster node.
+    /// </summary>
+    public interface IClusterNode
+    {
+        /// <summary>
+        /// Gets the local node id. Changes after node restart.
+        /// </summary>
+        string Id { get; }
+
+        /// <summary>
+        /// Gets the unique name of the cluster member. Does not change after node restart.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Gets the node address.
+        /// </summary>
+        IPEndPoint Address { get; }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite/RetryReadPolicy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/RetryReadPolicy.cs
@@ -54,6 +54,7 @@ namespace Apache.Ignite
                 ClientOperationType.TupleDeleteExact => false,
                 ClientOperationType.TupleDeleteAllExact => false,
                 ClientOperationType.TupleGetAndDelete => false,
+                ClientOperationType.ComputeExecute => false,
                 var unsupported => throw new NotSupportedException("Unsupported operation type: " + unsupported)
             };
         }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -41,6 +41,9 @@ public class PlatformTestNodeRunner {
     /** Test node name. */
     private static final String NODE_NAME = PlatformTestNodeRunner.class.getCanonicalName();
 
+    /** Test node name 2. */
+    private static final String NODE_NAME2 = PlatformTestNodeRunner.class.getCanonicalName() + "_2";
+
     private static final String SCHEMA_NAME = "PUB";
 
     private static final String TABLE_NAME = "tbl1";
@@ -58,6 +61,19 @@ public class PlatformTestNodeRunner {
                     + "  \"clientConnector\":{\"port\": 10942,\"portRange\":10,\"idleTimeout\":1000},"
                     + "  \"network\": {\n"
                     + "    \"port\":3344,\n"
+                    + "    \"nodeFinder\": {\n"
+                    + "      \"netClusterNodes\":[ \"localhost:3344\", \"localhost:3345\" ]\n"
+                    + "    }\n"
+                    + "  }\n"
+                    + "}");
+
+            put(NODE_NAME2, "{\n"
+                    + "  \"node\": {\n"
+                    + "    \"metastorageNodes\":[ \"" + NODE_NAME + "\" ]\n"
+                    + "  },\n"
+                    + "  \"clientConnector\":{\"port\": 10942,\"portRange\":10,\"idleTimeout\":1000},"
+                    + "  \"network\": {\n"
+                    + "    \"port\":3345,\n"
                     + "    \"nodeFinder\": {\n"
                     + "      \"netClusterNodes\":[ \"localhost:3344\", \"localhost:3345\" ]\n"
                     + "    }\n"


### PR DESCRIPTION
* Add and implement `ICompute` interface. 
* For now all operations go through the default node; cluster awareness to be implemented separately (IGNITE-16823). 
* Add temporary `IIgnite.GetClusterNodes` to enable Compute usage while Cluster API is not available.