### PR TITLE
IGNITE-17830 .NET: Fix Guid serialization to match UUID

### DIFF
--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
@@ -501,8 +501,8 @@ public class ClientMessagePacker implements AutoCloseable {
 
         packExtensionTypeHeader(ClientMsgPackType.UUID, 16);
 
-        buf.writeLong(val.getMostSignificantBits());
-        buf.writeLong(val.getLeastSignificantBits());
+        buf.writeLongLE(val.getMostSignificantBits());
+        buf.writeLongLE(val.getLeastSignificantBits());
     }
 
     /**

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
@@ -706,7 +706,7 @@ public class ClientMessageUnpacker implements AutoCloseable {
             throw new MessageSizeException("Expected 16 bytes for UUID extension, but got " + len, len);
         }
 
-        return new UUID(buf.readLong(), buf.readLong());
+        return new UUID(buf.readLongLE(), buf.readLongLE());
     }
 
     /**

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -200,10 +200,8 @@ namespace Apache.Ignite.Tests.Compute
             await Test(BigInteger.Pow(1234, 56));
 
             await Test(Guid.Empty);
-
-            // TODO IGNITE-17830 String representation should be the same in Java and C#.
-            await Test(
-                new Guid(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }), "07080506-0102-0304-100f-0e0d0c0b0a09");
+            await Test(new Guid(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }));
+            await Test(Guid.NewGuid());
 
             async Task Test(object val, string? expectedStr = null)
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/MessagePackExtensionsTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/MessagePackExtensionsTest.cs
@@ -35,7 +35,7 @@ namespace Apache.Ignite.Tests.Proto
         /** Byte representation of the UUID above, serialized by Java ClientMessagePacker. */
         private static readonly sbyte[] JavaUuidBytes =
         {
-            -40, 3, 111, 36, 20, 106, 36, 74, 64, 24, -93, 108, 62, -100, -11, -76, 32, -126
+            -40, 3, 24, 64, 74, 36, 106, 20, 36, 111, -126, 32, -76, -11, -100, 62, 108, -93
         };
 
         private static readonly string?[] TestStrings =

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/UuidSerializer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/UuidSerializer.cs
@@ -57,18 +57,18 @@ namespace Apache.Ignite.Internal.Proto
         /// <returns>Guid.</returns>
         public static Guid Read(ReadOnlySpan<byte> span)
         {
-            // Hoist bounds checks.
-            var k = span[15];
-            var a = BinaryPrimitives.ReverseEndianness(MemoryMarshal.Read<int>(span));
-            var b = BinaryPrimitives.ReverseEndianness(MemoryMarshal.Read<short>(span[4..]));
-            var c = BinaryPrimitives.ReverseEndianness(MemoryMarshal.Read<short>(span[6..]));
-            var d = span[8];
-            var e = span[9];
-            var f = span[10];
-            var g = span[11];
-            var h = span[12];
-            var i = span[13];
-            var j = span[14];
+            var d = span[15];
+            var e = span[14];
+            var f = span[13];
+            var g = span[12];
+            var h = span[11];
+            var i = span[10];
+            var j = span[9];
+            var k = span[8];
+
+            var a = MemoryMarshal.Read<int>(span[4..8]);
+            var b = MemoryMarshal.Read<short>(span[2..4]);
+            var c = MemoryMarshal.Read<short>(span[..2]);
 
             return new Guid(a, b, c, d, e, f, g, h, i, j, k);
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/UuidSerializer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/UuidSerializer.cs
@@ -66,9 +66,9 @@ namespace Apache.Ignite.Internal.Proto
             var j = span[9];
             var k = span[8];
 
-            var a = MemoryMarshal.Read<int>(span[4..8]);
-            var b = MemoryMarshal.Read<short>(span[2..4]);
-            var c = MemoryMarshal.Read<short>(span[..2]);
+            var a = BinaryPrimitives.ReadInt32LittleEndian(span[4..8]);
+            var b = BinaryPrimitives.ReadInt16LittleEndian(span[2..4]);
+            var c = BinaryPrimitives.ReadInt16LittleEndian(span[..2]);
 
             return new Guid(a, b, c, d, e, f, g, h, i, j, k);
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/UuidSerializer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/UuidSerializer.cs
@@ -37,15 +37,17 @@ namespace Apache.Ignite.Internal.Proto
             var written = guid.TryWriteBytes(span);
             Debug.Assert(written, "written");
 
-            // Reverse endianness of the first part.
-            var a = BinaryPrimitives.ReverseEndianness(MemoryMarshal.Read<int>(span));
-            MemoryMarshal.Write(span, ref a);
+            // Reverse first part order: abc -> cba. Parts are little-endian on any system.
+            var a = MemoryMarshal.Read<int>(span);
+            var b = MemoryMarshal.Read<short>(span[4..]);
+            var c = MemoryMarshal.Read<short>(span[6..]);
 
-            var b = BinaryPrimitives.ReverseEndianness(MemoryMarshal.Read<short>(span[4..]));
-            MemoryMarshal.Write(span[4..], ref b);
+            MemoryMarshal.Write(span[4..8], ref a);
+            MemoryMarshal.Write(span[2..4], ref b);
+            MemoryMarshal.Write(span[..2], ref c);
 
-            var c = BinaryPrimitives.ReverseEndianness(MemoryMarshal.Read<short>(span[6..]));
-            MemoryMarshal.Write(span[6..], ref c);
+            // Reverse second part order: defghijk -> kjihgfed.
+            span[8..16].Reverse();
         }
 
         /// <summary>


### PR DESCRIPTION
* Use the same little-endian UUID format in MessagePack and BinaryTuple.
* Fix .NET Guid to match Java UUID format so that string representation is the same (important for debugging and logging).