### PR TITLE
IGNITE-17794 .NET: Fix source generators performance

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/Apache.Ignite.Internal.Generators.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/Apache.Ignite.Internal.Generators.csproj
@@ -26,7 +26,7 @@
     
     <ItemGroup>
         <!-- Source Generators -->
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/Apache.Ignite.Internal.Generators.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/Apache.Ignite.Internal.Generators.csproj
@@ -26,7 +26,7 @@
     
     <ItemGroup>
         <!-- Source Generators -->
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ErrorGroupsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ErrorGroupsGenerator.cs
@@ -31,26 +31,13 @@ namespace Apache.Ignite.Internal.Generators
     /// Generates error groups source from ErrorGroups.java.
     /// </summary>
     [Generator]
-    public sealed class ErrorGroupsGenerator : IIncrementalGenerator
+    public sealed class ErrorGroupsGenerator : JavaToCsharpGeneratorBase
     {
-        public void Initialize(IncrementalGeneratorInitializationContext context)
-        {
-            context.RegisterPostInitializationOutput(ctx =>
-            {
-                // TODO: Get from context somehow.
-                var javaModulesDirectory = "/home/pavel/w/ignite-3/modules";
-
-                foreach (var (name, code) in ExecuteInternal(javaModulesDirectory))
-                {
-                    ctx.AddSource(name, code);
-                }
-            });
-        }
-
-        private static IEnumerable<(string Name, string Code)> ExecuteInternal(string javaModulesDirectory)
+        /// <inheritdoc/>
+        protected override IEnumerable<(string Name, string Code)> ExecuteInternal(GeneratorExecutionContext context)
         {
             var javaErrorGroupsFile = Path.GetFullPath(Path.Combine(
-                javaModulesDirectory,
+                context.GetJavaModulesDirectory(),
                 "core",
                 "src",
                 "main",

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ErrorGroupsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ErrorGroupsGenerator.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Internal.Generators
 {
     using System;
+    using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
     using System.Linq;
@@ -33,10 +34,8 @@ namespace Apache.Ignite.Internal.Generators
     public sealed class ErrorGroupsGenerator : JavaToCsharpGeneratorBase
     {
         /// <inheritdoc/>
-        protected override void ExecuteInternal(GeneratorExecutionContext context)
+        protected override IEnumerable<(string Name, string Code)> ExecuteInternal(GeneratorExecutionContext context)
         {
-            File.AppendAllLines("/home/pavel/w/ErrorGroupsGenerator.log", new[] { DateTime.Now + " Execute " + GetHashCode() });
-
             var javaErrorGroupsFile = Path.GetFullPath(Path.Combine(
                 context.GetJavaModulesDirectory(),
                 "core",
@@ -140,7 +139,7 @@ namespace Apache.Ignite.Internal.Generators
             sb.AppendLine("    }");
             sb.AppendLine("}");
 
-            context.AddSource("ErrorGroups.g.cs", sb.ToString());
+            yield return ("ErrorGroups.g.cs", sb.ToString());
         }
 
         private static string SnakeToCamelCase(string str) =>

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ErrorGroupsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ErrorGroupsGenerator.cs
@@ -31,13 +31,26 @@ namespace Apache.Ignite.Internal.Generators
     /// Generates error groups source from ErrorGroups.java.
     /// </summary>
     [Generator]
-    public sealed class ErrorGroupsGenerator : JavaToCsharpGeneratorBase
+    public sealed class ErrorGroupsGenerator : IIncrementalGenerator
     {
-        /// <inheritdoc/>
-        protected override IEnumerable<(string Name, string Code)> ExecuteInternal(GeneratorExecutionContext context)
+        public void Initialize(IncrementalGeneratorInitializationContext context)
+        {
+            context.RegisterPostInitializationOutput(ctx =>
+            {
+                // TODO: Get from context somehow.
+                var javaModulesDirectory = "/home/pavel/w/ignite-3/modules";
+
+                foreach (var (name, code) in ExecuteInternal(javaModulesDirectory))
+                {
+                    ctx.AddSource(name, code);
+                }
+            });
+        }
+
+        private static IEnumerable<(string Name, string Code)> ExecuteInternal(string javaModulesDirectory)
         {
             var javaErrorGroupsFile = Path.GetFullPath(Path.Combine(
-                context.GetJavaModulesDirectory(),
+                javaModulesDirectory,
                 "core",
                 "src",
                 "main",

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ErrorGroupsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ErrorGroupsGenerator.cs
@@ -30,17 +30,13 @@ namespace Apache.Ignite.Internal.Generators
     /// Generates error groups source from ErrorGroups.java.
     /// </summary>
     [Generator]
-    public sealed class ErrorGroupsGenerator : ISourceGenerator
+    public sealed class ErrorGroupsGenerator : JavaToCsharpGeneratorBase
     {
         /// <inheritdoc/>
-        public void Initialize(GeneratorInitializationContext context)
+        protected override void ExecuteInternal(GeneratorExecutionContext context)
         {
-            // No-op.
-        }
+            File.AppendAllLines("/home/pavel/w/ErrorGroupsGenerator.log", new[] { DateTime.Now + " Execute " + GetHashCode() });
 
-        /// <inheritdoc/>
-        public void Execute(GeneratorExecutionContext context)
-        {
             var javaErrorGroupsFile = Path.GetFullPath(Path.Combine(
                 context.GetJavaModulesDirectory(),
                 "core",

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
@@ -31,16 +31,10 @@ namespace Apache.Ignite.Internal.Generators
     /// Generates exception classes from Java exceptions.
     /// </summary>
     [Generator]
-    public sealed class ExceptionsGenerator : ISourceGenerator
+    public sealed class ExceptionsGenerator : JavaToCsharpGeneratorBase
     {
         /// <inheritdoc/>
-        public void Initialize(GeneratorInitializationContext context)
-        {
-            // No-op.
-        }
-
-        /// <inheritdoc/>
-        public void Execute(GeneratorExecutionContext context)
+        protected override void ExecuteInternal(GeneratorExecutionContext context)
         {
             var javaModulesDirectory = context.GetJavaModulesDirectory();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
@@ -34,7 +34,7 @@ namespace Apache.Ignite.Internal.Generators
     public sealed class ExceptionsGenerator : JavaToCsharpGeneratorBase
     {
         /// <inheritdoc/>
-        protected override void ExecuteInternal(GeneratorExecutionContext context)
+        protected override IEnumerable<(string Name, string Code)> ExecuteInternal(GeneratorExecutionContext context)
         {
             var javaModulesDirectory = context.GetJavaModulesDirectory();
 
@@ -82,12 +82,12 @@ namespace Apache.Ignite.Internal.Generators
                     .Replace("XMLDOC", GetXmlDoc(className, javaException.Value.Source))
                     .Replace("NAMESPACE", dotNetNamespace);
 
-                context.AddSource(className + ".g.cs", src);
+                yield return (className + ".g.cs", src);
 
                 classMap.Add((javaPackage + "." + className, dotNetNamespace + "." + className));
             }
 
-            EmitClassMap(context, classMap);
+            yield return EmitClassMap(classMap);
 
             bool IsIgniteException(string? ex) =>
                 ex != null &&
@@ -95,7 +95,7 @@ namespace Apache.Ignite.Internal.Generators
                  IsIgniteException(javaExceptionsWithParents.TryGetValue(ex, out var parent) ? parent.Parent : null));
         }
 
-        private static void EmitClassMap(GeneratorExecutionContext context, List<(string JavaClass, string DotNetClass)> classMap)
+        private static (string Name, string Code) EmitClassMap(List<(string JavaClass, string DotNetClass)> classMap)
         {
             var sb = new StringBuilder();
 
@@ -121,7 +121,7 @@ namespace Apache.Ignite.Internal.Generators
             sb.AppendLine("    }");
             sb.AppendLine("}");
 
-            context.AddSource("ExceptionMapper.g.cs", sb.ToString());
+            return ("ExceptionMapper.g.cs", sb.ToString());
         }
 
         private static string GetXmlDoc(string javaClassName, string javaSource)

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/JavaToCsharpGeneratorBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/JavaToCsharpGeneratorBase.cs
@@ -24,8 +24,11 @@ using Microsoft.CodeAnalysis;
 
 /// <summary>
 /// Base class for Java -> C# source generators.
+/// <para />
+/// <see cref="IIncrementalGenerator"/> is not used because it makes directory detection too hard.
+/// <see cref="GeneratorInitializationContext.RegisterForPostInitialization"/> is not used for the same reason.
 /// </summary>
-public abstract class JavaToCsharpGeneratorBase : ISourceGenerator // TODO: Use incremental generator?
+public abstract class JavaToCsharpGeneratorBase : ISourceGenerator
 {
     private int _executed;
 

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/JavaToCsharpGeneratorBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/JavaToCsharpGeneratorBase.cs
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Internal.Generators;
+
+using System.Threading;
+using Microsoft.CodeAnalysis;
+
+/// <summary>
+/// Base class for Java -> C# source generators.
+/// </summary>
+public abstract class JavaToCsharpGeneratorBase : ISourceGenerator
+{
+    private int _executed;
+
+    /// <inheritdoc/>
+    public void Initialize(GeneratorInitializationContext context)
+    {
+        // No-op.
+    }
+
+    /// <inheritdoc/>
+    public void Execute(GeneratorExecutionContext context)
+    {
+        if (Interlocked.CompareExchange(ref _executed, 1, 0) != 0)
+        {
+            // Execute the generator only once during full build.
+            // Do not execute otherwise (while C# code is being changed).
+            return;
+        }
+
+        ExecuteInternal(context);
+    }
+
+    /// <summary>
+    /// Called to perform source generation.
+    /// </summary>
+    /// <param name="context">The <see cref="GeneratorExecutionContext"/> to add source to.</param>
+    protected abstract void ExecuteInternal(GeneratorExecutionContext context);
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/JavaToCsharpGeneratorBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/JavaToCsharpGeneratorBase.cs
@@ -25,7 +25,7 @@ using Microsoft.CodeAnalysis;
 /// <summary>
 /// Base class for Java -> C# source generators.
 /// </summary>
-public abstract class JavaToCsharpGeneratorBase : ISourceGenerator
+public abstract class JavaToCsharpGeneratorBase : ISourceGenerator // TODO: Use incremental generator?
 {
     private int _executed;
 

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/JavaToCsharpGeneratorBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/JavaToCsharpGeneratorBase.cs
@@ -47,7 +47,10 @@ public abstract class JavaToCsharpGeneratorBase : ISourceGenerator // TODO: Use 
             _generatedCode = ExecuteInternal(context).ToList();
         }
 
-        _generatedCode.ForEach(unit => context.AddSource(unit.Name, unit.Code));
+        foreach (var (name, code) in _generatedCode)
+        {
+            context.AddSource(name, code);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Generate code only on build. Do not generate when C# code changes, because the logic is based only on Java code. Fixes potentially degraded IDE performance due to unnecessary processing.