### PR TITLE
IGNITE-16356 .NET: Add mapped column name customization with ColumnAttribute

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/PocoCustomColumnMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/PocoCustomColumnMapping.cs
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests.Table;
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+/// <summary>
+/// Custom column name mapping test.
+/// </summary>
+public record PocoCustomColumnMapping([property: Column("Key")] long Id, [property: Column("Val")] string? Name);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewCustomMappingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewCustomMappingTest.cs
@@ -15,18 +15,52 @@
  * limitations under the License.
  */
 
+// ReSharper disable NotAccessedPositionalProperty.Local
 namespace Apache.Ignite.Tests.Table;
 
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Threading.Tasks;
 using Ignite.Table;
+using NUnit.Framework;
 
 /// <summary>
 /// Tests custom user type mapping behavior in <see cref="IRecordView{T}"/>.
 /// </summary>
-public class RecordViewCustomMappingTest
+public class RecordViewCustomMappingTest : IgniteTestsBase
 {
+    private const long Key = 1;
+
+    private const string Val = "val1";
+
     // TODO: classes, structs, records
     // TODO: Fields and properties
     // TODO: Properties without fields?
-    public record PocoCustomColumnMapping([property: Column("Key")] long Id, [property: Column("Val")] string? Name);
+    [SetUp]
+    public async Task SetUp()
+    {
+        await Table.RecordBinaryView.UpsertAsync(null, GetTuple(Key, Val));
+    }
+
+    [Test]
+    public async Task TestFieldMapping()
+    {
+        var res = await Table.GetRecordView<FieldMapping>().GetAsync(null, new FieldMapping(Key));
+        Assert.AreEqual(Val, res.Value.Name);
+    }
+
+    [Test]
+    public async Task TestPropertyMapping()
+    {
+        // TODO
+        await Task.Delay(1);
+    }
+
+    [Test]
+    public async Task TestComputedPropertyMapping()
+    {
+        // TODO
+        await Task.Delay(1);
+    }
+
+    private record FieldMapping([field: Column("Key")] long Id, [field: Column("Val")] string? Name = null);
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewCustomMappingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewCustomMappingTest.cs
@@ -18,8 +18,15 @@
 namespace Apache.Ignite.Tests.Table;
 
 using System.ComponentModel.DataAnnotations.Schema;
+using Ignite.Table;
 
 /// <summary>
-/// Custom column name mapping test.
+/// Tests custom user type mapping behavior in <see cref="IRecordView{T}"/>.
 /// </summary>
-public record PocoCustomColumnMapping([property: Column("Key")] long Id, [property: Column("Val")] string? Name);
+public class RecordViewCustomMappingTest
+{
+    // TODO: classes, structs, records
+    // TODO: Fields and properties
+    // TODO: Properties without fields?
+    public record PocoCustomColumnMapping([property: Column("Key")] long Id, [property: Column("Val")] string? Name);
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewCustomMappingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewCustomMappingTest.cs
@@ -56,10 +56,17 @@ public class RecordViewCustomMappingTest : IgniteTestsBase
     }
 
     [Test]
-    public async Task TestComputedPropertyMapping()
+    public void TestComputedPropertyMappingThrowsException()
     {
-        var res = await Table.GetRecordView<ComputedPropertyMapping>().GetAsync(null, new ComputedPropertyMapping { Key = Key });
-        Assert.AreEqual(Val, res.Value.Val);
+        var ex = Assert.ThrowsAsync<IgniteClientException>(async () =>
+            await Table.GetRecordView<ComputedPropertyMapping>().GetAsync(null, new ComputedPropertyMapping { Id = Key }));
+
+        Assert.AreEqual(ErrorGroups.Client.Configuration, ex!.Code);
+
+        Assert.AreEqual(
+            "Can't map 'Apache.Ignite.Tests.Table.RecordViewCustomMappingTest+ComputedPropertyMapping' to columns" +
+            " 'Int64 KEY, String VAL'. Matching fields not found.",
+            ex.Message);
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewCustomMappingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewCustomMappingTest.cs
@@ -17,6 +17,8 @@
 
 // ReSharper disable NotAccessedPositionalProperty.Local
 // ReSharper disable UnusedMember.Local
+// ReSharper disable UnusedAutoPropertyAccessor.Local
+// ReSharper disable AutoPropertyCanBeMadeGetOnly.Local
 namespace Apache.Ignite.Tests.Table;
 
 using System.ComponentModel.DataAnnotations.Schema;
@@ -33,8 +35,6 @@ public class RecordViewCustomMappingTest : IgniteTestsBase
 
     private const string Val = "val1";
 
-    // TODO: classes, structs, records
-    // TODO: Duplicate column names
     [SetUp]
     public async Task SetUp()
     {
@@ -49,9 +49,30 @@ public class RecordViewCustomMappingTest : IgniteTestsBase
     }
 
     [Test]
-    public async Task TestPropertyMapping()
+    public async Task TestRecordPropertyMapping()
     {
         var res = await Table.GetRecordView<PropertyMapping>().GetAsync(null, new PropertyMapping(Key));
+        Assert.AreEqual(Val, res.Value.Name);
+    }
+
+    [Test]
+    public async Task TestClassPropertyMapping()
+    {
+        var res = await Table.GetRecordView<ClassPropertyMapping>().GetAsync(null, new ClassPropertyMapping { Id = Key });
+        Assert.AreEqual(Val, res.Value.Name);
+    }
+
+    [Test]
+    public async Task TestStructFieldMapping()
+    {
+        var res = await Table.GetRecordView<StructFieldMapping>().GetAsync(null, new StructFieldMapping(Key));
+        Assert.AreEqual(Val, res.Value.Name);
+    }
+
+    [Test]
+    public async Task TestStructPropertyMapping()
+    {
+        var res = await Table.GetRecordView<StructPropertyMapping>().GetAsync(null, new StructPropertyMapping(Key));
         Assert.AreEqual(Val, res.Value.Name);
     }
 
@@ -85,9 +106,22 @@ public class RecordViewCustomMappingTest : IgniteTestsBase
             ex.Message);
     }
 
