### PR TITLE
IGNITE-17528 Use parameter instead of option in config show commands

### DIFF
--- a/modules/cli/src/integrationTest/java/org/apache/ignite/cli/deprecated/ItConfigCommandTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/cli/deprecated/ItConfigCommandTest.java
@@ -157,7 +157,6 @@ public class ItConfigCommandTest extends AbstractCliIntegrationTest {
                 "show",
                 "--node-url",
                 "http://localhost:" + node.restAddress().port(),
-                "--selector",
                 "network"
         );
 

--- a/modules/cli/src/main/java/org/apache/ignite/cli/commands/cluster/config/ClusterConfigShowReplSubCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/commands/cluster/config/ClusterConfigShowReplSubCommand.java
@@ -34,6 +34,7 @@ import org.apache.ignite.cli.core.flow.builder.Flows;
 import org.apache.ignite.rest.client.invoker.ApiException;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 
 /**
  * Command that shows configuration from the cluster in REPL mode.
@@ -45,7 +46,7 @@ public class ClusterConfigShowReplSubCommand extends BaseCommand implements Runn
     /**
      * Configuration selector option.
      */
-    @Option(names = {"--selector"}, description = "Configuration path selector.")
+    @Parameters(arity = "0..1", description = "Configuration path selector")
     private String selector;
 
     /**

--- a/modules/cli/src/main/java/org/apache/ignite/cli/commands/cluster/config/ClusterConfigShowSubCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/commands/cluster/config/ClusterConfigShowSubCommand.java
@@ -30,6 +30,7 @@ import org.apache.ignite.cli.commands.decorators.JsonDecorator;
 import org.apache.ignite.cli.core.call.CallExecutionPipeline;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 
 /**
  * Command that shows configuration from the cluster.
@@ -41,7 +42,7 @@ public class ClusterConfigShowSubCommand extends BaseCommand implements Callable
     /**
      * Configuration selector option.
      */
-    @Option(names = {"--selector"}, description = "Configuration path selector.")
+    @Parameters(arity = "0..1", description = "Configuration path selector")
     private String selector;
 
     /**

--- a/modules/cli/src/main/java/org/apache/ignite/cli/commands/node/config/NodeConfigShowReplSubCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/commands/node/config/NodeConfigShowReplSubCommand.java
@@ -30,6 +30,7 @@ import org.apache.ignite.cli.core.flow.Flowable;
 import org.apache.ignite.cli.core.flow.builder.Flows;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 
 /**
  * Command that shows node configuration from the cluster in REPL mode.
@@ -41,7 +42,7 @@ public class NodeConfigShowReplSubCommand extends BaseCommand implements Runnabl
     /**
      * Configuration selector option.
      */
-    @Option(names = {"--selector"}, description = "Configuration path selector.")
+    @Parameters(arity = "0..1", description = "Configuration path selector")
     private String selector;
 
     /**

--- a/modules/cli/src/main/java/org/apache/ignite/cli/commands/node/config/NodeConfigShowSubCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/commands/node/config/NodeConfigShowSubCommand.java
@@ -30,6 +30,7 @@ import org.apache.ignite.cli.commands.decorators.JsonDecorator;
 import org.apache.ignite.cli.core.call.CallExecutionPipeline;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 
 /**
  * Command that shows configuration from the cluster.
@@ -41,7 +42,7 @@ public class NodeConfigShowSubCommand extends BaseCommand implements Callable<In
     /**
      * Configuration selector option.
      */
