### PR TITLE
IGNITE-17920 Develop docker-compose file for Ignite cluster

### DIFF
--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -437,6 +437,14 @@ Run docker container with ignite node:
 docker run -it --rm -p 10300:10300 apacheignite/ignite3
 ```
 
+There's a sample docker compose file which allows to run 3 nodes in a cluster in the `packaging/docker` directory. You can also use CLI from
+the docker image using `cli` parameter and connect to nodes using their names from the docker network.
+```shell
+docker compose -f packaging/docker/docker-compose.yml -d up
+docker run -it --rm --net ignite3_default apacheignite/ignite3 cli
+> connect http://node1:10300
+> cluster init --cluster-name cluster --meta-storage-node node1 --meta-storage-node node2 --meta-storage-node node3
+```
 
 ## Release candidate verification
 1. Build all packages (this will also run unit tests and all checks)

--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -440,7 +440,7 @@ docker run -it --rm -p 10300:10300 apacheignite/ignite3
 There's a sample docker compose file which allows to run 3 nodes in a cluster in the `packaging/docker` directory. You can also use CLI from
 the docker image using `cli` parameter and connect to nodes using their names from the docker network.
 ```shell
-docker compose -f packaging/docker/docker-compose.yml -d up
+docker compose -f packaging/docker/docker-compose.yml up -d
 docker run -it --rm --net ignite3_default apacheignite/ignite3 cli
 > connect http://node1:10300
 > cluster init --cluster-name cluster --meta-storage-node node1 --meta-storage-node node2 --meta-storage-node node3

