### PR TITLE
IGNITE-17510 NPE in cluster configuration REST calls

### DIFF
--- a/modules/cli/src/integrationTest/java/org/apache/ignite/cli/commands/cluster/config/ItClusterConfigCommandNotInitializedTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/cli/commands/cluster/config/ItClusterConfigCommandNotInitializedTest.java
@@ -36,7 +36,7 @@ class ItClusterConfigCommandNotInitializedTest extends CliCommandTestNotInitiali
                 this::assertOutputIsEmpty,
                 () -> assertExitCodeIs(1),
                 () -> assertErrOutputContains("Cannot show cluster config" + System.lineSeparator()
-                + "Probably, you have not initialized the cluster, try to run cluster init command")
+                + "Probably, you have not initialized the cluster, try to run ignite cluster init command")
         );
     }
 }

--- a/modules/cli/src/integrationTest/java/org/apache/ignite/cli/commands/cluster/topology/ItTopologyCommandNotInitializedClusterTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/cli/commands/cluster/topology/ItTopologyCommandNotInitializedClusterTest.java
@@ -52,8 +52,8 @@ class ItTopologyCommandNotInitializedClusterTest extends CliCommandTestNotInitia
         // Then prints nothing
         assertAll(
                 this::assertOutputIsEmpty,
-                () -> assertErrOutputContains(
-                        "Cluster not initialized. Call /management/v1/cluster/init in order to initialize cluster"
+                () -> assertErrOutputContains("Cannot show logical topology" + System.lineSeparator()
+                                + "Probably, you have not initialized the cluster, try to run ignite cluster init command"
                 )
         );
     }

--- a/modules/cli/src/main/java/org/apache/ignite/cli/commands/cluster/config/ClusterConfigShowCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/commands/cluster/config/ClusterConfigShowCommand.java
@@ -24,7 +24,7 @@ import org.apache.ignite.cli.call.configuration.ClusterConfigShowCallInput;
 import org.apache.ignite.cli.commands.BaseCommand;
 import org.apache.ignite.cli.commands.cluster.ClusterUrlProfileMixin;
 import org.apache.ignite.cli.core.call.CallExecutionPipeline;
-import org.apache.ignite.cli.core.exception.handler.ShowConfigExceptionHandler;
+import org.apache.ignite.cli.core.exception.handler.ClusterNotInitializedExceptionHandler;
 import org.apache.ignite.cli.decorators.JsonDecorator;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
@@ -56,7 +56,9 @@ public class ClusterConfigShowCommand extends BaseCommand implements Callable<In
                 .output(spec.commandLine().getOut())
                 .errOutput(spec.commandLine().getErr())
                 .decorator(new JsonDecorator())
-                .exceptionHandler(new ShowConfigExceptionHandler())
+                .exceptionHandler(new ClusterNotInitializedExceptionHandler(
+                        "Cannot show cluster config", "ignite cluster init"
+                ))
                 .build()
                 .runPipeline();
     }

--- a/modules/cli/src/main/java/org/apache/ignite/cli/commands/cluster/config/ClusterConfigShowReplCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/commands/cluster/config/ClusterConfigShowReplCommand.java
@@ -23,7 +23,7 @@ import org.apache.ignite.cli.call.configuration.ClusterConfigShowCallInput;
 import org.apache.ignite.cli.commands.BaseCommand;
 import org.apache.ignite.cli.commands.cluster.ClusterUrlMixin;
 import org.apache.ignite.cli.commands.questions.ConnectToClusterQuestion;
-import org.apache.ignite.cli.core.exception.handler.ShowConfigExceptionHandler;
+import org.apache.ignite.cli.core.exception.handler.ClusterNotInitializedExceptionHandler;
 import org.apache.ignite.cli.core.flow.Flowable;
 import org.apache.ignite.cli.core.flow.builder.Flows;
 import picocli.CommandLine.Command;
