### PR TITLE
IGNITE-17739 Add Partition Awareness to all table APIs in Java client 

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueBinaryView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueBinaryView.java
@@ -333,7 +333,9 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
         return tbl.doSchemaOutInOpAsync(
                 ClientOp.TUPLE_GET_AND_DELETE,
                 (s, w) -> ser.writeTuple(tx, key, s, w, true),
-                ClientTupleSerializer::readValueTuple);
+                ClientTupleSerializer::readValueTuple,
+                null,
+                ClientTupleSerializer.getHashFunction(tx, key));
     }
 
     /**
@@ -376,7 +378,8 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
         return tbl.doSchemaOutOpAsync(
                 ClientOp.TUPLE_REPLACE,
                 (s, w) -> ser.writeKvTuple(tx, key, val, s, w, false),
-                ClientMessageUnpacker::unpackBoolean);
+                ClientMessageUnpacker::unpackBoolean,
+                ClientTupleSerializer.getHashFunction(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -390,7 +393,8 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                     ser.writeKvTuple(tx, key, oldVal, s, w, false);
                     ser.writeKvTuple(tx, key, newVal, s, w, true);
                 },
-                ClientMessageUnpacker::unpackBoolean);
+                ClientMessageUnpacker::unpackBoolean,
+                ClientTupleSerializer.getHashFunction(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -408,7 +412,9 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
         return tbl.doSchemaOutInOpAsync(
                 ClientOp.TUPLE_GET_AND_REPLACE,
                 (s, w) -> ser.writeKvTuple(tx, key, val, s, w, false),
-                ClientTupleSerializer::readValueTuple);
+                ClientTupleSerializer::readValueTuple,
+                null,
+                ClientTupleSerializer.getHashFunction(tx, key));
     }
 
     /**

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueBinaryView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueBinaryView.java
@@ -75,7 +75,9 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
         return tbl.doSchemaOutInOpAsync(
                 ClientOp.TUPLE_GET,
                 (s, w) -> ser.writeTuple(tx, key, s, w, true),
-                ClientTupleSerializer::readValueTuple);
+                ClientTupleSerializer::readValueTuple,
+                null,
+                ClientTupleSerializer.getHashFunction(tx, key));
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueBinaryView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueBinaryView.java
@@ -91,11 +91,16 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
     public @NotNull CompletableFuture<Map<Tuple, Tuple>> getAllAsync(@Nullable Transaction tx, @NotNull Collection<Tuple> keys) {
         Objects.requireNonNull(keys);
 
+        if (keys.isEmpty()) {
+            return CompletableFuture.completedFuture(Collections.emptyMap());
+        }
+
         return tbl.doSchemaOutInOpAsync(
                 ClientOp.TUPLE_GET_ALL,
                 (s, w) -> ser.writeTuples(tx, keys, s, w, true),
                 ClientTupleSerializer::readKvTuplesNullable,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                ClientTupleSerializer.getHashFunction(tx, keys.iterator().next()));
     }
 
     /**
@@ -132,7 +137,9 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
         return tbl.doSchemaOutInOpAsync(
                 ClientOp.TUPLE_GET,
                 (s, w) -> ser.writeTuple(tx, key, s, w, true),
-                (s, r) -> IgniteUtils.nonNullOrElse(ClientTupleSerializer.readValueTuple(s, r), defaultValue));
+                (s, r) -> IgniteUtils.nonNullOrElse(ClientTupleSerializer.readValueTuple(s, r), defaultValue),
+                null,
+                ClientTupleSerializer.getHashFunction(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -149,7 +156,8 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
         return tbl.doSchemaOutOpAsync(
                 ClientOp.TUPLE_CONTAINS_KEY,
                 (s, w) -> ser.writeTuple(tx, key, s, w, true),
-                ClientMessageUnpacker::unpackBoolean);
+                ClientMessageUnpacker::unpackBoolean,
+                ClientTupleSerializer.getHashFunction(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -166,7 +174,8 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
         return tbl.doSchemaOutOpAsync(
                 ClientOp.TUPLE_UPSERT,
                 (s, w) -> ser.writeKvTuple(tx, key, val, s, w, false),
-                r -> null);
+                r -> null,
+                ClientTupleSerializer.getHashFunction(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -180,15 +189,20 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
     public @NotNull CompletableFuture<Void> putAllAsync(@Nullable Transaction tx, @NotNull Map<Tuple, Tuple> pairs) {
         Objects.requireNonNull(pairs);
 
+        if (pairs.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+
         return tbl.doSchemaOutOpAsync(
                 ClientOp.TUPLE_UPSERT_ALL,
                 (s, w) -> ser.writeKvTuples(tx, pairs, s, w),
-                r -> null);
+                r -> null,
+                ClientTupleSerializer.getHashFunction(tx, pairs.keySet().iterator().next()));
     }
 
     /** {@inheritDoc} */
     @Override
