### PR TITLE
IGNITE-17529 Override CLI config file path via environment variable

### DIFF
--- a/modules/cli/src/main/java/org/apache/ignite/cli/config/ConfigConstants.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/config/ConfigConstants.java
@@ -24,21 +24,63 @@ import java.nio.file.Path;
  * Util class for config CLI.
  */
 public final class ConfigConstants {
+    /**
+     * Environment variable which points to the base directory for configuration files according to XDG spec.
+     */
     private static final String XDG_CONFIG_HOME = "XDG_CONFIG_HOME";
+
+    /**
+     * Subdirectory name under the base configuration directory for ignite configuration files.
+     */
     private static final String PARENT_FOLDER_NAME = "ignitecli";
+
+    /**
+     * Main configuration file name.
+     */
     private static final String CONFIG_FILE_NAME = "defaults";
 
+    /**
+     * Environment variable which points to the configuration file.
+     */
+    private static final String IGNITE_CLI_CONFIG_FILE = "IGNITE_CLI_CONFIG_FILE";
+
+    /**
+     * Current profile property name.
+     */
     public static final String CURRENT_PROFILE = "current_profile";
+
+    /**
+     * Default cluster or node URL property name.
+     */
     public static final String CLUSTER_URL = "ignite.cluster-endpoint-url";
+
+    /**
+     * Default JDBC URL property name.
+     */
     public static final String JDBC_URL = "ignite.jdbc-url";
+
+    /**
+     * Last connected URL property name.
+     */
     public static final String LAST_CONNECTED_URL = "ignite.last-connected-url";
 
     private ConfigConstants() {
-
     }
 
-
+    /**
+     * Gets the {@link File} with user-specific configuration file.
+     * The file location can be overridden using {@code IGNITE_CLI_CONFIG_FILE} environment variable,
+     * otherwise base directory is specified by the
+     * <a href="https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html">XDG Base Directory Specification</a>
+     * and the configuration file name is {@code ignitecli/defaults} under the base directory.
+     *
+     * @return configuration file.
+     */
     public static File getConfigFile() {
+        String configFile = System.getenv(IGNITE_CLI_CONFIG_FILE);
+        if (configFile != null) {
+            return new File(configFile);
+        }
         return getConfigRoot().resolve(PARENT_FOLDER_NAME).resolve(CONFIG_FILE_NAME).toFile();
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-17529

Allow changing config file path, which is now determined by the XDG spec.