### PR TITLE
IGNITE-17491 Fix testIgniteExceptionInJobPropagatesToClientWithMessageAndCodeAndTraceId flakiness

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItAbstractThinClientTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItAbstractThinClientTest.java
@@ -34,6 +34,7 @@ import org.apache.ignite.client.IgniteClient;
 import org.apache.ignite.internal.app.IgniteImpl;
 import org.apache.ignite.internal.schema.configuration.SchemaConfigurationConverter;
 import org.apache.ignite.internal.testframework.IgniteAbstractTest;
+import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.internal.testframework.WorkDirectory;
 import org.apache.ignite.internal.testframework.WorkDirectoryExtension;
 import org.apache.ignite.internal.util.IgniteUtils;
@@ -71,7 +72,7 @@ public abstract class ItAbstractThinClientTest extends IgniteAbstractTest {
      * Before each.
      */
     @BeforeAll
-    void beforeAll(TestInfo testInfo, @WorkDirectory Path workDir) {
+    void beforeAll(TestInfo testInfo, @WorkDirectory Path workDir) throws InterruptedException {
         this.workDir = workDir;
 
         String node0Name = testNodeName(testInfo, 3344);
@@ -120,6 +121,7 @@ public abstract class ItAbstractThinClientTest extends IgniteAbstractTest {
         );
 
         client = IgniteClient.builder().addresses(getClientAddresses().toArray(new String[0])).build();
+        IgniteTestUtils.waitForCondition(() -> client.connections().size() == 2, 3000);
     }
 
     /**


### PR DESCRIPTION
Wait for background client connections to be established.