### PR TITLE
IGNITE-17775 Invalid data in network buffers causes message deserialization errors and messages loss

### DIFF
--- a/modules/network/src/main/java/org/apache/ignite/network/MessageSerializationRegistryImpl.java
+++ b/modules/network/src/main/java/org/apache/ignite/network/MessageSerializationRegistryImpl.java
@@ -73,8 +73,12 @@ public class MessageSerializationRegistryImpl implements MessageSerializationReg
      * @throws NetworkConfigurationException if no serializers have been registered for the given group type and message type.
      */
     private <T extends NetworkMessage> MessageSerializationFactory<T> getFactory(short groupType, short messageType) {
-        assert groupType >= 0 : "group type must not be negative, groupType=" + groupType;
-        assert messageType >= 0 : "message type must not be negative, messageType=" + messageType;
+        if (groupType < 0) {
+            throw new NetworkConfigurationException("Group type must not be negative, groupType=" + groupType);
+        }
+        if (messageType < 0) {
+            throw new NetworkConfigurationException("Message type must not be negative, messageType=" + messageType);
+        }
 
         MessageSerializationFactory<?>[] groupFactories = factories[groupType];
 

--- a/modules/network/src/test/java/org/apache/ignite/network/serialization/MessageSerializationRegistryImplTest.java
+++ b/modules/network/src/test/java/org/apache/ignite/network/serialization/MessageSerializationRegistryImplTest.java
@@ -25,8 +25,6 @@ import org.apache.ignite.network.MessageSerializationRegistryImpl;
 import org.apache.ignite.network.NetworkConfigurationException;
 import org.apache.ignite.network.NetworkMessage;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 
 /**
  * {@link MessageSerializationRegistryImpl} tests.
@@ -108,16 +106,16 @@ public class MessageSerializationRegistryImplTest {
         assertNotNull(registry.createSerializer(Short.MAX_VALUE, Short.MAX_VALUE));
     }
 
-    @ParameterizedTest
-    @EnumSource(CreationAction.class)
-    void exceptionIsThrownForNegativeGroupId(CreationAction creationAction) {
-        assertThrows(NetworkConfigurationException.class, () -> creationAction.create(registry, (short) -1, (short) 1));
+    @Test
+    void exceptionIsThrownForNegativeGroupId() {
+        assertThrows(NetworkConfigurationException.class, () -> registry.createSerializer((short) -1, (short) 1));
+        assertThrows(NetworkConfigurationException.class, () -> registry.createDeserializer((short) -1, (short) 1));
     }
 
-    @ParameterizedTest
-    @EnumSource(CreationAction.class)
-    void exceptionIsThrownForNegativeMessageTypeId(CreationAction creationAction) {
-        assertThrows(NetworkConfigurationException.class, () -> creationAction.create(registry, (short) 1, (short) -1));
+    @Test
+    void exceptionIsThrownForNegativeMessageTypeId() {
+        assertThrows(NetworkConfigurationException.class, () -> registry.createSerializer((short) 1, (short) -1));
+        assertThrows(NetworkConfigurationException.class, () -> registry.createDeserializer((short) 1, (short) -1));
     }
 
     /**
@@ -156,22 +154,5 @@ public class MessageSerializationRegistryImplTest {
         public MessageSerializer<Msg> createSerializer() {
             return mock(MessageSerializer.class);
         }
-    }
-
-    private enum CreationAction {
-        CREATE_SERIALIZER {
-            @Override
-            void create(MessageSerializationRegistry registry, short groupType, short messageType) {
-                registry.createSerializer(groupType, messageType);
-            }
-        },
-        CREATE_DESERIALIZER {
-            @Override
-            void create(MessageSerializationRegistry registry, short groupType, short messageType) {
-                registry.createDeserializer(groupType, messageType);
-            }
-        };
-
-        abstract void create(MessageSerializationRegistry registry, short groupType, short messageType);
     }
 }

--- a/modules/network/src/test/java/org/apache/ignite/network/serialization/MessageSerializationRegistryImplTest.java
+++ b/modules/network/src/test/java/org/apache/ignite/network/serialization/MessageSerializationRegistryImplTest.java
@@ -25,6 +25,8 @@ import org.apache.ignite.network.MessageSerializationRegistryImpl;
 import org.apache.ignite.network.NetworkConfigurationException;
 import org.apache.ignite.network.NetworkMessage;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 /**
  * {@link MessageSerializationRegistryImpl} tests.
@@ -106,6 +108,18 @@ public class MessageSerializationRegistryImplTest {
         assertNotNull(registry.createSerializer(Short.MAX_VALUE, Short.MAX_VALUE));
     }
 
+    @ParameterizedTest
+    @EnumSource(CreationAction.class)
+    void exceptionIsThrownForNegativeGroupId(CreationAction creationAction) {
+        assertThrows(NetworkConfigurationException.class, () -> creationAction.create(registry, (short) -1, (short) 1));
+    }
+
+    @ParameterizedTest
+    @EnumSource(CreationAction.class)
+    void exceptionIsThrownForNegativeMessageTypeId(CreationAction creationAction) {
+        assertThrows(NetworkConfigurationException.class, () -> creationAction.create(registry, (short) 1, (short) -1));
+    }
+
     /**
      * {@link NetworkMessage} implementation.
      */
@@ -142,5 +156,22 @@ public class MessageSerializationRegistryImplTest {
         public MessageSerializer<Msg> createSerializer() {
             return mock(MessageSerializer.class);
         }
+    }
+
+    private enum CreationAction {
+        CREATE_SERIALIZER {
+            @Override
+            void create(MessageSerializationRegistry registry, short groupType, short messageType) {
+                registry.createSerializer(groupType, messageType);
+            }
+        },
+        CREATE_DESERIALIZER {
+            @Override
+            void create(MessageSerializationRegistry registry, short groupType, short messageType) {
+                registry.createDeserializer(groupType, messageType);
+            }
+        };
+
+        abstract void create(MessageSerializationRegistry registry, short groupType, short messageType);
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-17775

Here, we just make the behavior between passing a negative group/messageType and passing an unknown group/messageType consistent. For further developments, see IGNITE-18072.