### PR TITLE
IGNITE-17930 Enable javadoc in gradle and fix doclint

### DIFF
--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -297,7 +297,18 @@ Run integration tests only:
 ***
 
 ## Checking and generating Javadoc
- [TBD](https://issues.apache.org/jira/browse/IGNITE-17930)
+Javadoc is generated and checked for correctness with [Gradle Javadoc Plugin](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.javadoc.Javadoc.html).
+
+Build Javadoc site (found in `build/docs/aggregateJavadoc/index.html`):
+```
+./gradlew aggregateJavadoc 
+```
+
+If you don't need to aggregate all javadoc you can use javadoc task and find generated 
+artifacts in each module (for example `modules/api/build/docs/javadoc`)
+```
+./gradlew javadoc
+```
 ***
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.time.LocalDate
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -20,6 +22,7 @@
 plugins {
     alias(libs.plugins.javacc) apply false
     alias(libs.plugins.modernizer) apply false
+    alias(libs.plugins.aggregateJavadoc)
 }
 
 repositories {
@@ -76,6 +79,53 @@ allprojects {
 
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
+    }
+
+    tasks.withType(Javadoc) {
+        options.addStringOption('bottom', """
+            <table width="100%" border="0" cellspacing=0 cellpadding=0 style="padding: 5px">
+            <tr>
+                <td>
+                    <table style="padding-left: 0; margin: 0">
+                        <tbody style="padding: 0; margin: 0">
+                            <tr style="padding: 0; margin: 0">
+                                <td>
+                                    <a target=_blank href="https://ignite.apache.org"><nobr>${LocalDate.now().year} Copyright &#169; Apache Software Foundation</nobr></a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+                <td width="100%" align="right" valign="center">
+                    <a href="https://twitter.com/ApacheIgnite" class="twitter-follow-button" data-show-count="false" data-size="large">Follow @ApacheIgnite</a>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2" valign="top" align="left">
+                    <table style="padding-left: 0; margin: 0">
+                        <tbody style="padding: 0; margin: 0">
+                            <tr style="padding: 0; margin: 0">
+                                <td>
+                                    <b>Ignite Database and Caching Platform</b>
+                                </td>
+                                <td>:&nbsp;&nbsp;
+                                    ver. <strong>${project.version}</strong>
+                                </td>
+                            </tr>
+                            <tr style="padding: 0; margin: 0">
+                                <td>
+                                    <b>Release Date</b>
+                                </td>
+                                <td>:&nbsp;&nbsp;
+                                    ${LocalDate.now()}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+            </table>
+""")
     }
 }
 

--- a/buildscripts/java-core.gradle
+++ b/buildscripts/java-core.gradle
@@ -94,9 +94,18 @@ jacoco {
 }
 
 javadoc {
-    source = sourceSets.main.java
+    source = sourceSets.main.allJava
     classpath = configurations.compileClasspath
-    enabled = false
+
+    def sourceDirs = sourceSets.main.java.sourceDirectories.join(":")
+    def generatedSources = "$buildDir/generated/sources/annotationProcessor/java/main"
+
+    options.addStringOption("-source-path", sourceDirs + ":" + generatedSources)
+
+    exclude 'org/apache/ignite/internal/**'
+    exclude 'com/facebook/presto/**'
+
+    enabled = true
 }
 
 jacocoTestReport {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,6 +86,7 @@ modernizer = "com.github.andygoossens.modernizer:1.6.2"
 nebula = "nebula.ospackage:9.1.1"
 docker = "com.palantir.docker:0.34.0"
 checksum = "org.gradle.crypto.checksum:1.4.0"
+aggregateJavadoc = "io.freefair.aggregate-javadoc:6.5.1"
 
 [libraries]
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }

--- a/modules/raft/src/main/java/org/apache/ignite/raft/jraft/Iterator.java
+++ b/modules/raft/src/main/java/org/apache/ignite/raft/jraft/Iterator.java
@@ -33,7 +33,7 @@ public interface Iterator extends java.util.Iterator<ByteBuffer> {
     /**
      * Return a unique and monotonically increasing identifier of the current task: - Uniqueness guarantees that
      * committed tasks in different peers with the same index are always the same and kept unchanged. - Monotonicity
-     * guarantees that for any index pair i, j (i < j), task at index |i| must be applied before task at index |j| in
+     * guarantees that for any index pair i, j (i less than j), task at index |i| must be applied before task at index |j| in
      * all the peers from the group.
      */
     long getIndex();
@@ -44,12 +44,12 @@ public interface Iterator extends java.util.Iterator<ByteBuffer> {
     long getTerm();
 
     /**
-     * If done() is non-NULL, you must call done()->Run() after applying this task no matter this operation succeeds or
+     * If done() is non-NULL, you must call done() then Run() after applying this task no matter this operation succeeds or
      * fails, otherwise the corresponding resources would leak.
-     *
+     * <p>
      * If this task is proposed by this Node when it was the leader of this group and the leadership has not changed
      * before this point, done() is exactly what was passed to Node#apply(Task) which may stand for some continuation
-     * (such as respond to the client) after updating the StateMachine with the given task. Otherwise done() must be
+     * (such as respond to the client) after updating the StateMachine with the given task. Otherwise, done() must be
      * NULL.
      */
     Closure done();

--- a/modules/raft/src/main/java/org/apache/ignite/raft/jraft/Node.java
+++ b/modules/raft/src/main/java/org/apache/ignite/raft/jraft/Node.java
@@ -129,8 +129,8 @@ public interface Node extends Lifecycle<NodeOptions>, Describer {
     List<PeerId> listPeers();
 
     /**
-     * List all alive peers of this raft group, only leader returns.</p>
-     *
+     * List all alive peers of this raft group, only leader returns.
+     * <p>
      * [NOTE] <strong>list_alive_peers is just a transient data (snapshot) and a short-term loss of response by the
      * follower will cause it to temporarily not exist in this list.</strong>
      *
@@ -139,8 +139,8 @@ public interface Node extends Lifecycle<NodeOptions>, Describer {
     List<PeerId> listAlivePeers();
 
     /**
-     * List all learners of this raft group, only leader returns.</p>
-     *
+     * List all learners of this raft group, only leader returns.
+     * <p>
      * [NOTE] <strong>when listLearners concurrency with {@link #addLearners(List, Closure)}/{@link
      * #removeLearners(List, Closure)}/{@link #resetLearners(List, Closure)}, maybe return peers is staled.  Because
      * {@link #addLearners(List, Closure)}/{@link #removeLearners(List, Closure)}/{@link #resetLearners(List, Closure)}
@@ -151,8 +151,8 @@ public interface Node extends Lifecycle<NodeOptions>, Describer {
     List<PeerId> listLearners();
 
     /**
-     * List all alive learners of this raft group, only leader returns.</p>
-     *
+     * List all alive learners of this raft group, only leader returns.
+     * <p>
      * [NOTE] <strong>when listAliveLearners concurrency with {@link #addLearners(List, Closure)}/{@link
      * #removeLearners(List, Closure)}/{@link #resetLearners(List, Closure)}, maybe return peers is staled.  Because
      * {@link #addLearners(List, Closure)}/{@link #removeLearners(List, Closure)}/{@link #resetLearners(List, Closure)}

--- a/modules/raft/src/main/java/org/apache/ignite/raft/jraft/util/Recyclers.java
+++ b/modules/raft/src/main/java/org/apache/ignite/raft/jraft/util/Recyclers.java
@@ -24,7 +24,7 @@ import org.apache.ignite.internal.logger.Loggers;
 
 /**
  * Light-weight object pool based on a thread-local stack.
- * <p/>
+ *
  * Forked from <a href="https://github.com/netty/netty">Netty</a>.
  *
  * @param <T> the type of the pooled object

--- a/modules/raft/src/main/java/org/apache/ignite/raft/jraft/util/concurrent/AdjustableSemaphore.java
+++ b/modules/raft/src/main/java/org/apache/ignite/raft/jraft/util/concurrent/AdjustableSemaphore.java
@@ -104,7 +104,7 @@ public final class AdjustableSemaphore implements Serializable {
     /**
      * Returns if the permits is available of the semaphore.
      *
-     * @return {@code true} if current number of permits > 0
+     * @return {@code true} if current number of permits more than 0
      */
     public boolean isAvailable() {
         return availablePermits() > 0;


### PR DESCRIPTION
Now javadoc site can be built with gradle aggregateJavadoc task. By default, this task runs DocLint which performs some checks. There were several errors in raft module that now are fixed as well.