### PR TITLE
IGNITE-17500 Fix minor issues in RocksDB-based partition storages

### DIFF
--- a/modules/storage-rocksdb/src/main/java/org/apache/ignite/internal/storage/rocksdb/RocksDbTableStorage.java
+++ b/modules/storage-rocksdb/src/main/java/org/apache/ignite/internal/storage/rocksdb/RocksDbTableStorage.java
@@ -81,6 +81,12 @@ class RocksDbTableStorage implements TableStorage, MvTableStorage {
     /** Write options for write operations. */
     private final WriteOptions writeOptions = new WriteOptions().setDisableWAL(true);
 
+    /**
+     * Flush options to be used to asynchronously flush the Rocks DB memtable. It needs to be cached, because
+     * {@link RocksDB#flush(FlushOptions)} contract requires this object to not be GC-ed.
+     */
+    private final FlushOptions flushOptions = new FlushOptions().setWaitForFlush(false);
+
     /** Meta information. */
     private volatile RocksDbMetaStorage meta;
 
@@ -227,7 +233,7 @@ class RocksDbTableStorage implements TableStorage, MvTableStorage {
                     return;
                 }
 
-                try (FlushOptions flushOptions = new FlushOptions().setWaitForFlush(false)) {
+                try {
                     db.flush(flushOptions);
                 } catch (RocksDBException e) {
                     LOG.error("Error occurred during the explicit flush for table '{}'", e, tableCfg.name());
@@ -259,6 +265,8 @@ class RocksDbTableStorage implements TableStorage, MvTableStorage {
         resources.add(db);
 
         resources.add(writeOptions);
+
+        resources.add(flushOptions);
 
         for (int i = 0; i < partitions.length(); i++) {
             MvPartitionStorage partition = partitions.get(i);
@@ -335,13 +343,23 @@ class RocksDbTableStorage implements TableStorage, MvTableStorage {
     public CompletableFuture<?> destroyPartition(int partitionId) throws StorageException {
         RocksDbMvPartitionStorage mvPartition = getMvPartition(partitionId);
 
-        if (mvPartition != null) {
-            partitions.set(partitionId, null);
-
-            mvPartition.destroy();
+        if (mvPartition == null) {
+            return CompletableFuture.completedFuture(null);
         }
 
-        return CompletableFuture.completedFuture(null);
+        partitions.set(partitionId, null);
+
+        mvPartition.destroy();
+
+        // Wait for the data to actually be removed from the disk and close the storage.
+        return mvPartition.flush()
+                .whenComplete((v, e) -> {
+                    try {
+                        mvPartition.close();
+                    } catch (Exception ex) {
+                        LOG.error("Error when closing partition storage for partId = {}", ex, partitionId);
+                    }
+                });
     }
 
     /** {@inheritDoc} */

--- a/modules/storage-rocksdb/src/main/java/org/apache/ignite/internal/storage/rocksdb/RocksDbTableStorage.java
+++ b/modules/storage-rocksdb/src/main/java/org/apache/ignite/internal/storage/rocksdb/RocksDbTableStorage.java
@@ -347,13 +347,13 @@ class RocksDbTableStorage implements TableStorage, MvTableStorage {
             return CompletableFuture.completedFuture(null);
         }
 
-        partitions.set(partitionId, null);
-
         mvPartition.destroy();
 
         // Wait for the data to actually be removed from the disk and close the storage.
         return mvPartition.flush()
                 .whenComplete((v, e) -> {
+                    partitions.set(partitionId, null);
+
                     try {
                         mvPartition.close();
                     } catch (Exception ex) {


### PR DESCRIPTION
* "Destroy" method returns a future that completes after the data is flushed
* Storage is closed after "destroy" is called
* FlushOptions are cached in RocksDbTableStorage so that they do not get GC-ed

https://issues.apache.org/jira/browse/IGNITE-17500