### PR TITLE
IGNITE-18036 Rename packages

### DIFF
--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -347,8 +347,8 @@ You can build zip and run CLI with the following commands:
 ```shell
 ./gradlew clean packaging-cli:distZip -x test -x check
 cd packaging/cli/build/distributions
-unzip ignite3cli-3.<version>
-cd ignite3cli-3.<version>
+unzip ignite3-cli-<version>
+cd ignite3-cli-<version>
 ./bin/ignite3
 ```
 
@@ -356,14 +356,14 @@ To build a zip file with ignite-runner and run it:
 ```shell
 ./gradlew clean packaging-db:distZip -x test -x check
 cd packaging/db/build/distributions
-unzip ignite3db-3.<version>
-cd ignite3db-3.<version>
-./bin/ignite3db.sh start
+unzip ignite3-db-<version>
+cd ignite3-db-<version>
+./bin/ignite3db start
 ```
 
 To stop the started node run:
 ```shell
-./bin/ignite3db.sh stop
+./bin/ignite3db stop
 ```
 
 ### RPM/DEB packaging
@@ -372,19 +372,19 @@ There is also RPM/DEB packaging for Ignite. To build those packages run:
 ```shell
 ./gradlew clean buildDeb buildRpm -x test -x check
 ```
-`ignite3cli` packages are located in `packaging/cli/build/distributions/` and `ignite3db` packages in `packaging/db/build/distributions/`.
+`ignite3-cli` packages are located in `packaging/cli/build/distributions/` and `ignite3-db` packages in `packaging/db/build/distributions/`.
 ***
 
 To install RPM packages run:
 ```shell
-rpm -i ignite3cli_3.<version>.noarch.rpm
-rpm -i ignite3db_3.<version>.noarch.rpm
+rpm -i ignite3-cli-<version>.noarch.rpm
+rpm -i ignite3-db-<version>.noarch.rpm
 ```
 
 To install DEB packages run:
 ```shell
-dpkg --install ignite3cli_3.<version>_all.deb
-dpkg --install ignite3db_3.<version>_all.deb
+dpkg --install ignite3-cli_<version>_all.deb
+dpkg --install ignite3-db_<version>_all.deb
 ```
 
 Run ignite3db service:
@@ -404,14 +404,14 @@ ignite3
 
 To uninstall RPM packages run:
 ```shell
-rpm -e ignite3cli
-rpm -e ignite3db
+rpm -e ignite3-cli
+rpm -e ignite3-db
 ```
 
 To uninstall DEB packages run:
 ```shell
-dpkg --remove ignite3cli
-dpkg --remove ignite3db
+dpkg --remove ignite3-cli
+dpkg --remove ignite3-db
 ```
 
 ### Docker image
@@ -435,25 +435,25 @@ docker run -it --rm -p 10300:10300 apacheignite/ignite3
 1. Go to the `packaging/build/distributions` directory which now contains the packaged CLI tool and Ignite
     ```shell
    cd packaging/build/distributions
-   unzip ignite3-3.<version> 
+   unzip ignite3-<version> 
     ```
 1. Run the tool without parameters (full list of available commands should appear)
     ```shell
-   cd ignite3cli-3.<version>
+   cd ignite3-cli-<version>
    ./bin/ignite3
     ```
 1. Start a node
     ```shell
-   cd ../ignite3db-3.<version>
+   cd ../ignite3-db-<version>
    ./bin/ignite3db start
     ```
 1. Check that the new node is up and running
     ```shell
-    cd ../ignite3cli-3.<version>
+    cd ../ignite3-cli-<version>
    ./bin/ignite3 node status
     ```
 1. Stop the node
