### PR TITLE
IGNITE-16771 Thin client: Add cluster awareness to Compute

### DIFF
--- a/modules/api/src/main/java/org/apache/ignite/network/ClusterNode.java
+++ b/modules/api/src/main/java/org/apache/ignite/network/ClusterNode.java
@@ -57,7 +57,7 @@ public class ClusterNode implements Serializable {
     }
 
     /**
-     * Returns the unique name of this node in a cluster. Doesn't change between restarts.
+     * Returns the unique name (consistent id) of this node in a cluster. Doesn't change between restarts.
      *
      * @return Unique name of the member in a cluster.
      */

--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
@@ -23,6 +23,7 @@ import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_RECONNECT_
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_RECONNECT_THROTTLING_RETRIES;
 import static org.apache.ignite.internal.client.ClientUtils.sync;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -31,6 +32,7 @@ import java.util.function.Function;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.internal.client.IgniteClientConfigurationImpl;
 import org.apache.ignite.internal.client.TcpIgniteClient;
+import org.apache.ignite.network.ClusterNode;
 
 /**
  * Ignite client entry point.
@@ -42,6 +44,13 @@ public interface IgniteClient extends Ignite {
      * @return Configuration.
      */
     IgniteClientConfiguration configuration();
+
+    /**
+     * Gets active client connections.
+     *
+     * @return List of connected cluster nodes.
+     */
+    List<ClusterNode> connections();
 
     /**
      * Gets a new client builder.

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientChannel.java
@@ -50,4 +50,11 @@ public interface ClientChannel extends AutoCloseable {
      * @return {@code True} channel is closed.
      */
     public boolean closed();
