### PR TITLE
IGNITE-17965: Enable remote build cache for Gradle build on CI.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,4 @@
 org.gradle.configureondemand=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+org.gradle.caching=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -113,3 +113,22 @@ project(":ignite-replicator").projectDir = file('modules/replicator')
 project(":packaging-cli").projectDir = file('packaging/cli')
 project(":packaging-db").projectDir = file('packaging/db')
 project(":packaging").projectDir = file('packaging')
+
+ext.isCiServer = System.getenv().containsKey("IGNITE_CI")
+
+buildCache {
+    local {
+        enabled = !isCiServer
+        push = !isCiServer
+    }
+    remote(HttpBuildCache) {
+        enabled = isCiServer
+        push = isCiServer
+        url = System.getenv()["GRADLE_BUILD_CACHE_URI"] + "/cache/"
+        allowInsecureProtocol = true
+        credentials {
+            username = System.getenv()["GRADLE_BUILD_CACHE_USERNAME"]
+            password = System.getenv()["GRADLE_BUILD_CACHE_PASSWORD"]
+        }
+    }
+}


### PR DESCRIPTION
* Optimization and fix for race cache modification

https://issues.apache.org/jira/browse/IGNITE-17965