### PR TITLE
IGNITE-17209 Allow passing sql query as a parameter

### DIFF
--- a/modules/cli/src/integrationTest/java/org/apache/ignite/cli/commands/sql/ItSqlCommandTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/cli/commands/sql/ItSqlCommandTest.java
@@ -46,7 +46,7 @@ class ItSqlCommandTest extends CliCommandTestIntegrationBase {
     @Test
     @DisplayName("Should execute select * from table and display table when jdbc-url is correct")
     void selectFromTable() {
-        execute("sql", "--execute", "select * from person", "--jdbc-url", JDBC_URL);
+        execute("sql", "select * from person", "--jdbc-url", JDBC_URL);
 
         assertAll(
                 this::assertExitCodeIsZero,
@@ -58,7 +58,7 @@ class ItSqlCommandTest extends CliCommandTestIntegrationBase {
     @Test
     @DisplayName("Should display readable error when wrong jdbc is given")
     void wrongJdbcUrl() {
-        execute("sql", "--execute", "select * from person", "--jdbc-url", "jdbc:ignite:thin://no-such-host.com:10800");
+        execute("sql", "select * from person", "--jdbc-url", "jdbc:ignite:thin://no-such-host.com:10800");
 
         assertAll(
                 () -> assertExitCodeIs(1),
@@ -71,7 +71,7 @@ class ItSqlCommandTest extends CliCommandTestIntegrationBase {
     @Test
     @DisplayName("Should display readable error when wrong query is given")
     void incorrectQueryTest() {
-        execute("sql", "--execute", "select", "--jdbc-url", JDBC_URL);
+        execute("sql", "select", "--jdbc-url", JDBC_URL);
 
         assertAll(
                 () -> assertExitCodeIs(1),

--- a/modules/cli/src/main/java/org/apache/ignite/cli/commands/sql/SqlCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/commands/sql/SqlCommand.java
@@ -35,6 +35,7 @@ import org.apache.ignite.cli.sql.SqlManager;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 
 /**
  * Command for sql execution.
@@ -50,10 +51,10 @@ public class SqlCommand extends BaseCommand implements Callable<Integer> {
     private ExecOptions execOptions;
 
     private static class ExecOptions {
-        @Option(names = {"-e", "--execute", "--exec"}) //todo: can be passed as parameter, not option (see IGNITE-17209)
+        @Parameters(index = "0", description = "SQL query to execute.")
         private String command;
 
-        @Option(names = {"-f", "--script-file"})
+        @Option(names = {"-f", "--script-file"}, description = "Path to file with SQL commands to execute.")
         private File file;
     }
 

--- a/modules/cli/src/main/java/org/apache/ignite/cli/commands/sql/SqlReplCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/commands/sql/SqlReplCommand.java
@@ -41,6 +41,7 @@ import org.apache.ignite.cli.sql.SqlSchemaProvider;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 
 /**
  * Command for sql execution in REPL mode.
@@ -57,10 +58,10 @@ public class SqlReplCommand extends BaseCommand implements Runnable {
     private ExecOptions execOptions;
 
     private static class ExecOptions {
-        @Option(names = {"-e", "--execute", "--exec"}) //todo: can be passed as parameter, not option (see IEP-88)
+        @Parameters(index = "0", description = "SQL query to execute.")
         private String command;
 
-        @Option(names = {"-f", "--script-file"})
+        @Option(names = {"-f", "--script-file"}, description = "Path to file with SQL commands to execute.")
         private File file;
     }
 

--- a/modules/cli/src/test/java/org/apache/ignite/cli/commands/sql/SqlCommandTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/cli/commands/sql/SqlCommandTest.java
@@ -38,19 +38,19 @@ class SqlCommandTest extends CliCommandTestBase {
         assertAll(
                 () -> assertExitCodeIs(2),
                 this::assertOutputIsEmpty,
-                () -> assertErrOutputContains("Missing required argument (specify one of these): (-e=<command> | -f=<file>)")
+                () -> assertErrOutputContains("Missing required argument (specify one of these): (<command> | -f=<file>)")
         );
     }
 
     @Test
     @DisplayName("Should throw error if both --execute or --script-file options are present")
     void mutuallyExclusiveOptions() {
-        execute("--jdbc-url=", "--execute=", "--script-file=");
+        execute("--jdbc-url=", "select", "--script-file=");
 
         assertAll(
                 () -> assertExitCodeIs(2),
                 this::assertOutputIsEmpty,
-                () -> assertErrOutputContains("--execute=<command>, --script-file=<file> are mutually exclusive (specify only one)")
+                () -> assertErrOutputContains("<command>, --script-file=<file> are mutually exclusive (specify only one)")
         );
     }
 }


### PR DESCRIPTION
Simplify sql command so that the query can be passed as a parameter without the need of -e/--exec option.
https://issues.apache.org/jira/browse/IGNITE-17209