### PR TITLE
IGNITE-17782 `sql` with white space in repl fails

### DIFF
--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/sql/SqlReplCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/sql/SqlReplCommand.java
@@ -80,7 +80,8 @@ public class SqlReplCommand extends BaseCommand implements Runnable {
     @Override
     public void run() {
         try (SqlManager sqlManager = new SqlManager(jdbc)) {
-            if (execOptions == null) {
+            // When passing white space to this command, picocli will treat it as a positional argument
+            if (execOptions == null || execOptions.command.isBlank()) {
                 replExecutorProvider.get().execute(Repl.builder()
                         .withPromptProvider(() -> "sql-cli> ")
                         .withCompleter(new SqlCompleter(new SqlSchemaProvider(sqlManager::getMetadata)))


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-17782

Picocli treats white space as a positional argument and creates a arg group object, so we need to add a check for this.