### PR TITLE
IGNITE-18008 Slow dns cause slow cli startup

### DIFF
--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/Main.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/Main.java
@@ -20,6 +20,9 @@ package org.apache.ignite.internal.cli;
 import static org.apache.ignite.internal.cli.config.ConfigConstants.IGNITE_CLI_LOGS_DIR;
 
 import io.micronaut.configuration.picocli.MicronautFactory;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.ApplicationContextBuilder;
+import io.micronaut.context.env.Environment;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -58,7 +61,8 @@ public class Main {
         initJavaLoggerProps();
 
         int exitCode = 0;
-        try (MicronautFactory micronautFactory = new MicronautFactory()) {
+        ApplicationContextBuilder builder = ApplicationContext.builder(Environment.CLI).deduceEnvironment(false);
+        try (MicronautFactory micronautFactory = new MicronautFactory(builder.start())) {
             AnsiConsole.systemInstall();
             if (args.length != 0 || !isatty()) { // do not enter REPL if input or output is redirected
                 try {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-18008

Simple fix which disables micronaut's environment detection which internally does some domain probing to detect whether it runs in cloud.