### PR TITLE
IGNITE-18105 Remove ivy dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,6 @@
 #
 
 [versions]
-ivy = "2.5.0"
 assertj = "3.22.0"
 asm = "9.0"
 compileTesting = "0.19"
@@ -139,8 +138,6 @@ jansi-core = { module = "org.fusesource.jansi:jansi", version.ref = "jansi" }
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
-
-apache-ivy = { module = "org.apache.ivy:ivy", version.ref = "ivy" }
 
 typesafe-config = { module = "com.typesafe:config", version.ref = "typesafe" }
 slf4j-jdk14 = { module = "org.slf4j:slf4j-jdk14", version.ref = "slf4j" }

--- a/modules/cli/build.gradle
+++ b/modules/cli/build.gradle
@@ -49,7 +49,6 @@ dependencies {
     implementation libs.picocli.shell.jline3
     implementation libs.picocli.core
     implementation libs.jackson.databind
-    implementation libs.apache.ivy
     implementation libs.typesafe.config
     implementation libs.slf4j.jdk14
     implementation libs.gson.core

--- a/modules/cli/pom.xml
+++ b/modules/cli/pom.xml
@@ -105,11 +105,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.ivy</groupId>
-            <artifactId>ivy</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
         </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -51,7 +51,6 @@
         <maven.compiler.target>11</maven.compiler.target>
 
         <!-- Dependencies versions -->
-        <apache.ivy.version>2.5.0</apache.ivy.version>
         <assertj-core.version>3.22.0</assertj-core.version>
         <asm.framework.version>9.0</asm.framework.version>
         <compile.testing.library.version>0.19</compile.testing.library.version>
@@ -551,12 +550,6 @@
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
                 <version>${checker.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.ivy</groupId>
-                <artifactId>ivy</artifactId>
-                <version>${apache.ivy.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-18105

Ivy was used for bootstrap command which was removed.