### PR TITLE
IGNITE-18133 .NET: Ignore CLI module and build artifacts in ExceptionsGenerator

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
@@ -42,7 +42,8 @@ namespace Apache.Ignite.Internal.Generators
             var exclude = new[]
             {
                 "internal",
-                string.Format(CultureInfo.InvariantCulture, "{0}target{0}", Path.DirectorySeparatorChar),
+                string.Format(CultureInfo.InvariantCulture, "{0}target{0}", Path.DirectorySeparatorChar), // Maven
+                string.Format(CultureInfo.InvariantCulture, "{0}build{0}", Path.DirectorySeparatorChar), // Gradle
                 Path.Combine("modules", "cli")
             };
 

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Internal.Generators
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Reflection;
@@ -41,7 +42,7 @@ namespace Apache.Ignite.Internal.Generators
             var exclude = new[]
             {
                 "internal",
-                string.Format("{0}target{0}", Path.DirectorySeparatorChar),
+                string.Format(CultureInfo.InvariantCulture, "{0}target{0}", Path.DirectorySeparatorChar),
                 Path.Combine("modules", "cli")
             };
 

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
@@ -38,11 +38,18 @@ namespace Apache.Ignite.Internal.Generators
         {
             var javaModulesDirectory = context.GetJavaModulesDirectory();
 
+            var exclude = new[]
+            {
+                "internal",
+                string.Format("{0}target{0}", Path.DirectorySeparatorChar),
+                Path.Combine("modules", "cli")
+            };
+
             var javaExceptionsWithParents = Directory.EnumerateFiles(
                     javaModulesDirectory,
                     "*Exception.java",
                     SearchOption.AllDirectories)
-                .Where(x => !x.Contains("internal"))
+                .Where(x => !exclude.Any(x.Contains))
                 .Select(File.ReadAllText)
                 .Select(x => (
                     Class: Regex.Match(x, @"public class (\w+) extends (\w+)"),

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessTests.cs
@@ -23,7 +23,6 @@ using System.Threading.Tasks;
 using Ignite.Table;
 using Internal.Proto;
 using NUnit.Framework;
-using Table;
 
 /// <summary>
 /// Tests partition awareness.


### PR DESCRIPTION
Generated classes may be present multiple times in build artifacts, which breaks .NET build. Skip them - we don't need those classes.