### PR TITLE
IGNITE-17994 Use toByteArray for colocation hash of BigDecimal and BigInteger

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
@@ -461,7 +461,7 @@ public class ClientTupleSerializer {
 
         for (ClientColumn col : schema.colocationColumns()) {
             Object value = rec.valueOrDefault(col.name(), null);
-            hashCalc.append(value);
+            hashCalc.append(value, col.scale());
         }
 
         return hashCalc.hash();
@@ -474,7 +474,7 @@ public class ClientTupleSerializer {
 
         for (ClientColumn col : schema.colocationColumns()) {
             Object value = marsh.value(rec, col.schemaIndex());
-            hashCalc.append(value);
+            hashCalc.append(value, col.scale());
         }
 
         return hashCalc.hash();

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/HashCalculator.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/HashCalculator.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.util;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -39,7 +40,7 @@ public class HashCalculator {
      *
      * @param v Value to update hash.
      */
-    public void append(Object v) {
+    public void append(Object v, int scale) {
         if (v == null) {
             appendNull();
             return;
@@ -60,7 +61,7 @@ public class HashCalculator {
         } else if (v.getClass() == BigInteger.class) {
             appendNumber((BigInteger) v);
         } else if (v.getClass() == BigDecimal.class) {
-            appendDecimal((BigDecimal) v);
+            appendDecimal((BigDecimal) v, scale);
         } else if (v.getClass() == UUID.class) {
             appendUuid((UUID) v);
         } else if (v.getClass() == LocalDate.class) {
@@ -148,8 +149,8 @@ public class HashCalculator {
      *
      * @param v Value to update hash.
      */
-    public void appendDecimal(BigDecimal v) {
-        appendBytes(v.unscaledValue().toByteArray());
+    public void appendDecimal(BigDecimal v, int columnScale) {
+        appendBytes(v.setScale(columnScale, RoundingMode.HALF_UP).unscaledValue().toByteArray());
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/HashCalculator.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/HashCalculator.java
@@ -149,7 +149,7 @@ public class HashCalculator {
      * @param v Value to update hash.
      */
     public void appendDecimal(BigDecimal v) {
-        appendDouble(v.doubleValue());
+        appendBytes(v.unscaledValue().toByteArray());
     }
 
     /**
@@ -158,7 +158,7 @@ public class HashCalculator {
      * @param v Value to update hash.
      */
     public void appendNumber(BigInteger v) {
-        appendDouble(v.doubleValue());
+        appendBytes(v.toByteArray());
     }
 
     /**

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/row/Row.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/row/Row.java
@@ -823,7 +823,7 @@ public class Row implements BinaryRowEx, SchemaAware, InternalTuple {
             HashCalculator hashCalc = new HashCalculator();
 
             for (Column c : schema().colocationColumns()) {
-                ColocationUtils.append(hashCalc, value(c.schemaIndex()), c.type().spec());
+                ColocationUtils.append(hashCalc, value(c.schemaIndex()), c.type());
             }
 
             colocationHash = h0 = hashCalc.hash();

--- a/modules/schema/src/main/java/org/apache/ignite/internal/util/ColocationUtils.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/util/ColocationUtils.java
@@ -25,6 +25,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.BitSet;
 import java.util.UUID;
+import org.apache.ignite.internal.schema.DecimalNativeType;
+import org.apache.ignite.internal.schema.NativeType;
 import org.apache.ignite.internal.schema.NativeTypeSpec;
 
 /**
@@ -43,15 +45,15 @@ public class ColocationUtils {
      *
      * @param calc Hash calculator.
      * @param v Value to update hash.
-     * @param typeSpec Value type.
+     * @param type Value type.
      */
-    public static void append(HashCalculator calc, Object v, NativeTypeSpec typeSpec) {
+    public static void append(HashCalculator calc, Object v, NativeType type) {
         if (v == null) {
             calc.appendNull();
             return;
         }
 
-        switch (typeSpec) {
+        switch (type.spec()) {
             case INT8:
                 calc.appendByte((byte) v);
                 return;
@@ -77,7 +79,7 @@ public class ColocationUtils {
                 return;
 
             case DECIMAL:
-                calc.appendDecimal((BigDecimal) v);
+                calc.appendDecimal((BigDecimal) v, ((DecimalNativeType)type).scale());
                 return;
 
             case UUID:
@@ -117,7 +119,7 @@ public class ColocationUtils {
                 return;
 
             default:
-                throw new IllegalStateException("Unexpected type: " + typeSpec);
+                throw new IllegalStateException("Unexpected type: " + type.spec());
         }
     }
 }

--- a/modules/schema/src/main/java/org/apache/ignite/internal/util/ColocationUtils.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/util/ColocationUtils.java
@@ -27,7 +27,6 @@ import java.util.BitSet;
 import java.util.UUID;
 import org.apache.ignite.internal.schema.DecimalNativeType;
 import org.apache.ignite.internal.schema.NativeType;
-import org.apache.ignite.internal.schema.NativeTypeSpec;
 
 /**
  * Colocation hash utilities.
@@ -79,7 +78,7 @@ public class ColocationUtils {
                 return;
 
             case DECIMAL:
-                calc.appendDecimal((BigDecimal) v, ((DecimalNativeType)type).scale());
+                calc.appendDecimal((BigDecimal) v, ((DecimalNativeType) type).scale());
                 return;
 
             case UUID:

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/ColocationHashCalculationTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/ColocationHashCalculationTest.java
@@ -27,6 +27,7 @@ import java.util.stream.IntStream;
 import org.apache.ignite.internal.logger.Loggers;
 import org.apache.ignite.internal.schema.ByteBufferRow;
 import org.apache.ignite.internal.schema.Column;
+import org.apache.ignite.internal.schema.DecimalNativeType;
 import org.apache.ignite.internal.schema.NativeType;
 import org.apache.ignite.internal.schema.SchemaDescriptor;
 import org.apache.ignite.internal.schema.SchemaTestUtils;
@@ -133,7 +134,8 @@ public class ColocationHashCalculationTest {
     private int colocationHash(Row r) {
         HashCalculator hashCalc = new HashCalculator();
         for (Column c : r.schema().colocationColumns()) {
-            hashCalc.append(r.value(c.schemaIndex()));
+            var scale = c.type() instanceof DecimalNativeType ? ((DecimalNativeType) c.type()).scale() : 0;
+            hashCalc.append(r.value(c.schemaIndex()), scale);
         }
 
         return hashCalc.hash();


### PR DESCRIPTION
Use toByteArray instead of conversion to double to make the logic portable to other languages.