### PR TITLE
IGNITE-17826 .NET: Propagate Java exception stack traces

### DIFF
--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -263,7 +263,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter {
     }
 
     private void writeError(long requestId, Throwable err, ChannelHandlerContext ctx) {
-        LOG.debug("Error processing client request", err);
+        LOG.warn("Error processing client request", err);
 
         var packer = getPacker(ctx.alloc());
 
@@ -506,7 +506,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter {
     /** {@inheritDoc} */
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        LOG.info(cause.getMessage(), cause);
+        LOG.warn("Exception in client connector pipeline: " + cause.getMessage(), cause);
 
         ctx.close();
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
@@ -107,16 +107,16 @@ namespace Apache.Ignite.Internal.Generators
             sb.AppendLine();
             sb.AppendLine("    internal static class ExceptionMapper");
             sb.AppendLine("    {");
-            sb.AppendLine("        public static IgniteException GetException(Guid traceId, int code, string javaClass, string? message) =>");
+            sb.AppendLine("        public static IgniteException GetException(Guid traceId, int code, string javaClass, string? message, string? javaStackTrace) =>");
             sb.AppendLine("            javaClass switch");
             sb.AppendLine("            {");
 
             foreach (var (javaClass, dotNetClass) in classMap)
             {
-                sb.AppendLine($"                \"{javaClass}\" => new {dotNetClass}(traceId, code, message, new IgniteException(traceId, code, javaClass)),");
+                sb.AppendLine($"                \"{javaClass}\" => new {dotNetClass}(traceId, code, message, new IgniteException(traceId, code, javaStackTrace ?? javaClass)),");
             }
 
-            sb.AppendLine("                _ => new IgniteException(traceId, code, message, new IgniteException(traceId, code, javaClass))");
+            sb.AppendLine("                _ => new IgniteException(traceId, code, message, new IgniteException(traceId, code, javaStackTrace ?? javaClass))");
             sb.AppendLine("            };");
             sb.AppendLine("    }");
             sb.AppendLine("}");

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -53,6 +53,8 @@ namespace Apache.Ignite.Tests.Compute
 
         private const string DropTableJob = PlatformTestNodeRunner + "$DropTableJob";
 
+        private const string ExceptionJob = PlatformTestNodeRunner + "$ExceptionJob";
+
         [Test]
         public async Task TestGetClusterNodes()
         {
@@ -274,6 +276,12 @@ namespace Apache.Ignite.Tests.Compute
             {
                 await Client.Compute.ExecuteAsync<string>(nodes, DropTableJob, tableName);
             }
+        }
+
+        [Test]
+        public async Task TestExceptionInJobWithSendServerExceptionStackTraceToClientPropagatesToClientWithStackTrace()
+        {
+            await Client.Compute.ExecuteAsync<object>(await GetNodeAsync(1), ExceptionJob);
         }
 
         private async Task<List<IClusterNode>> GetNodeAsync(int index) =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -143,7 +143,7 @@ namespace Apache.Ignite.Tests.Compute
 
             StringAssert.Contains("Custom job error", ex!.Message);
 
-            Assert.AreEqual(
+            StringAssert.StartsWith(
                 "org.apache.ignite.internal.runner.app.client.ItThinClientComputeTest$CustomException",
                 ex.InnerException!.Message);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -306,6 +306,7 @@ namespace Apache.Ignite.Internal
             int code = reader.TryReadNil() ? 65537 : reader.ReadInt32();
             string className = reader.ReadString();
             string? message = reader.ReadString();
+            string? javaStackTrace = reader.ReadString();
 
             return ExceptionMapper.GetException(traceId, code, className, message);
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -308,7 +308,7 @@ namespace Apache.Ignite.Internal
             string? message = reader.ReadString();
             string? javaStackTrace = reader.ReadString();
 
-            return ExceptionMapper.GetException(traceId, code, className, message);
+            return ExceptionMapper.GetException(traceId, code, className, message, javaStackTrace);
         }
 
         private static async ValueTask<PooledBuffer> ReadResponseAsync(

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -223,4 +223,15 @@ public class PlatformTestNodeRunner {
             return tableName;
         }
     }
+
+    /**
+     * Compute job that throws an exception.
+     */
+    @SuppressWarnings({"unused"}) // Used by platform tests.
+    private static class ExceptionJob implements ComputeJob<String> {
+        @Override
+        public String execute(JobExecutionContext context, Object... args) {
+            throw new RuntimeException("Test exception: " + args[0]);
+        }
+    }
 }


### PR DESCRIPTION
* Read Java exception stack trace from server (when present) and include it in the `InnerException`.
* Fix logging in `ClientInboundMessageHandler`.