-    public Tuple getAndPut(@Nullable Transaction tx, @NotNull Tuple key, Tuple val) {
+    public Tuple getAndPut(@Nullable Transaction tx, @NotNull Tuple key, @NotNull Tuple val) {
         return sync(getAndPutAsync(tx, key, val));
     }
 
@@ -201,7 +215,9 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
         return tbl.doSchemaOutInOpAsync(
                 ClientOp.TUPLE_GET_AND_UPSERT,
                 (s, w) -> ser.writeKvTuple(tx, key, val, s, w, false),
-                ClientTupleSerializer::readValueTuple);
+                ClientTupleSerializer::readValueTuple,
+                null,
+                ClientTupleSerializer.getHashFunction(tx, key));
     }
 
     /**
@@ -239,7 +255,8 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
         return tbl.doSchemaOutOpAsync(
                 ClientOp.TUPLE_INSERT,
                 (s, w) -> ser.writeKvTuple(tx, key, val, s, w, false),
-                ClientMessageUnpacker::unpackBoolean);
+                ClientMessageUnpacker::unpackBoolean,
+                ClientTupleSerializer.getHashFunction(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -262,7 +279,8 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
         return tbl.doSchemaOutOpAsync(
                 ClientOp.TUPLE_DELETE,
                 (s, w) -> ser.writeTuple(tx, key, s, w, true),
-                ClientMessageUnpacker::unpackBoolean);
+                ClientMessageUnpacker::unpackBoolean,
+                ClientTupleSerializer.getHashFunction(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -274,7 +292,8 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
         return tbl.doSchemaOutOpAsync(
                 ClientOp.TUPLE_DELETE_EXACT,
                 (s, w) -> ser.writeKvTuple(tx, key, val, s, w, false),
-                ClientMessageUnpacker::unpackBoolean);
+                ClientMessageUnpacker::unpackBoolean,
+                ClientTupleSerializer.getHashFunction(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -288,11 +307,16 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
     public @NotNull CompletableFuture<Collection<Tuple>> removeAllAsync(@Nullable Transaction tx, @NotNull Collection<Tuple> keys) {
         Objects.requireNonNull(keys);
 
+        if (keys.isEmpty()) {
+            return CompletableFuture.completedFuture(Collections.emptyList());
+        }
+
         return tbl.doSchemaOutInOpAsync(
                 ClientOp.TUPLE_DELETE_ALL,
                 (s, w) -> ser.writeTuples(tx, keys, s, w, true),
                 (s, r) -> ClientTupleSerializer.readTuples(s, r, true),
-                Collections.emptyList());
+                Collections.emptyList(),
+                ClientTupleSerializer.getHashFunction(tx, keys.iterator().next()));
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueView.java
@@ -143,7 +143,8 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                 ClientOp.TUPLE_GET_ALL,
                 (s, w) -> keySer.writeRecs(tx, keys, s, w, TuplePart.KEY),
                 this::readGetAllResponse,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), keys.iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -160,7 +161,8 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
         return tbl.doSchemaOutOpAsync(
                 ClientOp.TUPLE_CONTAINS_KEY,
                 (s, w) -> keySer.writeRec(tx, key, s, w, TuplePart.KEY),
-                ClientMessageUnpacker::unpackBoolean);
+                ClientMessageUnpacker::unpackBoolean,
+                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -177,7 +179,8 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
         return tbl.doSchemaOutOpAsync(
                 ClientOp.TUPLE_UPSERT,
                 (s, w) -> writeKeyValue(s, w, tx, key, val),
-                r -> null);
+                r -> null,
+                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -205,7 +208,8 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                         writeKeyValueRaw(s, w, e.getKey(), e.getValue());
                     }
                 },
-                r -> null);
+                r -> null,
+                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), pairs.keySet().iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -223,7 +227,9 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
         return tbl.doSchemaOutInOpAsync(
                 ClientOp.TUPLE_GET_AND_UPSERT,
                 (s, w) -> writeKeyValue(s, w, tx, key, val),
-                (s, r) -> valSer.readRec(s, r, TuplePart.VAL));
+                (s, r) -> valSer.readRec(s, r, TuplePart.VAL),
+                null,
+                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -252,7 +258,8 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
         return tbl.doSchemaOutOpAsync(
                 ClientOp.TUPLE_INSERT,
                 (s, w) -> writeKeyValue(s, w, tx, key, val),
-                ClientMessageUnpacker::unpackBoolean);
+                ClientMessageUnpacker::unpackBoolean,
+                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -275,7 +282,8 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
         return tbl.doSchemaOutOpAsync(
                 ClientOp.TUPLE_DELETE,
                 (s, w) -> keySer.writeRec(tx, key, s, w, TuplePart.KEY),
-                ClientMessageUnpacker::unpackBoolean);
+                ClientMessageUnpacker::unpackBoolean,
+                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -286,7 +294,8 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
         return tbl.doSchemaOutOpAsync(
                 ClientOp.TUPLE_DELETE_EXACT,
                 (s, w) -> writeKeyValue(s, w, tx, key, val),
-                ClientMessageUnpacker::unpackBoolean);
+                ClientMessageUnpacker::unpackBoolean,
+                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -308,7 +317,8 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                 ClientOp.TUPLE_DELETE_ALL,
                 (s, w) -> keySer.writeRecs(tx, keys, s, w, TuplePart.KEY),
                 (s, r) -> keySer.readRecs(s, r, false, TuplePart.KEY),
-                Collections.emptyList());
+                Collections.emptyList(),
+                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), keys.iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -325,7 +335,9 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
         return tbl.doSchemaOutInOpAsync(
                 ClientOp.TUPLE_GET_AND_DELETE,
                 (s, w) -> keySer.writeRec(tx, key, s, w, TuplePart.KEY),
-                (s, r) -> valSer.readRec(s, r, TuplePart.VAL));
+                (s, r) -> valSer.readRec(s, r, TuplePart.VAL),
+                null,
+                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -362,7 +374,8 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
         return tbl.doSchemaOutOpAsync(
                 ClientOp.TUPLE_REPLACE,
                 (s, w) -> writeKeyValue(s, w, tx, key, val),
-                ClientMessageUnpacker::unpackBoolean);
+                ClientMessageUnpacker::unpackBoolean,
+                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -377,7 +390,8 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                     writeKeyValueRaw(s, w, key, oldVal);
                     writeKeyValueRaw(s, w, key, newVal);
                 },
-                ClientMessageUnpacker::unpackBoolean);
+                ClientMessageUnpacker::unpackBoolean,
+                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -395,7 +409,9 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
         return tbl.doSchemaOutInOpAsync(
                 ClientOp.TUPLE_GET_AND_REPLACE,
                 (s, w) -> writeKeyValue(s, w, tx, key, val),
-                (s, r) -> valSer.readRec(s, r, TuplePart.VAL));
+                (s, r) -> valSer.readRec(s, r, TuplePart.VAL),
+                null,
+                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueView.java
@@ -510,7 +510,7 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
     private Integer getColocationHash(ClientSchema schema, K rec) {
         // Colocation columns are always part of the key - https://cwiki.apache.org/confluence/display/IGNITE/IEP-86%3A+Colocation+Key.
         var hashCalc = new HashCalculator();
-        var marsh = schema.getMarshaller(keySer.mapper(), TuplePart.KEY_AND_VAL);
+        var marsh = schema.getMarshaller(keySer.mapper(), TuplePart.KEY);
 
         for (ClientColumn col : schema.colocationColumns()) {
             Object value = marsh.value(rec, col.schemaIndex());

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordBinaryView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordBinaryView.java
@@ -86,8 +86,9 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
     public @NotNull CompletableFuture<Collection<Tuple>> getAllAsync(@Nullable Transaction tx, @NotNull Collection<Tuple> keyRecs) {
         Objects.requireNonNull(keyRecs);
 
-        if (keyRecs.isEmpty())
+        if (keyRecs.isEmpty()) {
             return CompletableFuture.completedFuture(Collections.emptyList());
+        }
 
         return tbl.doSchemaOutInOpAsync(
                 ClientOp.TUPLE_GET_ALL,

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordBinaryView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordBinaryView.java
@@ -158,7 +158,8 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
         return tbl.doSchemaOutOpAsync(
                 ClientOp.TUPLE_INSERT,
                 (s, w) -> ser.writeTuple(tx, rec, s, w, false),
-                ClientMessageUnpacker::unpackBoolean);
+                ClientMessageUnpacker::unpackBoolean,
+                ClientTupleSerializer.getHashFunction(tx, rec));
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordBinaryView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordBinaryView.java
@@ -173,11 +173,16 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
     public @NotNull CompletableFuture<Collection<Tuple>> insertAllAsync(@Nullable Transaction tx, @NotNull Collection<Tuple> recs) {
         Objects.requireNonNull(recs);
 
+        if (recs.isEmpty()) {
+            return CompletableFuture.completedFuture(Collections.emptyList());
+        }
+
         return tbl.doSchemaOutInOpAsync(
                 ClientOp.TUPLE_INSERT_ALL,
                 (s, w) -> ser.writeTuples(tx, recs, s, w, false),
                 ClientTupleSerializer::readTuples,
-                Collections.emptyList());
+                Collections.emptyList(),
+                ClientTupleSerializer.getHashFunction(tx, recs.iterator().next()));
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordView.java
@@ -361,7 +361,7 @@ public class ClientRecordView<R> implements RecordView<R> {
     private Integer getColocationHash(ClientSchema schema, R rec) {
         // Colocation columns are always part of the key - https://cwiki.apache.org/confluence/display/IGNITE/IEP-86%3A+Colocation+Key.
         var hashCalc = new HashCalculator();
-        var marsh = schema.getMarshaller(ser.mapper(), TuplePart.KEY_AND_VAL);
+        var marsh = schema.getMarshaller(ser.mapper(), TuplePart.KEY);
 
         for (ClientColumn col : schema.colocationColumns()) {
             Object value = marsh.value(rec, col.schemaIndex());

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordView.java
@@ -359,7 +359,7 @@ public class ClientRecordView<R> implements RecordView<R> {
     }
 
     private Integer getColocationHash(ClientSchema schema, R rec) {
-        // TODO: Are colocation columns required to be a part of the key?
+        // Colocation columns are always part of the key - https://cwiki.apache.org/confluence/display/IGNITE/IEP-86%3A+Colocation+Key.
         var hashCalc = new HashCalculator();
         var marsh = schema.getMarshaller(ser.mapper(), TuplePart.KEY_AND_VAL);
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordView.java
@@ -359,6 +359,7 @@ public class ClientRecordView<R> implements RecordView<R> {
     }
 
     private Integer getColocationHash(ClientSchema schema, R rec) {
+        // TODO: Are colocation columns required to be a part of the key?
         var hashCalc = new HashCalculator();
         var marsh = schema.getMarshaller(ser.mapper(), TuplePart.KEY_AND_VAL);
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordView.java
@@ -25,11 +25,15 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
 import org.apache.ignite.internal.client.proto.ClientMessageUnpacker;
 import org.apache.ignite.internal.client.proto.ClientOp;
 import org.apache.ignite.internal.client.proto.TuplePart;
+import org.apache.ignite.internal.util.HashCalculator;
 import org.apache.ignite.table.InvokeProcessor;
 import org.apache.ignite.table.RecordView;
+import org.apache.ignite.table.Tuple;
 import org.apache.ignite.table.mapper.Mapper;
 import org.apache.ignite.tx.Transaction;
 import org.jetbrains.annotations.NotNull;
@@ -70,7 +74,9 @@ public class ClientRecordView<R> implements RecordView<R> {
         return tbl.doSchemaOutInOpAsync(
                 ClientOp.TUPLE_GET,
                 (s, w) -> ser.writeRec(tx, keyRec, s, w, TuplePart.KEY),
-                (s, r) -> ser.readValRec(keyRec, s, r));
+                (s, r) -> ser.readValRec(keyRec, s, r),
+                null,
+                getHashFunction(tx, keyRec));
     }
 
     /** {@inheritDoc} */
