### PR TITLE
IGNITE-17461 Status command incorrectly handle invalid URLs

### DIFF
--- a/modules/cli/src/main/java/org/apache/ignite/cli/call/cluster/status/ClusterStatusCall.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/call/cluster/status/ClusterStatusCall.java
@@ -60,6 +60,8 @@ public class ClusterStatusCall implements Call<StatusCallInput, ClusterStatus> {
             } else {
                 return DefaultCallOutput.failure(new IgniteCliApiException(e, input.getClusterUrl()));
             }
+        } catch (IllegalArgumentException e) {
+            return DefaultCallOutput.failure(new IgniteCliApiException(e, input.getClusterUrl()));
         }
 
         return DefaultCallOutput.success(clusterStatusBuilder.build());

--- a/modules/cli/src/main/java/org/apache/ignite/cli/call/node/status/NodeStatusCall.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/call/node/status/NodeStatusCall.java
@@ -44,7 +44,7 @@ public class NodeStatusCall implements Call<StatusCallInput, NodeStatus> {
                             .state(nodeState.getState().getValue())
                             .build()
             );
-        } catch (ApiException e) {
+        } catch (ApiException | IllegalArgumentException e) {
             return DefaultCallOutput.failure(new IgniteCliApiException(e, input.getClusterUrl()));
         }
     }

--- a/modules/cli/src/test/java/org/apache/ignite/cli/commands/UrlOptionsNegativeTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/cli/commands/UrlOptionsNegativeTest.java
@@ -34,11 +34,16 @@ import org.apache.ignite.cli.commands.cluster.config.ClusterConfigShowReplSubCom
 import org.apache.ignite.cli.commands.cluster.config.ClusterConfigShowSubCommand;
 import org.apache.ignite.cli.commands.cluster.config.ClusterConfigUpdateReplSubCommand;
 import org.apache.ignite.cli.commands.cluster.config.ClusterConfigUpdateSubCommand;
+import org.apache.ignite.cli.commands.cluster.status.ClusterStatusReplSubCommand;
+import org.apache.ignite.cli.commands.cluster.status.ClusterStatusSubCommand;
 import org.apache.ignite.cli.commands.connect.ConnectCommand;
 import org.apache.ignite.cli.commands.node.config.NodeConfigShowReplSubCommand;
 import org.apache.ignite.cli.commands.node.config.NodeConfigShowSubCommand;
 import org.apache.ignite.cli.commands.node.config.NodeConfigUpdateReplSubCommand;
 import org.apache.ignite.cli.commands.node.config.NodeConfigUpdateSubCommand;
+import org.apache.ignite.cli.commands.node.status.NodeStatusReplSubCommand;
+import org.apache.ignite.cli.commands.topology.LogicalTopologyReplSubCommand;
+import org.apache.ignite.cli.commands.topology.PhysicalTopologyReplSubCommand;
 import org.apache.ignite.cli.config.ini.IniConfigManager;
 import org.apache.ignite.cli.core.repl.context.CommandLineContextProvider;
 import org.junit.jupiter.api.DisplayName;
@@ -92,13 +97,12 @@ public class UrlOptionsNegativeTest {
                 Arguments.arguments(NodeConfigShowSubCommand.class, "--node-url=", List.of()),
                 Arguments.arguments(NodeConfigUpdateSubCommand.class, "--node-url=", List.of("{key: value}")),
                 Arguments.arguments(ClusterConfigShowSubCommand.class, "--cluster-endpoint-url=", List.of()),
-                Arguments.arguments(ClusterConfigUpdateSubCommand.class, "--cluster-endpoint-url=", List.of("{key: value}"))
-        // TODO https://issues.apache.org/jira/browse/IGNITE-17091
-        //                Arguments.arguments(StatusCommand.class, "--cluster-endpoint-url=", List.of()),
+                Arguments.arguments(ClusterConfigUpdateSubCommand.class, "--cluster-endpoint-url=", List.of("{key: value}")),
+                Arguments.arguments(ClusterStatusSubCommand.class, "--cluster-endpoint-url=", List.of()),
+                Arguments.arguments(LogicalTopologyReplSubCommand.class, "--cluster-endpoint-url=", List.of()),
+                Arguments.arguments(PhysicalTopologyReplSubCommand.class, "--cluster-endpoint-url=", List.of())
         // TODO https://issues.apache.org/jira/browse/IGNITE-17102
         //                Arguments.arguments(ClusterShowCommand.class, "--cluster-endpoint-url=", List.of()),
-        // TODO https://issues.apache.org/jira/browse/IGNITE-17092
-        //                Arguments.arguments(TopologyCommand.class, "--cluster-endpoint-url", List.of()),
         // TODO https://issues.apache.org/jira/browse/IGNITE-17162
         //                Arguments.arguments(ClusterCommandSpec.InitClusterCommandSpec.class, "---cluster-endpoint-url=",
         //                        List.of("--cluster-name=cluster", "--meta-storage-node=test"))
@@ -109,15 +113,15 @@ public class UrlOptionsNegativeTest {
         return List.of(
                 Arguments.arguments(NodeConfigShowReplSubCommand.class, "--node-url=", List.of()),
                 Arguments.arguments(NodeConfigUpdateReplSubCommand.class, "--node-url=", List.of("{key: value}")),
+                Arguments.arguments(NodeStatusReplSubCommand.class, "--node-url=", List.of()),
                 Arguments.arguments(ClusterConfigShowReplSubCommand.class, "--cluster-endpoint-url=", List.of()),
                 Arguments.arguments(ClusterConfigUpdateReplSubCommand.class, "--cluster-endpoint-url=", List.of("{key: value}")),
-                Arguments.arguments(ConnectCommand.class, "", List.of())
-        // TODO https://issues.apache.org/jira/browse/IGNITE-17091
-        //                Arguments.arguments(StatusReplCommand.class, "--cluster-endpoint-url=", List.of()),
+                Arguments.arguments(ConnectCommand.class, "", List.of()),
+                Arguments.arguments(ClusterStatusReplSubCommand.class, "--cluster-endpoint-url=", List.of()),
+                Arguments.arguments(LogicalTopologyReplSubCommand.class, "--cluster-endpoint-url=", List.of()),
+                Arguments.arguments(PhysicalTopologyReplSubCommand.class, "--cluster-endpoint-url=", List.of())
         // TODO https://issues.apache.org/jira/browse/IGNITE-17102
         //                Arguments.arguments(ClusterShowReplCommand.class, "--cluster-endpoint-url=", List.of()),
-        // TODO https://issues.apache.org/jira/browse/IGNITE-17092
-        //                Arguments.arguments(TopologyReplCommand.class, "--cluster-endpoint-url", List.of()),
         // TODO https://issues.apache.org/jira/browse/IGNITE-17162
         //                Arguments.arguments(ClusterReplCommandSpec.InitClusterCommandSpec.class, "---cluster-endpoint-url=",
         //                        List.of("--cluster-name=cluster", "--meta-storage-node=test"))


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-17461

Similar to other calls, we need to catch IAE to properly show the error to user.