### PR TITLE
IGNITE-18059 .NET: Convert error codes to constants

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ErrorGroupsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ErrorGroupsGenerator.cs
@@ -127,11 +127,10 @@ namespace Apache.Ignite.Internal.Generators
                 foreach (var (errorName, errorCode) in javaErrors)
                 {
                     var dotNetErrorName = SnakeToCamelCase(errorName);
-                    var fullCode = (groupCode << 16) | (errorCode & 0xFFFF);
 
                     sb.AppendLine();
                     sb.AppendLine($"            /// <summary> {dotNetErrorName} error. </summary>");
-                    sb.AppendLine($"            public const int {dotNetErrorName} = {fullCode};");
+                    sb.AppendLine($"            public const int {dotNetErrorName} = (GroupCode << 16) | ({errorCode} & 0xFFFF);");
                 }
 
                 sb.AppendLine("        }");

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ErrorGroupsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ErrorGroupsGenerator.cs
@@ -127,10 +127,11 @@ namespace Apache.Ignite.Internal.Generators
                 foreach (var (errorName, errorCode) in javaErrors)
                 {
                     var dotNetErrorName = SnakeToCamelCase(errorName);
+                    var fullCode = (groupCode << 16) | (errorCode & 0xFFFF);
 
                     sb.AppendLine();
                     sb.AppendLine($"            /// <summary> {dotNetErrorName} error. </summary>");
-                    sb.AppendLine($"            public static readonly int {dotNetErrorName} = GetFullCode(GroupCode, {errorCode});");
+                    sb.AppendLine($"            public const int {dotNetErrorName} = {fullCode};");
                 }
 
                 sb.AppendLine("        }");


### PR DESCRIPTION
Replace `static readonly int` with `const int` in generated error codes - constants work better in pattern matching scenarios.