@@ -350,5 +356,23 @@ public class ClientRecordView<R> implements RecordView<R> {
             InvokeProcessor<R, R, T> proc
     ) {
         throw new UnsupportedOperationException();
+    }
+
+    private Integer getColocationHash(ClientSchema schema, R rec) {
+        var hashCalc = new HashCalculator();
+        var marsh = schema.getMarshaller(ser.mapper(), TuplePart.KEY_AND_VAL);
+
+        for (ClientColumn col : schema.colocationColumns()) {
+            Object value = marsh.value(rec, col.schemaIndex());
+            hashCalc.append(value);
+        }
+
+        return hashCalc.hash();
+    }
+
+    @Nullable
+    private Function<ClientSchema, Integer> getHashFunction(@Nullable Transaction tx, @NotNull R rec) {
+        // Disable partition awareness when transaction is used: tx belongs to a default connection.
+        return tx != null ? null : schema -> getColocationHash(schema, rec);
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -283,18 +283,8 @@ public class ClientTable implements Table {
 
         return CompletableFuture.allOf(schemaFut, partitionsFut)
                 .thenCompose(v -> {
-                    List<String> partitions = partitionsFut.getNow(null);
                     ClientSchema schema = schemaFut.getNow(null);
-
-                    String preferredNodeId = null;
-
-                    if (partitions != null && partitions.size() > 0 && hashFunction != null) {
-                        Integer hash = hashFunction.apply(schema);
-
-                        if (hash != null) {
-                            preferredNodeId = partitions.get(Math.abs(hash % partitions.size()));
-                        }
-                    }
+                    String preferredNodeId = getPreferredNodeId(hashFunction, partitionsFut.getNow(null), schema);
 
                     return ch.serviceAsync(opCode,
                             w -> writer.accept(schema, w),
@@ -324,17 +314,29 @@ public class ClientTable implements Table {
                                 w -> writer.accept(schema, w),
                                 r -> reader.apply(r.in())));
     }
+
     <T> CompletableFuture<T> doSchemaOutOpAsync(
             int opCode,
             BiConsumer<ClientSchema, PayloadOutputChannel> writer,
             Function<ClientMessageUnpacker, T> reader,
             Function<ClientSchema, Integer> hashFunction) {
-        // TODO IGNITE-17739 PA
-        return getLatestSchema()
-                .thenCompose(schema ->
-                        ch.serviceAsync(opCode,
-                                w -> writer.accept(schema, w),
-                                r -> reader.apply(r.in())));
+
+        CompletableFuture<ClientSchema> schemaFut = getLatestSchema();
+        CompletableFuture<List<String>> partitionsFut = hashFunction == null
+                ? CompletableFuture.completedFuture(null)
+                : getPartitionAssignment();
+
+        return CompletableFuture.allOf(schemaFut, partitionsFut)
+                .thenCompose(v -> {
+                    ClientSchema schema = schemaFut.getNow(null);
+                    String preferredNodeId = getPreferredNodeId(hashFunction, partitionsFut.getNow(null), schema);
+
+                    return ch.serviceAsync(opCode,
+                            w -> writer.accept(schema, w),
+                            r -> reader.apply(r.in()),
+                            null,
+                            preferredNodeId);
+                });
     }
 
     private <T> Object readSchemaAndReadData(
@@ -414,5 +416,20 @@ public class ClientTable implements Table {
 
                     return res;
                 });
+    }
+
+    @Nullable
+    private static String getPreferredNodeId(Function<ClientSchema, Integer> hashFunction, List<String> partitions, ClientSchema schema) {
+        if (partitions == null || partitions.isEmpty() || hashFunction == null) {
+            return null;
+        }
+
+        Integer hash = hashFunction.apply(schema);
+
+        if (hash == null) {
+            return null;
+        }
+
+        return partitions.get(Math.abs(hash % partitions.size()));
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -324,6 +324,18 @@ public class ClientTable implements Table {
                                 w -> writer.accept(schema, w),
                                 r -> reader.apply(r.in())));
     }
+    <T> CompletableFuture<T> doSchemaOutOpAsync(
+            int opCode,
+            BiConsumer<ClientSchema, PayloadOutputChannel> writer,
+            Function<ClientMessageUnpacker, T> reader,
+            Function<ClientSchema, Integer> hashFunction) {
+        // TODO IGNITE-17739 PA
+        return getLatestSchema()
+                .thenCompose(schema ->
+                        ch.serviceAsync(opCode,
+                                w -> writer.accept(schema, w),
+                                r -> reader.apply(r.in())));
+    }
 
     private <T> Object readSchemaAndReadData(
             ClientSchema knownSchema,

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
@@ -34,7 +34,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
-
 import org.apache.ignite.internal.binarytuple.BinaryTupleBuilder;
 import org.apache.ignite.internal.binarytuple.BinaryTupleReader;
 import org.apache.ignite.internal.client.PayloadOutputChannel;

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
@@ -33,15 +33,20 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+
 import org.apache.ignite.internal.binarytuple.BinaryTupleBuilder;
 import org.apache.ignite.internal.binarytuple.BinaryTupleReader;
 import org.apache.ignite.internal.client.PayloadOutputChannel;
 import org.apache.ignite.internal.client.proto.ClientBinaryTupleUtils;
 import org.apache.ignite.internal.client.proto.ClientDataType;
 import org.apache.ignite.internal.client.proto.ClientMessageUnpacker;
+import org.apache.ignite.internal.client.proto.TuplePart;
+import org.apache.ignite.internal.util.HashCalculator;
 import org.apache.ignite.lang.IgniteBiTuple;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.table.Tuple;
+import org.apache.ignite.table.mapper.Mapper;
 import org.apache.ignite.tx.Transaction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -438,5 +443,41 @@ public class ClientTupleSerializer {
         } catch (ClassCastException e) {
             throw new IgniteException(PROTOCOL_ERR, "Incorrect value type for column '" + col.name() + "': " + e.getMessage(), e);
         }
+    }
+
+    @Nullable
+    static Function<ClientSchema, Integer> getHashFunction(@Nullable Transaction tx, @NotNull Tuple rec) {
+        // Disable partition awareness when transaction is used: tx belongs to a default connection.
+        return tx != null ? null : schema -> getColocationHash(schema, rec);
+    }
+
+    @Nullable
+    static Function<ClientSchema, Integer> getHashFunction(@Nullable Transaction tx, Mapper<?> mapper, @NotNull Object rec) {
+        // Disable partition awareness when transaction is used: tx belongs to a default connection.
+        return tx != null ? null : schema -> getColocationHash(schema, mapper, rec);
+    }
+
+    private static Integer getColocationHash(ClientSchema schema, Tuple rec) {
+        var hashCalc = new HashCalculator();
+
+        for (ClientColumn col : schema.colocationColumns()) {
+            Object value = rec.valueOrDefault(col.name(), null);
+            hashCalc.append(value);
+        }
+
+        return hashCalc.hash();
+    }
+
+    private static Integer getColocationHash(ClientSchema schema, Mapper<?> mapper, Object rec) {
+        // Colocation columns are always part of the key - https://cwiki.apache.org/confluence/display/IGNITE/IEP-86%3A+Colocation+Key.
+        var hashCalc = new HashCalculator();
+        var marsh = schema.getMarshaller(mapper, TuplePart.KEY);
+
+        for (ClientColumn col : schema.colocationColumns()) {
+            Object value = marsh.value(rec, col.schemaIndex());
+            hashCalc.append(value);
+        }
+
+        return hashCalc.hash();
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -105,10 +105,6 @@ public class PartitionAwarenessTest extends AbstractClientTest {
 
     @Test
     public void testGetRecordRoutesRequestToPrimaryNode() {
-        // TODO: Refactor everything to be based on BinaryTuple? That way affinity calc is the same.
-        // But perf might suffer - we'll have to deserialize column values back to compute affinity.
-        // On the other hand, it might be faster to deserialize than to retrieve by name from tuple or object.
-        // The fastest way would be to combine serialization and affinity calculation - by wrapping BinaryTupleBuilder in another class (or derived)
         RecordView<AbstractClientTableTest.PersonPojo> recordView = defaultTable().recordView(Mapper.of(AbstractClientTableTest.PersonPojo.class));
 
         assertOpOnNode("server-1", "get", x -> recordView.get(null, new AbstractClientTableTest.PersonPojo(0L)));

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -208,6 +208,10 @@ public class PartitionAwarenessTest extends AbstractClientTest {
     @Test
     public void testAllRecordBinaryViewOperations() {
         // TODO IGNITE-17739 Add Partition Awareness to all table APIs
+        RecordView<Tuple> recordView = defaultTable().recordView();
+
+        assertOpOnNode("server-1", "upsert", x -> recordView.upsert(null, Tuple.create().set("ID", 0L)));
+        assertOpOnNode("server-2", "upsert", x -> recordView.upsert(null, Tuple.create().set("ID", 1L)));
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -284,6 +284,9 @@ public class PartitionAwarenessTest extends AbstractClientTest {
         assertOpOnNode("server-1", "get", x -> kvView.get(null, t1));
         assertOpOnNode("server-2", "get", x -> kvView.get(null, t2));
 
+        assertOpOnNode("server-1", "contains", x -> kvView.contains(null, t1));
+        assertOpOnNode("server-2", "contains", x -> kvView.contains(null, t2));
+
         assertOpOnNode("server-1", "getAll", x -> kvView.getAll(null, List.of(t1)));
         assertOpOnNode("server-2", "getAll", x -> kvView.getAll(null, List.of(t2)));
 

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -208,7 +208,6 @@ public class PartitionAwarenessTest extends AbstractClientTest {
 
     @Test
     public void testAllRecordBinaryViewOperations() {
-        // TODO IGNITE-17739 Add Partition Awareness to all table APIs
         RecordView<Tuple> recordView = defaultTable().recordView();
 
         Tuple t1 = Tuple.create().set("ID", 0L);
@@ -223,11 +222,41 @@ public class PartitionAwarenessTest extends AbstractClientTest {
         assertOpOnNode("server-1", "upsert", x -> recordView.upsert(null, t1));
         assertOpOnNode("server-2", "upsert", x -> recordView.upsert(null, t2));
 
+        assertOpOnNode("server-1", "upsertAll", x -> recordView.upsertAll(null, List.of(t1)));
+        assertOpOnNode("server-2", "upsertAll", x -> recordView.upsertAll(null, List.of(t2)));
+
+        assertOpOnNode("server-1", "insert", x -> recordView.get(null, t1));
+        assertOpOnNode("server-2", "insert", x -> recordView.get(null, t2));
+
+        assertOpOnNode("server-1", "getAll", x -> recordView.getAll(null, List.of(t1)));
+        assertOpOnNode("server-2", "getAll", x -> recordView.getAll(null, List.of(t2)));
+
         assertOpOnNode("server-1", "getAndUpsert", x -> recordView.getAndUpsert(null, t1));
         assertOpOnNode("server-2", "getAndUpsert", x -> recordView.getAndUpsert(null, t2));
 
-        assertOpOnNode("server-1", "upsertAll", x -> recordView.upsertAll(null, List.of(t1)));
-        assertOpOnNode("server-2", "upsertAll", x -> recordView.upsertAll(null, List.of(t2)));
+        assertOpOnNode("server-1", "getAndReplace", x -> recordView.getAndReplace(null, t1));
+        assertOpOnNode("server-2", "getAndReplace", x -> recordView.getAndReplace(null, t2));
+
+        assertOpOnNode("server-1", "getAndDelete", x -> recordView.getAndDelete(null, t1));
+        assertOpOnNode("server-2", "getAndDelete", x -> recordView.getAndDelete(null, t2));
+
+        assertOpOnNode("server-1", "replace", x -> recordView.replace(null, t1));
+        assertOpOnNode("server-2", "replace", x -> recordView.replace(null, t2));
+
+        assertOpOnNode("server-1", "replace", x -> recordView.replace(null, t1, t1));
+        assertOpOnNode("server-2", "replace", x -> recordView.replace(null, t2, t2));
+
+        assertOpOnNode("server-1", "delete", x -> recordView.delete(null, t1));
+        assertOpOnNode("server-2", "delete", x -> recordView.delete(null, t2));
+
+        assertOpOnNode("server-1", "deleteExact", x -> recordView.deleteExact(null, t1));
+        assertOpOnNode("server-2", "deleteExact", x -> recordView.deleteExact(null, t2));
+
+        assertOpOnNode("server-1", "deleteAll", x -> recordView.deleteAll(null, List.of(t1)));
+        assertOpOnNode("server-2", "deleteAll", x -> recordView.deleteAll(null, List.of(t2)));
+
+        assertOpOnNode("server-1", "deleteAllExact", x -> recordView.deleteAllExact(null, List.of(t1)));
+        assertOpOnNode("server-2", "deleteAllExact", x -> recordView.deleteAllExact(null, List.of(t2)));
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -205,6 +205,55 @@ public class PartitionAwarenessTest extends AbstractClientTest {
     @Test
     public void testAllRecordViewOperations() {
         // TODO IGNITE-17739 Add Partition Awareness to all table APIs
+        RecordView<AbstractClientTableTest.PersonPojo> pojoView = defaultTable().recordView(Mapper.of(AbstractClientTableTest.PersonPojo.class));
+
+        var t1 = new AbstractClientTableTest.PersonPojo(0L);
+        var t2 = new AbstractClientTableTest.PersonPojo(1L);
+
+        assertOpOnNode("server-1", "insert", x -> pojoView.insert(null, t1));
+        assertOpOnNode("server-2", "insert", x -> pojoView.insert(null, t2));
+
+        assertOpOnNode("server-1", "insertAll", x -> pojoView.insertAll(null, List.of(t1)));
+        assertOpOnNode("server-2", "insertAll", x -> pojoView.insertAll(null, List.of(t2)));
+
+        assertOpOnNode("server-1", "upsert", x -> pojoView.upsert(null, t1));
+        assertOpOnNode("server-2", "upsert", x -> pojoView.upsert(null, t2));
+
+        assertOpOnNode("server-1", "upsertAll", x -> pojoView.upsertAll(null, List.of(t1)));
+        assertOpOnNode("server-2", "upsertAll", x -> pojoView.upsertAll(null, List.of(t2)));
+
+        assertOpOnNode("server-1", "get", x -> pojoView.get(null, t1));
+        assertOpOnNode("server-2", "get", x -> pojoView.get(null, t2));
+
+        assertOpOnNode("server-1", "getAll", x -> pojoView.getAll(null, List.of(t1)));
+        assertOpOnNode("server-2", "getAll", x -> pojoView.getAll(null, List.of(t2)));
+
+        assertOpOnNode("server-1", "getAndUpsert", x -> pojoView.getAndUpsert(null, t1));
+        assertOpOnNode("server-2", "getAndUpsert", x -> pojoView.getAndUpsert(null, t2));
+
+        assertOpOnNode("server-1", "getAndReplace", x -> pojoView.getAndReplace(null, t1));
+        assertOpOnNode("server-2", "getAndReplace", x -> pojoView.getAndReplace(null, t2));
+
+        assertOpOnNode("server-1", "getAndDelete", x -> pojoView.getAndDelete(null, t1));
+        assertOpOnNode("server-2", "getAndDelete", x -> pojoView.getAndDelete(null, t2));
+
+        assertOpOnNode("server-1", "replace", x -> pojoView.replace(null, t1));
+        assertOpOnNode("server-2", "replace", x -> pojoView.replace(null, t2));
+
+        assertOpOnNode("server-1", "replace", x -> pojoView.replace(null, t1, t1));
+        assertOpOnNode("server-2", "replace", x -> pojoView.replace(null, t2, t2));
+
+        assertOpOnNode("server-1", "delete", x -> pojoView.delete(null, t1));
+        assertOpOnNode("server-2", "delete", x -> pojoView.delete(null, t2));
+
+        assertOpOnNode("server-1", "deleteExact", x -> pojoView.deleteExact(null, t1));
+        assertOpOnNode("server-2", "deleteExact", x -> pojoView.deleteExact(null, t2));
+
+        assertOpOnNode("server-1", "deleteAll", x -> pojoView.deleteAll(null, List.of(t1)));
+        assertOpOnNode("server-2", "deleteAll", x -> pojoView.deleteAll(null, List.of(t2)));
+
+        assertOpOnNode("server-1", "deleteAllExact", x -> pojoView.deleteAllExact(null, List.of(t1)));
+        assertOpOnNode("server-2", "deleteAllExact", x -> pojoView.deleteAllExact(null, List.of(t2)));
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -28,6 +28,7 @@ import org.apache.ignite.client.fakes.FakeIgnite;
 import org.apache.ignite.client.fakes.FakeIgniteTables;
 import org.apache.ignite.client.fakes.FakeInternalTable;
 import org.apache.ignite.internal.table.TableImpl;
+import org.apache.ignite.table.KeyValueView;
 import org.apache.ignite.table.RecordView;
 import org.apache.ignite.table.Table;
 import org.apache.ignite.table.Tuple;
@@ -111,6 +112,16 @@ public class PartitionAwarenessTest extends AbstractClientTest {
         assertOpOnNode("server-2", "get", x -> recordView.get(null, new AbstractClientTableTest.PersonPojo(1L)));
         assertOpOnNode("server-1", "get", x -> recordView.get(null, new AbstractClientTableTest.PersonPojo(2L)));
         assertOpOnNode("server-2", "get", x -> recordView.get(null, new AbstractClientTableTest.PersonPojo(3L)));
+    }
+
+    @Test
+    public void testGetKeyValueRoutesRequestToPrimaryNode() {
+        KeyValueView<Long, String> pojoView = defaultTable().keyValueView(Mapper.of(Long.class), Mapper.of(String.class));
+
+        assertOpOnNode("server-1", "get", x -> pojoView.get(null, 0L));
+        assertOpOnNode("server-2", "get", x -> pojoView.get(null, 1L));
+        assertOpOnNode("server-1", "get", x -> pojoView.get(null, 2L));
+        assertOpOnNode("server-2", "get", x -> pojoView.get(null, 3L));
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -276,7 +276,7 @@ public class PartitionAwarenessTest extends AbstractClientTest {
         op.accept(null);
 
         assertEquals(expectedOp, lastOp);
-        assertEquals(expectedNode, lastOpServerName);
+        assertEquals(expectedNode, lastOpServerName, "Operation " + expectedOp + " was not executed on expected node");
     }
 
     private Table defaultTable() {

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -284,8 +284,8 @@ public class PartitionAwarenessTest extends AbstractClientTest {
         assertOpOnNode("server-1", "get", x -> kvView.get(null, t1));
         assertOpOnNode("server-2", "get", x -> kvView.get(null, t2));
 
-        assertOpOnNode("server-1", "contains", x -> kvView.contains(null, t1));
-        assertOpOnNode("server-2", "contains", x -> kvView.contains(null, t2));
+        assertOpOnNode("server-1", "get", x -> kvView.contains(null, t1));
+        assertOpOnNode("server-2", "get", x -> kvView.contains(null, t2));
 
         assertOpOnNode("server-1", "getAll", x -> kvView.getAll(null, List.of(t1)));
         assertOpOnNode("server-2", "getAll", x -> kvView.getAll(null, List.of(t2)));

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.netty.util.ResourceLeakDetector;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
 import org.apache.ignite.Ignite;
@@ -210,8 +211,23 @@ public class PartitionAwarenessTest extends AbstractClientTest {
         // TODO IGNITE-17739 Add Partition Awareness to all table APIs
         RecordView<Tuple> recordView = defaultTable().recordView();
 
-        assertOpOnNode("server-1", "upsert", x -> recordView.upsert(null, Tuple.create().set("ID", 0L)));
-        assertOpOnNode("server-2", "upsert", x -> recordView.upsert(null, Tuple.create().set("ID", 1L)));
+        Tuple t1 = Tuple.create().set("ID", 0L);
+        Tuple t2 = Tuple.create().set("ID", 1L);
+
+        assertOpOnNode("server-1", "insert", x -> recordView.insert(null, t1));
+        assertOpOnNode("server-2", "insert", x -> recordView.insert(null, t2));
+
+        assertOpOnNode("server-1", "insertAll", x -> recordView.insertAll(null, List.of(t1)));
+        assertOpOnNode("server-2", "insertAll", x -> recordView.insertAll(null, List.of(t2)));
+
+        assertOpOnNode("server-1", "upsert", x -> recordView.upsert(null, t1));
+        assertOpOnNode("server-2", "upsert", x -> recordView.upsert(null, t2));
+
+        assertOpOnNode("server-1", "getAndUpsert", x -> recordView.getAndUpsert(null, t1));
+        assertOpOnNode("server-2", "getAndUpsert", x -> recordView.getAndUpsert(null, t2));
+
+        assertOpOnNode("server-1", "upsertAll", x -> recordView.upsertAll(null, List.of(t1)));
+        assertOpOnNode("server-2", "upsertAll", x -> recordView.upsertAll(null, List.of(t2)));
     }
 
     @Test
@@ -230,8 +246,8 @@ public class PartitionAwarenessTest extends AbstractClientTest {
 
         op.accept(null);
 
-        assertEquals(expectedNode, lastOpServerName);
         assertEquals(expectedOp, lastOp);
+        assertEquals(expectedNode, lastOpServerName);
     }
 
     private Table defaultTable() {

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -106,22 +106,32 @@ public class PartitionAwarenessTest extends AbstractClientTest {
 
     @Test
     public void testGetRecordRoutesRequestToPrimaryNode() {
-        RecordView<AbstractClientTableTest.PersonPojo> recordView = defaultTable().recordView(Mapper.of(AbstractClientTableTest.PersonPojo.class));
+        RecordView<AbstractClientTableTest.PersonPojo> pojoView = defaultTable().recordView(Mapper.of(AbstractClientTableTest.PersonPojo.class));
 
-        assertOpOnNode("server-1", "get", x -> recordView.get(null, new AbstractClientTableTest.PersonPojo(0L)));
-        assertOpOnNode("server-2", "get", x -> recordView.get(null, new AbstractClientTableTest.PersonPojo(1L)));
-        assertOpOnNode("server-1", "get", x -> recordView.get(null, new AbstractClientTableTest.PersonPojo(2L)));
-        assertOpOnNode("server-2", "get", x -> recordView.get(null, new AbstractClientTableTest.PersonPojo(3L)));
+        assertOpOnNode("server-1", "get", x -> pojoView.get(null, new AbstractClientTableTest.PersonPojo(0L)));
+        assertOpOnNode("server-2", "get", x -> pojoView.get(null, new AbstractClientTableTest.PersonPojo(1L)));
+        assertOpOnNode("server-1", "get", x -> pojoView.get(null, new AbstractClientTableTest.PersonPojo(2L)));
+        assertOpOnNode("server-2", "get", x -> pojoView.get(null, new AbstractClientTableTest.PersonPojo(3L)));
     }
 
     @Test
     public void testGetKeyValueRoutesRequestToPrimaryNode() {
-        KeyValueView<Long, String> pojoView = defaultTable().keyValueView(Mapper.of(Long.class), Mapper.of(String.class));
+        KeyValueView<Long, String> kvView = defaultTable().keyValueView(Mapper.of(Long.class), Mapper.of(String.class));
 
-        assertOpOnNode("server-1", "get", x -> pojoView.get(null, 0L));
-        assertOpOnNode("server-2", "get", x -> pojoView.get(null, 1L));
-        assertOpOnNode("server-1", "get", x -> pojoView.get(null, 2L));
-        assertOpOnNode("server-2", "get", x -> pojoView.get(null, 3L));
+        assertOpOnNode("server-1", "get", x -> kvView.get(null, 0L));
+        assertOpOnNode("server-2", "get", x -> kvView.get(null, 1L));
+        assertOpOnNode("server-1", "get", x -> kvView.get(null, 2L));
+        assertOpOnNode("server-2", "get", x -> kvView.get(null, 3L));
+    }
+
+    @Test
+    public void testGetKeyValueBinaryRoutesRequestToPrimaryNode() {
+        KeyValueView<Tuple, Tuple> kvView = defaultTable().keyValueView();
+
+        assertOpOnNode("server-1", "get", x -> kvView.get(null, Tuple.create().set("ID", 0L)));
+        assertOpOnNode("server-2", "get", x -> kvView.get(null, Tuple.create().set("ID", 1L)));
+        assertOpOnNode("server-1", "get", x -> kvView.get(null, Tuple.create().set("ID", 2L)));
+        assertOpOnNode("server-2", "get", x -> kvView.get(null, Tuple.create().set("ID", 3L)));
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -105,6 +105,10 @@ public class PartitionAwarenessTest extends AbstractClientTest {
 
     @Test
     public void testGetRecordRoutesRequestToPrimaryNode() {
+        // TODO: Refactor everything to be based on BinaryTuple? That way affinity calc is the same.
+        // But perf might suffer - we'll have to deserialize column values back to compute affinity.
+        // On the other hand, it might be faster to deserialize than to retrieve by name from tuple or object.
+        // The fastest way would be to combine serialization and affinity calculation!
         RecordView<AbstractClientTableTest.PersonPojo> recordView = defaultTable().recordView(Mapper.of(AbstractClientTableTest.PersonPojo.class));
 
         assertOpOnNode("server-1", "get", x -> recordView.get(null, new AbstractClientTableTest.PersonPojo(0L)));

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -31,6 +31,7 @@ import org.apache.ignite.internal.table.TableImpl;
 import org.apache.ignite.table.RecordView;
 import org.apache.ignite.table.Table;
 import org.apache.ignite.table.Tuple;
+import org.apache.ignite.table.mapper.Mapper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -93,13 +94,23 @@ public class PartitionAwarenessTest extends AbstractClientTest {
     }
 
     @Test
-    public void testGetRoutesRequestToPrimaryNode() {
+    public void testGetTupleRoutesRequestToPrimaryNode() {
         RecordView<Tuple> recordView = defaultTable().recordView();
 
         assertOpOnNode("server-1", "get", x -> recordView.get(null, Tuple.create().set("ID", 0L)));
         assertOpOnNode("server-2", "get", x -> recordView.get(null, Tuple.create().set("ID", 1L)));
         assertOpOnNode("server-1", "get", x -> recordView.get(null, Tuple.create().set("ID", 2L)));
         assertOpOnNode("server-2", "get", x -> recordView.get(null, Tuple.create().set("ID", 3L)));
+    }
+
+    @Test
+    public void testGetRecordRoutesRequestToPrimaryNode() {
+        RecordView<AbstractClientTableTest.PersonPojo> recordView = defaultTable().recordView(Mapper.of(AbstractClientTableTest.PersonPojo.class));
+
+        assertOpOnNode("server-1", "get", x -> recordView.get(null, new AbstractClientTableTest.PersonPojo(0L)));
+        assertOpOnNode("server-2", "get", x -> recordView.get(null, new AbstractClientTableTest.PersonPojo(1L)));
+        assertOpOnNode("server-1", "get", x -> recordView.get(null, new AbstractClientTableTest.PersonPojo(2L)));
+        assertOpOnNode("server-2", "get", x -> recordView.get(null, new AbstractClientTableTest.PersonPojo(3L)));
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -108,7 +108,8 @@ public class PartitionAwarenessTest extends AbstractClientTest {
 
     @Test
     public void testGetRecordRoutesRequestToPrimaryNode() {
-        RecordView<AbstractClientTableTest.PersonPojo> pojoView = defaultTable().recordView(Mapper.of(AbstractClientTableTest.PersonPojo.class));
+        RecordView<AbstractClientTableTest.PersonPojo> pojoView = defaultTable().recordView(
+                Mapper.of(AbstractClientTableTest.PersonPojo.class));
 
         assertOpOnNode("server-1", "get", x -> pojoView.get(null, new AbstractClientTableTest.PersonPojo(0L)));
         assertOpOnNode("server-2", "get", x -> pojoView.get(null, new AbstractClientTableTest.PersonPojo(1L)));
@@ -204,7 +205,8 @@ public class PartitionAwarenessTest extends AbstractClientTest {
 
     @Test
     public void testAllRecordViewOperations() {
-        RecordView<AbstractClientTableTest.PersonPojo> pojoView = defaultTable().recordView(Mapper.of(AbstractClientTableTest.PersonPojo.class));
+        RecordView<AbstractClientTableTest.PersonPojo> pojoView = defaultTable().recordView(
+                Mapper.of(AbstractClientTableTest.PersonPojo.class));
 
         var t1 = new AbstractClientTableTest.PersonPojo(0L);
         var t2 = new AbstractClientTableTest.PersonPojo(1L);

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.netty.util.ResourceLeakDetector;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
 import org.apache.ignite.Ignite;
@@ -266,7 +267,49 @@ public class PartitionAwarenessTest extends AbstractClientTest {
 
     @Test
     public void testAllKeyValueBinaryViewOperations() {
-        // TODO IGNITE-17739 Add Partition Awareness to all table APIs
+        KeyValueView<Tuple, Tuple> kvView = defaultTable().keyValueView();
+
+        Tuple t1 = Tuple.create().set("ID", 0L);
+        Tuple t2 = Tuple.create().set("ID", 1L);
+
+        assertOpOnNode("server-1", "insert", x -> kvView.putIfAbsent(null, t1, t1));
+        assertOpOnNode("server-2", "insert", x -> kvView.putIfAbsent(null, t2, t2));
+
+        assertOpOnNode("server-1", "upsert", x -> kvView.put(null, t1, t1));
+        assertOpOnNode("server-2", "upsert", x -> kvView.put(null, t2, t2));
+
+        assertOpOnNode("server-1", "upsertAll", x -> kvView.putAll(null, Map.of(t1, t1)));
+        assertOpOnNode("server-2", "upsertAll", x -> kvView.putAll(null, Map.of(t2, t2)));
+
+        assertOpOnNode("server-1", "get", x -> kvView.get(null, t1));
+        assertOpOnNode("server-2", "get", x -> kvView.get(null, t2));
+
+        assertOpOnNode("server-1", "getAll", x -> kvView.getAll(null, List.of(t1)));
+        assertOpOnNode("server-2", "getAll", x -> kvView.getAll(null, List.of(t2)));
+
+        assertOpOnNode("server-1", "getAndUpsert", x -> kvView.getAndPut(null, t1, t1));
+        assertOpOnNode("server-2", "getAndUpsert", x -> kvView.getAndPut(null, t2, t2));
+
+        assertOpOnNode("server-1", "getAndReplace", x -> kvView.getAndReplace(null, t1, t1));
+        assertOpOnNode("server-2", "getAndReplace", x -> kvView.getAndReplace(null, t2, t2));
+
+        assertOpOnNode("server-1", "getAndDelete", x -> kvView.getAndRemove(null, t1));
+        assertOpOnNode("server-2", "getAndDelete", x -> kvView.getAndRemove(null, t2));
+
+        assertOpOnNode("server-1", "replace", x -> kvView.replace(null, t1, t1));
+        assertOpOnNode("server-2", "replace", x -> kvView.replace(null, t2, t2));
+
+        assertOpOnNode("server-1", "replace", x -> kvView.replace(null, t1, t1, t1));
+        assertOpOnNode("server-2", "replace", x -> kvView.replace(null, t2, t2, t2));
+
+        assertOpOnNode("server-1", "delete", x -> kvView.remove(null, t1));
+        assertOpOnNode("server-2", "delete", x -> kvView.remove(null, t2));
+
+        assertOpOnNode("server-1", "deleteExact", x -> kvView.remove(null, t1, t1));
+        assertOpOnNode("server-2", "deleteExact", x -> kvView.remove(null, t2, t2));
+
+        assertOpOnNode("server-1", "deleteAll", x -> kvView.removeAll(null, List.of(t1)));
+        assertOpOnNode("server-2", "deleteAll", x -> kvView.removeAll(null, List.of(t2)));
     }
 
     private void assertOpOnNode(String expectedNode, String expectedOp, Consumer<Void> op) {

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -225,8 +225,8 @@ public class PartitionAwarenessTest extends AbstractClientTest {
         assertOpOnNode("server-1", "upsertAll", x -> recordView.upsertAll(null, List.of(t1)));
         assertOpOnNode("server-2", "upsertAll", x -> recordView.upsertAll(null, List.of(t2)));
 
-        assertOpOnNode("server-1", "insert", x -> recordView.get(null, t1));
-        assertOpOnNode("server-2", "insert", x -> recordView.get(null, t2));
+        assertOpOnNode("server-1", "get", x -> recordView.get(null, t1));
+        assertOpOnNode("server-2", "get", x -> recordView.get(null, t2));
 
         assertOpOnNode("server-1", "getAll", x -> recordView.getAll(null, List.of(t1)));
         assertOpOnNode("server-2", "getAll", x -> recordView.getAll(null, List.of(t2)));

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -108,7 +108,7 @@ public class PartitionAwarenessTest extends AbstractClientTest {
         // TODO: Refactor everything to be based on BinaryTuple? That way affinity calc is the same.
         // But perf might suffer - we'll have to deserialize column values back to compute affinity.
         // On the other hand, it might be faster to deserialize than to retrieve by name from tuple or object.
-        // The fastest way would be to combine serialization and affinity calculation!
+        // The fastest way would be to combine serialization and affinity calculation - by wrapping BinaryTupleBuilder in another class (or derived)
         RecordView<AbstractClientTableTest.PersonPojo> recordView = defaultTable().recordView(Mapper.of(AbstractClientTableTest.PersonPojo.class));
 
         assertOpOnNode("server-1", "get", x -> recordView.get(null, new AbstractClientTableTest.PersonPojo(0L)));

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -204,7 +204,6 @@ public class PartitionAwarenessTest extends AbstractClientTest {
 
     @Test
     public void testAllRecordViewOperations() {
-        // TODO IGNITE-17739 Add Partition Awareness to all table APIs
         RecordView<AbstractClientTableTest.PersonPojo> pojoView = defaultTable().recordView(Mapper.of(AbstractClientTableTest.PersonPojo.class));
 
         var t1 = new AbstractClientTableTest.PersonPojo(0L);

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -310,7 +310,53 @@ public class PartitionAwarenessTest extends AbstractClientTest {
 
     @Test
     public void testAllKeyValueViewOperations() {
-        // TODO IGNITE-17739 Add Partition Awareness to all table APIs
+        KeyValueView<Long, String> kvView = defaultTable().keyValueView(Mapper.of(Long.class), Mapper.of(String.class));
+
+        var k1 = 0L;
+        var k2 = 1L;
+        var v = "v";
+
+        assertOpOnNode("server-1", "insert", x -> kvView.putIfAbsent(null, k1, v));
+        assertOpOnNode("server-2", "insert", x -> kvView.putIfAbsent(null, k2, v));
+
+        assertOpOnNode("server-1", "upsert", x -> kvView.put(null, k1, v));
+        assertOpOnNode("server-2", "upsert", x -> kvView.put(null, k2, v));
+
+        assertOpOnNode("server-1", "upsertAll", x -> kvView.putAll(null, Map.of(k1, v)));
+        assertOpOnNode("server-2", "upsertAll", x -> kvView.putAll(null, Map.of(k2, v)));
+
+        assertOpOnNode("server-1", "get", x -> kvView.get(null, k1));
+        assertOpOnNode("server-2", "get", x -> kvView.get(null, k2));
+
+        assertOpOnNode("server-1", "get", x -> kvView.contains(null, k1));
+        assertOpOnNode("server-2", "get", x -> kvView.contains(null, k2));
+
+        assertOpOnNode("server-1", "getAll", x -> kvView.getAll(null, List.of(k1)));
+        assertOpOnNode("server-2", "getAll", x -> kvView.getAll(null, List.of(k2)));
+
+        assertOpOnNode("server-1", "getAndUpsert", x -> kvView.getAndPut(null, k1, v));
+        assertOpOnNode("server-2", "getAndUpsert", x -> kvView.getAndPut(null, k2, v));
+
+        assertOpOnNode("server-1", "getAndReplace", x -> kvView.getAndReplace(null, k1, v));
+        assertOpOnNode("server-2", "getAndReplace", x -> kvView.getAndReplace(null, k2, v));
+
+        assertOpOnNode("server-1", "getAndDelete", x -> kvView.getAndRemove(null, k1));
+        assertOpOnNode("server-2", "getAndDelete", x -> kvView.getAndRemove(null, k2));
+
+        assertOpOnNode("server-1", "replace", x -> kvView.replace(null, k1, v));
+        assertOpOnNode("server-2", "replace", x -> kvView.replace(null, k2, v));
+
+        assertOpOnNode("server-1", "replace", x -> kvView.replace(null, k1, v, v));
+        assertOpOnNode("server-2", "replace", x -> kvView.replace(null, k2, v, v));
+
+        assertOpOnNode("server-1", "delete", x -> kvView.remove(null, k1));
+        assertOpOnNode("server-2", "delete", x -> kvView.remove(null, k2));
+
+        assertOpOnNode("server-1", "deleteExact", x -> kvView.remove(null, k1, v));
+        assertOpOnNode("server-2", "deleteExact", x -> kvView.remove(null, k2, v));
+
+        assertOpOnNode("server-1", "deleteAll", x -> kvView.removeAll(null, List.of(k1)));
+        assertOpOnNode("server-2", "deleteAll", x -> kvView.removeAll(null, List.of(k2)));
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
@@ -179,7 +179,7 @@ public class RetryPolicyTest {
 
     @Test
     public void testRetryReadPolicyDoesNotRetryWriteOperations() throws Exception {
-        initServer(reqId -> reqId % 5 == 0);
+        initServer(reqId -> reqId % 6 == 0);
 
         try (var client = getClient(new RetryReadPolicy())) {
             RecordView<Tuple> recView = client.tables().table("t").recordView();

--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeInternalTable.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeInternalTable.java
@@ -153,24 +153,22 @@ public class FakeInternalTable implements InternalTable {
     /** {@inheritDoc} */
     @Override
     public CompletableFuture<Boolean> insert(BinaryRowEx row, @Nullable InternalTransaction tx) {
-        onDataAccess("insert", row);
-
         var old = get(row, tx).getNow(null);
+        boolean res = false;
 
         if (old == null) {
             upsert(row, tx);
 
-            return CompletableFuture.completedFuture(true);
+            res = true;
         }
 
-        return CompletableFuture.completedFuture(false);
+        onDataAccess("insert", row);
+        return CompletableFuture.completedFuture(res);
     }
 
     /** {@inheritDoc} */
     @Override
     public CompletableFuture<Collection<BinaryRow>> insertAll(Collection<BinaryRowEx> rows, @Nullable InternalTransaction tx) {
-        onDataAccess("insertAll", rows);
-
         var skipped = new ArrayList<BinaryRow>();
 
         for (var row : rows) {
@@ -179,6 +177,7 @@ public class FakeInternalTable implements InternalTable {
             }
         }
 
+        onDataAccess("insertAll", rows);
         return CompletableFuture.completedFuture(skipped);
     }
 


### PR DESCRIPTION
* Move common hash calculation logic to `ClientTupleSerializer`.
* Add partition awareness to all APIs in `ClientRecordView`, `ClientRecordBinaryView`, `ClientKeyValueView`, `ClientKeyValueBinaryView`.

https://issues.apache.org/jira/browse/IGNITE-17739