### PR TITLE
IGNITE-16823 .NET: Add cluster awareness to Compute

### DIFF
--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -189,11 +189,14 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter {
 
             // Response.
             ProtocolVersion.LATEST_VER.pack(packer);
-
             packer.packInt(ClientErrorCode.SUCCESS);
+
+            // TODO: Update handshake format in IEP
+            packer.packLong(configuration.idleTimeout());
+            packer.packString(clusterService.topologyService().localMember().name());
+
             packer.packBinaryHeader(0); // Features.
             packer.packMapHeader(0); // Extensions.
-            packer.packLong(configuration.idleTimeout());
 
             write(packer, ctx);
         } catch (Throwable t) {

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -73,6 +73,7 @@ import org.apache.ignite.internal.sql.engine.QueryProcessor;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.lang.IgniteInternalCheckedException;
 import org.apache.ignite.lang.IgniteLogger;
+import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.table.manager.IgniteTables;
 import org.apache.ignite.tx.IgniteTransactions;
@@ -193,7 +194,10 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter {
 
             // TODO: Update handshake format in IEP
             packer.packLong(configuration.idleTimeout());
-            packer.packString(clusterService.topologyService().localMember().name());
+
+            ClusterNode localMember = clusterService.topologyService().localMember();
+            packer.packString(localMember.id());
+            packer.packString(localMember.name());
 
             packer.packBinaryHeader(0); // Features.
             packer.packMapHeader(0); // Extensions.

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -192,7 +192,6 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter {
             ProtocolVersion.LATEST_VER.pack(packer);
             packer.packInt(ClientErrorCode.SUCCESS);
 
-            // TODO: Update handshake format in IEP
             packer.packLong(configuration.idleTimeout());
 
             ClusterNode localMember = clusterService.topologyService().localMember();

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ProtocolContext.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ProtocolContext.java
@@ -22,6 +22,7 @@ import java.util.EnumSet;
 import java.util.Set;
 import org.apache.ignite.client.IgniteClientFeatureNotSupportedByServerException;
 import org.apache.ignite.internal.client.proto.ProtocolVersion;
+import org.apache.ignite.network.ClusterNode;
 
 /**
  * Protocol Context.
@@ -36,8 +37,8 @@ public class ProtocolContext {
     /** Server idle timeout. */
     private final long serverIdleTimeout;
 
-    /** Cluster node name. */
-    private final String clusterNodeName;
+    /** Cluster node. */
+    private final ClusterNode clusterNode;
 
     /**
      * Constructor.
@@ -45,17 +46,17 @@ public class ProtocolContext {
      * @param ver Protocol version.
      * @param features Supported features.
      * @param serverIdleTimeout Server idle timeout.
-     * @param clusterNodeName Cluster node name.
+     * @param clusterNode Cluster node.
      */
     public ProtocolContext(
             ProtocolVersion ver,
             EnumSet<ProtocolBitmaskFeature> features,
             long serverIdleTimeout,
-            String clusterNodeName) {
+            ClusterNode clusterNode) {
         this.ver = ver;
         this.features = Collections.unmodifiableSet(features != null ? features : EnumSet.noneOf(ProtocolBitmaskFeature.class));
         this.serverIdleTimeout = serverIdleTimeout;
-        this.clusterNodeName = clusterNodeName;
+        this.clusterNode = clusterNode;
     }
 
     /**
@@ -108,11 +109,11 @@ public class ProtocolContext {
     }
 
     /**
-     * Returns cluster node name.
+     * Returns cluster node.
      *
-     * @return Cluster node name.
+     * @return Cluster node.
      */
-    public String clusterNodeName() {
-        return clusterNodeName;
+    public ClusterNode clusterNode() {
+        return clusterNode;
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ProtocolContext.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ProtocolContext.java
@@ -17,7 +17,9 @@
 
 package org.apache.ignite.internal.client;
 
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Set;
 import org.apache.ignite.client.IgniteClientFeatureNotSupportedByServerException;
 import org.apache.ignite.internal.client.proto.ProtocolVersion;
 
@@ -29,22 +31,30 @@ public class ProtocolContext {
     private final ProtocolVersion ver;
 
     /** Features. */
-    private final EnumSet<ProtocolBitmaskFeature> features;
+    private final Set<ProtocolBitmaskFeature> features;
 
     /** Server idle timeout. */
     private final long serverIdleTimeout;
 
+    /** Cluster node name. */
+    private final String clusterNodeName;
+
     /**
      * Constructor.
-     *
-     * @param ver Protocol version.
+     *  @param ver Protocol version.
      * @param features Supported features.
      * @param serverIdleTimeout Server idle timeout.
+     * @param clusterNodeName Cluster node name.
      */
-    public ProtocolContext(ProtocolVersion ver, EnumSet<ProtocolBitmaskFeature> features, long serverIdleTimeout) {
+    public ProtocolContext(
+            ProtocolVersion ver,
+            EnumSet<ProtocolBitmaskFeature> features,
+            long serverIdleTimeout,
+            String clusterNodeName) {
         this.ver = ver;
-        this.features = features != null ? features : EnumSet.noneOf(ProtocolBitmaskFeature.class);
+        this.features = Collections.unmodifiableSet(features != null ? features : EnumSet.noneOf(ProtocolBitmaskFeature.class));
         this.serverIdleTimeout = serverIdleTimeout;
+        this.clusterNodeName = clusterNodeName;
     }
 
     /**
@@ -74,7 +84,7 @@ public class ProtocolContext {
      *
      * @return Supported features.
      */
-    public EnumSet<ProtocolBitmaskFeature> features() {
+    public Set<ProtocolBitmaskFeature> features() {
         return features;
     }
 
@@ -92,7 +102,16 @@ public class ProtocolContext {
      *
      * @return Server idle timeout.
      */
-    public long getServerIdleTimeout() {
+    public long serverIdleTimeout() {
         return serverIdleTimeout;
+    }
+
+    /**
+     * Returns cluster node name.
+     *
+     * @return Cluster node name.
+     */
+    public String clusterNodeName() {
+        return clusterNodeName;
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ProtocolContext.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ProtocolContext.java
@@ -41,7 +41,8 @@ public class ProtocolContext {
 
     /**
      * Constructor.
-     *  @param ver Protocol version.
+     *
+     * @param ver Protocol version.
      * @param features Supported features.
      * @param serverIdleTimeout Server idle timeout.
      * @param clusterNodeName Cluster node name.

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -385,7 +385,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
                 if (errCode == ClientErrorCode.AUTH_FAILED) {
                     throw new IgniteClientAuthenticationException(msg);
                 } else if (proposedVer.equals(srvVer)) {
-                    throw new IgniteClientException("Client protocol error: unexpected server response.");
+                    throw new IgniteClientException("Client protocol error: unexpected server response '" + msg + "'.");
                 } else if (!supportedVers.contains(srvVer)) {
                     throw new IgniteClientException(String.format(
                             "Protocol version mismatch: client %s / server %s. Server details: %s",

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -373,10 +373,11 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
      *
      * @param ver Protocol version.
      * @param serverIdleTimeout Server idle timeout.
+     * @param clusterNodeName Cluster node name.
      * @return Protocol context for a version.
      */
-    private ProtocolContext protocolContextFromVersion(ProtocolVersion ver, long serverIdleTimeout) {
-        return new ProtocolContext(ver, ProtocolBitmaskFeature.allFeaturesAsEnumSet(), serverIdleTimeout);
+    private ProtocolContext protocolContextFromVersion(ProtocolVersion ver, long serverIdleTimeout, String clusterNodeName) {
+        return new ProtocolContext(ver, ProtocolBitmaskFeature.allFeaturesAsEnumSet(), serverIdleTimeout, clusterNodeName);
     }
 
     /** Receive and handle handshake response. */
@@ -418,7 +419,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
             var extensionsLen = unpacker.unpackMapHeader();
             unpacker.skipValues(extensionsLen);
 
-            protocolCtx = protocolContextFromVersion(srvVer, serverIdleTimeout);
+            protocolCtx = protocolContextFromVersion(srvVer, serverIdleTimeout, clusterNodeName);
         }
     }
 
@@ -454,7 +455,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
      * @return Resolved interval.
      */
     private long getHeartbeatInterval(long configuredInterval) {
-        long serverIdleTimeoutMs = protocolCtx.getServerIdleTimeout();
+        long serverIdleTimeoutMs = protocolCtx.serverIdleTimeout();
 
         if (serverIdleTimeoutMs <= 0) {
             return configuredInterval;

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -409,13 +409,14 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
                 throw new IgniteClientConnectionException(msg);
             }
 
+            var serverIdleTimeout = unpacker.unpackLong();
+            var clusterNodeName = unpacker.unpackString();
+
             var featuresLen = unpacker.unpackBinaryHeader();
             unpacker.skipValues(featuresLen);
 
             var extensionsLen = unpacker.unpackMapHeader();
             unpacker.skipValues(extensionsLen);
-
-            var serverIdleTimeout = unpacker.unpackLong();
 
             protocolCtx = protocolContextFromVersion(srvVer, serverIdleTimeout);
         }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -131,11 +131,7 @@ public class ClientCompute implements IgniteCompute {
     private <R> CompletableFuture<R> executeOnOneNode(ClusterNode node, String jobClassName, Object[] args) {
         return ch.serviceAsync(ClientOp.COMPUTE_EXECUTE, w -> {
             // TODO: Cluster awareness (IGNITE-16771): if the specified node matches existing connection, send nil.
-            w.out().packString(node.id());
             w.out().packString(node.name());
-            w.out().packString(node.address().host());
-            w.out().packInt(node.address().port());
-
             w.out().packString(jobClassName);
             w.out().packObjectArray(args);
         }, r -> (R) r.in().unpackObjectWithType());

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/io/ClientConnection.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/io/ClientConnection.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.client.io;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
+import java.net.InetSocketAddress;
 import org.apache.ignite.lang.IgniteException;
 
 /**
@@ -39,6 +40,13 @@ public interface ClientConnection extends AutoCloseable {
      * @return Buffer.
      */
     ByteBuf getBuffer();
+
+    /**
+     * Gets the remote address.
+     *
+     * @return Remote address.
+     */
+    InetSocketAddress remoteAddress();
 
     /**
      * Closes the connection.

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/io/netty/NettyClientConnection.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/io/netty/NettyClientConnection.java
@@ -22,6 +22,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.util.AttributeKey;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import org.apache.ignite.internal.client.io.ClientConnection;
 import org.apache.ignite.internal.client.io.ClientConnectionStateHandler;
 import org.apache.ignite.internal.client.io.ClientMessageHandler;
@@ -69,6 +70,12 @@ public class NettyClientConnection implements ClientConnection {
     @Override
     public ByteBuf getBuffer() {
         return channel.alloc().buffer();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public InetSocketAddress remoteAddress() {
+        return (InetSocketAddress) channel.remoteAddress();
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.client;
 
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 
 import io.netty.bootstrap.ServerBootstrap;
@@ -43,6 +44,7 @@ import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.network.NettyBootstrapFactory;
 import org.jetbrains.annotations.Nullable;
+import org.mockito.Mockito;
 
 /**
  * Client handler module for tests.
@@ -139,6 +141,10 @@ public class TestClientHandlerModule implements IgniteComponent {
 
         ServerBootstrap bootstrap = bootstrapFactory.createServerBootstrap();
 
+        ClusterService clusterService = mock(ClusterService.class, RETURNS_DEEP_STUBS);
+        Mockito.when(clusterService.topologyService().localMember().id()).thenReturn("id");
+        Mockito.when(clusterService.topologyService().localMember().name()).thenReturn("consistent-id");
+
         bootstrap.childHandler(new ChannelInitializer<>() {
                     @Override
                     protected void initChannel(Channel ch) {
@@ -151,7 +157,7 @@ public class TestClientHandlerModule implements IgniteComponent {
                                         mock(QueryProcessor.class),
                                         configuration,
                                         mock(IgniteCompute.class),
-                                        mock(ClusterService.class)));
+                                        clusterService));
                     }
                 })
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, configuration.connectTimeout());

--- a/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.client;
 
 import static org.apache.ignite.configuration.annotation.ConfigurationType.LOCAL;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 
 import java.net.InetSocketAddress;
@@ -37,6 +38,7 @@ import org.apache.ignite.internal.configuration.storage.TestConfigurationStorage
 import org.apache.ignite.internal.manager.IgniteComponent;
 import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.network.NettyBootstrapFactory;
+import org.mockito.Mockito;
 
 /**
  * Test server.
@@ -98,6 +100,10 @@ public class TestServer implements AutoCloseable {
 
         bootstrapFactory.start();
 
+        ClusterService clusterService = mock(ClusterService.class, RETURNS_DEEP_STUBS);
+        Mockito.when(clusterService.topologyService().localMember().id()).thenReturn("id");
+        Mockito.when(clusterService.topologyService().localMember().name()).thenReturn("consistent-id");
+
         module = shouldDropConnection != null
                 ? new TestClientHandlerModule(ignite, cfg, bootstrapFactory, shouldDropConnection)
                 : new ClientHandlerModule(
@@ -106,7 +112,7 @@ public class TestServer implements AutoCloseable {
                         ignite.transactions(),
                         cfg,
                         mock(IgniteCompute.class),
-                        mock(ClusterService.class),
+                        clusterService,
                         bootstrapFactory
                 );
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests.ruleset
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests.ruleset
@@ -52,5 +52,8 @@
 
     <!-- UnusedParameters -->
     <Rule Id="CA1801" Action="None" />
+
+    <!-- Validate parameters. -->
+    <Rule Id="CA1062" Action="None" />
   </Rules>
 </RuleSet>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
@@ -32,11 +32,11 @@ namespace Apache.Ignite.Tests.Compute
             // - Check that request arrives to proper node
             // - Check that retry works properly for cluster aware calls
             // - Check that default node is used when no direct connection exists
-            using var server = new FakeServer();
+            using var server = new FakeServer(nodeName: nameof(TestClusterAwareness));
             using var client = await server.ConnectClientAsync();
 
             var res = await client.Compute.ExecuteAsync<string>(nodes: new[] { server.Node }, jobClassName: string.Empty);
-            Assert.AreEqual(server.Node.Name, res);
+            Assert.AreEqual(nameof(TestClusterAwareness), res);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests.Compute
+{
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests compute cluster awareness: client requests can be sent to correct server nodes when a direct connection is available.
+    /// </summary>
+    public class ComputeClusterAwarenessTests
+    {
+        [Test]
+        public async Task TestClusterAwareness()
+        {
+            // TODO: Test with fake server (start 3 of them):
+            // - Check that request arrives to proper node
+            // - Check that retry works properly for cluster aware calls
+            // - Check that default node is used when no direct connection exists
+            using var server = new FakeServer();
+            using var client = await server.ConnectClientAsync();
+
+            var res = await client.Compute.ExecuteAsync<string>(nodes: new[] { server.Node }, jobClassName: string.Empty);
+            Assert.AreEqual(server.Node.Name, res);
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
@@ -74,6 +74,8 @@ namespace Apache.Ignite.Tests.Compute
 
             Assert.IsEmpty(server2.ClientOps);
             Assert.IsEmpty(server3.ClientOps);
+
+            Assert.AreEqual(server1.Node, client.GetConnections().Single());
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
@@ -44,13 +44,16 @@ namespace Apache.Ignite.Tests.Compute
             // ReSharper disable once AccessToDisposedClosure
             TestUtils.WaitForCondition(() => client.GetConnections().Count == 3);
 
-            var res = await client.Compute.ExecuteAsync<string>(nodes: new[] { server3.Node }, jobClassName: string.Empty);
+            var res2 = await client.Compute.ExecuteAsync<string>(nodes: new[] { server2.Node }, jobClassName: string.Empty);
+            var res3 = await client.Compute.ExecuteAsync<string>(nodes: new[] { server3.Node }, jobClassName: string.Empty);
 
-            Assert.AreEqual("s3", res);
-            Assert.AreEqual(ClientOp.ComputeExecute, server3.ClientOps.Last());
+            Assert.AreEqual("s2", res2);
+            Assert.AreEqual("s3", res3);
+
+            Assert.AreEqual(ClientOp.ComputeExecute, server2.ClientOps.Single());
+            Assert.AreEqual(ClientOp.ComputeExecute, server3.ClientOps.Single());
 
             Assert.IsEmpty(server1.ClientOps);
-            Assert.IsEmpty(server2.ClientOps);
         }
 
         [Test]
@@ -61,10 +64,13 @@ namespace Apache.Ignite.Tests.Compute
             using var server3 = new FakeServer(nodeName: "s3");
 
             using var client = await server1.ConnectClientAsync();
-            var res = await client.Compute.ExecuteAsync<string>(nodes: new[] { server3.Node }, jobClassName: string.Empty);
 
-            Assert.AreEqual("s1", res);
-            Assert.AreEqual(ClientOp.ComputeExecute, server1.ClientOps.Last());
+            var res2 = await client.Compute.ExecuteAsync<string>(nodes: new[] { server2.Node }, jobClassName: string.Empty);
+            var res3 = await client.Compute.ExecuteAsync<string>(nodes: new[] { server3.Node }, jobClassName: string.Empty);
+
+            Assert.AreEqual("s1", res2);
+            Assert.AreEqual("s1", res3);
+            Assert.AreEqual(new[] { ClientOp.ComputeExecute, ClientOp.ComputeExecute }, server1.ClientOps);
 
             Assert.IsEmpty(server2.ClientOps);
             Assert.IsEmpty(server3.ClientOps);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
@@ -63,20 +63,16 @@ namespace Apache.Ignite.Tests.Compute
 
             var clientCfg = new IgniteClientConfiguration
             {
-                Endpoints = { server1.Node.Address.ToString(), server2.Node.Address.ToString() }
+                Endpoints = { server1.Node.Address.ToString() }
             };
 
             using var client = await IgniteClient.StartAsync(clientCfg);
-
-            // ReSharper disable once AccessToDisposedClosure
-            TestUtils.WaitForCondition(() => client.GetConnections().Count == 2);
-
             var res = await client.Compute.ExecuteAsync<string>(nodes: new[] { server3.Node }, jobClassName: string.Empty);
 
-            Assert.AreEqual("s2", res);
-            Assert.AreEqual(ClientOp.ComputeExecute, server2.ClientOps.Last());
+            Assert.AreEqual("s1", res);
+            Assert.AreEqual(ClientOp.ComputeExecute, server1.ClientOps.Last());
 
-            Assert.IsEmpty(server1.ClientOps);
+            Assert.IsEmpty(server2.ClientOps);
             Assert.IsEmpty(server3.ClientOps);
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -165,6 +165,16 @@ namespace Apache.Ignite.Tests.Compute
             }
         }
 
+        [Test]
+        public async Task TestClusterAwareness()
+        {
+            // TODO: Test with fake server (start 3 of them):
+            // - Check that request arrives to proper node
+            // - Check that retry works properly for cluster aware calls
+            // - Check that default node is used when no direct connection exists
+            await Task.Yield();
+        }
+
         private async Task<List<IClusterNode>> GetNodeAsync(int index) =>
             (await Client.GetClusterNodesAsync()).OrderBy(n => n.Name).Skip(index).Take(1).ToList();
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -23,6 +23,7 @@ namespace Apache.Ignite.Tests.Compute
     using System.Net;
     using System.Threading.Tasks;
     using Ignite.Compute;
+    using Internal.Network;
     using Network;
     using NUnit.Framework;
 
@@ -128,6 +129,17 @@ namespace Apache.Ignite.Tests.Compute
                 await Client.Compute.ExecuteAsync<string>(await Client.GetClusterNodesAsync(), ErrorJob, "unused"));
 
             Assert.AreEqual("class org.apache.ignite.tx.TransactionException: Custom job error", ex!.Message);
+        }
+
+        [Test]
+        public void TestUnknownNodeThrows()
+        {
+            var unknownNode = new ClusterNode("x", "y", new IPEndPoint(IPAddress.Loopback, 0));
+
+            var ex = Assert.ThrowsAsync<IgniteClientException>(async () =>
+                await Client.Compute.ExecuteAsync<string>(new[] { unknownNode }, EchoJob, "unused"));
+
+            Assert.AreEqual("Specified node is not present in the cluster: y", ex!.Message);
         }
 
         // TODO: Support all types (IGNITE-15431).

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -165,16 +165,6 @@ namespace Apache.Ignite.Tests.Compute
             }
         }
 
-        [Test]
-        public async Task TestClusterAwareness()
-        {
-            // TODO: Test with fake server (start 3 of them):
-            // - Check that request arrives to proper node
-            // - Check that retry works properly for cluster aware calls
-            // - Check that default node is used when no direct connection exists
-            await Task.Yield();
-        }
-
         private async Task<List<IClusterNode>> GetNodeAsync(int index) =>
             (await Client.GetClusterNodesAsync()).OrderBy(n => n.Name).Skip(index).Take(1).ToList();
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -216,6 +216,8 @@ namespace Apache.Ignite.Tests
                         handler.Send(new byte[] { 0, 0, 0, (byte)(4 + arrayBufferWriter.WrittenCount) }); // Size.
                         handler.Send(new byte[] { 0, requestId, 0, (byte)ClientDataType.String });
                         handler.Send(arrayBufferWriter.WrittenSpan);
+
+                        continue;
                     }
 
                     // Fake error message for any other op code.

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -127,6 +127,7 @@ namespace Apache.Ignite.Tests
                 var handshakeBufferWriter = new ArrayBufferWriter<byte>();
                 var handshakeWriter = new MessagePackWriter(handshakeBufferWriter);
                 handshakeWriter.Write(0); // Idle timeout.
+                handshakeWriter.Write(Node.Id); // Node id.
                 handshakeWriter.Write(Node.Name); // Node name (consistent id).
                 handshakeWriter.WriteBinHeader(0); // Features.
                 handshakeWriter.WriteMapHeader(0); // Extensions.

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -206,6 +206,18 @@ namespace Apache.Ignite.Tests
                         continue;
                     }
 
+                    if (opCode == ClientOp.ComputeExecute)
+                    {
+                        var arrayBufferWriter = new ArrayBufferWriter<byte>();
+                        var writer = new MessagePackWriter(arrayBufferWriter);
+                        writer.Write(Node.Name);
+                        writer.Flush();
+
+                        handler.Send(new byte[] { 0, 0, 0, (byte)(4 + arrayBufferWriter.WrittenCount) }); // Size.
+                        handler.Send(new byte[] { 0, requestId, 0, (byte)ClientDataType.String });
+                        handler.Send(arrayBufferWriter.WrittenSpan);
+                    }
+
                     // Fake error message for any other op code.
                     handler.Send(new byte[] { 0, 0, 0, 8 }); // Size.
                     handler.Send(new byte[] { 0, requestId, 1, 160 | 4, (byte)Err[0], (byte)Err[1], (byte)Err[2], (byte)Err[3] });

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/RawSocketConnectionTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/RawSocketConnectionTests.cs
@@ -83,7 +83,7 @@ namespace Apache.Ignite.Tests
 
             var str = Encoding.UTF8.GetString(msg);
 
-            Assert.AreEqual(10, msgSize, str);
+            Assert.AreEqual(110, msgSize, str);
 
             // Protocol version.
             Assert.AreEqual(3, msg[0]);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/TestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/TestUtils.cs
@@ -18,9 +18,12 @@
 namespace Apache.Ignite.Tests
 {
     using System;
+    using System.Diagnostics;
     using System.IO;
     using System.Reflection;
     using System.Runtime.InteropServices;
+    using System.Threading;
+    using NUnit.Framework;
 
     public static class TestUtils
     {
@@ -29,6 +32,28 @@ namespace Apache.Ignite.Tests
         public static readonly string RepoRootDir = Path.Combine(GetSolutionDir(), "..", "..", "..");
 
         public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        public static void WaitForCondition(Func<bool> condition, int timeoutMs = 1000)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            var sw = Stopwatch.StartNew();
+
+            while (sw.ElapsedMilliseconds < timeoutMs)
+            {
+                if (condition())
+                {
+                    return;
+                }
+
+                Thread.Sleep(50);
+            }
+
+            Assert.Fail("Condition not reached after " + sw.Elapsed);
+        }
 
         private static string GetSolutionDir()
         {

--- a/modules/platforms/dotnet/Apache.Ignite/IIgnite.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IIgnite.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Compute;
+    using Internal.Network;
     using Network;
     using Table;
     using Transactions;

--- a/modules/platforms/dotnet/Apache.Ignite/IIgnite.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IIgnite.cs
@@ -20,7 +20,6 @@ namespace Apache.Ignite
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Compute;
-    using Internal.Network;
     using Network;
     using Table;
     using Transactions;

--- a/modules/platforms/dotnet/Apache.Ignite/IIgniteClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IIgniteClient.cs
@@ -18,6 +18,8 @@
 namespace Apache.Ignite
 {
     using System;
+    using System.Collections.Generic;
+    using Network;
 
     /// <summary>
     /// Ignite client.
@@ -30,5 +32,11 @@ namespace Apache.Ignite
         /// Gets the configuration.
         /// </summary>
         IgniteClientConfiguration Configuration { get; }
+
+        /// <summary>
+        /// Gets active connections.
+        /// </summary>
+        /// <returns>A list of connected cluster nodes.</returns>
+        IList<IClusterNode> GetConnections();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClient.cs
@@ -35,9 +35,7 @@ namespace Apache.Ignite
         {
             IgniteArgumentCheck.NotNull(configuration, nameof(configuration));
 
-            var socket = new ClientFailoverSocket(configuration);
-
-            await socket.ConnectAsync().ConfigureAwait(false);
+            var socket = await ClientFailoverSocket.ConnectAsync(configuration).ConfigureAwait(false);
 
             return new IgniteClientInternal(socket);
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Internal
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
@@ -43,6 +44,9 @@ namespace Apache.Ignite.Internal
 
         /** Endpoints with corresponding hosts - from configuration. */
         private readonly IReadOnlyList<SocketEndpoint> _endPoints;
+
+        /** Cluster node unique name to endpoint map. */
+        private readonly ConcurrentDictionary<string, SocketEndpoint> _endPointsMap = new();
 
         /** <see cref="_socket"/> lock. */
         [SuppressMessage(
@@ -274,6 +278,8 @@ namespace Apache.Ignite.Internal
             var socket = await ClientSocket.ConnectAsync(endPoint.EndPoint, Configuration).ConfigureAwait(false);
 
             endPoint.Socket = socket;
+
+            _endPointsMap[socket.ConnectionContext.ClusterNodeName] = endPoint;
 
             return socket;
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -61,7 +61,7 @@ namespace Apache.Ignite.Internal
         /// Initializes a new instance of the <see cref="ClientFailoverSocket"/> class.
         /// </summary>
         /// <param name="configuration">Client configuration.</param>
-        public ClientFailoverSocket(IgniteClientConfiguration configuration)
+        private ClientFailoverSocket(IgniteClientConfiguration configuration)
         {
             if (configuration.Endpoints.Count == 0)
             {
@@ -84,10 +84,15 @@ namespace Apache.Ignite.Internal
         /// <summary>
         /// Connects the socket.
         /// </summary>
+        /// <param name="configuration">Client configuration.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task ConnectAsync()
+        public static async Task<ClientFailoverSocket> ConnectAsync(IgniteClientConfiguration configuration)
         {
-            await GetSocketAsync().ConfigureAwait(false);
+            var socket = new ClientFailoverSocket(configuration);
+
+            await socket.GetSocketAsync().ConfigureAwait(false);
+
+            return socket;
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -28,7 +28,6 @@ namespace Apache.Ignite.Internal
     using System.Threading;
     using System.Threading.Tasks;
     using Buffers;
-    using Ignite.Network;
     using Log;
     using Proto;
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -186,6 +186,11 @@ namespace Apache.Ignite.Internal
             Justification = "Secondary connection errors can be ignored.")]
         private async Task ConnectAllSockets()
         {
+            if (_endPoints.Count == 1)
+            {
+                return;
+            }
+
             await _socketLock.WaitAsync().ConfigureAwait(false);
 
             var tasks = new List<Task>(_endPoints.Count);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -340,7 +340,7 @@ namespace Apache.Ignite.Internal
 
             endpoint.Socket = socket;
 
-            _endpointsMap[socket.ConnectionContext.ClusterNodeName] = endpoint;
+            _endpointsMap[socket.ConnectionContext.ClusterNode.Name] = endpoint;
 
             return socket;
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -28,6 +28,7 @@ namespace Apache.Ignite.Internal
     using System.Threading;
     using System.Threading.Tasks;
     using Buffers;
+    using Ignite.Network;
     using Log;
     using Proto;
 
@@ -239,6 +240,16 @@ namespace Apache.Ignite.Internal
                 _socketLock.Release();
             }
         }
+
+        /// <summary>
+        /// Gets active connections.
+        /// </summary>
+        /// <returns>Active connections.</returns>
+        public IEnumerable<ConnectionContext> GetConnections() =>
+            _endpoints
+                .Select(e => e.Socket?.ConnectionContext)
+                .Where(ctx => ctx != null)
+                .ToList()!;
 
         [SuppressMessage(
             "Microsoft.Design",

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -111,9 +111,7 @@ namespace Apache.Ignite.Internal
 
             // Because this call is not awaited, execution of the current method continues before the call is completed.
             // Receive loop runs in the background and should not be awaited.
-#pragma warning disable 4014
-            RunReceiveLoop(_disposeTokenSource.Token);
-#pragma warning restore 4014
+            _ = RunReceiveLoop(_disposeTokenSource.Token);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -89,25 +89,45 @@ namespace Apache.Ignite.Internal.Compute
         {
             IgniteArgumentCheck.NotNull(node, nameof(node));
 
-            // TODO:
-            // 1. Locate matching active connection in ClientFailoverSocket
-            // 2. If there is one, write without node details, send request.
-            // 3. If failed, fallback to default socket with retry policy.
-            using var writer = new PooledArrayBufferWriter();
-            Write();
+            // Try direct connection to the specified node.
+            if (_socket.GetEndpoint(node.Name) is { } endpoint)
+            {
+                using var writerWithoutNode = new PooledArrayBufferWriter();
+                Write(writerWithoutNode, writeNode: false);
 
-            using var resBuf = await _socket.DoOutInOpAsync(ClientOp.ComputeExecute, writer).ConfigureAwait(false);
+                using var res1 = await _socket.TryDoOutInOpAsync(endpoint, ClientOp.ComputeExecute, writerWithoutNode)
+                    .ConfigureAwait(false);
 
-            return Read();
+                // Result is null when there was a connection issue, but retry policy allows another try.
+                if (res1 != null)
+                {
+                    return Read(res1.Value);
+                }
+            }
 
-            void Write()
+            // When direct connection is not available, use default connection and pass target node info to the server.
+            using var writerWithNode = new PooledArrayBufferWriter();
+            Write(writerWithNode, writeNode: true);
+
+            using var res2 = await _socket.DoOutInOpAsync(ClientOp.ComputeExecute, writerWithNode).ConfigureAwait(false);
+
+            return Read(res2);
+
+            void Write(PooledArrayBufferWriter writer, bool writeNode)
             {
                 var w = writer.GetMessageWriter();
 
-                w.Write(node.Id);
-                w.Write(node.Name);
-                w.Write(node.Address.Address.ToString());
-                w.Write(node.Address.Port);
+                if (writeNode)
+                {
+                    w.Write(node.Id);
+                    w.Write(node.Name);
+                    w.Write(node.Address.Address.ToString());
+                    w.Write(node.Address.Port);
+                }
+                else
+                {
+                    w.WriteNil();
+                }
 
                 w.Write(jobClassName);
                 w.WriteObjectArrayWithTypes(args);
@@ -115,9 +135,9 @@ namespace Apache.Ignite.Internal.Compute
                 w.Flush();
             }
 
-            T Read()
+            static T Read(in PooledBuffer buf)
             {
-                var reader = resBuf.GetReader();
+                var reader = buf.GetReader();
 
                 return (T)reader.ReadObjectWithType()!;
             }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -119,6 +119,7 @@ namespace Apache.Ignite.Internal.Compute
 
                 if (writeNode)
                 {
+                    // TODO: Only name is necessary here.
                     w.Write(node.Id);
                     w.Write(node.Name);
                     w.Write(node.Address.Address.ToString());

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -89,6 +89,10 @@ namespace Apache.Ignite.Internal.Compute
         {
             IgniteArgumentCheck.NotNull(node, nameof(node));
 
+            // TODO:
+            // 1. Locate matching active connection in ClientFailoverSocket
+            // 2. If there is one, write without node details, send request.
+            // 3. If failed, fallback to default socket with retry policy.
             using var writer = new PooledArrayBufferWriter();
             Write();
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -119,11 +119,7 @@ namespace Apache.Ignite.Internal.Compute
 
                 if (writeNode)
                 {
-                    // TODO: Only name is necessary here.
-                    w.Write(node.Id);
                     w.Write(node.Name);
-                    w.Write(node.Address.Address.ToString());
-                    w.Write(node.Address.Port);
                 }
                 else
                 {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ConnectionContext.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ConnectionContext.cs
@@ -18,12 +18,13 @@
 namespace Apache.Ignite.Internal
 {
     using System;
+    using Ignite.Network;
 
     /// <summary>
     /// Socket connection context.
     /// </summary>
     /// <param name="Version">Protocol version.</param>
     /// <param name="IdleTimeout">Server idle timeout.</param>
-    /// <param name="ClusterNodeName">Cluster node name.</param>
-    internal record ConnectionContext(ClientProtocolVersion Version, TimeSpan IdleTimeout, string ClusterNodeName);
+    /// <param name="ClusterNode">Cluster node.</param>
+    internal record ConnectionContext(ClientProtocolVersion Version, TimeSpan IdleTimeout, IClusterNode ClusterNode);
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ConnectionContext.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ConnectionContext.cs
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Internal
+{
+    using System;
+
+    /// <summary>
+    /// Socket connection context.
+    /// </summary>
+    /// <param name="Version">Protocol version.</param>
+    /// <param name="IdleTimeout">Server idle timeout.</param>
+    /// <param name="ClusterNodeName">Cluster node name.</param>
+    internal record ConnectionContext(ClientProtocolVersion Version, TimeSpan IdleTimeout, string ClusterNodeName);
+}

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ConnectionContext.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ConnectionContext.cs
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+// XMLDoc check fails on older SDKs: https://github.com/dotnet/roslyn/issues/44571.
+#pragma warning disable CS1572
+#pragma warning disable CS1573
 namespace Apache.Ignite.Internal
 {
     using System;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Internal
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
     using Ignite.Compute;
@@ -85,6 +86,10 @@ namespace Apache.Ignite.Internal
                 return res;
             }
         }
+
+        /// <inheritdoc/>
+        public IList<IClusterNode> GetConnections() =>
+            _socket.GetConnections().Select(ctx => ctx.ClusterNode).ToList();
 
         /// <inheritdoc/>
         public void Dispose()

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Schema.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Schema.cs
@@ -15,13 +15,12 @@
  * limitations under the License.
  */
 
+// XMLDoc check fails on older SDKs: https://github.com/dotnet/roslyn/issues/44571.
+#pragma warning disable CS1572
+#pragma warning disable CS1573
 namespace Apache.Ignite.Internal.Table
 {
     using System.Collections.Generic;
-
-    // XMLDoc check fails on older SDKs: https://github.com/dotnet/roslyn/issues/44571.
-#pragma warning disable CS1572
-#pragma warning disable CS1573
 
     /// <summary>
     /// Schema.


### PR DESCRIPTION
* Include node id and name into handshake response.
* Establish connections to all known endpoints in background.
* During Compute calls, match target node name against active connections and send request directly to the correct node when possible.