### PR TITLE
IGNITE-16930 .NET: Thin 3.0: Add Compute.ExecuteColocated

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -181,7 +181,7 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestExecuteColocatedByTupleKey()
         {
-            await Client.Compute.ExecuteColocatedAsync<string>("TODO", new IgniteTuple(), EchoJob);
+            await Client.Compute.ExecuteColocatedAsync<string>(TableName, new IgniteTuple(), EchoJob);
         }
 
         [Test]
@@ -190,7 +190,7 @@ namespace Apache.Ignite.Tests.Compute
             var ex = Assert.ThrowsAsync<IgniteClientException>(async () =>
                 await Client.Compute.ExecuteColocatedAsync<string>("unknownTable", new IgniteTuple(), EchoJob));
 
-            Assert.AreEqual("Specified node is not present in the cluster: y", ex!.Message);
+            Assert.AreEqual("Table 'unknownTable' does not exist.", ex!.Message);
         }
 
         private async Task<List<IClusterNode>> GetNodeAsync(int index) =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -179,16 +179,16 @@ namespace Apache.Ignite.Tests.Compute
         }
 
         [Test]
-        [TestCase(1, "PlatformTestNodeRunner")]
-        [TestCase(2, "PlatformTestNodeRunner_2")]
-        [TestCase(3, "PlatformTestNodeRunner")]
-        [TestCase(5, "PlatformTestNodeRunner_2")]
+        [TestCase(1, "")]
+        [TestCase(2, "_2")]
+        [TestCase(3, "")]
+        [TestCase(5, "_2")]
         public async Task TestExecuteColocatedByTupleKey(int key, string nodeName)
         {
             var keyTuple = new IgniteTuple { [KeyCol] = key };
             var resNodeName = await Client.Compute.ExecuteColocatedAsync<string>(TableName, keyTuple, NodeNameJob);
 
-            Assert.AreEqual(nodeName, resNodeName);
+            Assert.AreEqual(PlatformTestNodeRunner + nodeName, resNodeName);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -179,12 +179,16 @@ namespace Apache.Ignite.Tests.Compute
         }
 
         [Test]
