### PR TITLE
IGNITE-17812 Fix RetryPolicy exception handling, propagate exceptions to API caller

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/client/RetryReadPolicy.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/RetryReadPolicy.java
@@ -51,6 +51,8 @@ public class RetryReadPolicy extends RetryLimitPolicy {
             case TUPLE_INSERT:
             case TUPLE_GET_AND_UPSERT:
             case TUPLE_UPSERT_ALL:
+            case SQL_EXECUTE:
+            case SQL_CURSOR_NEXT_PAGE:
                 return false;
 
             default:

--- a/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
@@ -222,6 +222,11 @@ public class RetryPolicyTest {
         }
     }
 
+    @Test
+    public void testExceptionInRetryPolicyPropagatesToCaller() {
+        // TODO IGNITE-17812
+    }
+
     private IgniteClient getClient(RetryPolicy retryPolicy) {
         return IgniteClient.builder()
                 .addresses("127.0.0.1:" + server.port())

--- a/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
@@ -29,6 +29,8 @@ import java.util.function.Function;
 import org.apache.ignite.client.fakes.FakeIgnite;
 import org.apache.ignite.client.fakes.FakeIgniteTables;
 import org.apache.ignite.internal.client.ClientUtils;
+import org.apache.ignite.internal.client.IgniteClientConfigurationImpl;
+import org.apache.ignite.internal.client.RetryPolicyContextImpl;
 import org.apache.ignite.internal.client.proto.ClientOp;
 import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.lang.IgniteException;
@@ -208,6 +210,17 @@ public class RetryPolicyTest {
                 + String.join(", ", nullOpFields);
 
         assertEquals(expectedNullCount, nullOpFields.size(), msg);
+    }
+
+    @Test
+    public void testRetryReadPolicyAllOperationsSupported() throws IllegalAccessException {
+        var plc = new RetryReadPolicy();
+        var cfg = new IgniteClientConfigurationImpl(null, null, 0, 0, 0, null, 0, null, null);
+
+        for (var op : ClientOperationType.values()) {
+            var ctx = new RetryPolicyContextImpl(cfg, op, 0, null);
+            plc.shouldRetry(ctx);
+        }
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
@@ -223,8 +223,14 @@ public class RetryPolicyTest {
     }
 
     @Test
-    public void testExceptionInRetryPolicyPropagatesToCaller() {
-        // TODO IGNITE-17812
+    public void testExceptionInRetryPolicyPropagatesToCaller() throws Exception {
+        initServer(reqId -> reqId % 2 == 0);
+        var plc = new TestRetryPolicy();
+        plc.shouldThrow = true;
+
+        try (var client = getClient(plc)) {
+            assertThrows(IgniteException.class, () -> client.tables().tables());
+        }
     }
 
     private IgniteClient getClient(RetryPolicy retryPolicy) {

--- a/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
@@ -229,7 +229,13 @@ public class RetryPolicyTest {
         plc.shouldThrow = true;
 
         try (var client = getClient(plc)) {
-            assertThrows(IgniteException.class, () -> client.tables().tables());
+            IgniteException ex = assertThrows(IgniteException.class, () -> client.tables().tables());
+
+            var cause = (IgniteClientConnectionException) ex.getCause();
+            Throwable[] suppressed = cause.getSuppressed();
+
+            assertEquals("TestRetryPolicy exception.", suppressed[0].getMessage());
+            assertEquals(1, suppressed.length);
         }
     }
 

--- a/modules/client/src/test/java/org/apache/ignite/client/TestRetryPolicy.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestRetryPolicy.java
@@ -27,10 +27,17 @@ public class TestRetryPolicy extends RetryLimitPolicy {
     /** Policy invocations. */
     public final List<RetryPolicyContext> invocations = new ArrayList<>();
 
+    /** Whether the policy should throw. */
+    public boolean shouldThrow;
+
     /** {@inheritDoc} */
     @Override
     public boolean shouldRetry(RetryPolicyContext context) {
         invocations.add(context);
+
+        if (shouldThrow) {
+            throw new RuntimeException("TestRetryPolicy exception.");
+        }
 
         return super.shouldRetry(context);
     }


### PR DESCRIPTION
Fix API call hang when there is an exception in `RetryPolicy` implementation. Catch exceptions and propagate to the caller.