@@ -56,7 +56,7 @@ public class ClusterConfigShowReplCommand extends BaseCommand implements Runnabl
     @Override
     public void run() {
         question.askQuestionIfNotConnected(clusterUrl.getClusterUrl())
-                .exceptionHandler(new ShowConfigExceptionHandler())
+                .exceptionHandler(new ClusterNotInitializedExceptionHandler("Cannot show cluster config", "cluster init"))
                 .map(this::configShowCallInput)
                 .then(Flows.fromCall(call))
                 .toOutput(spec.commandLine().getOut(), spec.commandLine().getErr())

--- a/modules/cli/src/main/java/org/apache/ignite/cli/commands/cluster/config/ClusterConfigUpdateCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/commands/cluster/config/ClusterConfigUpdateCommand.java
@@ -24,6 +24,7 @@ import org.apache.ignite.cli.call.configuration.ClusterConfigUpdateCallInput;
 import org.apache.ignite.cli.commands.BaseCommand;
 import org.apache.ignite.cli.commands.cluster.ClusterUrlProfileMixin;
 import org.apache.ignite.cli.core.call.CallExecutionPipeline;
+import org.apache.ignite.cli.core.exception.handler.ClusterNotInitializedExceptionHandler;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Parameters;
@@ -51,6 +52,9 @@ public class ClusterConfigUpdateCommand extends BaseCommand implements Callable<
                 .inputProvider(this::buildCallInput)
                 .output(spec.commandLine().getOut())
                 .errOutput(spec.commandLine().getErr())
+                .exceptionHandler(new ClusterNotInitializedExceptionHandler(
+                        "Cannot update cluster config", "ignite cluster init"
+                ))
                 .build()
                 .runPipeline();
     }

--- a/modules/cli/src/main/java/org/apache/ignite/cli/commands/cluster/config/ClusterConfigUpdateReplCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/commands/cluster/config/ClusterConfigUpdateReplCommand.java
@@ -23,6 +23,7 @@ import org.apache.ignite.cli.call.configuration.ClusterConfigUpdateCallInput;
 import org.apache.ignite.cli.commands.BaseCommand;
 import org.apache.ignite.cli.commands.cluster.ClusterUrlMixin;
 import org.apache.ignite.cli.commands.questions.ConnectToClusterQuestion;
+import org.apache.ignite.cli.core.exception.handler.ClusterNotInitializedExceptionHandler;
 import org.apache.ignite.cli.core.flow.Flowable;
 import org.apache.ignite.cli.core.flow.builder.Flows;
 import picocli.CommandLine.Command;
@@ -52,6 +53,7 @@ public class ClusterConfigUpdateReplCommand extends BaseCommand implements Runna
     @Override
     public void run() {
         question.askQuestionIfNotConnected(clusterUrl.getClusterUrl())
+                .exceptionHandler(new ClusterNotInitializedExceptionHandler("Cannot update cluster config", "cluster init"))
                 .map(this::configUpdateCallInput)
                 .then(Flows.fromCall(call))
                 .toOutput(spec.commandLine().getOut(), spec.commandLine().getErr())

--- a/modules/cli/src/main/java/org/apache/ignite/cli/commands/topology/LogicalTopologyCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/commands/topology/LogicalTopologyCommand.java
@@ -24,6 +24,7 @@ import org.apache.ignite.cli.call.cluster.topology.TopologyCallInput;
 import org.apache.ignite.cli.commands.BaseCommand;
 import org.apache.ignite.cli.commands.cluster.ClusterUrlProfileMixin;
 import org.apache.ignite.cli.core.call.CallExecutionPipeline;
+import org.apache.ignite.cli.core.exception.handler.ClusterNotInitializedExceptionHandler;
 import org.apache.ignite.cli.decorators.TopologyDecorator;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
@@ -47,6 +48,9 @@ public class LogicalTopologyCommand extends BaseCommand implements Callable<Inte
                 .inputProvider(() -> TopologyCallInput.builder().clusterUrl(clusterUrl.getClusterUrl()).build())
                 .output(spec.commandLine().getOut())
                 .errOutput(spec.commandLine().getErr())
+                .exceptionHandler(new ClusterNotInitializedExceptionHandler(
+                        "Cannot show logical topology", "ignite cluster init"
+                ))
                 .decorator(new TopologyDecorator())
                 .build()
                 .runPipeline();

--- a/modules/cli/src/main/java/org/apache/ignite/cli/commands/topology/LogicalTopologyReplCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/commands/topology/LogicalTopologyReplCommand.java
@@ -27,6 +27,7 @@ import org.apache.ignite.cli.call.cluster.topology.TopologyCallInput.TopologyCal
 import org.apache.ignite.cli.commands.BaseCommand;
 import org.apache.ignite.cli.commands.cluster.ClusterUrlMixin;
 import org.apache.ignite.cli.core.call.CallExecutionPipeline;
+import org.apache.ignite.cli.core.exception.handler.ClusterNotInitializedExceptionHandler;
 import org.apache.ignite.cli.core.repl.Session;
 import org.apache.ignite.cli.decorators.TopologyDecorator;
 import picocli.CommandLine.Command;
@@ -66,6 +67,7 @@ public class LogicalTopologyReplCommand extends BaseCommand implements Callable<
                 .output(spec.commandLine().getOut())
                 .errOutput(spec.commandLine().getErr())
                 .decorator(new TopologyDecorator())
+                .exceptionHandler(new ClusterNotInitializedExceptionHandler("Cannot show logical topology", "cluster init"))
                 .build()
                 .runPipeline();
     }

