### PR TITLE
IGNITE-17346 Ignite3 CLI long output not readable in windows terminal

### DIFF
--- a/modules/cli/src/main/java/org/apache/ignite/cli/core/repl/context/CommandLineContextProvider.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/core/repl/context/CommandLineContextProvider.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.cli.core.repl.context;
 
 import java.io.PrintWriter;
+import java.util.function.Consumer;
 import picocli.CommandLine;
 
 /**
@@ -27,6 +28,8 @@ import picocli.CommandLine;
 public class CommandLineContextProvider {
 
     private static volatile CommandLine cmd;
+
+    private static volatile Consumer<Runnable> printWrapper = Runnable::run;
 
     /**
      * Getter for {@link CommandLineContext}.
@@ -49,5 +52,23 @@ public class CommandLineContextProvider {
 
     public static void setCmd(CommandLine cmd) {
         CommandLineContextProvider.cmd = cmd;
+    }
+
+    /**
+     * Sets the wrapper which will be used when printing from the flow.
+     *
+     * @param printWrapper print wrapper.
+     */
+    public static void setPrintWrapper(Consumer<Runnable> printWrapper) {
+        CommandLineContextProvider.printWrapper = printWrapper;
+    }
+
+    /**
+     * Passes the @{link Runnable} to the print wrapper.
+     *
+     * @param printer lambda which will be wrapped.
+     */
+    public static void print(Runnable printer) {
+        printWrapper.accept(printer);
     }
 }

--- a/modules/cli/src/main/java/org/apache/ignite/cli/core/repl/executor/ReplExecutor.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/core/repl/executor/ReplExecutor.java
@@ -103,6 +103,13 @@ public class ReplExecutor {
                 TailTipWidgets widgets = new TailTipWidgets(reader, registry::commandDescription, 5,
                         TailTipWidgets.TipType.COMPLETER);
                 widgets.enable();
+                // Workaround for the https://issues.apache.org/jira/browse/IGNITE-17346
+                // Turn off tailtip widgets before printing to the output
+                CommandLineContextProvider.setPrintWrapper(printer -> {
+                    widgets.disable();
+                    printer.run();
+                    widgets.enable();
+                });
                 // Workaround for jline issue where TailTipWidgets will produce NPE when passed a bracket
                 registry.setScriptDescription(cmdLine -> null);
             }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-17346

This is a workaround for the either jline or Windows terminal bug where long output is cropped.
I reported an issue in the jline repository.