### PR TITLE
IGNITE-16925 Java thin: Add partition awareness to executeColocated

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -56,6 +56,7 @@ import org.apache.ignite.internal.client.io.netty.NettyClientConnectionMultiplex
 import org.apache.ignite.internal.logger.IgniteLogger;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.network.ClusterNode;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Communication channel with failover and partition awareness.
@@ -174,8 +175,8 @@ public final class ReliableChannel implements AutoCloseable {
             int opCode,
             PayloadWriter payloadWriter,
             PayloadReader<T> payloadReader,
-            String preferredNodeName,
-            String preferredNodeId
+            @Nullable String preferredNodeName,
+            @Nullable String preferredNodeId
     ) {
         CompletableFuture<T> fut = new CompletableFuture<>();
 
@@ -218,9 +219,9 @@ public final class ReliableChannel implements AutoCloseable {
             int opCode,
             PayloadWriter payloadWriter,
             PayloadReader<T> payloadReader,
-            String preferredNodeName,
-            String preferredNodeId,
-            IgniteClientConnectionException failure,
+            @Nullable String preferredNodeName,
+            @Nullable String preferredNodeId,
+            @Nullable IgniteClientConnectionException failure,
             int attempt) {
         ClientChannel ch = null;
         ClientChannelHolder holder = null;

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -119,9 +119,8 @@ public class ClientCompute implements IgniteCompute {
         Objects.requireNonNull(key);
         Objects.requireNonNull(jobClassName);
 
-        // TODO: IGNITE-16925 - implement partition awareness.
         return getTable(tableName)
-                .thenCompose(table -> this.<R>executeColocatedTupleKey(table, key, jobClassName, args))
+                .thenCompose(table -> (CompletableFuture<R>)executeColocatedTupleKey(table, key, jobClassName, args))
                 .handle((res, err) -> handleMissingTable(tableName, res, err))
                 .thenCompose(r ->
                         // If a table was dropped, try again: maybe a new table was created with the same name and new id.
@@ -138,9 +137,8 @@ public class ClientCompute implements IgniteCompute {
         Objects.requireNonNull(keyMapper);
         Objects.requireNonNull(jobClassName);
 
-        // TODO: IGNITE-16925 - implement partition awareness.
         return getTable(tableName)
-                .thenCompose(table -> this.<K, R>executeColocatedObjectKey(table, key, keyMapper, jobClassName, args))
+                .thenCompose(table -> (CompletableFuture<R>)executeColocatedObjectKey(table, key, keyMapper, jobClassName, args))
                 .handle((res, err) -> handleMissingTable(tableName, res, err))
                 .thenCompose(r ->
                         // If a table was dropped, try again: maybe a new table was created with the same name and new id.
@@ -186,7 +184,7 @@ public class ClientCompute implements IgniteCompute {
         }, r -> (R) r.in().unpackObjectFromBinaryTuple(), node.name(), null);
     }
 
-    private ClusterNode randomNode(Set<ClusterNode> nodes) {
+    private static ClusterNode randomNode(Set<ClusterNode> nodes) {
         if (nodes.size() == 1) {
             return nodes.iterator().next();
         }
@@ -201,7 +199,7 @@ public class ClientCompute implements IgniteCompute {
         return iterator.next();
     }
 
-    private <K, R> CompletableFuture<R> executeColocatedObjectKey(
+    private static <K, R> CompletableFuture<R> executeColocatedObjectKey(
             ClientTable t,
             K key,
             Mapper<K> keyMapper,
@@ -220,10 +218,11 @@ public class ClientCompute implements IgniteCompute {
                     w.packString(jobClassName);
                     w.packObjectArrayAsBinaryTuple(args);
                 },
-                r -> (R) r.unpackObjectFromBinaryTuple());
+                r -> (R) r.unpackObjectFromBinaryTuple(),
+                ClientTupleSerializer.getHashFunction(null, keyMapper, key));
     }
 
-    private <R> CompletableFuture<R> executeColocatedTupleKey(
+    private static <R> CompletableFuture<R> executeColocatedTupleKey(
             ClientTable t,
             Tuple key,
             String jobClassName,
@@ -241,7 +240,8 @@ public class ClientCompute implements IgniteCompute {
                     w.packString(jobClassName);
                     w.packObjectArrayAsBinaryTuple(args);
                 },
-                r -> (R) r.unpackObjectFromBinaryTuple());
+                r -> (R) r.unpackObjectFromBinaryTuple(),
+                ClientTupleSerializer.getHashFunction(null, key));
     }
 
     private CompletableFuture<ClientTable> getTable(String tableName) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -120,7 +120,7 @@ public class ClientCompute implements IgniteCompute {
         Objects.requireNonNull(jobClassName);
 
         return getTable(tableName)
-                .thenCompose(table -> (CompletableFuture<R>)executeColocatedTupleKey(table, key, jobClassName, args))
+                .thenCompose(table -> (CompletableFuture<R>) executeColocatedTupleKey(table, key, jobClassName, args))
                 .handle((res, err) -> handleMissingTable(tableName, res, err))
                 .thenCompose(r ->
                         // If a table was dropped, try again: maybe a new table was created with the same name and new id.
@@ -138,7 +138,7 @@ public class ClientCompute implements IgniteCompute {
         Objects.requireNonNull(jobClassName);
 
         return getTable(tableName)
-                .thenCompose(table -> (CompletableFuture<R>)executeColocatedObjectKey(table, key, keyMapper, jobClassName, args))
+                .thenCompose(table -> (CompletableFuture<R>) executeColocatedObjectKey(table, key, keyMapper, jobClassName, args))
                 .handle((res, err) -> handleMissingTable(tableName, res, err))
                 .thenCompose(r ->
                         // If a table was dropped, try again: maybe a new table was created with the same name and new id.

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -145,7 +145,7 @@ public class ClientTable implements Table {
         return loadSchema(ver);
     }
 
-    private CompletableFuture<ClientSchema> loadSchema(Integer ver) {
+    private CompletableFuture<ClientSchema> loadSchema(@Nullable Integer ver) {
         return ch.serviceAsync(ClientOp.SCHEMAS_GET, w -> {
             w.out().packUuid(id);
 
@@ -259,7 +259,7 @@ public class ClientTable implements Table {
             int opCode,
             BiConsumer<ClientSchema, PayloadOutputChannel> writer,
             BiFunction<ClientSchema, ClientMessageUnpacker, T> reader,
-            T defaultValue
+            @Nullable T defaultValue
     ) {
         return getLatestSchema()
                 .thenCompose(schema ->
@@ -339,11 +339,11 @@ public class ClientTable implements Table {
                 });
     }
 
-    private <T> Object readSchemaAndReadData(
+    private <T> @Nullable Object readSchemaAndReadData(
             ClientSchema knownSchema,
             ClientMessageUnpacker in,
             BiFunction<ClientSchema, ClientMessageUnpacker, T> fn,
-            T defaultValue
+            @Nullable T defaultValue
     ) {
         if (in.tryUnpackNil()) {
             return defaultValue;

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -273,8 +273,8 @@ public class ClientTable implements Table {
             int opCode,
             BiConsumer<ClientSchema, PayloadOutputChannel> writer,
             BiFunction<ClientSchema, ClientMessageUnpacker, T> reader,
-            T defaultValue,
-            Function<ClientSchema, Integer> hashFunction
+            @Nullable T defaultValue,
+            @Nullable Function<ClientSchema, Integer> hashFunction
     ) {
         CompletableFuture<ClientSchema> schemaFut = getLatestSchema();
         CompletableFuture<List<String>> partitionsFut = hashFunction == null
@@ -315,7 +315,7 @@ public class ClientTable implements Table {
                                 r -> reader.apply(r.in())));
     }
 
-    <T> CompletableFuture<T> doSchemaOutOpAsync(
+    public <T> CompletableFuture<T> doSchemaOutOpAsync(
             int opCode,
             BiConsumer<ClientSchema, PayloadOutputChannel> writer,
             Function<ClientMessageUnpacker, T> reader,

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -315,6 +315,16 @@ public class ClientTable implements Table {
                                 r -> reader.apply(r.in())));
     }
 
+    /**
+     * Performs a schema-based operation.
+     *
+     * @param opCode Op code.
+     * @param writer Writer.
+     * @param reader Reader.
+     * @param hashFunction Hash function for partition awareness.
+     * @param <T> Result type.
+     * @return Future representing pending completion of the operation.
+     */
     public <T> CompletableFuture<T> doSchemaOutOpAsync(
             int opCode,
             BiConsumer<ClientSchema, PayloadOutputChannel> writer,

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -319,7 +319,7 @@ public class ClientTable implements Table {
             int opCode,
             BiConsumer<ClientSchema, PayloadOutputChannel> writer,
             Function<ClientMessageUnpacker, T> reader,
-            Function<ClientSchema, Integer> hashFunction) {
+            @Nullable Function<ClientSchema, Integer> hashFunction) {
 
         CompletableFuture<ClientSchema> schemaFut = getLatestSchema();
         CompletableFuture<List<String>> partitionsFut = hashFunction == null
@@ -419,7 +419,10 @@ public class ClientTable implements Table {
     }
 
     @Nullable
-    private static String getPreferredNodeId(Function<ClientSchema, Integer> hashFunction, List<String> partitions, ClientSchema schema) {
+    private static String getPreferredNodeId(
+            @Nullable Function<ClientSchema, Integer> hashFunction,
+            @Nullable List<String> partitions,
+            ClientSchema schema) {
         if (partitions == null || partitions.isEmpty() || hashFunction == null) {
             return null;
         }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
@@ -445,13 +445,13 @@ public class ClientTupleSerializer {
     }
 
     @Nullable
-    static Function<ClientSchema, Integer> getHashFunction(@Nullable Transaction tx, @NotNull Tuple rec) {
+    public static Function<ClientSchema, Integer> getHashFunction(@Nullable Transaction tx, @NotNull Tuple rec) {
         // Disable partition awareness when transaction is used: tx belongs to a default connection.
         return tx != null ? null : schema -> getColocationHash(schema, rec);
     }
 
     @Nullable
-    static Function<ClientSchema, Integer> getHashFunction(@Nullable Transaction tx, Mapper<?> mapper, @NotNull Object rec) {
+    public static Function<ClientSchema, Integer> getHashFunction(@Nullable Transaction tx, Mapper<?> mapper, @NotNull Object rec) {
         // Disable partition awareness when transaction is used: tx belongs to a default connection.
         return tx != null ? null : schema -> getColocationHash(schema, mapper, rec);
     }


### PR DESCRIPTION
Send `executeColocated` request to the target node if a direct connection exists.