--- a/modules/cli/src/main/java/org/apache/ignite/cli/core/exception/handler/ClusterNotInitializedExceptionHandler.java
+++ b/modules/cli/src/main/java/org/apache/ignite/cli/core/exception/handler/ClusterNotInitializedExceptionHandler.java
@@ -24,20 +24,34 @@ import org.apache.ignite.cli.core.style.element.UiElements;
 import org.apache.ignite.rest.client.invoker.ApiException;
 
 /**
- * This exception handler is used only for `cluster config show` command and handles a tricky case with the 500 error on not initialized
- * cluster.
+ * This exception handler is used for cluster commands and handles a case when the cluster is not initialized.
  */
-public class ShowConfigExceptionHandler extends IgniteCliApiExceptionHandler {
+public class ClusterNotInitializedExceptionHandler extends IgniteCliApiExceptionHandler {
+    private final String header;
+
+    private final String command;
+
+    /**
+     * Constructs a new exception handler with corresponding header and command to suggest.
+     *
+     * @param header text to display as a header
+     * @param command command to suggest
+     */
+    public ClusterNotInitializedExceptionHandler(String header, String command) {
+        this.header = header;
+        this.command = command;
+    }
+
     @Override
     public int handle(ExceptionWriter err, IgniteCliApiException e) {
         if (e.getCause() instanceof ApiException) {
             ApiException apiException = (ApiException) e.getCause();
-            if (apiException.getCode() == 500) { //TODO: https://issues.apache.org/jira/browse/IGNITE-17510
+            if (apiException.getCode() == 404) {
                 err.write(
                         ErrorUiComponent.builder()
-                                .header("Cannot show cluster config")
+                                .header(header)
                                 .details("Probably, you have not initialized the cluster, try to run %s command",
-                                        UiElements.command("cluster init"))
+                                        UiElements.command(command))
                                 .build()
                                 .render()
                 );

--- a/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/rest/ClusterManagementController.java
+++ b/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/rest/ClusterManagementController.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ExecutionException;
 import org.apache.ignite.internal.cluster.management.ClusterInitializer;
 import org.apache.ignite.internal.cluster.management.ClusterManagementGroupManager;
 import org.apache.ignite.internal.cluster.management.ClusterState;
-import org.apache.ignite.internal.cluster.management.rest.exception.ClusterNotInitializedException;
 import org.apache.ignite.internal.cluster.management.rest.exception.InvalidArgumentClusterInitializationException;
 import org.apache.ignite.internal.logger.IgniteLogger;
 import org.apache.ignite.internal.logger.Loggers;
@@ -34,6 +33,7 @@ import org.apache.ignite.internal.rest.api.cluster.ClusterStateDto;
 import org.apache.ignite.internal.rest.api.cluster.ClusterTagDto;
 import org.apache.ignite.internal.rest.api.cluster.IgniteProductVersionDto;
 import org.apache.ignite.internal.rest.api.cluster.InitCommand;
+import org.apache.ignite.internal.rest.exception.ClusterNotInitializedException;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.lang.IgniteInternalException;
 

--- a/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/rest/TopologyController.java
+++ b/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/rest/TopologyController.java
@@ -22,10 +22,10 @@ import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.apache.ignite.internal.cluster.management.ClusterManagementGroupManager;
-import org.apache.ignite.internal.cluster.management.rest.exception.ClusterNotInitializedException;
 import org.apache.ignite.internal.rest.api.cluster.ClusterNodeDto;
 import org.apache.ignite.internal.rest.api.cluster.NetworkAddressDto;
 import org.apache.ignite.internal.rest.api.cluster.TopologyApi;
+import org.apache.ignite.internal.rest.exception.ClusterNotInitializedException;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.network.TopologyService;
 

--- a/modules/configuration/src/main/java/org/apache/ignite/internal/configuration/ComponentNotStartedException.java
+++ b/modules/configuration/src/main/java/org/apache/ignite/internal/configuration/ComponentNotStartedException.java
@@ -15,13 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.internal.cluster.management.rest.exception;
+package org.apache.ignite.internal.configuration;
 
 /**
- * Exception that is thrown when the cluster is not initialized.
+ * Exception thrown when component is not started.
  */
-public class ClusterNotInitializedException extends RuntimeException {
-    public ClusterNotInitializedException() {
-        super();
+public class ComponentNotStartedException extends RuntimeException {
+    public ComponentNotStartedException() {
     }
 }

--- a/modules/configuration/src/main/java/org/apache/ignite/internal/configuration/ComponentNotStartedException.java
+++ b/modules/configuration/src/main/java/org/apache/ignite/internal/configuration/ComponentNotStartedException.java
@@ -17,10 +17,14 @@
 
 package org.apache.ignite.internal.configuration;
 
+import org.apache.ignite.lang.ErrorGroups.Common;
+import org.apache.ignite.lang.IgniteInternalException;
+
 /**
  * Exception thrown when component is not started.
  */
-public class ComponentNotStartedException extends RuntimeException {
+public class ComponentNotStartedException extends IgniteInternalException {
     public ComponentNotStartedException() {
+        super(Common.COMPONENT_NOT_STARTED_ERR);
     }
 }

--- a/modules/configuration/src/main/java/org/apache/ignite/internal/configuration/ConfigurationChanger.java
+++ b/modules/configuration/src/main/java/org/apache/ignite/internal/configuration/ConfigurationChanger.java
@@ -463,19 +463,31 @@ public abstract class ConfigurationChanger implements DynamicConfigurationChange
      * Get storage super root.
      *
      * @return Super root storage.
+     * @throws ComponentNotStartedException if changer is not started.
      */
     public SuperRoot superRoot() {
-        return storageRoots.roots;
+        StorageRoots localRoots = storageRoots;
+
+        if (localRoots == null) {
+            throw new ComponentNotStartedException();
+        }
+
+        return localRoots.roots;
     }
 
     /**
      * Entry point for configuration changes.
      *
      * @param src Configuration source.
-     * @return fut Future that will be completed after changes are written to the storage.
+     * @return Future that will be completed after changes are written to the storage.
+     * @throws ComponentNotStartedException if changer is not started.
      */
     private CompletableFuture<Void> changeInternally(ConfigurationSource src) {
         StorageRoots localRoots = storageRoots;
+
+        if (localRoots == null) {
+            throw new ComponentNotStartedException();
+        }
 
         return storage.lastRevision()
             .thenCompose(storageRevision -> {
@@ -503,7 +515,7 @@ public abstract class ConfigurationChanger implements DynamicConfigurationChange
      * Internal configuration change method that completes provided future.
      *
      * @param src Configuration source.
-     * @return fut Future that will be completed after changes are written to the storage.
+     * @return Future that will be completed after changes are written to the storage.
      */
     private CompletableFuture<Void> changeInternally0(StorageRoots localRoots, ConfigurationSource src) {
         return CompletableFuture

--- a/modules/configuration/src/main/java/org/apache/ignite/internal/rest/configuration/AbstractConfigurationController.java
+++ b/modules/configuration/src/main/java/org/apache/ignite/internal/rest/configuration/AbstractConfigurationController.java
@@ -40,7 +40,7 @@ public abstract class AbstractConfigurationController {
      * @return the presentation of configuration.
      */
     public String getConfiguration() {
-        return this.cfgPresentation.represent();
+        return cfgPresentation.represent();
     }
 
     /**

--- a/modules/configuration/src/main/java/org/apache/ignite/internal/rest/configuration/ClusterConfigurationController.java
+++ b/modules/configuration/src/main/java/org/apache/ignite/internal/rest/configuration/ClusterConfigurationController.java
@@ -21,8 +21,10 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.annotation.Controller;
 import jakarta.inject.Named;
 import java.util.concurrent.CompletableFuture;
+import org.apache.ignite.internal.configuration.ComponentNotStartedException;
 import org.apache.ignite.internal.configuration.rest.presentation.ConfigurationPresentation;
 import org.apache.ignite.internal.rest.api.configuration.ClusterConfigurationApi;
+import org.apache.ignite.internal.rest.exception.ClusterNotInitializedException;
 import org.apache.ignite.internal.rest.exception.handler.IgniteExceptionHandler;
 
 /**
@@ -43,7 +45,11 @@ public class ClusterConfigurationController extends AbstractConfigurationControl
      */
     @Override
     public String getConfiguration() {
-        return super.getConfiguration();
+        try {
+            return super.getConfiguration();
+        } catch (ComponentNotStartedException e) {
+            throw new ClusterNotInitializedException();
+        }
     }
 
     /**
@@ -54,7 +60,11 @@ public class ClusterConfigurationController extends AbstractConfigurationControl
      */
     @Override
     public String getConfigurationByPath(String path) {
-        return super.getConfigurationByPath(path);
+        try {
+            return super.getConfigurationByPath(path);
+        } catch (ComponentNotStartedException e) {
+            throw new ClusterNotInitializedException();
+        }
     }
 
     /**
@@ -64,6 +74,10 @@ public class ClusterConfigurationController extends AbstractConfigurationControl
      */
     @Override
     public CompletableFuture<Void> updateConfiguration(String updatedConfiguration) {
-        return super.updateConfiguration(updatedConfiguration);
+        try {
+            return super.updateConfiguration(updatedConfiguration);
+        } catch (ComponentNotStartedException e) {
+            throw new ClusterNotInitializedException();
+        }
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/lang/ErrorGroups.java
+++ b/modules/core/src/main/java/org/apache/ignite/lang/ErrorGroups.java
@@ -33,6 +33,9 @@ public class ErrorGroups {
         /** Node stopping error. */
         public static final int NODE_STOPPING_ERR = COMMON_ERR_GROUP.registerErrorCode(2);
 
+        /** Component not started error. */
+        public static final int COMPONENT_NOT_STARTED_ERR = COMMON_ERR_GROUP.registerErrorCode(3);
+
         /** Unknown error. */
         @Deprecated
         public static final int UNKNOWN_ERR = COMMON_ERR_GROUP.registerErrorCode(0xFFFF);

--- a/modules/rest-api/pom.xml
+++ b/modules/rest-api/pom.xml
@@ -73,6 +73,9 @@
             <artifactId>micronaut-http-server</artifactId>
         </dependency>
 
+        <!--
+            This is needed because micronaut-openapi generator in ignite-rest module uses these types to detect nullable properties
+        -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>

--- a/modules/rest-api/pom.xml
+++ b/modules/rest-api/pom.xml
@@ -74,6 +74,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/api/Problem.java
+++ b/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/api/Problem.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.UUID;
+import javax.annotation.Nullable;
 import org.apache.ignite.internal.rest.constants.HttpCode;
 import org.apache.ignite.internal.rest.problem.Builder;
 
@@ -60,11 +61,11 @@ public class Problem {
             @JsonProperty("title") String title,
             @JsonProperty("status") int status,
             @JsonProperty("code") String code,
-            @JsonProperty("type") String type,
-            @JsonProperty("detail") String detail,
-            @JsonProperty("node") String node,
-            @JsonProperty("traceId") UUID traceId,
-            @JsonProperty("invalidParams") Collection<InvalidParam> invalidParams) {
+            @JsonProperty("type") @Nullable String type,
+            @JsonProperty("detail") @Nullable String detail,
+            @JsonProperty("node") @Nullable String node,
+            @JsonProperty("traceId") @Nullable UUID traceId,
+            @JsonProperty("invalidParams") @Nullable Collection<InvalidParam> invalidParams) {
         this.title = title;
         this.status = status;
         this.code = code;

--- a/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/api/cluster/ClusterManagementApi.java
+++ b/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/api/cluster/ClusterManagementApi.java
@@ -45,9 +45,9 @@ public interface ClusterManagementApi {
     @Get("state")
     @Operation(operationId = "clusterState")
     @ApiResponse(responseCode = "200", description = "Return cluster state",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON,
-                    schema = @Schema(implementation = ClusterStateDto.class)))
-    @ApiResponse(responseCode = "404", description = "Cluster state not found, it means that the cluster is not initialized")
+            content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ClusterStateDto.class)))
+    @ApiResponse(responseCode = "404", description = "Cluster state not found, it means that the cluster is not initialized",
+            content = @Content(mediaType = MediaType.PROBLEM_JSON, schema = @Schema(implementation = Problem.class)))
     @ApiResponse(responseCode = "500", description = "Internal error",
             content = @Content(mediaType = MediaType.PROBLEM_JSON, schema = @Schema(implementation = Problem.class)))
     @Produces({

--- a/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/api/cluster/TopologyApi.java
+++ b/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/api/cluster/TopologyApi.java
@@ -53,6 +53,8 @@ public interface TopologyApi {
     @Get("logical")
     @Operation(operationId = "logical")
     @ApiResponse(responseCode = "200", description = "Logical topology returned")
+    @ApiResponse(responseCode = "404", description = "Logical topology not found, it means that the cluster is not initialized",
+            content = @Content(mediaType = MediaType.PROBLEM_JSON, schema = @Schema(implementation = Problem.class)))
     @ApiResponse(responseCode = "500", description = "Internal error",
             content = @Content(mediaType = MediaType.PROBLEM_JSON, schema = @Schema(implementation = Problem.class)))
     @Produces(MediaType.APPLICATION_JSON)

--- a/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/api/configuration/ClusterConfigurationApi.java
+++ b/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/api/configuration/ClusterConfigurationApi.java
@@ -54,6 +54,8 @@ public interface ClusterConfigurationApi {
             content = @Content(mediaType = MediaType.PROBLEM_JSON, schema = @Schema(implementation = Problem.class)))
     @ApiResponse(responseCode = "400", description = "Incorrect configuration",
             content = @Content(mediaType = MediaType.PROBLEM_JSON, schema = @Schema(implementation = Problem.class)))
+    @ApiResponse(responseCode = "404", description = "Configuration not found, it means that the cluster is not initialized",
+            content = @Content(mediaType = MediaType.PROBLEM_JSON, schema = @Schema(implementation = Problem.class)))
     @Produces({
             MediaType.TEXT_PLAIN,
             MediaType.PROBLEM_JSON
@@ -71,6 +73,8 @@ public interface ClusterConfigurationApi {
     @ApiResponse(responseCode = "500", description = "Internal error",
             content = @Content(mediaType = MediaType.PROBLEM_JSON, schema = @Schema(implementation = Problem.class)))
     @ApiResponse(responseCode = "400", description = "Incorrect configuration",
+            content = @Content(mediaType = MediaType.PROBLEM_JSON, schema = @Schema(implementation = Problem.class)))
+    @ApiResponse(responseCode = "404", description = "Configuration not found, it means that the cluster is not initialized",
             content = @Content(mediaType = MediaType.PROBLEM_JSON, schema = @Schema(implementation = Problem.class)))
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.PROBLEM_JSON)
@@ -90,6 +94,8 @@ public interface ClusterConfigurationApi {
     @ApiResponse(responseCode = "500", description = "Internal error",
             content = @Content(mediaType = MediaType.PROBLEM_JSON, schema = @Schema(implementation = Problem.class)))
     @ApiResponse(responseCode = "400", description = "Incorrect configuration",
+            content = @Content(mediaType = MediaType.PROBLEM_JSON, schema = @Schema(implementation = Problem.class)))
+    @ApiResponse(responseCode = "404", description = "Configuration not found, it means that the cluster is not initialized",
             content = @Content(mediaType = MediaType.PROBLEM_JSON, schema = @Schema(implementation = Problem.class)))
     @Produces({
             MediaType.TEXT_PLAIN,

--- a/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/exception/ClusterNotInitializedException.java
+++ b/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/exception/ClusterNotInitializedException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.rest.exception;
+
+/**
+ * Exception that is thrown when the cluster is not initialized.
+ */
+public class ClusterNotInitializedException extends RuntimeException {
+    public ClusterNotInitializedException() {
+        super();
+    }
+}

--- a/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/exception/handler/ClusterNotInitializedExceptionHandler.java
+++ b/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/exception/handler/ClusterNotInitializedExceptionHandler.java
@@ -15,16 +15,16 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.internal.cluster.management.rest.exception.handler;
+package org.apache.ignite.internal.rest.exception.handler;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.server.exceptions.ExceptionHandler;
 import jakarta.inject.Singleton;
-import org.apache.ignite.internal.cluster.management.rest.exception.ClusterNotInitializedException;
 import org.apache.ignite.internal.rest.api.Problem;
 import org.apache.ignite.internal.rest.constants.HttpCode;
+import org.apache.ignite.internal.rest.exception.ClusterNotInitializedException;
 import org.apache.ignite.internal.rest.problem.HttpProblemResponse;
 
 /**

--- a/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/exception/handler/JavaExceptionHandler.java
+++ b/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/exception/handler/JavaExceptionHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.rest.exception.handler;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.server.exceptions.ExceptionHandler;
+import jakarta.inject.Singleton;
+import org.apache.ignite.internal.logger.IgniteLogger;
+import org.apache.ignite.internal.logger.Loggers;
+import org.apache.ignite.internal.rest.api.Problem;
+import org.apache.ignite.internal.rest.constants.HttpCode;
+import org.apache.ignite.internal.rest.problem.HttpProblemResponse;
+
+/**
+ * Handles {@link Exception} and represents it as an application/problem+json response. This will catch all unhandled exceptions since all
+ * REST endpoints are marked as producing problem json.
+ */
+@Singleton
+@Requires(classes = {Exception.class, ExceptionHandler.class})
+public class JavaExceptionHandler implements ExceptionHandler<Exception, HttpResponse<? extends Problem>> {
+    private static final IgniteLogger LOG = Loggers.forClass(JavaExceptionHandler.class);
+
+    @Override
+    public HttpResponse<? extends Problem> handle(HttpRequest request, Exception exception) {
+        LOG.error("Unhandled exception", exception);
+        return HttpProblemResponse.from(
+                Problem.fromHttpCode(HttpCode.INTERNAL_ERROR)
+                        .detail(exception.getMessage())
+        );
+    }
+}

--- a/modules/rest/openapi/openapi.yaml
+++ b/modules/rest/openapi/openapi.yaml
@@ -55,6 +55,10 @@ paths:
         "404":
           description: "Cluster state not found, it means that the cluster is not\
             \ initialized"
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         "500":
           description: Internal error
           content:
@@ -76,6 +80,13 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ClusterNode'
+        "404":
+          description: "Logical topology not found, it means that the cluster is not\
+            \ initialized"
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         "500":
           description: Internal error
           content:
@@ -128,6 +139,13 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        "404":
+          description: "Configuration not found, it means that the cluster is not\
+            \ initialized"
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
     patch:
       tags:
       - clusterConfiguration
@@ -158,6 +176,13 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        "404":
+          description: "Configuration not found, it means that the cluster is not\
+            \ initialized"
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
   /management/v1/configuration/cluster/{path}:
     get:
       tags:
@@ -184,6 +209,13 @@ paths:
                 $ref: '#/components/schemas/Problem'
         "400":
           description: Incorrect configuration
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        "404":
+          description: "Configuration not found, it means that the cluster is not\
+            \ initialized"
           content:
             application/problem+json:
               schema:

--- a/modules/rest/openapi/openapi.yaml
+++ b/modules/rest/openapi/openapi.yaml
@@ -442,13 +442,8 @@ components:
     Problem:
       required:
       - code
-      - detail
-      - invalidParams
-      - node
       - status
       - title
-      - traceId
-      - type
       type: object
       properties:
         title:


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-17510

This improves exceptions handling in REST controllers. In cluster configuration endpoints we produce special exception telling the user that the cluster is not initialized. In all other cases we produce generic problem json.