### PR TITLE
IGNITE-18058 .NET: Add timeout for handshake and heartbeats

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -99,6 +99,8 @@ namespace Apache.Ignite.Tests
 
         public TimeSpan HandshakeDelay { get; set; }
 
+        public TimeSpan HeartbeatDelay { get; set; }
+
         public int Port => ((IPEndPoint)_listener.LocalEndPoint!).Port;
 
         public string Endpoint => "127.0.0.1:" + Port;
@@ -547,6 +549,11 @@ namespace Apache.Ignite.Tests
 
                         case ClientOp.SqlCursorNextPage:
                             SqlCursorNextPage(handler, requestId);
+                            continue;
+
+                        case ClientOp.Heartbeat:
+                            Thread.Sleep(HeartbeatDelay);
+                            Send(handler, requestId, Array.Empty<byte>());
                             continue;
                     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -97,6 +97,8 @@ namespace Apache.Ignite.Tests
 
         public bool PartitionAssignmentChanged { get; set; }
 
+        public TimeSpan HandshakeDelay { get; set; }
+
         public int Port => ((IPEndPoint)_listener.LocalEndPoint!).Port;
 
         public string Endpoint => "127.0.0.1:" + Port;
@@ -404,6 +406,7 @@ namespace Apache.Ignite.Tests
 
                 // Write handshake response.
                 handler.Send(ProtoCommon.MagicBytes);
+                Thread.Sleep(HandshakeDelay);
 
                 using var handshakeBufferWriter = new PooledArrayBufferWriter();
                 var handshakeWriter = handshakeBufferWriter.GetMessageWriter();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ListLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ListLogger.cs
@@ -117,7 +117,7 @@ namespace Apache.Ignite.Tests
                     message += Environment.NewLine + ex;
                 }
 
-                _entries.Add(new Entry(message, level, category));
+                _entries.Add(new Entry(message, level, category, ex));
             }
         }
 
@@ -128,6 +128,6 @@ namespace Apache.Ignite.Tests
         }
 
         [SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible", Justification = "Tests.")]
-        public record Entry(string Message, LogLevel Level, string? Category);
+        public record Entry(string Message, LogLevel Level, string? Category, Exception? Exception);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/SocketTimeoutTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/SocketTimeoutTest.cs
@@ -59,7 +59,7 @@ public class SocketTimeoutTest
 
         using var client = await server.ConnectClientAsync(cfg);
 
-        await Task.Delay(100);
+        await Task.Delay(200);
 
         var ex = Assert.ThrowsAsync<TimeoutException>(async () => await client.Tables.GetTablesAsync());
         StringAssert.Contains("at Apache.Ignite.Internal.ClientSocket.SendHeartbeatAsync", ex!.ToString());

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/SocketTimeoutTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/SocketTimeoutTest.cs
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests;
+
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests <see cref="IgniteClientConfiguration.SocketTimeout"/> behavior.
+/// </summary>
+public class SocketTimeoutTest
+{
+    [Test]
+    public void TestHandshakeTimeoutThrowsException()
+    {
+        using var server = new FakeServer
+        {
+            HandshakeDelay = TimeSpan.FromMilliseconds(100)
+        };
+
+        var cfg = new IgniteClientConfiguration
+        {
+            SocketTimeout = TimeSpan.FromMilliseconds(50)
+        };
+
+        Assert.ThrowsAsync<TimeoutException>(async () => await server.ConnectClientAsync(cfg));
+    }
+
+    [Test]
+    public async Task TestHeartbeatTimeoutThrowsException()
+    {
+        await Task.Delay(1);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/SocketTimeoutTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/SocketTimeoutTest.cs
@@ -67,7 +67,7 @@ public class SocketTimeoutTest
 
         var expectedLog = "Exception while reading from socket, connection closed: The operation was canceled.";
         Assert.IsTrue(
-            condition: log.Entries.Any(e => e.Message.Contains(expectedLog)),
+            condition: log.Entries.Any(e => e.Message.Contains(expectedLog) && e.Exception is TimeoutException),
             message: string.Join(Environment.NewLine, log));
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/SocketTimeoutTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/SocketTimeoutTest.cs
@@ -65,9 +65,9 @@ public class SocketTimeoutTest
         using var client = await server.ConnectClientAsync(cfg);
         await Task.Delay(200);
 
-        var expectedLog = "Exception while reading from socket, connection closed: The operation was canceled.";
+        var expectedLog = "Heartbeat failed: The operation has timed out.";
         Assert.IsTrue(
             condition: log.Entries.Any(e => e.Message.Contains(expectedLog) && e.Exception is TimeoutException),
-            message: string.Join(Environment.NewLine, log));
+            message: string.Join(Environment.NewLine, log.Entries));
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
@@ -88,7 +88,12 @@ namespace Apache.Ignite
         public IIgniteLogger? Logger { get; set; }
 
         /// <summary>
-        /// Gets or sets the socket operation timeout. Zero or negative means infinite timeout.
+        /// Gets or sets the socket timeout.
+        /// <para />
+        /// The timeout applies to handshake and heartbeats (see <see cref="HeartbeatInterval"/>). If the server does not respond
+        /// to a handshake or heartbeat in the specified time, the connection is closed with <see cref="TimeoutException"/>.
+        /// <para />
+        /// -1 means infinite timeout.
         /// </summary>
         [DefaultValue(typeof(TimeSpan), "00:00:05")]
         public TimeSpan SocketTimeout { get; set; } = DefaultSocketTimeout;

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
@@ -90,8 +90,9 @@ namespace Apache.Ignite
         /// <summary>
         /// Gets or sets the socket timeout.
         /// <para />
-        /// The timeout applies to handshake and heartbeats (see <see cref="HeartbeatInterval"/>). If the server does not respond
-        /// to a handshake or heartbeat in the specified time, the connection is closed with <see cref="TimeoutException"/>.
+        /// The timeout applies to the initial handshake procedure and heartbeats (see <see cref="HeartbeatInterval"/>).
+        /// If the server does not respond to the initial handshake message or a periodic heartbeat in the specified time,
+        /// the connection is closed with a <see cref="TimeoutException"/>.
         /// <para />
         /// -1 means infinite timeout.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -272,7 +272,7 @@ namespace Apache.Ignite.Internal
                         }
                         catch (Exception e)
                         {
-                            _logger?.Warn($"Failed to connect to preferred node {preferredNode}: {e.Message}", e);
+                            _logger?.Warn(e, $"Failed to connect to preferred node {preferredNode}: {e.Message}");
                         }
                     }
                 }
