### PR TITLE
IGNITE-17486 Fix barriers for Gradle verifications on CI

### DIFF
--- a/buildscripts/java-core.gradle
+++ b/buildscripts/java-core.gradle
@@ -93,6 +93,12 @@ jacoco {
     toolVersion = libs.versions.jacocoTool.get()
 }
 
+javadoc {
+    source = sourceSets.main.java
+    classpath = configurations.compileClasspath
+    enabled = false
+}
+
 jacocoTestReport {
     reports {
         xml.required = false

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -16,7 +16,9 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
+apply from: "$rootDir/buildscripts/java-integration-test.gradle"
 
 description = 'ignite-examples'
 
@@ -24,8 +26,17 @@ dependencies {
     implementation project(':ignite-runner')
     implementation project(':ignite-client')
     implementation project(':ignite-api')
+
     testImplementation project(':ignite-core')
     testImplementation libs.hamcrest.core
+
+    integrationTestImplementation project(':ignite-core')
+    integrationTestImplementation project(':ignite-storage-page-memory')
+    integrationTestImplementation project(':ignite-page-memory')
+    integrationTestImplementation project(':ignite-storage-rocksdb')
+    integrationTestImplementation project(':ignite-configuration')
+    integrationTestImplementation(testFixtures(project(':ignite-core')))
+    integrationTestImplementation libs.hamcrest.core
 }
 
 checkstyleMain {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+org.gradle.configureondemand=true
+org.gradle.daemon=true
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8

--- a/modules/affinity/build.gradle
+++ b/modules/affinity/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 description = 'ignite-affinity'

--- a/modules/api/build.gradle
+++ b/modules/api/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 

--- a/modules/baseline/build.gradle
+++ b/modules/baseline/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/binary-tuple/build.gradle
+++ b/modules/binary-tuple/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 description = 'ignite-binary-tuple'

--- a/modules/bytecode/build.gradle
+++ b/modules/bytecode/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 description = 'ignite-bytecode'

--- a/modules/cli/build.gradle
+++ b/modules/cli/build.gradle
@@ -23,6 +23,7 @@ plugins {
 }
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-integration-test.gradle"
 

--- a/modules/client-common/build.gradle
+++ b/modules/client-common/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/client-handler/build.gradle
+++ b/modules/client-handler/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-integration-test.gradle"
 

--- a/modules/client/build.gradle
+++ b/modules/client/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/cluster-management/build.gradle
+++ b/modules/cluster-management/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-test-fixtures.gradle"
 apply from: "$rootDir/buildscripts/java-integration-test.gradle"
@@ -58,7 +59,6 @@ dependencies {
     integrationTestImplementation(testFixtures(project(':ignite-configuration')))
     integrationTestImplementation(testFixtures(project(':ignite-network')))
     integrationTestImplementation libs.micronaut.junit5
-
     integrationTestImplementation libs.micronaut.test
     integrationTestImplementation libs.micronaut.http.client
     integrationTestImplementation libs.micronaut.http.server.netty

--- a/modules/compute/build.gradle
+++ b/modules/compute/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/configuration-annotation-processor/build.gradle
+++ b/modules/configuration-annotation-processor/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-integration-test.gradle"
 

--- a/modules/configuration-api/build.gradle
+++ b/modules/configuration-api/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/configuration/build.gradle
+++ b/modules/configuration/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-test-fixtures.gradle"
 

--- a/modules/core/build.gradle
+++ b/modules/core/build.gradle
@@ -20,6 +20,7 @@ plugins {
 }
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-test-fixtures.gradle"
 
@@ -53,7 +54,7 @@ test {
 
 shadowJar {
     archiveAppendix.set('shaded')
-    archiveClassifier.set('')
+    archiveClassifier.set('shaded')
 
     minimize()
 

--- a/modules/extended-api/build.gradle
+++ b/modules/extended-api/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/file-io/build.gradle
+++ b/modules/file-io/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/index/build.gradle
+++ b/modules/index/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/jacoco-report/build.gradle
+++ b/modules/jacoco-report/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/marshaller-common/build.gradle
+++ b/modules/marshaller-common/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 description = 'ignite-marshaller-common'

--- a/modules/metastorage-client/build.gradle
+++ b/modules/metastorage-client/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-integration-test.gradle"
 

--- a/modules/metastorage-common/build.gradle
+++ b/modules/metastorage-common/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/metastorage-server/build.gradle
+++ b/modules/metastorage-server/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-test-fixtures.gradle"
 

--- a/modules/metastorage/build.gradle
+++ b/modules/metastorage/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/metrics/build.gradle
+++ b/modules/metrics/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-integration-test.gradle"
 

--- a/modules/network-annotation-processor/build.gradle
+++ b/modules/network-annotation-processor/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/network-api/build.gradle
+++ b/modules/network-api/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/network/build.gradle
+++ b/modules/network/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-test-fixtures.gradle"
 apply from: "$rootDir/buildscripts/java-integration-test.gradle"

--- a/modules/page-memory/build.gradle
+++ b/modules/page-memory/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-integration-test.gradle"
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -33,7 +33,9 @@ namespace Apache.Ignite.Tests
     {
         private const int DefaultClientPort = 10942;
 
-        private const int ConnectTimeoutSeconds = 20;
+        private const int ConnectTimeoutSeconds = 120;
+
+        private const string GradleCommandExec = ":ignite-runner:runnerPlatformTest";
 
         /** Maven command to execute the main class. */
         private const string MavenCommandExec = "exec:java@platform-test-node-runner";
@@ -41,8 +43,14 @@ namespace Apache.Ignite.Tests
         /** Maven arg to perform a dry run to ensure that code is compiled and all artifacts are downloaded. */
         private const string MavenCommandDryRunArg = " -Dexec.args=dry-run";
 
+        /** Gradle arg to perform a dry run to ensure that code is compiled and all artifacts are downloaded. */
+        private const string GradleCommandDryRunArg = " --dry-run";
+
         /** Full path to Maven binary. */
         private static readonly string MavenPath = GetMaven();
+
+         /** Full path to Gradle binary. */
+        private static readonly string GradlePath = GetGradle();
 
         private static volatile bool _dryRunComplete;
 
@@ -183,7 +191,7 @@ namespace Apache.Ignite.Tests
                     ArgumentList =
                     {
                         TestUtils.IsWindows ? "/c" : "-c",
-                        $"{MavenPath} {MavenCommandExec}" + (dryRun ? MavenCommandDryRunArg : string.Empty)
+                        $"{GradlePath} {GradleCommandExec}" + (dryRun ? GradleCommandDryRunArg : string.Empty)
                     },
                     CreateNoWindow = true,
                     UseShellExecute = false,
@@ -260,6 +268,15 @@ namespace Apache.Ignite.Tests
                 .SelectMany(x => extensions.Select(ext => x + ext))
                 .Where(File.Exists)
                 .FirstOrDefault() ?? "mvn";
+        }
+
+        private static string GetGradle()
+        {
+            var gradleWrapper = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? "gradlew.bat"
+                : "gradlew";
+
+            return Path.Combine(TestUtils.RepoRootDir, gradleWrapper);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -36,7 +36,7 @@ namespace Apache.Ignite.Tests
         private const int ConnectTimeoutSeconds = 20;
 
         private const string GradleCommandExec = ":ignite-runner:runnerPlatformTest"
-          + "-x compileJava -x compileIntegrationTestJava -x compileTestJava";
+          + " -x compileJava -x compileTestFixturesJava -x compileIntegrationTestJava -x compileTestJava";
 
          /** Full path to Gradle binary. */
         private static readonly string GradlePath = GetGradle();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -36,7 +36,7 @@ namespace Apache.Ignite.Tests
         private const int ConnectTimeoutSeconds = 20;
 
         private const string GradleCommandExec = ":ignite-runner:runnerPlatformTest"
-          + " -x compileJava -x compileTestFixturesJava -x compileIntegrationTestJava -x compileTestJava";
+          + " -x compileJava -x compileIntegrationTestJava -x compileTestJava";
 
          /** Full path to Gradle binary. */
         private static readonly string GradlePath = GetGradle();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -36,7 +36,7 @@ namespace Apache.Ignite.Tests
         private const int ConnectTimeoutSeconds = 20;
 
         private const string GradleCommandExec = ":ignite-runner:runnerPlatformTest"
-          + "-x compileJava -x compileTestFixturesJava -x compileIntegrationTestJava -x compileTestJava";
+          + "-x compileJava -x compileIntegrationTestJava -x compileTestJava";
 
          /** Full path to Gradle binary. */
         private static readonly string GradlePath = GetGradle();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -67,7 +67,6 @@ namespace Apache.Ignite.Tests
 
             Log(">>> Java server is not detected, starting...");
 
-            EnsureBuild();
             var process = CreateProcess();
 
             var evt = new ManualResetEventSlim(false);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -37,17 +37,8 @@ namespace Apache.Ignite.Tests
 
         private const string GradleCommandExec = ":ignite-runner:runnerPlatformTest";
 
-        /** Maven command to execute the main class. */
-        private const string MavenCommandExec = "exec:java@platform-test-node-runner";
-
-        /** Maven arg to perform a dry run to ensure that code is compiled and all artifacts are downloaded. */
-        private const string MavenCommandDryRunArg = " -Dexec.args=dry-run";
-
         /** Gradle arg to perform a dry run to ensure that code is compiled and all artifacts are downloaded. */
         private const string GradleCommandDryRunArg = " --dry-run";
-
-        /** Full path to Maven binary. */
-        private static readonly string MavenPath = GetMaven();
 
          /** Full path to Gradle binary. */
         private static readonly string GradlePath = GetGradle();
@@ -133,7 +124,7 @@ namespace Apache.Ignite.Tests
         }
 
         /// <summary>
-        /// Performs a dry run of the Maven executable to ensure that code is compiled and all artifacts are downloaded.
+        /// Performs a dry run of the Gradle executable to ensure that code is compiled and all artifacts are downloaded.
         /// Does not start the actual node.
         /// </summary>
         private static void EnsureBuild()
@@ -168,12 +159,12 @@ namespace Apache.Ignite.Tests
             if (!process.WaitForExit(5 * 60_000))
             {
                 process.Kill();
-                throw new Exception("Failed to wait for Maven exec dry run.");
+                throw new Exception("Failed to wait for Gradle exec dry run.");
             }
 
             if (process.ExitCode != 0)
             {
-                throw new Exception($"Maven exec failed with code {process.ExitCode}, check log for details.");
+                throw new Exception($"Gradle exec failed with code {process.ExitCode}, check log for details.");
             }
 
             _dryRunComplete = true;
@@ -250,24 +241,6 @@ namespace Apache.Ignite.Tests
 
                 return e;
             }
-        }
-
-        /// <summary>
-        /// Gets maven path.
-        /// </summary>
-        private static string GetMaven()
-        {
-            var extensions = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? new[] {".cmd", ".bat"}
-                : new[] {string.Empty};
-
-            return new[] {"MAVEN_HOME", "M2_HOME", "M3_HOME", "MVN_HOME"}
-                .Select(Environment.GetEnvironmentVariable)
-                .Where(x => !string.IsNullOrEmpty(x))
-                .Select(x => Path.Combine(x!, "bin", "mvn"))
-                .SelectMany(x => extensions.Select(ext => x + ext))
-                .Where(File.Exists)
-                .FirstOrDefault() ?? "mvn";
         }
 
         private static string GetGradle()

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -33,7 +33,7 @@ namespace Apache.Ignite.Tests
     {
         private const int DefaultClientPort = 10942;
 
-        private const int ConnectTimeoutSeconds = 120;
+        private const int ConnectTimeoutSeconds = 20;
 
         private const string GradleCommandExec = ":ignite-runner:runnerPlatformTest"
           + "-x compileJava -x compileTestFixturesJava -x compileIntegrationTestJava -x compileTestJava";

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -36,7 +36,7 @@ namespace Apache.Ignite.Tests
         private const int ConnectTimeoutSeconds = 20;
 
         private const string GradleCommandExec = ":ignite-runner:runnerPlatformTest"
-          + " -x compileJava -x compileIntegrationTestJava -x compileTestJava";
+          + " -x compileJava -x compileTestFixturesJava -x compileIntegrationTestJava -x compileTestJava";
 
          /** Full path to Gradle binary. */
         private static readonly string GradlePath = GetGradle();
@@ -134,7 +134,7 @@ namespace Apache.Ignite.Tests
                     },
                     CreateNoWindow = true,
                     UseShellExecute = false,
-                    WorkingDirectory = Path.Combine(TestUtils.RepoRootDir, "modules", "runner"),
+                    WorkingDirectory = TestUtils.RepoRootDir,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true
                 }

--- a/modules/raft-client/build.gradle
+++ b/modules/raft-client/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 description = 'ignite-raft-client'

--- a/modules/raft/build.gradle
+++ b/modules/raft/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-test-fixtures.gradle"
 apply from: "$rootDir/buildscripts/java-integration-test.gradle"

--- a/modules/replicator/build.gradle
+++ b/modules/replicator/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 

--- a/modules/rest-api/build.gradle
+++ b/modules/rest-api/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/rest/build.gradle
+++ b/modules/rest/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 description = 'ignite-rest'

--- a/modules/rocksdb-common/build.gradle
+++ b/modules/rocksdb-common/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/runner/build.gradle
+++ b/modules/runner/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-integration-test.gradle"
 
@@ -95,6 +96,30 @@ dependencies {
     integrationTestImplementation libs.jsonpath.assert
     integrationTestImplementation libs.typesafe.config
 
+}
+
+def sqlIntegrationTest = tasks.register("sqlIntegrationTest", Test) {
+    description = 'Runs sql integration tests.'
+    group = 'verification'
+    useJUnitPlatform {
+        includeTags "sqllogic"
+    }
+    maxHeapSize = "16g"
+
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+}
+
+def runnerPlatformTest = tasks.register("runnerPlatformTest", JavaExec) {
+    mainClass = "org.apache.ignite.internal.runner.app.PlatformTestNodeRunner"
+
+    classpath = sourceSets.integrationTest.runtimeClasspath
+}
+
+integrationTest {
+    useJUnitPlatform {
+        excludeTags "sqllogic"
+    }
 }
 
 checkstyleMain {

--- a/modules/schema/build.gradle
+++ b/modules/schema/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-test-fixtures.gradle"
 

--- a/modules/sql-engine/build.gradle
+++ b/modules/sql-engine/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/sql-parser-generator.gradle"
 

--- a/modules/storage-api/build.gradle
+++ b/modules/storage-api/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-test-fixtures.gradle"
 

--- a/modules/storage-page-memory/build.gradle
+++ b/modules/storage-page-memory/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/storage-rocksdb/build.gradle
+++ b/modules/storage-rocksdb/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {

--- a/modules/table/build.gradle
+++ b/modules/table/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-integration-test.gradle"
 

--- a/modules/transactions/build.gradle
+++ b/modules/transactions/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-test-fixtures.gradle"
 

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -16,6 +16,7 @@
  */
 
 apply from: "$rootDir/buildscripts/java-core.gradle"
+apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 apply from: "$rootDir/buildscripts/java-test-fixtures.gradle"
 apply from: "$rootDir/buildscripts/java-integration-test.gradle"


### PR DESCRIPTION
Changes required for CI Gradle verification:
* Fix scripts.
* Update .NET tests to run nodes with Gradle instead of Maven (via PlatformTestNodeRunner class).

https://issues.apache.org/jira/browse/IGNITE-17714
https://issues.apache.org/jira/browse/IGNITE-17486
