### PR TITLE
IGNITE-16776 Thin client: Fix potential resource leak on disconnect

### DIFF
--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -160,7 +160,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter {
     /** {@inheritDoc} */
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        resources.clean();
+        resources.close();
 
         super.channelInactive(ctx);
     }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -71,6 +71,7 @@ import org.apache.ignite.internal.client.proto.ProtocolVersion;
 import org.apache.ignite.internal.client.proto.ServerMessageType;
 import org.apache.ignite.internal.sql.engine.QueryProcessor;
 import org.apache.ignite.lang.IgniteException;
+import org.apache.ignite.lang.IgniteInternalCheckedException;
 import org.apache.ignite.lang.IgniteLogger;
 import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.table.manager.IgniteTables;
@@ -306,7 +307,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter {
             ClientMessageUnpacker in,
             ClientMessagePacker out,
             int opCode
-    ) {
+    ) throws IgniteInternalCheckedException {
         switch (opCode) {
             case ClientOp.HEARTBEAT:
                 return null;

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientResourceRegistry.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientResourceRegistry.java
@@ -22,7 +22,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 import org.apache.ignite.lang.IgniteException;
 
 /**

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTableCommon.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTableCommon.java
@@ -42,6 +42,8 @@ import org.apache.ignite.internal.schema.SchemaRegistry;
 import org.apache.ignite.internal.table.IgniteTablesInternal;
 import org.apache.ignite.internal.table.TableImpl;
 import org.apache.ignite.lang.IgniteException;
+import org.apache.ignite.lang.IgniteInternalCheckedException;
+import org.apache.ignite.lang.IgniteInternalException;
 import org.apache.ignite.lang.NodeStoppingException;
 import org.apache.ignite.table.Tuple;
 import org.apache.ignite.table.manager.IgniteTables;
@@ -394,7 +396,11 @@ class ClientTableCommon {
             return null;
         }
 
-        return resources.get(in.unpackLong()).get(Transaction.class);
+        try {
+            return resources.get(in.unpackLong()).get(Transaction.class);
+        } catch (IgniteInternalCheckedException e) {
+            throw new IgniteInternalException(e.getMessage(), e);
+        }
     }
 
     private static void readAndSetColumnValue(ClientMessageUnpacker unpacker, Tuple tuple, Column col) {

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/tx/ClientTransactionCommitRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/tx/ClientTransactionCommitRequest.java
@@ -18,7 +18,6 @@
 package org.apache.ignite.client.handler.requests.tx;
 
 import java.util.concurrent.CompletableFuture;
-
 import org.apache.ignite.client.handler.ClientResourceRegistry;
 import org.apache.ignite.internal.client.proto.ClientMessageUnpacker;
 import org.apache.ignite.lang.IgniteInternalCheckedException;

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/tx/ClientTransactionCommitRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/tx/ClientTransactionCommitRequest.java
@@ -18,8 +18,10 @@
 package org.apache.ignite.client.handler.requests.tx;
 
 import java.util.concurrent.CompletableFuture;
+
 import org.apache.ignite.client.handler.ClientResourceRegistry;
 import org.apache.ignite.internal.client.proto.ClientMessageUnpacker;
+import org.apache.ignite.lang.IgniteInternalCheckedException;
 import org.apache.ignite.tx.Transaction;
 
 /**
@@ -33,7 +35,8 @@ public class ClientTransactionCommitRequest {
      * @param resources Resources.
      * @return Future.
      */
-    public static CompletableFuture<Void> process(ClientMessageUnpacker in, ClientResourceRegistry resources) {
+    public static CompletableFuture<Void> process(ClientMessageUnpacker in, ClientResourceRegistry resources)
+            throws IgniteInternalCheckedException {
         long resourceId = in.unpackLong();
 
         Transaction t = resources.remove(resourceId).get(Transaction.class);

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/tx/ClientTransactionRollbackRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/tx/ClientTransactionRollbackRequest.java
@@ -20,6 +20,7 @@ package org.apache.ignite.client.handler.requests.tx;
 import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.client.handler.ClientResourceRegistry;
 import org.apache.ignite.internal.client.proto.ClientMessageUnpacker;
+import org.apache.ignite.lang.IgniteInternalCheckedException;
 import org.apache.ignite.tx.Transaction;
 
 /**
@@ -33,7 +34,8 @@ public class ClientTransactionRollbackRequest {
      * @param resources Resources.
      * @return Future.
      */
-    public static CompletableFuture<Void> process(ClientMessageUnpacker in, ClientResourceRegistry resources) {
+    public static CompletableFuture<Void> process(ClientMessageUnpacker in, ClientResourceRegistry resources)
+            throws IgniteInternalCheckedException {
         long resourceId = in.unpackLong();
 
         Transaction t = resources.remove(resourceId).get(Transaction.class);

--- a/modules/client-handler/src/test/java/ClientResourceRegistryTest.java
+++ b/modules/client-handler/src/test/java/ClientResourceRegistryTest.java
@@ -20,7 +20,6 @@ import org.apache.ignite.client.handler.ClientResourceRegistry;
 import org.apache.ignite.lang.IgniteException;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -40,12 +39,13 @@ public class ClientResourceRegistryTest {
 
         assertSame(resource, returned);
         assertSame(resource, removed);
-        assertThrows(IgniteException.class, () -> reg.get(id));
+
+        var ex = assertThrows(IgniteException.class, () -> reg.get(id));
+        assertEquals("Failed to find resource with id: 1", ex.getMessage());
     }
 
     @Test
     public void testCloseReleasesAllResourcesAndBlocksUsage() {
-        // TODO
         var reg = new ClientResourceRegistry();
         var closed = new AtomicLong();
 
@@ -55,8 +55,14 @@ public class ClientResourceRegistryTest {
         reg.close();
 
         assertEquals(2, closed.get());
-        assertThrows(IgniteException.class, () -> reg.get(0));
-        assertThrows(IgniteException.class, () -> reg.put(new ClientResource(1, null)));
-        assertThrows(IgniteException.class, () -> reg.remove(0));
+
+        var ex = assertThrows(IgniteException.class, () -> reg.put(new ClientResource(1, null)));
+        assertEquals("Resource registry is closed.", ex.getMessage());
+
+        ex = assertThrows(IgniteException.class, () -> reg.get(0));
+        assertEquals("Resource registry is closed.", ex.getMessage());
+
+        ex = assertThrows(IgniteException.class, () -> reg.remove(0));
+        assertEquals("Resource registry is closed.", ex.getMessage());
     }
 }

--- a/modules/client-handler/src/test/java/ClientResourceRegistryTest.java
+++ b/modules/client-handler/src/test/java/ClientResourceRegistryTest.java
@@ -22,7 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.ignite.client.handler.ClientResource;
 import org.apache.ignite.client.handler.ClientResourceRegistry;
-import org.apache.ignite.lang.IgniteException;
+import org.apache.ignite.lang.IgniteInternalCheckedException;
+import org.apache.ignite.lang.IgniteInternalException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,7 +31,7 @@ import org.junit.jupiter.api.Test;
  */
 public class ClientResourceRegistryTest {
     @Test
-    public void testPutGetRemove() {
+    public void testPutGetRemove() throws IgniteInternalCheckedException {
         var reg = new ClientResourceRegistry();
         ClientResource resource = new ClientResource(1, null);
 
@@ -41,12 +42,12 @@ public class ClientResourceRegistryTest {
         assertSame(resource, returned);
         assertSame(resource, removed);
 
-        var ex = assertThrows(IgniteException.class, () -> reg.get(id));
+        var ex = assertThrows(IgniteInternalException.class, () -> reg.get(id));
         assertEquals("Failed to find resource with id: 1", ex.getMessage());
     }
 
     @Test
-    public void testCloseReleasesAllResourcesAndBlocksUsage() {
+    public void testCloseReleasesAllResourcesAndBlocksUsage() throws IgniteInternalCheckedException {
         var reg = new ClientResourceRegistry();
         var closed = new AtomicLong();
 
@@ -57,13 +58,13 @@ public class ClientResourceRegistryTest {
 
         assertEquals(2, closed.get());
 
-        var ex = assertThrows(IgniteException.class, () -> reg.put(new ClientResource(1, null)));
+        var ex = assertThrows(IgniteInternalCheckedException.class, () -> reg.put(new ClientResource(1, null)));
         assertEquals("Resource registry is closed.", ex.getMessage());
 
-        ex = assertThrows(IgniteException.class, () -> reg.get(0));
+        ex = assertThrows(IgniteInternalCheckedException.class, () -> reg.get(0));
         assertEquals("Resource registry is closed.", ex.getMessage());
 
-        ex = assertThrows(IgniteException.class, () -> reg.remove(0));
+        ex = assertThrows(IgniteInternalCheckedException.class, () -> reg.remove(0));
         assertEquals("Resource registry is closed.", ex.getMessage());
     }
 }

--- a/modules/client-handler/src/test/java/ClientResourceRegistryTest.java
+++ b/modules/client-handler/src/test/java/ClientResourceRegistryTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link org.apache.ignite.client.handler.ClientResourceRegistry}.
+ */
+public class ClientResourceRegistryTest {
+    @Test
+    public void testCloseReleasesAllResourcesAndBlocksUsage() {
+        // TODO
+    }
+
+    @Test
+    public void testPutGetRemove() {
+        // TODO
+    }
+}

--- a/modules/client-handler/src/test/java/ClientResourceRegistryTest.java
+++ b/modules/client-handler/src/test/java/ClientResourceRegistryTest.java
@@ -15,14 +15,15 @@
  * limitations under the License.
  */
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.ignite.client.handler.ClientResource;
 import org.apache.ignite.client.handler.ClientResourceRegistry;
 import org.apache.ignite.lang.IgniteException;
 import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.atomic.AtomicLong;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for {@link org.apache.ignite.client.handler.ClientResourceRegistry}.


### PR DESCRIPTION
Guard `ClientResourceRegistry` with an `RwLock` so that new resources can't be added to a closed registry.