### PR TITLE
IGNITE-17918 Fix uber zip task dependencies

### DIFF
--- a/packaging/build.gradle
+++ b/packaging/build.gradle
@@ -94,8 +94,3 @@ task createChecksums(type: Checksum) {
 }
 
 allDistZip.finalizedBy(createChecksums)
-
-// copyCliAndDbZi depends on configurations.cliZip and configurations.dbZip
-// it makes allDistZip be depended on configurations.cliZip and configurations.dbZip
-// https://issues.apache.org/jira/browse/IGNITE-17918
-allDistZip.dependsOn copyCliAndDbZip

--- a/packaging/build.gradle
+++ b/packaging/build.gradle
@@ -72,15 +72,10 @@ docker {
 }
 
 // create an uber zip with all distributions
-
-task copyCliAndDbZip(type: Copy) {
-    from(configurations.cliZip)
-    from(configurations.dbZip)
-    into("$buildDir/tmp/zip/")
-}
-
 task allDistZip(type: Zip) {
     archiveBaseName = "ignite3"
+    dependsOn configurations.cliZip, configurations.dbZip
+
     def allZipFiles = configurations.cliZip + configurations.dbZip
     allZipFiles.each {
         from(zipTree(it))


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-17918

There wasn't dependency on configurations declared in allDistZip. That's why we needed a workaround copy task.