### PR TITLE
IGNITE-17879 Packaging is broken

### DIFF
--- a/packaging/build.gradle
+++ b/packaging/build.gradle
@@ -47,39 +47,36 @@ task cliStartScript(type: CreateStartScripts) {
     applicationName = 'ignite3-cli'
 }
 
-def dbContents = spec -> {
-    // create empty dirs that are required to start Ignite
-    into('') {
-        File.createTempDir().with {
-            ["log", "etc", "work"].each {new File(absolutePath, it).mkdirs() }
-            from (absolutePath) {
-                includeEmptyDirs = true
-            }
-        }
-    }
-    into('') {
-        from ("$rootDir/LICENSE")
-        from ("$rootDir/NOTICE")
-        from ("$rootDir/assembly/README.md")
-    }
-    into('etc') {
-        from ("${buildDir}/scripts/bootstrap-config")
-        from ("${buildDir}/config/ignite-config.conf")
-        from ("${buildDir}/config/ignite.java.util.logging.properties")
-    }
-    into('bin') {
-        fileMode 0755
-        from ("$rootDir/packaging/scripts/ignite3-db.sh")
-    }
-    into('lib') {
-        from(configurations.dbArtifacts)
-    }
-}
-
 distributions {
     db {
         distributionBaseName = 'ignite3-db'
-        contents dbContents
+        contents {
+            into('') {
+                File.createTempDir().with {
+                    ["log", "etc", "work"].each { new File(absolutePath, it).mkdirs() }
+                    from(absolutePath) {
+                        includeEmptyDirs = true
+                    }
+                }
+            }
+            into('') {
+                from("$rootDir/LICENSE")
+                from("$rootDir/NOTICE")
+                from("$rootDir/assembly/README.md")
+            }
+            into('etc') {
+                from("${buildDir}/scripts/bootstrap-config")
+                from("${buildDir}/config/ignite-config.conf")
+                from("${buildDir}/config/ignite.java.util.logging.properties")
+            }
+            into('bin') {
+                fileMode 0755
+                from("$rootDir/packaging/scripts/ignite3-db.sh")
+            }
+            into('lib') {
+                from(configurations.dbArtifacts)
+            }
+        }
     }
 
     cli {
@@ -92,8 +89,6 @@ distributions {
                         includeEmptyDirs = true
                     }
                 }
-            }
-            into('') {
                 from ("$rootDir/LICENSE")
                 from ("$rootDir/NOTICE")
                 from ("$rootDir/assembly/README.md")
@@ -115,10 +110,29 @@ docker {
     name 'apacheignite/ignite3'
     dockerfile file('docker/Dockerfile')
 
-    copySpec.into 'dist', dbContents
-    copySpec.into('dist/bin') {
-        fileMode 0755
-        from('docker/docker-entrypoint.sh')
+    copySpec.into 'dist', {
+        into('') {
+            File.createTempDir().with {
+                ['etc', 'work'].each { new File(absolutePath, it).mkdirs() }
+                from(absolutePath) {
+                    includeEmptyDirs = true
+                }
+            }
+            from("$rootDir/LICENSE")
+            from("$rootDir/NOTICE")
+            from("$rootDir/assembly/README.md")
+        }
+        into('etc') {
+            from('config/ignite-config.conf')
+            from('docker/ignite.java.util.logging.properties')
+        }
+        into('bin') {
+            fileMode 0755
+            from('docker/docker-entrypoint.sh')
+        }
+        into('lib') {
+            from(configurations.dbArtifacts)
+        }
     }
 }
 

--- a/packaging/docker/ignite.java.util.logging.properties
+++ b/packaging/docker/ignite.java.util.logging.properties
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#########################################################################
+#       Default java.util.logging configuration for Ignite instance.
+#
+# To use another config file use `java.util.logging.config.file` system
+# property. For example `java -Djava.util.logging.config.file=myfile`
+#########################################################################
+
+#
+# Comma-separated list of logging "handlers". Note that some of them may be
+# reconfigured (or even removed) at runtime according to system properties.
+handlers=java.util.logging.ConsoleHandler
+
+#
+# Default global logging level.
+# This specifies which kinds of events are logged across all loggers.
+# For any given category this global level can be overridden by a category
+# specific level.
+# Note that handlers also have a separate level setting to limit messages
+# printed through it.
+#
+.level=INFO
+
+# Console handler logs all messages with importance level `INFO` and above
+# into standard error stream (`System.err`).
+#
+java.util.logging.ConsoleHandler.formatter = org.apache.ignite.lang.JavaLoggerFormatter
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.encoding = UTF-8

--- a/packaging/linux/start.sh
+++ b/packaging/linux/start.sh
@@ -38,6 +38,6 @@ ${IGNITE3_EXTRA_JVM_ARGS} \
 -classpath @INSTALL_DIR@/lib:@INSTALL_DIR@/lib/* org.apache.ignite.app.IgniteCliRunner \
 --config-path ${CONFIG_FILE} \
 --work-dir ${WORK_DIR} \
-${NODE_NAME}"
+--node-name ${NODE_NAME}"
 
 ${CMD}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-17879

Docker image doesn't need replace tokens task so split the CopySpec again and customize it for the docker.
Also the docker container should log the output to the console so the previous logging.properties is restored for it.
Start script for DEB/RPM was missing the --node-name argument.