-        public async Task TestExecuteColocatedByTupleKey()
+        [TestCase(1, "PlatformTestNodeRunner")]
+        [TestCase(2, "PlatformTestNodeRunner_2")]
+        [TestCase(3, "PlatformTestNodeRunner")]
+        [TestCase(5, "PlatformTestNodeRunner_2")]
+        public async Task TestExecuteColocatedByTupleKey(int key, string nodeName)
         {
-            var keyTuple = new IgniteTuple { [KeyCol] = 1 };
-            var nodeName = await Client.Compute.ExecuteColocatedAsync<string>(TableName, keyTuple, NodeNameJob);
+            var keyTuple = new IgniteTuple { [KeyCol] = key };
+            var resNodeName = await Client.Compute.ExecuteColocatedAsync<string>(TableName, keyTuple, NodeNameJob);
 
-            Assert.AreEqual("ItThinClientComputeTest_null_3345", nodeName);
+            Assert.AreEqual(nodeName, resNodeName);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -27,6 +27,7 @@ namespace Apache.Ignite.Tests.Compute
     using Internal.Network;
     using Network;
     using NUnit.Framework;
+    using Table;
 
     /// <summary>
     /// Tests <see cref="ICompute"/>.
@@ -183,12 +184,17 @@ namespace Apache.Ignite.Tests.Compute
         [TestCase(2, "_2")]
         [TestCase(3, "")]
         [TestCase(5, "_2")]
-        public async Task TestExecuteColocatedByTupleKey(int key, string nodeName)
+        public async Task TestExecuteColocated(int key, string nodeName)
         {
             var keyTuple = new IgniteTuple { [KeyCol] = key };
             var resNodeName = await Client.Compute.ExecuteColocatedAsync<string>(TableName, keyTuple, NodeNameJob);
 
-            Assert.AreEqual(PlatformTestNodeRunner + nodeName, resNodeName);
+            var keyPoco = new Poco { Key = key };
+            var resNodeName2 = await Client.Compute.ExecuteColocatedAsync<string, Poco>(TableName, keyPoco, NodeNameJob);
+
+            var expectedNodeName = PlatformTestNodeRunner + nodeName;
+            Assert.AreEqual(expectedNodeName, resNodeName);
+            Assert.AreEqual(expectedNodeName, resNodeName2);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -226,7 +226,7 @@ namespace Apache.Ignite.Tests.Compute
         {
             // Create table and use it in ExecuteColocated.
             var nodes = await GetNodeAsync(0);
-            var tableName = await Client.Compute.ExecuteAsync<string>(nodes, CreateTableJob, "drop-me");
+            var tableName = await Client.Compute.ExecuteAsync<string>(nodes, CreateTableJob, "PUB.drop-me");
 
             var keyTuple = new IgniteTuple { [KeyCol] = 1 };
             var resNodeName = await Client.Compute.ExecuteColocatedAsync<string>(TableName, keyTuple, NodeNameJob);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -50,8 +50,6 @@ namespace Apache.Ignite.Tests.Compute
 
         private const string DropTableJob = PlatformTestNodeRunner + "$DropTableJob";
 
-        private const string TempTableName = "PUB.drop-me";
-
         [Test]
         public async Task TestGetClusterNodes()
         {
@@ -228,19 +226,19 @@ namespace Apache.Ignite.Tests.Compute
         {
             // Create table and use it in ExecuteColocated.
             var nodes = await GetNodeAsync(0);
-            var tableName = await Client.Compute.ExecuteAsync<string>(nodes, CreateTableJob, TempTableName);
+            var tableName = await Client.Compute.ExecuteAsync<string>(nodes, CreateTableJob, "PUB.drop-me");
 
             try
             {
                 var keyTuple = new IgniteTuple { [KeyCol] = 1 };
-                var resNodeName = await Client.Compute.ExecuteColocatedAsync<string>(TableName, keyTuple, NodeNameJob);
+                var resNodeName = await Client.Compute.ExecuteColocatedAsync<string>(tableName, keyTuple, NodeNameJob);
 
                 // Drop table and create a new one with a different ID, then execute a computation again.
                 // This should update the cached table and complete the computation successfully.
                 await Client.Compute.ExecuteAsync<string>(nodes, DropTableJob, tableName);
                 await Client.Compute.ExecuteAsync<string>(nodes, CreateTableJob, tableName);
 
-                var resNodeName2 = await Client.Compute.ExecuteColocatedAsync<string>(TableName, keyTuple, NodeNameJob);
+                var resNodeName2 = await Client.Compute.ExecuteColocatedAsync<string>(tableName, keyTuple, NodeNameJob);
 
                 Assert.AreEqual(resNodeName, resNodeName2);
             }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -23,6 +23,7 @@ namespace Apache.Ignite.Tests.Compute
     using System.Net;
     using System.Threading.Tasks;
     using Ignite.Compute;
+    using Ignite.Table;
     using Internal.Network;
     using Network;
     using NUnit.Framework;
@@ -175,6 +176,21 @@ namespace Apache.Ignite.Tests.Compute
 
                 Assert.AreEqual(expected ?? val, res);
             }
+        }
+
+        [Test]
+        public async Task TestExecuteColocatedByTupleKey()
+        {
+            await Client.Compute.ExecuteColocatedAsync<string>("TODO", new IgniteTuple(), EchoJob);
+        }
+
+        [Test]
+        public void TestExecuteColocatedThrowsWhenTableDoesNotExist()
+        {
+            var ex = Assert.ThrowsAsync<IgniteClientException>(async () =>
+                await Client.Compute.ExecuteColocatedAsync<string>("unknownTable", new IgniteTuple(), EchoJob));
+
+            Assert.AreEqual("Specified node is not present in the cluster: y", ex!.Message);
         }
 
         private async Task<List<IClusterNode>> GetNodeAsync(int index) =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -46,9 +46,9 @@ namespace Apache.Ignite.Tests.Compute
 
         private const string PlatformTestNodeRunner = "org.apache.ignite.internal.runner.app.PlatformTestNodeRunner";
 
-        private const string CreateTableJob = PlatformTestNodeRunner + "CreateTableJob";
+        private const string CreateTableJob = PlatformTestNodeRunner + "$CreateTableJob";
 
-        private const string DropTableJob = PlatformTestNodeRunner + "DropTableJob";
+        private const string DropTableJob = PlatformTestNodeRunner + "$DropTableJob";
 
         [Test]
         public async Task TestGetClusterNodes()

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -193,6 +193,15 @@ namespace Apache.Ignite.Tests.Compute
             Assert.AreEqual("Table 'unknownTable' does not exist.", ex!.Message);
         }
 
+        [Test]
+        public void TestExecuteColocatedThrowsWhenKeyColumnIsMissing()
+        {
+            var ex = Assert.ThrowsAsync<IgniteClientException>(async () =>
+                await Client.Compute.ExecuteColocatedAsync<string>(TableName, new IgniteTuple(), EchoJob));
+
+            StringAssert.Contains("Missed key column: KEY", ex!.Message);
+        }
+
         private async Task<List<IClusterNode>> GetNodeAsync(int index) =>
             (await Client.GetClusterNodesAsync()).OrderBy(n => n.Name).Skip(index).Take(1).ToList();
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -181,7 +181,10 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestExecuteColocatedByTupleKey()
         {
-            await Client.Compute.ExecuteColocatedAsync<string>(TableName, new IgniteTuple(), EchoJob);
+            var keyTuple = new IgniteTuple { [KeyCol] = 1 };
+            var nodeName = await Client.Compute.ExecuteColocatedAsync<string>(TableName, keyTuple, NodeNameJob);
+
+            Assert.AreEqual("ItThinClientComputeTest_null_3345", nodeName);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -18,7 +18,6 @@
 namespace Apache.Ignite.Tests
 {
     using System;
-    using System.Linq;
     using System.Threading.Tasks;
     using Ignite.Table;
     using Log;
@@ -83,10 +82,8 @@ namespace Apache.Ignite.Tests
         }
 
         [TearDown]
-        public async Task TearDown()
+        public void TearDown()
         {
-            await TupleView.DeleteAllAsync(null, Enumerable.Range(-5, 20).Select(x => GetTuple(x)));
-
             Assert.AreEqual(_eventListener.BuffersReturned, _eventListener.BuffersRented);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -74,7 +74,7 @@ namespace Apache.Ignite.Tests
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            // ReSharper disable once ConstantConditionalAccessQualifier
+            // ReSharper disable once ConstantConditionalAccessQualifier, ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
             Client?.Dispose();
 
             Assert.Greater(_eventListener.BuffersRented, 0);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -30,7 +30,7 @@ namespace Apache.Ignite.Tests
     /// </summary>
     public class IgniteTestsBase
     {
-        protected const string TableName = "PUB.tbl1";
+        protected const string TableName = "PUB.TBL1";
 
         protected const string KeyCol = "key";
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/RawSocketConnectionTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/RawSocketConnectionTests.cs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// ReSharper disable MustUseReturnValue
 namespace Apache.Ignite.Tests
 {
     using System;

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
@@ -30,6 +30,12 @@ namespace Apache.Ignite.Tests.Table
     /// </summary>
     public class RecordViewBinaryTests : IgniteTestsBase
     {
+        [TearDown]
+        public async Task CleanTable()
+        {
+            await TupleView.DeleteAllAsync(null, Enumerable.Range(-1, 15).Select(x => GetTuple(x)));
+        }
+
         [Test]
         public async Task TestUpsertGet()
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
@@ -33,7 +33,7 @@ namespace Apache.Ignite.Tests.Table
         [TearDown]
         public async Task CleanTable()
         {
-            await TupleView.DeleteAllAsync(null, Enumerable.Range(-1, 15).Select(x => GetTuple(x)));
+            await TupleView.DeleteAllAsync(null, Enumerable.Range(-1, 12).Select(x => GetTuple(x)));
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
@@ -32,7 +32,7 @@ namespace Apache.Ignite.Tests.Table
         [TearDown]
         public async Task CleanTable()
         {
-            await TupleView.DeleteAllAsync(null, Enumerable.Range(-5, 20).Select(x => GetTuple(x)));
+            await TupleView.DeleteAllAsync(null, Enumerable.Range(-1, 12).Select(x => GetTuple(x)));
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
@@ -29,6 +29,12 @@ namespace Apache.Ignite.Tests.Table
     /// </summary>
     public class RecordViewPocoTests : IgniteTestsBase
     {
+        [TearDown]
+        public async Task CleanTable()
+        {
+            await TupleView.DeleteAllAsync(null, Enumerable.Range(-5, 20).Select(x => GetTuple(x)));
+        }
+
         [Test]
         public async Task TestUpsertGet()
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TablesTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TablesTests.cs
@@ -33,7 +33,7 @@ namespace Apache.Ignite.Tests.Table
             var tables = await Client.Tables.GetTablesAsync();
 
             Assert.AreEqual(1, tables.Count);
-            Assert.AreEqual("PUB.TBL1", tables[0].Name);
+            Assert.AreEqual(TableName, tables[0].Name);
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace Apache.Ignite.Tests.Table
             var table = await Client.Tables.GetTableAsync(TableName);
 
             Assert.IsNotNull(table);
-            Assert.AreEqual("PUB.tbl1", table!.Name);
+            Assert.AreEqual(TableName, table!.Name);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
@@ -28,6 +28,12 @@ namespace Apache.Ignite.Tests.Transactions
     /// </summary>
     public class TransactionsTests : IgniteTestsBase
     {
+        [TearDown]
+        public async Task CleanTable()
+        {
+            await TupleView.DeleteAllAsync(null, Enumerable.Range(1, 2).Select(x => GetTuple(x)));
+        }
+
         [Test]
         public async Task TestRecordViewBinaryOperations()
         {

--- a/modules/platforms/dotnet/Apache.Ignite/ClientErrorCode.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/ClientErrorCode.cs
@@ -35,6 +35,11 @@ namespace Apache.Ignite
         /// <summary>
         /// Authentication or authorization failure.
         /// </summary>
-        AuthFailed = 2
+        AuthFailed = 2,
+
+        /// <summary>
+        /// Table id does not exist.
+        /// </summary>
+        TableIdDoesNotExist = 3
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Compute/ICompute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Compute/ICompute.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Compute
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Network;
+    using Table;
 
     /// <summary>
     /// Ignite Compute API provides distributed job execution functionality.
@@ -35,6 +36,29 @@ namespace Apache.Ignite.Compute
         /// <typeparam name="T">Job result type.</typeparam>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task<T> ExecuteAsync<T>(IEnumerable<IClusterNode> nodes, string jobClassName, params object[] args);
+
+        /// <summary>
+        /// Executes a job represented by the given class on one node where the given key is located.
+        /// </summary>
+        /// <param name="tableName">Name of the table to be used with <paramref name="key"/> to determine target node.</param>
+        /// <param name="key">Table key to be used to determine the target node for job execution.</param>
+        /// <param name="jobClassName">Java class name of the job to execute.</param>
+        /// <param name="args">Job arguments.</param>
+        /// <typeparam name="T">Job result type.</typeparam>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task<T> ExecuteColocatedAsync<T>(string tableName, IIgniteTuple key, string jobClassName, params object[] args);
+
+        /// <summary>
+        /// Executes a job represented by the given class on one node where the given key is located.
+        /// </summary>
+        /// <param name="tableName">Name of the table to be used with <paramref name="key"/> to determine target node.</param>
+        /// <param name="key">Table key to be used to determine the target node for job execution.</param>
+        /// <param name="jobClassName">Java class name of the job to execute.</param>
+        /// <param name="args">Job arguments.</param>
+        /// <typeparam name="T">Job result type.</typeparam>
+        /// <typeparam name="TKey">Key type.</typeparam>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task<T> ExecuteColocatedAsync<T, TKey>(string tableName, TKey key, string jobClassName, params object[] args);
 
         /// <summary>
         /// Executes a compute job represented by the given class on all of the specified nodes.

--- a/modules/platforms/dotnet/Apache.Ignite/Compute/ICompute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Compute/ICompute.cs
@@ -58,7 +58,8 @@ namespace Apache.Ignite.Compute
         /// <typeparam name="T">Job result type.</typeparam>
         /// <typeparam name="TKey">Key type.</typeparam>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task<T> ExecuteColocatedAsync<T, TKey>(string tableName, TKey key, string jobClassName, params object[] args);
+        Task<T> ExecuteColocatedAsync<T, TKey>(string tableName, TKey key, string jobClassName, params object[] args)
+            where TKey : class; // TODO: Remove class constraint (IGNITE-16355)
 
         /// <summary>
         /// Executes a compute job represented by the given class on all of the specified nodes.

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClientException.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClientException.cs
@@ -29,9 +29,6 @@ namespace Apache.Ignite
         /** Error code field. */
         private const string ErrorCodeField = "StatusCode";
 
-        /** Error code. */
-        private readonly ClientErrorCode _errorCode;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="IgniteClientException"/> class.
         /// </summary>
@@ -70,7 +67,7 @@ namespace Apache.Ignite
         public IgniteClientException(string message, Exception? cause, ClientErrorCode statusCode)
             : base(message, cause)
         {
-            _errorCode = statusCode;
+            ErrorCode = statusCode;
         }
 
         /// <summary>
@@ -81,8 +78,13 @@ namespace Apache.Ignite
         protected IgniteClientException(SerializationInfo info, StreamingContext ctx)
             : base(info, ctx)
         {
-            _errorCode = (ClientErrorCode) info.GetInt32(ErrorCodeField);
+            ErrorCode = (ClientErrorCode)info.GetInt32(ErrorCodeField);
         }
+
+        /// <summary>
+        /// Gets the error code.
+        /// </summary>
+        public ClientErrorCode ErrorCode { get; }
 
         /// <summary>
         /// When overridden in a derived class, sets the <see cref="SerializationInfo" />
@@ -96,7 +98,7 @@ namespace Apache.Ignite
         {
             base.GetObjectData(info, context);
 
-            info.AddValue(ErrorCodeField, (int) _errorCode);
+            info.AddValue(ErrorCodeField, (int) ErrorCode);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -26,6 +26,7 @@ namespace Apache.Ignite.Internal.Compute
     using Ignite.Network;
     using Ignite.Table;
     using Proto;
+    using Table;
 
     /// <summary>
     /// Compute API.
@@ -35,13 +36,18 @@ namespace Apache.Ignite.Internal.Compute
         /** Socket. */
         private readonly ClientFailoverSocket _socket;
 
+        /** Tables. */
+        private readonly Tables _tables;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Compute"/> class.
         /// </summary>
         /// <param name="socket">Socket.</param>
-        public Compute(ClientFailoverSocket socket)
+        /// <param name="tables">Tables.</param>
+        public Compute(ClientFailoverSocket socket, Tables tables)
         {
             _socket = socket;
+            _tables = tables;
         }
 
         /// <inheritdoc/>
@@ -54,10 +60,14 @@ namespace Apache.Ignite.Internal.Compute
         }
 
         /// <inheritdoc/>
-        public Task<T> ExecuteColocatedAsync<T>(string tableName, IIgniteTuple key, string jobClassName, params object[] args)
+        public async Task<T> ExecuteColocatedAsync<T>(string tableName, IIgniteTuple key, string jobClassName, params object[] args)
         {
             // TODO: IGNITE-16990 - implement partition awareness.
-            throw new System.NotImplementedException();
+            var table = await _tables.GetTableAsync(tableName).ConfigureAwait(false); // TODO: Cache
+            
+            table.RecordBinaryView.DeleteAsync()
+
+            return default!;
         }
 
         /// <inheritdoc/>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -95,6 +95,8 @@ namespace Apache.Ignite.Internal.Compute
 
                 w.Write(jobClassName);
                 w.WriteObjectArrayWithTypes(args);
+
+                w.Flush();
             }
 
             static T Read(in PooledBuffer buf)

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -63,10 +63,9 @@ namespace Apache.Ignite.Internal.Compute
         public async Task<T> ExecuteColocatedAsync<T>(string tableName, IIgniteTuple key, string jobClassName, params object[] args)
         {
             // TODO: IGNITE-16990 - implement partition awareness.
-            var table = await _tables.GetTableAsync(tableName).ConfigureAwait(false); // TODO: Cache
-            
-            table.RecordBinaryView.DeleteAsync()
+            var table = await _tables.GetTableAsync(tableName).ConfigureAwait(false); // TODO: Cache by name.
 
+            // var schema = table.GetLa
             return default!;
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -70,7 +70,7 @@ namespace Apache.Ignite.Internal.Compute
             await ExecuteColocatedAsync<T, IIgniteTuple>(
                     tableName,
                     key,
-                    serializerHandlerFunc: static _ => TupleSerializerHandler.Instance,
+                    serializerHandlerFunc: _ => TupleSerializerHandler.Instance,
                     jobClassName,
                     args)
                 .ConfigureAwait(false);
@@ -81,7 +81,7 @@ namespace Apache.Ignite.Internal.Compute
             await ExecuteColocatedAsync<T, TKey>(
                     tableName,
                     key,
-                    serializerHandlerFunc: static table => table.GetRecordViewInternal<TKey>().RecordSerializer.Handler,
+                    serializerHandlerFunc: table => table.GetRecordViewInternal<TKey>().RecordSerializer.Handler,
                     jobClassName,
                     args)
                 .ConfigureAwait(false);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -24,6 +24,7 @@ namespace Apache.Ignite.Internal.Compute
     using Common;
     using Ignite.Compute;
     using Ignite.Network;
+    using Ignite.Table;
     using Proto;
 
     /// <summary>
@@ -50,6 +51,20 @@ namespace Apache.Ignite.Internal.Compute
             IgniteArgumentCheck.NotNull(jobClassName, nameof(jobClassName));
 
             return await ExecuteOnOneNode<T>(GetRandomNode(nodes), jobClassName, args).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public Task<T> ExecuteColocatedAsync<T>(string tableName, IIgniteTuple key, string jobClassName, params object[] args)
+        {
+            // TODO: IGNITE-16990 - implement partition awareness.
+            throw new System.NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public Task<T> ExecuteColocatedAsync<T, TKey>(string tableName, TKey key, string jobClassName, params object[] args)
+        {
+            // TODO: IGNITE-16990 - implement partition awareness.
+            throw new System.NotImplementedException();
         }
 
         /// <inheritdoc/>
@@ -82,7 +97,7 @@ namespace Apache.Ignite.Internal.Compute
         }
 
         private static ICollection<IClusterNode> GetNodesCollection(IEnumerable<IClusterNode> nodes) =>
-            nodes is ICollection<IClusterNode> col ? col : nodes.ToList();
+            nodes as ICollection<IClusterNode> ?? nodes.ToList();
 
         private async Task<T> ExecuteOnOneNode<T>(IClusterNode node, string jobClassName, object[] args)
         {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -66,29 +66,25 @@ namespace Apache.Ignite.Internal.Compute
         }
 
         /// <inheritdoc/>
-        public async Task<T> ExecuteColocatedAsync<T>(string tableName, IIgniteTuple key, string jobClassName, params object[] args)
-        {
-            return await ExecuteColocatedAsync<T, IIgniteTuple>(
+        public async Task<T> ExecuteColocatedAsync<T>(string tableName, IIgniteTuple key, string jobClassName, params object[] args) =>
+            await ExecuteColocatedAsync<T, IIgniteTuple>(
                     tableName,
                     key,
-                    _ => TupleSerializerHandler.Instance,
+                    serializerHandlerFunc: static _ => TupleSerializerHandler.Instance,
                     jobClassName,
                     args)
                 .ConfigureAwait(false);
-        }
 
         /// <inheritdoc/>
         public async Task<T> ExecuteColocatedAsync<T, TKey>(string tableName, TKey key, string jobClassName, params object[] args)
-            where TKey : class
-        {
-            return await ExecuteColocatedAsync<T, TKey>(
+            where TKey : class =>
+            await ExecuteColocatedAsync<T, TKey>(
                     tableName,
                     key,
-                    table => table.GetRecordViewInternal<TKey>().RecordSerializer.Handler,
+                    serializerHandlerFunc: static table => table.GetRecordViewInternal<TKey>().RecordSerializer.Handler,
                     jobClassName,
                     args)
                 .ConfigureAwait(false);
-        }
 
         /// <inheritdoc/>
         public IDictionary<IClusterNode, Task<T>> BroadcastAsync<T>(IEnumerable<IClusterNode> nodes, string jobClassName, params object[] args)

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
@@ -44,9 +44,13 @@ namespace Apache.Ignite.Internal
         public IgniteClientInternal(ClientFailoverSocket socket)
         {
             _socket = socket;
-            Tables = new Tables(socket);
+
+            var tables = new Tables(socket);
+            Tables = tables;
+
             Transactions = new Transactions.Transactions(socket);
-            Compute = new Compute.Compute(socket);
+
+            Compute = new Compute.Compute(socket, tables);
         }
 
         /// <inheritdoc/>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientOp.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientOp.cs
@@ -95,6 +95,6 @@ namespace Apache.Ignite.Internal.Proto
         ClusterGetNodes = 48,
 
         /** Execute compute job. */
-        ComputeExecuteColocated = 39
+        ComputeExecuteColocated = 49
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientOp.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientOp.cs
@@ -92,6 +92,9 @@ namespace Apache.Ignite.Internal.Proto
         ComputeExecute = 47,
 
         /** Get cluster nodes. */
-        ClusterGetNodes = 48
+        ClusterGetNodes = 48,
+
+        /** Execute compute job. */
+        ComputeExecuteColocated = 39
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientOpExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ClientOpExtensions.cs
@@ -52,6 +52,7 @@ namespace Apache.Ignite.Internal.Proto
                 ClientOp.TupleDeleteAllExact => ClientOperationType.TupleDeleteAllExact,
                 ClientOp.TupleGetAndDelete => ClientOperationType.TupleGetAndDelete,
                 ClientOp.ComputeExecute => ClientOperationType.ComputeExecute,
+                ClientOp.ComputeExecuteColocated => ClientOperationType.ComputeExecute,
                 ClientOp.TxBegin => null,
                 ClientOp.TxCommit => null,
                 ClientOp.TxRollback => null,

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -52,6 +52,11 @@ namespace Apache.Ignite.Internal.Table
             _ser = ser;
         }
 
+        /// <summary>
+        /// Gets the record serializer.
+        /// </summary>
+        public RecordSerializer<T> RecordSerializer => _ser;
+
         /// <inheritdoc/>
         public async Task<T?> GetAsync(ITransaction? transaction, T key)
         {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/RecordSerializer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/RecordSerializer.cs
@@ -21,6 +21,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
     using System.Collections.Generic;
     using Buffers;
     using MessagePack;
+    using Proto;
 
     /// <summary>
     /// Generic record serializer.
@@ -195,7 +196,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         {
             var w = buf.GetMessageWriter();
 
-            _table.WriteIdAndTx(ref w, tx);
+            WriteIdAndTx(ref w, tx);
             w.Write(schema.Version);
             w.Flush();
 
@@ -236,10 +237,29 @@ namespace Apache.Ignite.Internal.Table.Serialization
             T rec,
             bool keyOnly = false)
         {
-            _table.WriteIdAndTx(ref w, tx);
+            WriteIdAndTx(ref w, tx);
             w.Write(schema.Version);
 
             _handler.Write(ref w, schema, rec, keyOnly);
+        }
+
+        /// <summary>
+        /// Writes table id and transaction id, if present.
+        /// </summary>
+        /// <param name="w">Writer.</param>
+        /// <param name="tx">Transaction.</param>
+        private void WriteIdAndTx(ref MessagePackWriter w, Transactions.Transaction? tx)
+        {
+            w.Write(_table.Id);
+
+            if (tx == null)
+            {
+                w.WriteNil();
+            }
+            else
+            {
+                w.Write(tx.Id);
+            }
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/RecordSerializer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/RecordSerializer.cs
@@ -49,6 +49,11 @@ namespace Apache.Ignite.Internal.Table.Serialization
         }
 
         /// <summary>
+        /// Gets the handler.
+        /// </summary>
+        public IRecordSerializerHandler<T> Handler => _handler;
+
+        /// <summary>
         /// Reads the value part.
         /// </summary>
         /// <param name="buf">Buffer.</param>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -35,9 +35,6 @@ namespace Apache.Ignite.Internal.Table
         /** Socket. */
         private readonly ClientFailoverSocket _socket;
 
-        /** Table id. */
-        private readonly Guid _id;
-
         /** Schemas. */
         private readonly ConcurrentDictionary<int, Schema> _schemas = new();
 
@@ -60,7 +57,7 @@ namespace Apache.Ignite.Internal.Table
         {
             _socket = socket;
             Name = name;
-            _id = id;
+            Id = id;
 
             RecordBinaryView = new RecordView<IIgniteTuple>(
                 this,
@@ -78,6 +75,11 @@ namespace Apache.Ignite.Internal.Table
         /// </summary>
         internal ClientFailoverSocket Socket => _socket;
 
+        /// <summary>
+        /// Gets the table id.
+        /// </summary>
+        internal Guid Id { get; }
+
         /// <inheritdoc/>
         public IRecordView<T> GetRecordView<T>()
             where T : class
@@ -86,25 +88,6 @@ namespace Apache.Ignite.Internal.Table
             return (IRecordView<T>)_recordViews.GetOrAdd(
                 typeof(T),
                 _ => new RecordView<T>(this, new RecordSerializer<T>(this, new ObjectSerializerHandler<T>())));
-        }
-
-        /// <summary>
-        /// Writes the transaction id, if present.
-        /// </summary>
-        /// <param name="w">Writer.</param>
-        /// <param name="tx">Transaction.</param>
-        internal void WriteIdAndTx(ref MessagePackWriter w, Transactions.Transaction? tx)
-        {
-            w.Write(_id);
-
-            if (tx == null)
-            {
-                w.WriteNil();
-            }
-            else
-            {
-                w.Write(tx.Id);
-            }
         }
 
         /// <summary>
@@ -168,7 +151,7 @@ namespace Apache.Ignite.Internal.Table
             void Write()
             {
                 var w = writer.GetMessageWriter();
-                w.Write(_id);
+                w.Write(Id);
 
                 if (version == null)
                 {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -82,10 +82,19 @@ namespace Apache.Ignite.Internal.Table
 
         /// <inheritdoc/>
         public IRecordView<T> GetRecordView<T>()
+            where T : class =>
+            GetRecordViewInternal<T>();
+
+        /// <summary>
+        /// Gets the record view for the specified type.
+        /// </summary>
+        /// <typeparam name="T">Record type.</typeparam>
+        /// <returns>Record view.</returns>
+        internal RecordView<T> GetRecordViewInternal<T>()
             where T : class
         {
             // ReSharper disable once HeapView.CanAvoidClosure (generics prevent this)
-            return (IRecordView<T>)_recordViews.GetOrAdd(
+            return (RecordView<T>)_recordViews.GetOrAdd(
                 typeof(T),
                 _ => new RecordView<T>(this, new RecordSerializer<T>(this, new ObjectSerializerHandler<T>())));
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Tables.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Tables.cs
@@ -35,7 +35,7 @@ namespace Apache.Ignite.Internal.Table
         /** Socket. */
         private readonly ClientFailoverSocket _socket;
 
-        /** Cached tables. */
+        /** Cached tables. Caching here is required to retain schema and serializer caches in <see cref="Table"/>. */
         private readonly ConcurrentDictionary<Guid, ITable> _tables = new();
 
         /// <summary>
@@ -90,6 +90,8 @@ namespace Apache.Ignite.Internal.Table
                 {
                     var id = r.ReadGuid();
                     var name = r.ReadString();
+
+                    // TODO: Instance caching? Do we even need it?
                     res.Add(new Table(name, id, _socket));
                 }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Tables.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Tables.cs
@@ -70,9 +70,10 @@ namespace Apache.Ignite.Internal.Table
                     var id = r.ReadGuid();
                     var name = r.ReadString();
 
+                    // ReSharper disable once LambdaExpressionMustBeStatic (not supported by .NET Core 3.1, TODO IGNITE-16994)
                     var table = _tables.GetOrAdd(
                         id,
-                        static (Guid i, (string Name, ClientFailoverSocket Socket) arg) => new Table(arg.Name, i, arg.Socket),
+                        (Guid id0, (string Name, ClientFailoverSocket Socket) arg) => new Table(arg.Name, id0, arg.Socket),
                         (name, _socket));
 
                     res.Add(table);
@@ -109,7 +110,7 @@ namespace Apache.Ignite.Internal.Table
                     ? null
                     : _tables.GetOrAdd(
                         r.ReadGuid(),
-                        static (Guid id, (string Name, ClientFailoverSocket Socket) arg) => new Table(arg.Name, id, arg.Socket),
+                        (Guid id, (string Name, ClientFailoverSocket Socket) arg) => new Table(arg.Name, id, arg.Socket),
                         (name, _socket));
         }
     }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -35,6 +35,7 @@ import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.schema.SchemaBuilders;
 import org.apache.ignite.schema.definition.ColumnType;
 import org.apache.ignite.schema.definition.TableDefinition;
+import org.apache.ignite.table.Table;
 
 /**
  * Helper class for non-Java platform tests (.NET, C++, Python, ...). Starts nodes, populates tables and data for tests.
@@ -161,7 +162,8 @@ public class PlatformTestNodeRunner {
         @Override
         public String execute(JobExecutionContext context, Object... args) {
             String tableName = (String) args[0];
-            context.ignite().tables().createTable(
+
+            Table table = context.ignite().tables().createTable(
                     tableName,
                     tblChanger -> tblChanger
                             .changeColumns(cols ->
@@ -169,7 +171,7 @@ public class PlatformTestNodeRunner {
                             .changePrimaryKey(pk -> pk.changeColumns("key").changeColocationColumns("key"))
             );
 
-            return tableName;
+            return table.name();
         }
     }
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -161,7 +161,13 @@ public class PlatformTestNodeRunner {
         @Override
         public String execute(JobExecutionContext context, Object... args) {
             String tableName = (String) args[0];
-            context.ignite().tables().createTable(tableName, null);
+            context.ignite().tables().createTable(
+                    tableName,
+                    tblChanger -> tblChanger
+                            .changeColumns(cols ->
+                                    cols.create("key", col -> col.changeType(t -> t.changeType("INT64")).changeNullable(false)))
+                            .changePrimaryKey(pk -> pk.changeColumns("key").changeColocationColumns("key"))
+            );
 
             return tableName;
         }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -27,6 +27,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgnitionManager;
+import org.apache.ignite.compute.ComputeJob;
+import org.apache.ignite.compute.JobExecutionContext;
 import org.apache.ignite.internal.app.IgniteImpl;
 import org.apache.ignite.internal.schema.configuration.SchemaConfigurationConverter;
 import org.apache.ignite.internal.util.IgniteUtils;
@@ -149,5 +151,31 @@ public class PlatformTestNodeRunner {
      */
     private static int getPort(IgniteImpl node) {
         return node.clientAddress().port();
+    }
+
+    /**
+     * Compute job that creates a table.
+     */
+    private static class CreateTableJob implements ComputeJob<String> {
+        @Override
+        public String execute(JobExecutionContext context, Object... args) {
+            String tableName = (String) args[0];
+            context.ignite().tables().createTable(tableName, null);
+
+            return tableName;
+        }
+    }
+
+    /**
+     * Compute job that drops a table.
+     */
+    private static class DropTableJob implements ComputeJob<String> {
+        @Override
+        public String execute(JobExecutionContext context, Object... args) {
+            String tableName = (String) args[0];
+            context.ignite().tables().dropTable(tableName);
+
+            return tableName;
+        }
     }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -156,6 +156,7 @@ public class PlatformTestNodeRunner {
     /**
      * Compute job that creates a table.
      */
+    @SuppressWarnings({"unused"}) // Used by platform tests.
     private static class CreateTableJob implements ComputeJob<String> {
         @Override
         public String execute(JobExecutionContext context, Object... args) {
@@ -169,6 +170,7 @@ public class PlatformTestNodeRunner {
     /**
      * Compute job that drops a table.
      */
+    @SuppressWarnings({"unused"}) // Used by platform tests.
     private static class DropTableJob implements ComputeJob<String> {
         @Override
         public String execute(JobExecutionContext context, Object... args) {


### PR DESCRIPTION
* Implement `ExecuteColocated` in .NET client. Send requests to default node, partition awareness will be added later (IGNITE-16930).
* To avoid extra table request on every `ExecuteColocated` call (we need table id and schemas), cache tables by name. If a table gets dropped and created again with the same name and a different id, retry the operation.