--- a/packaging/build.gradle
+++ b/packaging/build.gradle
@@ -28,6 +28,7 @@ import org.gradle.crypto.checksum.Checksum
 
 configurations {
     dbArtifacts
+    cliArtifacts
     cliZip
     dbZip
     cliRelease
@@ -37,6 +38,7 @@ configurations {
 
 dependencies {
     dbArtifacts(project(':ignite-runner'))
+    cliArtifacts(project(':ignite-cli'))
     cliZip(project(path: ':packaging-cli', configuration: 'cliZip'))
     dbZip(project(path: ':packaging-db', configuration: 'dbZip'))
     cliRelease(project(path: ':packaging-cli', configuration: 'cliRelease'))

--- a/packaging/build.gradle
+++ b/packaging/build.gradle
@@ -44,6 +44,17 @@ dependencies {
     platformsRelease(project(path: ':platforms', configuration: 'platformsRelease'))
 }
 
+// Task that generates start script for cli
+task cliStartScript(type: CreateStartScripts) {
+    // Will be passed to exec "java ... <mainClassName>"
+    mainClass = "org.apache.ignite.internal.cli.Main"
+    // Forms a classpath string that will be passed to exec "java -cp <classpath> .."
+    // it is expected to locate the "lib" dir together with "bin"
+    classpath = files 'lib/*'
+    outputDir = file "$buildDir/scripts"
+    applicationName = 'ignite3'
+}
+
 def tokens = [
         INSTALL_DIR         : '${IGNITE_HOME}',
         CONF_DIR            : '${IGNITE_HOME}/etc',
@@ -67,28 +78,44 @@ docker {
 
     copySpec.into 'dist', {
         into('') {
-            File.createTempDir().with {
-                ['etc', 'work'].each { new File(absolutePath, it).mkdirs() }
-                from(absolutePath) {
-                    includeEmptyDirs = true
-                }
-            }
-            from("$rootDir/LICENSE")
-            from("$rootDir/NOTICE")
-            from("$rootDir/assembly/README.md")
-        }
-        into('etc') {
-            from('config/ignite-config.conf')
-            from('docker/ignite.java.util.logging.properties')
-        }
-        into('bin') {
             fileMode 0755
             from("$buildDir/docker/docker-entrypoint.sh")
         }
-        into('lib') {
-            from(configurations.dbArtifacts)
-            from("$buildDir/docker/$tokens.BOOTSTRAP_FILE_NAME")
-            from("$buildDir/docker/$tokens.SETUP_JAVA_FILE_NAME")
+        into('db') {
+            into('') {
+                File.createTempDir().with {
+                    ['etc', 'work'].each { new File(absolutePath, it).mkdirs() }
+                    from(absolutePath) {
+                        includeEmptyDirs = true
+                    }
+                }
+                from("$rootDir/LICENSE")
+                from("$rootDir/NOTICE")
+                from("$rootDir/assembly/README.md")
+            }
+            into('etc') {
+                from('config/ignite-config.conf')
+                from('docker/ignite.java.util.logging.properties')
+            }
+            into('lib') {
+                from(configurations.dbArtifacts)
+                from("$buildDir/docker/$tokens.BOOTSTRAP_FILE_NAME")
+                from("$buildDir/docker/$tokens.SETUP_JAVA_FILE_NAME")
+            }
+        }
+        into('cli') {
+            into('') {
+                from("$rootDir/LICENSE")
+                from("$rootDir/NOTICE")
+                from("$rootDir/assembly/README.md")
+            }
+            into('bin') {
+                fileMode 0755
+                from(cliStartScript)
+            }
+            into('lib') {
+                from(configurations.cliArtifacts)
+            }
         }
     }
 }

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,5 +1,21 @@
-FROM eclipse-temurin:11-jre
+FROM eclipse-temurin:11 as jre-build
 
+RUN $JAVA_HOME/bin/jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+# Same base image as eclipse-temurin
+FROM ubuntu:22.04
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
+
+# Copy and setup DB app
 ENV IGNITE_HOME /opt/ignite
 
 ENV LIBS_DIR $IGNITE_HOME/lib
@@ -8,7 +24,16 @@ ENV IGNITE_NODE_NAME defaultNode
 ENV IGNITE_WORK_DIR $IGNITE_HOME/work
 ENV IGNITE_CONFIG_PATH $IGNITE_HOME/etc/ignite-config.conf
 
-WORKDIR $IGNITE_HOME
-COPY dist .
+COPY dist/db $IGNITE_HOME
+
 EXPOSE 3344 10300 10800
-ENTRYPOINT ["bin/docker-entrypoint.sh"]
+
+# Copy CLI app
+ENV IGNITE_CLI_HOME /opt/ignite3cli
+
+COPY dist/cli $IGNITE_CLI_HOME
+
+# Copy entrypoint script
+COPY dist/docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/packaging/docker/docker-compose.yml
+++ b/packaging/docker/docker-compose.yml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3.9"
+
+name: ignite3
+
+x-ignite-def:
+  &ignite-def
+  image: apacheignite/ignite3:${IGNITE3_VERSION:-latest}
+
+services:
+  node1:
+    << : *ignite-def
+    command: --join node1:3344,node2:3344,node3:3344 --node-name node1
+    ports:
+      - 10300:10300
+      - 3344:3344
+  node2:
+    << : *ignite-def
+    command: --join node1:3344,node2:3344,node3:3344 --node-name node2
+    ports:
+      - 10301:10300
+      - 3345:3344
+  node3:
+    << : *ignite-def
+    command: --join node1:3344,node2:3344,node3:3344 --node-name node3
+    ports:
+      - 10302:10300
+      - 3346:3344

--- a/packaging/docker/docker-entrypoint.sh
+++ b/packaging/docker/docker-entrypoint.sh
@@ -17,6 +17,11 @@
 # limitations under the License.
 #
 
+if [ "$1" = 'cli' ]; then
+  shift
+  exec sh "$IGNITE_CLI_HOME"/bin/ignite3 "$@"
+fi
+
 . @LIB_DIR@/@BOOTSTRAP_FILE_NAME@
 
 LOGGING_JAVA_OPTS="-Djava.util.logging.config.file=@CONF_DIR@/ignite.java.util.logging.properties"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-17920

Simple docker compose file to start an uninitialized 3 nodes cluster.
This also slims docker image by using custom JRE by about 100 MB and adds CLI to the image (which adds about 25 MB back) so it can be run using `docker run apacheignite/ignite3 cli`