+    private record struct StructFieldMapping([field: Column("Key")] long Id, [field: Column("Val")] string? Name = null);
+
+    private record struct StructPropertyMapping([property: Column("KEY")] long Id, [property: Column("VAL")] string? Name = null);
+
     private record FieldMapping([field: Column("Key")] long Id, [field: Column("Val")] string? Name = null);
 
     private record PropertyMapping([property: Column("Key")] long Id, [property: Column("Val")] string? Name = null);
+
+    private class ClassPropertyMapping
+    {
+        [Column("key")]
+        public long Id { get; set; }
+
+        [Column("val")]
+        public string Name { get; set; } = null!;
+    }
 
     // ReSharper disable MemberHidesStaticFromOuterClass
     private record ComputedPropertyMapping

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewCustomMappingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewCustomMappingTest.cs
@@ -119,7 +119,7 @@ public class RecordViewCustomMappingTest : IgniteTestsBase
         [Column("key")]
         public long Id { get; set; }
 
-        [Column("val")]
+        [Column("VAL")]
         public string Name { get; set; } = null!;
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
@@ -143,7 +143,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
             for (var index = 0; index < count; index++)
             {
                 var col = columns[index];
-                var fieldInfo = type.GetFieldIgnoreCase(col.Name);
+                var fieldInfo = type.GetFieldByColumnName(col.Name);
 
                 if (fieldInfo == null)
                 {
@@ -211,7 +211,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
                 }
                 else
                 {
-                    fieldInfo = (col.IsKey ? keyType : valType).GetFieldIgnoreCase(col.Name);
+                    fieldInfo = (col.IsKey ? keyType : valType).GetFieldByColumnName(col.Name);
                 }
 
                 if (fieldInfo == null)
@@ -296,7 +296,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
             for (var i = 0; i < count; i++)
             {
                 var col = columns[i];
-                var fieldInfo = type.GetFieldIgnoreCase(col.Name);
+                var fieldInfo = type.GetFieldByColumnName(col.Name);
 
                 EmitFieldRead(fieldInfo, il, col, i, local);
             }
@@ -345,7 +345,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
                     local = col.IsKey ? keyLocal : valLocal;
                     fieldInfo = local == null
                         ? null
-                        : (col.IsKey ? keyType : valType).GetFieldIgnoreCase(col.Name);
+                        : (col.IsKey ? keyType : valType).GetFieldByColumnName(col.Name);
                 }
 
                 EmitFieldRead(fieldInfo, il, col, i, local);