@@ -338,7 +338,7 @@ namespace Apache.Ignite.Internal
             }
             catch (Exception e)
             {
-                _logger?.Warn("Error while trying to establish secondary connections: " + e.Message, e);
+                _logger?.Warn(e, "Error while trying to establish secondary connections: " + e.Message);
             }
             finally
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -538,7 +538,7 @@ namespace Apache.Ignite.Internal
             }
             catch (Exception e)
             {
-                const string message = "Exception while reading from socket. Connection closed.";
+                var message = "Exception while reading from socket, connection closed: " + e.Message;
 
                 _logger?.Error(message, e);
                 Dispose(new IgniteClientConnectionException(ErrorGroups.Client.Connection, message, e));

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -379,7 +379,6 @@ namespace Apache.Ignite.Internal
 
             while (received < size)
             {
-                // TODO IGNITE-18058 This may wait forever, use IgniteClientConfiguration.SocketTimeout.
                 var res = await stream.ReadAsync(buffer.AsMemory(received, size - received), cancellationToken).ConfigureAwait(false);
 
                 if (res == 0)
@@ -540,7 +539,7 @@ namespace Apache.Ignite.Internal
             {
                 var message = "Exception while reading from socket, connection closed: " + e.Message;
 
-                _logger?.Error(message, e);
+                _logger?.Error(e, message);
                 Dispose(new IgniteClientConnectionException(ErrorGroups.Client.Connection, message, e));
             }
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -604,6 +604,8 @@ namespace Apache.Ignite.Internal
             }
             catch (Exception e)
             {
+                _logger?.Error(e, "Heartbeat failed: " + e.Message);
+
                 Dispose(e);
             }
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -77,6 +77,9 @@ namespace Apache.Ignite.Internal
         /** Effective heartbeat interval. */
         private readonly TimeSpan _heartbeatInterval;
 
+        /** Socket timeout for handshakes and heartbeats. */
+        private readonly TimeSpan _socketTimeout;
+
         /** Logger. */
         private readonly IIgniteLogger? _logger;
 
@@ -109,6 +112,7 @@ namespace Apache.Ignite.Internal
             ConnectionContext = connectionContext;
             _assignmentChangeCallback = assignmentChangeCallback;
             _logger = configuration.Logger.GetLogger(GetType());
+            _socketTimeout = configuration.SocketTimeout;
 
             _heartbeatInterval = GetHeartbeatInterval(configuration.HeartbeatInterval, connectionContext.IdleTimeout, _logger);
 
@@ -597,7 +601,7 @@ namespace Apache.Ignite.Internal
         {
             try
             {
-                await DoOutInOpAsync(ClientOp.Heartbeat).ConfigureAwait(false);
+                await DoOutInOpAsync(ClientOp.Heartbeat).WaitAsync(_socketTimeout).ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -164,7 +164,10 @@ namespace Apache.Ignite.Internal
 
                 var stream = new NetworkStream(socket, ownsSocket: true);
 
-                var context = await HandshakeAsync(stream, endPoint).ConfigureAwait(false);
+                var context = await HandshakeAsync(stream, endPoint)
+                    .WaitAsync(configuration.SocketTimeout)
+                    .ConfigureAwait(false);
+
                 logger?.Debug($"Handshake succeeded: {context}.");
 
                 return new ClientSocket(stream, configuration, context, assignmentChangeCallback);


### PR DESCRIPTION
If the server does not respond to the initial handshake message or a periodic heartbeat in the specified time, close the connection with a `TimeoutException`.