-    @Option(names = {"--selector"}, description = "Configuration path selector.")
+    @Parameters(arity = "0..1", description = "Configuration path selector")
     private String selector;
 
     /**

--- a/modules/cli/src/main/java/org/apache/ignite/cli/core/repl/completer/DynamicCompleterActivationPoint.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/core/repl/completer/DynamicCompleterActivationPoint.java
@@ -36,9 +36,9 @@ public class DynamicCompleterActivationPoint {
      * Registers all dynamic completers in given {@link DynamicCompleterRegistry}.
      */
     public void activateDynamicCompleter(DynamicCompleterRegistry registry) {
-        registry.register(new String[]{"cluster", "config", "show"}, factory.clusterConfigCompleter("--selector"));
+        registry.register(new String[]{"cluster", "config", "show"}, factory.clusterConfigCompleter(""));
         registry.register(new String[]{"cluster", "config", "update"}, factory.clusterConfigCompleter(""));
-        registry.register(new String[]{"node", "config", "show"}, factory.nodeConfigCompleter("--selector"));
+        registry.register(new String[]{"node", "config", "show"}, factory.nodeConfigCompleter(""));
         registry.register(new String[]{"node", "config", "update"}, factory.nodeConfigCompleter(""));
     }
 }

--- a/modules/cli/src/main/java/org/apache/ignite/cli/core/repl/completer/HoconDynamicCompleter.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/core/repl/completer/HoconDynamicCompleter.java
@@ -58,9 +58,9 @@ public class HoconDynamicCompleter implements DynamicCompleter {
     }
 
     /**
-     * Completes the given typed words with the config keys that a in the same level as the last typed words.
+     * Completes the given typed words with the config keys that are in the same level as the last typed words.
      * <p/>
-     * Example: given typed words ["cluster", "config", "show", "--selector", "a"], The last word is "a", only root config values will be
+     * Example: given typed words ["cluster", "config", "show", "a"], The last word is "a", only root config values will be
      * suggested to autocomplete: "aimem", "aipersist". If user hits "aimem" and types dot "." then only subkeys of "aimem." will be
      * suggested: "aimem.pageSize", "aimem.regions".
      */

