### PR TITLE
IGNITE-17402 Fix testClientSendsComputeJobToTargetNodeWhenDirectConnectionExists flakiness

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -720,6 +720,10 @@ public final class ReliableChannel implements AutoCloseable {
                     // No op.
                 }
 
+                if (serverNodeId != null) {
+                    nodeChannels.remove(serverNodeId, this);
+                }
+
                 ch = null;
             }
         }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -131,7 +131,7 @@ public final class ReliableChannel implements AutoCloseable {
     public List<ClusterNode> connections() {
         List<ClusterNode> res = new ArrayList<>(channels.size());
 
-        for (var holder : channels) {
+        for (var holder : nodeChannels.values()) {
             var ch = holder.ch;
 
             if (ch != null) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -185,6 +185,10 @@ public class ClientCompute implements IgniteCompute {
     }
 
     private ClusterNode randomNode(Set<ClusterNode> nodes) {
+        if (nodes.size() == 1) {
+            return nodes.iterator().next();
+        }
+
         int nodesToSkip = ThreadLocalRandom.current().nextInt(nodes.size());
 
         Iterator<ClusterNode> iterator = nodes.iterator();


### PR DESCRIPTION
Flakiness is caused by a race:
* `ClientChannelHolder.getOrCreateChannel` sets `ch` then updates `nodeChannels`.
* `IgniteClient.connections()` (used by the test to wait for connections to establish) uses `holder.ch`.
* `ReliableChannel.handleServiceAsync()` uses `nodeChannels` to send request to proper node.

As a result, it was possible that `connections()` return new connections, but `handleServiceAsync()` does not yet see them, sending the request to the default node.

Fixed by using `nodeChannels` in `IgniteClient.connections()`.