### PR TITLE
IGNITE-17105 Maven unused dependencies check false positive

### DIFF
--- a/check-rules/maven-check-scripts/CheckUnusedDependenciesAndPluginsInParent.sh
+++ b/check-rules/maven-check-scripts/CheckUnusedDependenciesAndPluginsInParent.sh
@@ -24,7 +24,7 @@ for xpath in "project/dependencyManagement/dependencies/dependency[not(scope='im
         FOUND=false
         for pom in ${POMS}; do
             local_xpath=$(sed -r -e 's|dependencyManagement/||' -e 's|pluginManagement/||' <<< ${xpath})
-            if xpath -q -e "${local_xpath}" "${pom}" | grep -E "${declaration}" 2>&1 1>/dev/null; then
+            if xpath -q -e "${local_xpath}" "${pom}" | grep -w -E "${declaration}" 2>&1 1>/dev/null; then
             	FOUND=true
                 continue 2
             fi


### PR DESCRIPTION
Previously this check grepped for `"<artifactId>${declaration}</artifactId>"` but was changed to simply `"${declaration}"` in the https://issues.apache.org/jira/browse/IGNITE-15393.
This leads to possible false positive where unused dependency artifactId is a substring of another dependency which is used.