--- a/modules/cli/src/test/java/org/apache/ignite/cli/core/repl/completer/DynamicCompleterFilterTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/cli/core/repl/completer/DynamicCompleterFilterTest.java
@@ -20,6 +20,7 @@ package org.apache.ignite.cli.core.repl.completer;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyArray;
 
 import org.apache.ignite.cli.core.repl.Session;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,7 @@ class DynamicCompleterFilterTest {
         // Given
         String[] words = new String[]{"cluster", "config", "show", ""};
         // And completion candidates
-        String[] candidates = new String[]{"--selector", "--cluster-endpoint-url", "--help", "-h"};
+        String[] candidates = new String[]{"--cluster-endpoint-url", "--help", "-h"};
         // And user is not connected to the cluster
         Session session = notConnected();
 
@@ -39,7 +40,7 @@ class DynamicCompleterFilterTest {
         String[] filtered = new DynamicCompleterFilter(session).filter(words, candidates);
 
         // Then help is filtered out
-        assertThat(asList(filtered), containsInAnyOrder("--selector", "--cluster-endpoint-url"));
+        assertThat(asList(filtered), containsInAnyOrder("--cluster-endpoint-url"));
     }
 
     private static Session notConnected() {
@@ -59,7 +60,7 @@ class DynamicCompleterFilterTest {
         // Given typed words that end with "-"
         String[] words = new String[]{"cluster", "config", "show", "-"};
         // And completion candidates
-        String[] candidates = new String[]{"--selector", "--cluster-endpoint-url", "--help", "-h"};
+        String[] candidates = new String[]{"--cluster-endpoint-url", "--help", "-h"};
         // And user is not connected to the cluster
         Session session = notConnected();
 
@@ -67,7 +68,7 @@ class DynamicCompleterFilterTest {
         String[] filtered = new DynamicCompleterFilter(session).filter(words, candidates);
 
         // Then help is NOT filtered out
-        assertThat(asList(filtered), containsInAnyOrder("--selector", "--cluster-endpoint-url", "--help", "-h"));
+        assertThat(asList(filtered), containsInAnyOrder("--cluster-endpoint-url", "--help", "-h"));
     }
 
     @Test
@@ -75,7 +76,7 @@ class DynamicCompleterFilterTest {
         // Given typed words that end with "-"
         String[] words = new String[]{"cluster", "config", "show", ""};
         // And completion candidates
-        String[] candidates = new String[]{"--selector", "--cluster-endpoint-url", "--help", "-h"};
+        String[] candidates = new String[]{"--cluster-endpoint-url", "--help", "-h"};
         // And
         Session session = connected();
 
@@ -83,7 +84,7 @@ class DynamicCompleterFilterTest {
         String[] filtered = new DynamicCompleterFilter(session).filter(words, candidates);
 
         // Then cluster-endpoint-url and help are filtered out
-        assertThat(asList(filtered), containsInAnyOrder("--selector"));
+        assertThat(filtered, emptyArray());
     }
 
     @Test
@@ -91,7 +92,7 @@ class DynamicCompleterFilterTest {
         // Given typed words that end with "-"
         String[] words = new String[]{"cluster", "config", "show", "-"};
         // And completion candidates
-        String[] candidates = new String[]{"--selector", "--cluster-endpoint-url", "--help", "-h"};
+        String[] candidates = new String[]{"--cluster-endpoint-url", "--help", "-h"};
         // And
         Session session = connected();
 
@@ -99,6 +100,6 @@ class DynamicCompleterFilterTest {
         String[] filtered = new DynamicCompleterFilter(session).filter(words, candidates);
 
         // Then help is NOT filtered out
-        assertThat(asList(filtered), containsInAnyOrder("--selector", "--cluster-endpoint-url", "--help", "-h"));
+        assertThat(asList(filtered), containsInAnyOrder("--cluster-endpoint-url", "--help", "-h"));
     }
 }

--- a/modules/cli/src/test/java/org/apache/ignite/cli/core/repl/completer/HoconDynamicCompleterTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/cli/core/repl/completer/HoconDynamicCompleterTest.java
@@ -24,13 +24,14 @@ import static org.hamcrest.Matchers.hasSize;
 import com.typesafe.config.ConfigFactory;
 import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class HoconDynamicCompleterTest {
     HoconDynamicCompleter completer;
 
     private static HoconDynamicCompleter completerFrom(String configString) {
-        Set<String> activationPostfixes = Set.of("--selector");
+        Set<String> activationPostfixes = Set.of("");
         return new HoconDynamicCompleter(activationPostfixes, ConfigFactory.parseString(configString));
     }
 
@@ -39,7 +40,7 @@ class HoconDynamicCompleterTest {
         // Given
         completer = completerFrom("root: { subRoot: { subSubRoot: value } }");
         // And
-        String[] typedWords = {"cluster", "config", "show", "--selector"};
+        String[] typedWords = {"cluster", "config", "show", ""};
 
         // When
         List<String> completions = completer.complete(typedWords);
@@ -56,7 +57,7 @@ class HoconDynamicCompleterTest {
                         + "root2: { subRoot2: value2 }, "
                         + "root3: value3");
         // And
-        String[] typedWords = {"cluster", "config", "show", "--selector"};
+        String[] typedWords = {"cluster", "config", "show", ""};
 
         // When
         List<String> completions = completer.complete(typedWords);
@@ -73,7 +74,7 @@ class HoconDynamicCompleterTest {
                         + "root2: { subRoot2: value2 }, "
                         + "root3: value3");
         // And last word is "roo"
-        String[] typedWords = {"cluster", "config", "show", "--selector", "roo"};
+        String[] typedWords = {"cluster", "config", "show", "roo"};
 
         // When
         List<String> completions = completer.complete(typedWords);
@@ -88,7 +89,7 @@ class HoconDynamicCompleterTest {
         // Given
         completer = completerFrom("root: { subRoot: { subSubRoot: value } }");
         // And typed a part of the path
-        String[] typedWords = {"cluster", "config", "show", "--selector", "root."};
+        String[] typedWords = {"cluster", "config", "show", "root."};
 
         // When
         List<String> completions = completer.complete(typedWords);
@@ -102,7 +103,7 @@ class HoconDynamicCompleterTest {
         // Given
         completer = completerFrom("root: { subRoot: { subSubRoot1: value1, subSubRoot2: value2 } }");
         // And typed a part of the path but with "." at the end
-        String[] typedWords = {"cluster", "config", "show", "--selector", "root.subRoot."};
+        String[] typedWords = {"cluster", "config", "show", "root.subRoot."};
 
         // When
         List<String> completions = completer.complete(typedWords);
@@ -116,7 +117,7 @@ class HoconDynamicCompleterTest {
         // Given
         completer = completerFrom("");
         // And
-        String[] typedWords = {"cluster", "config", "show", "--selector"};
+        String[] typedWords = {"cluster", "config", "show"};
 
         // When
         List<String> completions = completer.complete(typedWords);
@@ -140,6 +141,7 @@ class HoconDynamicCompleterTest {
     }
 
     @Test
+    @Disabled("https://issues.apache.org/jira/browse/IGNITE-17418")
     void doesNotCompletesIfLastWordIsClusterUrlAndEmptyString() {
         // Given
         completer = completerFrom("root: { subRoot: value }");
@@ -155,9 +157,8 @@ class HoconDynamicCompleterTest {
 
     @Test
     void shouldAlwaysCompleteIfActivationPostfixIsEmptyString() {
-        // Given empty string activation profile
-        Set<String> activationPostfixes = Set.of("");
-        completer = new HoconDynamicCompleter(activationPostfixes, ConfigFactory.parseString("root: { subRoot: value }"));
+        // Given
+        completer = completerFrom("root: { subRoot: value }");
         // And
         String[] typedWords = {"cluster", "config", "update", ""};
 

--- a/modules/cli/src/test/java/org/apache/ignite/cli/deprecated/IgniteCliInterfaceTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/cli/deprecated/IgniteCliInterfaceTest.java
@@ -471,7 +471,7 @@ public class IgniteCliInterfaceTest extends AbstractCliTest {
             }
 
             @Test
-            @DisplayName("show --node-url http://localhost:10300 --selector local.baseline")
+            @DisplayName("show --node-url http://localhost:10300 local.baseline")
             void showSubtree() {
                 clientAndServer
                         .when(request()
@@ -480,7 +480,7 @@ public class IgniteCliInterfaceTest extends AbstractCliTest {
                         )
                         .respond(response("{\"autoAdjust\":{\"enabled\":true}}"));
 
-                int exitCode = execute("node config show --node-url " + mockUrl + " --selector local.baseline");
+                int exitCode = execute("node config show --node-url " + mockUrl + " local.baseline");
 
                 assertThatExitCodeMeansSuccess(exitCode);
 
@@ -665,7 +665,7 @@ public class IgniteCliInterfaceTest extends AbstractCliTest {
             }
 
             @Test
-            @DisplayName("show --cluster-endpoint-url http://localhost:10300 --selector local.baseline")
+            @DisplayName("show --cluster-endpoint-url http://localhost:10300 local.baseline")
             void showSubtree() {
                 clientAndServer
                         .when(request()
@@ -674,7 +674,7 @@ public class IgniteCliInterfaceTest extends AbstractCliTest {
                         )
                         .respond(response("{\"autoAdjust\":{\"enabled\":true}}"));
 
-                int exitCode = execute("cluster config show --cluster-endpoint-url " + mockUrl + " --selector local.baseline");
+                int exitCode = execute("cluster config show --cluster-endpoint-url " + mockUrl + " local.baseline");
 
                 assertThatExitCodeMeansSuccess(exitCode);
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-17528

This drops the `--selector` option in `config show` commands and allow similar UX as `config update` commands so that the user can write `node config show network` rather than `node config show --selector network`.