@@ -403,7 +403,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
             for (var i = 0; i < columns.Count; i++)
             {
                 var col = columns[i];
-                var fieldInfo = type.GetFieldIgnoreCase(col.Name);
+                var fieldInfo = type.GetFieldByColumnName(col.Name);
 
                 if (col.IsKey)
                 {
@@ -456,7 +456,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
                 for (var i = schema.KeyColumnCount; i < columns.Count; i++)
                 {
                     var col = columns[i];
-                    var fieldInfo = valType.GetFieldIgnoreCase(col.Name);
+                    var fieldInfo = valType.GetFieldByColumnName(col.Name);
 
                     EmitFieldRead(fieldInfo, il, col, i - schema.KeyColumnCount, valLocal);
                 }
@@ -612,7 +612,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
 
             var keyValTypes = type.GetGenericArguments();
 
-            return (keyValTypes[0], keyValTypes[1], type.GetFieldIgnoreCase("Key")!, type.GetFieldIgnoreCase("Val")!);
+            return (keyValTypes[0], keyValTypes[1], type.GetFieldByColumnName("Key")!, type.GetFieldByColumnName("Val")!);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
@@ -51,6 +51,11 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// <returns>Fields.</returns>
         public static IEnumerable<FieldInfo> GetAllFields(this Type type)
         {
+            if (type.IsPrimitive)
+            {
+                yield break;
+            }
+
             const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public |
                                        BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
@@ -21,7 +21,6 @@ namespace Apache.Ignite.Internal.Table.Serialization
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations.Schema;
-    using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
     using System.Runtime.CompilerServices;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
@@ -74,6 +74,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// <returns>Field info, or null when no matching fields exist.</returns>
         public static FieldInfo? GetFieldIgnoreCase(this Type type, string name)
         {
+            // TODO: use System.ComponentModel.DataAnnotations.Schema.ColumnAttribute for custom names
             // ReSharper disable once HeapView.CanAvoidClosure, ConvertClosureToMethodGroup
             return FieldsByNameCache.GetOrAdd(type, t => GetFieldsByName(t)).TryGetValue(name, out var fieldInfo)
                 ? fieldInfo

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
@@ -115,7 +115,8 @@ namespace Apache.Ignite.Internal.Table.Serialization
         public static string GetCleanName(this MemberInfo memberInfo) => CleanFieldName(memberInfo.Name);
 
         /// <summary>
-        /// Gets cleaned up member name without compiler-generated prefixes and suffixes.
+        /// Gets column name for the specified field: uses <see cref="ColumnAttribute"/> when available,
+        /// falls back to cleaned up field name otherwise.
         /// </summary>
         /// <param name="fieldInfo">Member.</param>
         /// <returns>Clean name.</returns>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
@@ -98,6 +98,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// <returns>Clean name.</returns>
         public static string GetColumnName(this MemberInfo memberInfo)
         {
+            // TODO: Support attributes on properties, not only fields.
             if (memberInfo.GetCustomAttribute<ColumnAttribute>() is { } columnAttribute &&
                 columnAttribute.Name != null)
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
@@ -81,11 +81,11 @@ namespace Apache.Ignite.Internal.Table.Serialization
         public static FieldInfo? GetFieldByColumnName(this Type type, string name)
         {
             // ReSharper disable once HeapView.CanAvoidClosure, ConvertClosureToMethodGroup
-            return FieldsByColumnNameCache.GetOrAdd(type, t => GetFieldsByName(t)).TryGetValue(name, out var fieldInfo)
+            return FieldsByColumnNameCache.GetOrAdd(type, t => GetFieldsByColumnName(t)).TryGetValue(name, out var fieldInfo)
                 ? fieldInfo
                 : null;
 
-            static IReadOnlyDictionary<string, FieldInfo> GetFieldsByName(Type type)
+            static IReadOnlyDictionary<string, FieldInfo> GetFieldsByColumnName(Type type)
             {
                 var res = new Dictionary<string, FieldInfo>(StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
Support custom column names with a standard `System.ComponentModel.DataAnnotations.Schema.ColumnAttribute` when mapping user-defined types to Ignite columns in `RecordView<T>` and `KeyValueView<T>`.