### PR TITLE
IGNITE-17530 Can't start node with custom config file

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/IgniteCliRunnerTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/IgniteCliRunnerTest.java
@@ -53,7 +53,7 @@ public class IgniteCliRunnerTest {
         Path configPath = Path.of(IgniteCliRunnerTest.class.getResource("/ignite-config.json").toURI());
 
         CompletableFuture<Ignite> ign = IgniteCliRunner.start(
-                "--config-file", configPath.toAbsolutePath().toString(),
+                "--config-path", configPath.toAbsolutePath().toString(),
                 "--work-dir", workDir.resolve("node").toAbsolutePath().toString(),
                 NODE_NAME
         );

--- a/modules/runner/src/main/java/org/apache/ignite/app/IgniteCliRunner.java
+++ b/modules/runner/src/main/java/org/apache/ignite/app/IgniteCliRunner.java
@@ -68,7 +68,7 @@ public class IgniteCliRunner {
         CommandSpec spec = CommandSpec.create();
 
         OptionSpec configPath = OptionSpec
-                .builder("--config-file")
+                .builder("--config-path")
                 .paramLabel("configPath")
                 .type(Path.class)
                 .description("Path to node configuration file in HOCON format.")


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-17530

I forgot to change option name from `--config-file` to `--config-path` after review https://github.com/apache/ignite-3/pull/961

The option name should be the same as in the org.apache.ignite.app.IgniteCliRunner#start