-    ```
-    cd ../ignite3db-3.<version>
+    ```shell
+    cd ../ignite3-db-<version>
    ./bin/ignite3db stop
     ```

--- a/packaging/build.gradle
+++ b/packaging/build.gradle
@@ -92,6 +92,7 @@ signing {
 }
 
 task createChecksums(type: Checksum) {
+    //TODO: remove distribution name hard code IGNITE-18092
     files = files(files("${buildDir}/distributions/ignite3-${project.version}.zip"))
     outputDir = new File("${buildDir}/distributions")
     algorithm = Checksum.Algorithm.SHA512

--- a/packaging/cli/build.gradle
+++ b/packaging/cli/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 // Common for ZIP and RPM/DEB
 
 def tokens = [
-        PRODUCT_NAME        : 'ignite3cli',
+        PRODUCT_NAME        : 'ignite3-cli',
         PRODUCT_DISPLAY_NAME: 'Apache Ignite CLI',
         INSTALL_DIR         : '/usr/bin',
         LIB_DIR             : '/usr/lib/ignite3',
@@ -96,7 +96,7 @@ task cliStartScript(type: CreateStartScripts) {
 
 distributions {
     main {
-        distributionBaseName = 'ignite3cli'
+        distributionBaseName = 'ignite3-cli'
         contents {
             into('') {
                 from("$rootDir/LICENSE")

--- a/packaging/cli/build.gradle
+++ b/packaging/cli/build.gradle
@@ -72,7 +72,8 @@ distTar.dependsOn replaceScriptVars
 distZip.dependsOn replaceScriptVars
 
 task createChecksums(type: Checksum) {
-    files = files(file("${buildDir}/distributions/ignite3cli-${project.version}.zip"))
+    //TODO: remove distribution name hard code IGNITE-18092
+    files = files(file("${buildDir}/distributions/ignite3-cli-${project.version}.zip"))
     outputDir = new File("${buildDir}/distributions")
     algorithm = Checksum.Algorithm.SHA512
 }

--- a/packaging/db/build.gradle
+++ b/packaging/db/build.gradle
@@ -75,7 +75,8 @@ distributions {
 }
 
 task createChecksums(type: Checksum) {
-    files = files(file("${buildDir}/distributions/ignite3db-${project.version}.zip"))
+    //TODO: remove distribution name hard code IGNITE-18092
+    files = files(file("${buildDir}/distributions/ignite3-db-${project.version}.zip"))
     outputDir = new File("${buildDir}/distributions")
     algorithm = Checksum.Algorithm.SHA512
 }

--- a/packaging/db/build.gradle
+++ b/packaging/db/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 
 distributions {
     main {
-        distributionBaseName = 'ignite3db'
+        distributionBaseName = 'ignite3-db'
         contents {
             // create empty dirs that are required to start Ignite
             into('') {
@@ -63,6 +63,9 @@ distributions {
             into('bin') {
                 fileMode 0755
                 from("$rootDir/packaging/zip/ignite3db.sh")
+                rename {
+                    "ignite3db"
+                }
             }
             into('lib') {
                 from configurations.dbArtifacts
@@ -107,6 +110,7 @@ def args = '--config-path $IGNITE_CONFIG_FILE --work-dir $WORK_PATH $NODE_NAME'
 
 def tokens = [
         PRODUCT_NAME        : 'ignite3db',
+        PACKAGE_NAME        : 'ignite3-db',
         PRODUCT_DISPLAY_NAME: 'Apache Ignite',
         APP_JAR             : "${project(':ignite-runner').name}-${project(':ignite-runner').version}.jar".toString(),
         MAIN_CLASS          : 'org.apache.ignite.app.IgniteCliRunner',
@@ -166,7 +170,7 @@ buildDeb {
 
 ospackage {
     license "ASL 2.0"
-    packageName packageTokens.PRODUCT_NAME
+    packageName packageTokens.PACKAGE_NAME
     packageGroup "System Environment/Daemons"
     url "https://ignite.apache.org"
     user packageTokens.USERNAME


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-18036

Now RPM, DEB, and ZIP distributions are named
like ignite3-cli, ignite3-db. But was ignite3db, ignite3cli.