### PR TITLE
IGNITE-17901 .NET: Fix Java server termination, increase timeout

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -113,7 +113,7 @@ namespace Apache.Ignite.Tests
 
         public void Dispose()
         {
-            _process?.Kill();
+            _process?.Kill(true);
             _process?.Dispose();
             Log(">>> Java server stopped.");
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -33,7 +33,7 @@ namespace Apache.Ignite.Tests
     {
         private const int DefaultClientPort = 10942;
 
-        private const int ConnectTimeoutSeconds = 20;
+        private const int ConnectTimeoutSeconds = 120;
 
         private const string GradleCommandExec = ":ignite-runner:runnerPlatformTest --no-daemon"
           + " -x compileJava -x compileTestFixturesJava -x compileIntegrationTestJava -x compileTestJava";

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -101,7 +101,7 @@ namespace Apache.Ignite.Tests
 
             if (!evt.Wait(TimeSpan.FromSeconds(ConnectTimeoutSeconds)) || !WaitForServer(port))
             {
-                process.Kill(true);
+                process.Kill(entireProcessTree: true);
 
                 throw new InvalidOperationException("Failed to wait for the server to start. Check logs for details.");
             }
@@ -113,7 +113,7 @@ namespace Apache.Ignite.Tests
 
         public void Dispose()
         {
-            _process?.Kill(true);
+            _process?.Kill(entireProcessTree: true);
             _process?.Dispose();
             Log(">>> Java server stopped.");
         }


### PR DESCRIPTION
* Use `Process.Kill(entireProcessTree: true)` to ensure Java node termination after tests.
* Increase Java node startup timeout.