### PR TITLE
IGNITE-17763 Use retry policy when connecting default channel

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/client/ClientOperationType.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/ClientOperationType.java
@@ -29,6 +29,11 @@ import org.apache.ignite.tx.Transaction;
  */
 public enum ClientOperationType {
     /**
+     * Connect channel.
+     */
+    CHANNEL_CONNECT,
+
+     /**
      * Get tables ({@link IgniteTables#tables()}).
      */
     TABLES_GET,

--- a/modules/client/src/main/java/org/apache/ignite/client/ClientOperationType.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/ClientOperationType.java
@@ -33,7 +33,7 @@ public enum ClientOperationType {
      */
     CHANNEL_CONNECT,
 
-     /**
+    /**
      * Get tables ({@link IgniteTables#tables()}).
      */
     TABLES_GET,

--- a/modules/client/src/main/java/org/apache/ignite/client/RetryReadPolicy.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/RetryReadPolicy.java
@@ -34,6 +34,7 @@ public class RetryReadPolicy extends RetryLimitPolicy {
             case TUPLE_GET_ALL:
             case TUPLE_GET:
             case TABLE_GET:
+            case CHANNEL_CONNECT:
                 return true;
 
             case TUPLE_UPSERT:

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -45,6 +45,7 @@ import java.util.stream.IntStream;
 import org.apache.ignite.client.ClientOperationType;
 import org.apache.ignite.client.IgniteClientConfiguration;
 import org.apache.ignite.client.IgniteClientConnectionException;
+import org.apache.ignite.client.RetryLimitPolicy;
 import org.apache.ignite.client.RetryPolicy;
 import org.apache.ignite.client.RetryPolicyContext;
 import org.apache.ignite.internal.client.io.ClientConnectionMultiplexer;
@@ -589,7 +590,8 @@ public final class ReliableChannel implements AutoCloseable {
         ClientOperationType opType = ClientUtils.opCodeToClientOperationType(opCode);
 
         if (opType == null) {
-            return true; // System operation.
+            // System operation.
+            return iteration < RetryLimitPolicy.DFLT_RETRY_LIMIT;
         }
 
         RetryPolicy plc = clientCfg.retryPolicy();

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -575,7 +575,7 @@ public final class ReliableChannel implements AutoCloseable {
 
                 onChannelFailure(hld, c);
 
-                if (!shouldRetry(-1, attempt, e)) {
+                if (!shouldRetry(ClientOperationType.CHANNEL_CONNECT, attempt, e)) {
                     break;
                 }
             }
@@ -588,6 +588,11 @@ public final class ReliableChannel implements AutoCloseable {
     private boolean shouldRetry(int opCode, int iteration, IgniteClientConnectionException exception) {
         ClientOperationType opType = ClientUtils.opCodeToClientOperationType(opCode);
 
+        return shouldRetry(opType, iteration, exception);
+    }
+
+    /** Determines whether specified operation should be retried. */
+    private boolean shouldRetry(ClientOperationType opType, int iteration, IgniteClientConnectionException exception) {
         if (opType == null) {
             // System operation.
             return iteration < RetryLimitPolicy.DFLT_RETRY_LIMIT;

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -50,7 +50,6 @@ import org.apache.ignite.client.RetryPolicy;
 import org.apache.ignite.client.RetryPolicyContext;
 import org.apache.ignite.internal.client.io.ClientConnectionMultiplexer;
 import org.apache.ignite.internal.client.io.netty.NettyClientConnectionMultiplexer;
-import org.apache.ignite.internal.client.proto.ClientOp;
 import org.apache.ignite.internal.logger.IgniteLogger;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.network.ClusterNode;

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -49,6 +49,7 @@ import org.apache.ignite.client.RetryPolicy;
 import org.apache.ignite.client.RetryPolicyContext;
 import org.apache.ignite.internal.client.io.ClientConnectionMultiplexer;
 import org.apache.ignite.internal.client.io.netty.NettyClientConnectionMultiplexer;
+import org.apache.ignite.internal.client.proto.ClientOp;
 import org.apache.ignite.internal.logger.IgniteLogger;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.network.ClusterNode;
@@ -543,7 +544,7 @@ public final class ReliableChannel implements AutoCloseable {
     private ClientChannel getDefaultChannel() {
         IgniteClientConnectionException failure = null;
 
-        for (int attempt = 0; attempt < channels.size(); attempt++) {
+        for (int attempt = 0; ; attempt++) {
             ClientChannelHolder hld = null;
             ClientChannel c = null;
 
@@ -573,6 +574,10 @@ public final class ReliableChannel implements AutoCloseable {
                 }
 
                 onChannelFailure(hld, c);
+
+                if (!shouldRetry(-1, attempt, e)) {
+                    break;
+                }
             }
         }
 

--- a/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
@@ -71,7 +71,7 @@ public abstract class AbstractClientTest {
      * After each.
      */
     @BeforeEach
-    public void beforeEach() {
+    public void beforeEach() throws InterruptedException {
         dropTables(server);
     }
 

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -61,7 +62,7 @@ public class ClientComputeTest {
 
         // Provide same node multiple times to check this case as well.
         try (var client = getClient(server1, server2, server3, server1, server2)) {
-            IgniteTestUtils.waitForCondition(() -> client.connections().size() == 3, 3000);
+            assertTrue(IgniteTestUtils.waitForCondition(() -> client.connections().size() == 3, 3000));
 
             String res1 = client.compute().<String>execute(getClusterNodes("s1"), "job").join();
             String res2 = client.compute().<String>execute(getClusterNodes("s2"), "job").join();

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientLoggingTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientLoggingTest.java
@@ -54,7 +54,7 @@ public class ClientLoggingTest {
         FakeIgnite ignite1 = new FakeIgnite();
         ignite1.tables().createTable("t", c -> {});
 
-        server = startServer(10900, ignite1);
+        server = startServer(10950, ignite1);
 
         var loggerFactory1 = new TestLoggerFactory("client1");
         var loggerFactory2 = new TestLoggerFactory("client2");
@@ -73,7 +73,7 @@ public class ClientLoggingTest {
         FakeIgnite ignite2 = new FakeIgnite();
         ignite2.tables().createTable("t2", c -> {});
 
-        server2 = startServer(10950, ignite2);
+        server2 = startServer(10951, ignite2);
 
         assertEquals("t2", client1.tables().tables().get(0).name());
         assertEquals("t2", client2.tables().tables().get(0).name());
@@ -96,8 +96,7 @@ public class ClientLoggingTest {
 
     private IgniteClient createClient(LoggerFactory loggerFactory) {
         return IgniteClient.builder()
-                .addresses("127.0.0.1:10900..10910", "127.0.0.1:10950..10960")
-                .retryPolicy(new RetryLimitPolicy().retryLimit(1))
+                .addresses("127.0.0.1:10950..10960")
                 .loggerFactory(loggerFactory)
                 .build();
     }

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.netty.util.ResourceLeakDetector;
 import java.util.ArrayList;
@@ -96,7 +97,7 @@ public class PartitionAwarenessTest extends AbstractClientTest {
 
         initPartitionAssignment(null);
 
-        IgniteTestUtils.waitForCondition(() -> client2.connections().size() == 2, 3000);
+        assertTrue(IgniteTestUtils.waitForCondition(() -> client2.connections().size() == 2, 3000));
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -30,6 +30,7 @@ import org.apache.ignite.client.fakes.FakeIgnite;
 import org.apache.ignite.client.fakes.FakeIgniteTables;
 import org.apache.ignite.client.fakes.FakeInternalTable;
 import org.apache.ignite.internal.table.TableImpl;
+import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.table.KeyValueView;
 import org.apache.ignite.table.RecordView;
 import org.apache.ignite.table.Table;
@@ -89,11 +90,13 @@ public class PartitionAwarenessTest extends AbstractClientTest {
     }
 
     @BeforeEach
-    public void beforeEach() {
+    public void beforeEach() throws InterruptedException {
         dropTables(server);
         dropTables(server2);
 
         initPartitionAssignment(null);
+
+        IgniteTestUtils.waitForCondition(() -> client2.connections().size() == 2, 3000);
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/ReconnectTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ReconnectTest.java
@@ -53,7 +53,7 @@ public class ReconnectTest {
 
         var client = IgniteClient.builder()
                 .addresses("127.0.0.1:10900..10910", "127.0.0.1:10950..10960")
-                .retryPolicy(new RetryLimitPolicy().retryLimit(1))
+                .retryPolicy(new RetryLimitPolicy().retryLimit(100))
                 .build();
 
         assertEquals("t", client.tables().tables().get(0).name());

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItAbstractThinClientTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItAbstractThinClientTest.java
@@ -21,6 +21,7 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.testNodeName;
 import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willCompleteSuccessfully;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -121,7 +122,8 @@ public abstract class ItAbstractThinClientTest extends IgniteAbstractTest {
         );
 
         client = IgniteClient.builder().addresses(getClientAddresses().toArray(new String[0])).build();
-        IgniteTestUtils.waitForCondition(() -> client.connections().size() == 2, 3000);
+
+        assertTrue(IgniteTestUtils.waitForCondition(() -> client.connections().size() == 2, 3000));
     }
 
     /**


### PR DESCRIPTION
Introduce `ClientOperationType.CHANNEL_CONNECT` and pass it to `RetryPolicy` when performing connection attempts.

Fixes `testRetryReadPolicyRetriesReadOperations` flakiness caused by failed handshake.