+
+    /**
+     * Returns protocol context.
+     *
+     * @return Protocol context.
+     */
+    public ProtocolContext protocolContext();
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -690,6 +690,8 @@ public final class ReliableChannel implements AutoCloseable {
 
                     String newNodeId = ch.protocolContext().clusterNode().name();
 
+                    // There could be multiple holders map to the same serverNodeId if user provide the same
+                    // address multiple times in configuration.
                     nodeChannels.put(newNodeId, this);
 
                     if (serverNodeId != null && !serverNodeId.equals(newNodeId)) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -688,7 +688,16 @@ public final class ReliableChannel implements AutoCloseable {
 
                     ch = chFactory.apply(chCfg, connMgr);
 
-                    nodeChannels.put(ch.protocolContext().clusterNode().name(), this);
+                    String newNodeId = ch.protocolContext().clusterNode().name();
+
+                    nodeChannels.put(newNodeId, this);
+
+                    if (serverNodeId != null && !serverNodeId.equals(newNodeId)) {
+                        // New node on the old address.
+                        nodeChannels.remove(serverNodeId, this);
+                    }
+
+                    serverNodeId = newNodeId;
                 }
             }
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -470,7 +470,7 @@ public final class ReliableChannel implements AutoCloseable {
     }
 
     /**
-     * Apply specified {@code function} on any of available channel.
+     * Gets the default channel, reconnecting if necessary.
      */
     private ClientChannel getDefaultChannel() {
         IgniteClientConnectionException failure = null;

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -588,13 +588,13 @@ public final class ReliableChannel implements AutoCloseable {
                     List<ClientChannelHolder> holders = channels;
 
                     for (ClientChannelHolder hld : holders) {
-                        if (closed)
+                        if (closed) {
                             return; // New reinit task scheduled or channel is closed.
+                        }
 
                         try {
                             hld.getOrCreateChannel(true);
-                        }
-                        catch (Exception ignore) {
+                        } catch (Exception ignore) {
                             // No-op.
                         }
                     }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -26,7 +26,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -130,12 +129,15 @@ public final class ReliableChannel implements AutoCloseable {
      * @param payloadWriter Payload writer.
      * @param payloadReader Payload reader.
      * @param <T>           response type.
+     * @param preferredNodeName Unique name (consistent id) of the preferred target node. When a connection to the specified node exists,
+     *                          it will be used to handle the request; otherwise, default connection will be used.
      * @return Future for the operation.
      */
     public <T> CompletableFuture<T> serviceAsync(
             int opCode,
             PayloadWriter payloadWriter,
-            PayloadReader<T> payloadReader
+            PayloadReader<T> payloadReader,
+            String preferredNodeName
     ) {
         CompletableFuture<T> fut = new CompletableFuture<>();
 
@@ -143,6 +145,23 @@ public final class ReliableChannel implements AutoCloseable {
         handleServiceAsync(fut, opCode, payloadWriter, payloadReader, null, 0);
 
         return fut;
+    }
+
+    /**
+     * Sends request and handles response asynchronously.
+     *
+     * @param opCode        Operation code.
+     * @param payloadWriter Payload writer.
+     * @param payloadReader Payload reader.
+     * @param <T>           response type.
+     * @return Future for the operation.
+     */
+    public <T> CompletableFuture<T> serviceAsync(
+            int opCode,
+            PayloadWriter payloadWriter,
+            PayloadReader<T> payloadReader
+    ) {
+        return serviceAsync(opCode, payloadWriter, payloadReader, null);
     }
 
     /**
@@ -154,7 +173,7 @@ public final class ReliableChannel implements AutoCloseable {
      * @return Future for the operation.
      */
     public <T> CompletableFuture<T> serviceAsync(int opCode, PayloadReader<T> payloadReader) {
-        return serviceAsync(opCode, null, payloadReader);
+        return serviceAsync(opCode, null, payloadReader, null);
     }
 
     private <T> void handleServiceAsync(final CompletableFuture<T> fut,
@@ -230,17 +249,6 @@ public final class ReliableChannel implements AutoCloseable {
 
                     return null;
                 });
-    }
-
-    /**
-     * Sends request with payload and handles response asynchronously.
-     *
-     * @param opCode        Operation code.
-     * @param payloadWriter Payload writer.
-     * @return Future for the operation.
-     */
-    public CompletableFuture<Void> requestAsync(int opCode, PayloadWriter payloadWriter) {
-        return serviceAsync(opCode, payloadWriter, null);
     }
 
     /**

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -45,6 +45,7 @@ import org.apache.ignite.client.RetryPolicy;
 import org.apache.ignite.client.RetryPolicyContext;
 import org.apache.ignite.internal.client.io.ClientConnectionMultiplexer;
 import org.apache.ignite.internal.client.io.netty.NettyClientConnectionMultiplexer;
+import org.apache.ignite.network.ClusterNode;
 
 /**
  * Communication channel with failover and partition awareness.
@@ -120,6 +121,25 @@ public final class ReliableChannel implements AutoCloseable {
                 hld.close();
             }
         }
+    }
+
+    /**
+     * Gets active client connections.
+     *
+     * @return List of connected cluster nodes.
+     */
+    public List<ClusterNode> connections() {
+        List<ClusterNode> res = new ArrayList<>(channels.size());
+
+        for (var holder : channels) {
+            var ch = holder.ch;
+
+            if (ch != null) {
+                res.add(ch.protocolContext().clusterNode());
+            }
+        }
+
+        return res;
     }
 
     /**

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -321,6 +321,12 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
         return closed.get();
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public ProtocolContext protocolContext() {
+        return protocolCtx;
+    }
+
     private static void validateConfiguration(ClientChannelConfiguration cfg) {
         String error = null;
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpIgniteClient.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpIgniteClient.java
@@ -183,6 +183,12 @@ public class TcpIgniteClient implements IgniteClient {
         return cfg;
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public List<ClusterNode> connections() {
+        return ch.connections();
+    }
+
     /**
      * Sends ClientMessage request to server side asynchronously and returns result future.
      *

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -132,8 +132,7 @@ public class ClientCompute implements IgniteCompute {
         return ch.serviceAsync(ClientOp.COMPUTE_EXECUTE, w -> {
             if (w.clientChannel().protocolContext().clusterNode().name().equals(node.name())) {
                 w.out().packNil();
-            }
-            else {
+            } else {
                 w.out().packString(node.name());
             }
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -129,7 +129,6 @@ public class ClientCompute implements IgniteCompute {
     }
 
     private <R> CompletableFuture<R> executeOnOneNode(ClusterNode node, String jobClassName, Object[] args) {
-        // TODO: Cluster awareness (IGNITE-16771): send to known node when possible.
         return ch.serviceAsync(ClientOp.COMPUTE_EXECUTE, w -> {
             if (w.clientChannel().protocolContext().clusterNode().name().equals(node.name())) {
                 w.out().packNil();
@@ -140,7 +139,7 @@ public class ClientCompute implements IgniteCompute {
 
             w.out().packString(jobClassName);
             w.out().packObjectArray(args);
-        }, r -> (R) r.in().unpackObjectWithType());
+        }, r -> (R) r.in().unpackObjectWithType(), node.name());
     }
 
     private ClusterNode randomNode(Set<ClusterNode> nodes) {

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.ignite.client.fakes.FakeIgnite;
+import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.NetworkAddress;
@@ -48,7 +49,7 @@ public class ClientComputeTest {
         initServers(reqId -> false);
 
         try (var client = getClient()) {
-            Thread.sleep(500);
+            IgniteTestUtils.waitForCondition(() -> client.connections().size() == 3, 3000);
 
             String res1 = client.compute().<String>execute(getClusterNodes("s1"), "job").join();
             String res2 = client.compute().<String>execute(getClusterNodes("s2"), "job").join();

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
@@ -27,17 +27,19 @@ import org.junit.jupiter.api.Test;
  * Compute tests.
  */
 public class ClientComputeTest {
-    private TestServer server;
+    private TestServer server1;
+    private TestServer server2;
+    private TestServer server3;
 
     @AfterEach
     void tearDown() throws Exception {
-        IgniteUtils.closeAll(server);
+        IgniteUtils.closeAll(server1, server2, server3);
     }
 
     @Test
     public void testClientSendsComputeJobToTargetNodeWhenDirectConnectionExists() {
         // TODO: Multiple servers.
-        initServer(reqId -> false);
+        initServers(reqId -> false);
 
 
     }
@@ -54,12 +56,14 @@ public class ClientComputeTest {
 
     private IgniteClient getClient() {
         return IgniteClient.builder()
-                .addresses("127.0.0.1:" + server.port())
+                .addresses("127.0.0.1:" + server1.port(), "127.0.0.1:" + server2.port(), "127.0.0.1:" + server3.port())
                 .reconnectThrottlingPeriod(0)
                 .build();
     }
 
-    private void initServer(Function<Integer, Boolean> shouldDropConnection) {
-        server = new TestServer(10900, 10, 0, new FakeIgnite(), shouldDropConnection);
+    private void initServers(Function<Integer, Boolean> shouldDropConnection) {
+        server1 = new TestServer(10900, 10, 0, new FakeIgnite(), shouldDropConnection);
+        server2 = new TestServer(10910, 10, 0, new FakeIgnite(), shouldDropConnection);
+        server3 = new TestServer(10920, 10, 0, new FakeIgnite(), shouldDropConnection);
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client;
+
+import java.util.function.Function;
+import org.apache.ignite.client.fakes.FakeIgnite;
+import org.apache.ignite.internal.util.IgniteUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Compute tests.
+ */
+public class ClientComputeTest {
+    private TestServer server;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        IgniteUtils.closeAll(server);
+    }
+
+    @Test
+    public void testClientSendsComputeJobToTargetNodeWhenDirectConnectionExists() {
+        // TODO: Multiple servers.
+        initServer(reqId -> false);
+
+
+    }
+
+    @Test
+    public void testClientSendsComputeJobToDefaultNodeWhenDirectConnectionToTargetDoesNotExist() {
+
+    }
+
+    @Test
+    public void testClientRetriesComputeJobOnPrimaryAndDefaultNodes() {
+
+    }
+
+    private IgniteClient getClient() {
+        return IgniteClient.builder()
+                .addresses("127.0.0.1:" + server.port())
+                .reconnectThrottlingPeriod(0)
+                .build();
+    }
+
+    private void initServer(Function<Integer, Boolean> shouldDropConnection) {
+        server = new TestServer(10900, 10, 0, new FakeIgnite(), shouldDropConnection);
+    }
+}

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
@@ -48,9 +48,13 @@ public class ClientComputeTest {
         initServers(reqId -> false);
 
         try (var client = getClient()) {
-            String res = client.compute().<String>execute(getClusterNodes("s1"), "job").join();
+            String res1 = client.compute().<String>execute(getClusterNodes("s1"), "job").join();
+            String res2 = client.compute().<String>execute(getClusterNodes("s2"), "job").join();
+            String res3 = client.compute().<String>execute(getClusterNodes("s3"), "job").join();
 
-            assertEquals("x", res);
+            assertEquals("s1", res1);
+            assertEquals("s2", res2);
+            assertEquals("s3", res3);
         }
     }
 

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
@@ -48,7 +48,8 @@ public class ClientComputeTest {
     public void testClientSendsComputeJobToTargetNodeWhenDirectConnectionExists() throws Exception {
         initServers(reqId -> false);
 
-        try (var client = getClient(server1, server2, server3)) {
+        // Provide same node multiple times to check this case as well.
+        try (var client = getClient(server1, server2, server3, server1, server2)) {
             IgniteTestUtils.waitForCondition(() -> client.connections().size() == 3, 3000);
 
             String res1 = client.compute().<String>execute(getClusterNodes("s1"), "job").join();

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
@@ -48,6 +48,8 @@ public class ClientComputeTest {
         initServers(reqId -> false);
 
         try (var client = getClient()) {
+            Thread.sleep(500);
+
             String res1 = client.compute().<String>execute(getClusterNodes("s1"), "job").join();
             String res2 = client.compute().<String>execute(getClusterNodes("s2"), "job").join();
             String res3 = client.compute().<String>execute(getClusterNodes("s3"), "job").join();

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
@@ -78,7 +78,7 @@ public class ClientComputeTest {
 
     @Test
     public void testClientRetriesComputeJobOnPrimaryAndDefaultNodes() throws Exception {
-        initServers(reqId -> reqId % 2 == 0);
+        initServers(reqId -> reqId % 3 == 0);
 
         try (var client = getClient(server3)) {
             for (int i = 0; i < 100; i++) {

--- a/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
@@ -227,10 +227,10 @@ public class RetryPolicyTest {
                 .build();
     }
 
-    private void initServer(Function<Integer, Boolean> integerBooleanFunction) {
+    private void initServer(Function<Integer, Boolean> shouldDropConnection) {
         FakeIgnite ign = new FakeIgnite();
         ign.tables().createTable("t", c -> {});
 
-        server = new TestServer(10900, 10, 0, ign, integerBooleanFunction);
+        server = new TestServer(10900, 10, 0, ign, shouldDropConnection);
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
@@ -231,6 +231,6 @@ public class RetryPolicyTest {
         FakeIgnite ign = new FakeIgnite();
         ign.tables().createTable("t", c -> {});
 
-        server = new TestServer(10900, 10, 0, ign, shouldDropConnection);
+        server = new TestServer(10900, 10, 0, ign, shouldDropConnection, null);
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
@@ -71,6 +71,7 @@ public class TestClientHandlerModule implements IgniteComponent {
 
     /**
      * Constructor.
+     *
      * @param ignite               Ignite.
      * @param registry             Configuration registry.
      * @param bootstrapFactory     Bootstrap factory.

--- a/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
@@ -17,7 +17,6 @@
 
 package org.apache.ignite.client;
 
-import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 
 import io.netty.bootstrap.ServerBootstrap;
@@ -59,6 +58,9 @@ public class TestClientHandlerModule implements IgniteComponent {
     /** Connection drop condition. */
     private final Function<Integer, Boolean> shouldDropConnection;
 
+    /** Cluster service. */
+    private final ClusterService clusterService;
+
     /** Netty channel. */
     private volatile Channel channel;
 
@@ -67,17 +69,18 @@ public class TestClientHandlerModule implements IgniteComponent {
 
     /**
      * Constructor.
-     *
      * @param ignite               Ignite.
      * @param registry             Configuration registry.
      * @param bootstrapFactory     Bootstrap factory.
      * @param shouldDropConnection Connection drop condition.
+     * @param clusterService       Cluster service.
      */
     public TestClientHandlerModule(
             Ignite ignite,
             ConfigurationRegistry registry,
             NettyBootstrapFactory bootstrapFactory,
-            Function<Integer, Boolean> shouldDropConnection) {
+            Function<Integer, Boolean> shouldDropConnection,
+            ClusterService clusterService) {
         assert ignite != null;
         assert registry != null;
         assert bootstrapFactory != null;
@@ -86,6 +89,7 @@ public class TestClientHandlerModule implements IgniteComponent {
         this.registry = registry;
         this.bootstrapFactory = bootstrapFactory;
         this.shouldDropConnection = shouldDropConnection;
+        this.clusterService = clusterService;
     }
 
     /** {@inheritDoc} */
@@ -140,10 +144,6 @@ public class TestClientHandlerModule implements IgniteComponent {
         var requestCounter = new AtomicInteger();
 
         ServerBootstrap bootstrap = bootstrapFactory.createServerBootstrap();
-
-        ClusterService clusterService = mock(ClusterService.class, RETURNS_DEEP_STUBS);
-        Mockito.when(clusterService.topologyService().localMember().id()).thenReturn("id");
-        Mockito.when(clusterService.topologyService().localMember().name()).thenReturn("consistent-id");
 
         bootstrap.childHandler(new ChannelInitializer<>() {
                     @Override

--- a/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
@@ -43,7 +43,6 @@ import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.network.NettyBootstrapFactory;
 import org.jetbrains.annotations.Nullable;
-import org.mockito.Mockito;
 
 /**
  * Client handler module for tests.
@@ -61,6 +60,9 @@ public class TestClientHandlerModule implements IgniteComponent {
     /** Cluster service. */
     private final ClusterService clusterService;
 
+    /** Compute. */
+    private final IgniteCompute compute;
+
     /** Netty channel. */
     private volatile Channel channel;
 
@@ -74,13 +76,15 @@ public class TestClientHandlerModule implements IgniteComponent {
      * @param bootstrapFactory     Bootstrap factory.
      * @param shouldDropConnection Connection drop condition.
      * @param clusterService       Cluster service.
+     * @param compute              Compute.
      */
     public TestClientHandlerModule(
             Ignite ignite,
             ConfigurationRegistry registry,
             NettyBootstrapFactory bootstrapFactory,
             Function<Integer, Boolean> shouldDropConnection,
-            ClusterService clusterService) {
+            ClusterService clusterService,
+            IgniteCompute compute) {
         assert ignite != null;
         assert registry != null;
         assert bootstrapFactory != null;
@@ -90,6 +94,7 @@ public class TestClientHandlerModule implements IgniteComponent {
         this.bootstrapFactory = bootstrapFactory;
         this.shouldDropConnection = shouldDropConnection;
         this.clusterService = clusterService;
+        this.compute = compute;
     }
 
     /** {@inheritDoc} */
@@ -156,7 +161,7 @@ public class TestClientHandlerModule implements IgniteComponent {
                                         ignite.transactions(),
                                         mock(QueryProcessor.class),
                                         configuration,
-                                        mock(IgniteCompute.class),
+                                        compute,
                                         clusterService));
                     }
                 })

--- a/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
@@ -19,6 +19,7 @@ package org.apache.ignite.client;
 
 import static org.apache.ignite.configuration.annotation.ConfigurationType.LOCAL;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 
@@ -27,6 +28,7 @@ import java.net.SocketAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.client.fakes.FakeIgnite;
@@ -117,14 +119,17 @@ public class TestServer implements AutoCloseable {
         Mockito.when(clusterService.topologyService().getByConsistentId(anyString())).thenAnswer(
                 i -> getClusterNode(i.getArgument(0, String.class)));
 
+        IgniteCompute compute = mock(IgniteCompute.class);
+        Mockito.when(compute.execute(any(), anyString(), any())).thenReturn(CompletableFuture.completedFuture(nodeName));
+
         module = shouldDropConnection != null
-                ? new TestClientHandlerModule(ignite, cfg, bootstrapFactory, shouldDropConnection, clusterService)
+                ? new TestClientHandlerModule(ignite, cfg, bootstrapFactory, shouldDropConnection, clusterService, compute)
                 : new ClientHandlerModule(
                         ((FakeIgnite) ignite).queryEngine(),
                         ignite.tables(),
                         ignite.transactions(),
                         cfg,
-                        mock(IgniteCompute.class),
+                        compute,
                         clusterService,
                         bootstrapFactory
                 );

--- a/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
@@ -64,7 +64,7 @@ public class TestServer implements AutoCloseable {
             long idleTimeout,
             Ignite ignite
     ) {
-        this(port, portRange, idleTimeout, ignite, null);
+        this(port, portRange, idleTimeout, ignite, null, null);
     }
 
     /**
@@ -80,7 +80,8 @@ public class TestServer implements AutoCloseable {
             int portRange,
             long idleTimeout,
             Ignite ignite,
-            Function<Integer, Boolean> shouldDropConnection
+            Function<Integer, Boolean> shouldDropConnection,
+            String nodeName
     ) {
         cfg = new ConfigurationRegistry(
                 List.of(ClientConnectorConfiguration.KEY, NetworkConfiguration.KEY),
@@ -101,8 +102,8 @@ public class TestServer implements AutoCloseable {
         bootstrapFactory.start();
 
         ClusterService clusterService = mock(ClusterService.class, RETURNS_DEEP_STUBS);
-        Mockito.when(clusterService.topologyService().localMember().id()).thenReturn("id");
-        Mockito.when(clusterService.topologyService().localMember().name()).thenReturn("consistent-id");
+        Mockito.when(clusterService.topologyService().localMember().id()).thenReturn(nodeName == null ? "id" : nodeName + "-id");
+        Mockito.when(clusterService.topologyService().localMember().name()).thenReturn(nodeName == null ? "consistent-id" : nodeName);
 
         module = shouldDropConnection != null
                 ? new TestClientHandlerModule(ignite, cfg, bootstrapFactory, shouldDropConnection)

--- a/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
@@ -157,6 +157,6 @@ public class TestServer implements AutoCloseable {
     }
 
     private ClusterNode getClusterNode(String name) {
-        return new ClusterNode(name+ "-id", name, new NetworkAddress("127.0.0.1", 8080));
+        return new ClusterNode(name + "-id", name, new NetworkAddress("127.0.0.1", 8080));
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
@@ -43,9 +43,7 @@ import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.network.NettyBootstrapFactory;
 import org.apache.ignite.network.NetworkAddress;
-import org.jetbrains.annotations.NotNull;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 
 /**
  * Test server.

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
@@ -17,12 +17,15 @@
 
 package org.apache.ignite.internal.runner.app.client;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.apache.ignite.client.IgniteClient;
 import org.apache.ignite.internal.testframework.WorkDirectoryExtension;
+import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.table.RecordView;
 import org.apache.ignite.table.Table;
 import org.apache.ignite.table.Tuple;
@@ -62,6 +65,10 @@ public class ItThinClientConnectionTest extends ItAbstractThinClientTest {
                 assertEquals("Hello", pojoView.get(null, new TestPojo(1)).val);
 
                 assertTrue(recView.delete(null, keyTuple));
+
+                List<ClusterNode> nodes = client.connections();
+                assertEquals(1, nodes.size());
+                assertThat(nodes.get(0).name(), startsWith("ItThinClientConnectionTest_null_"));
             }
         }
     }


### PR DESCRIPTION
* Establish connections to all known endpoints in background.
* During Compute calls, match target node name against active connections and send request directly to the correct node when possible.