### PR TITLE
IGNITE-18138 .NET: LINQ: Avoid overfetching, select only mapped columns

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -41,6 +41,10 @@ public class LinqSqlGenerationTests
         AssertSql("select _T0.KEY from PUBLIC.tbl1 as _T0", q => q.Select(x => x.Key).ToList());
 
     [Test]
+    public void TestSelectAllColumns() =>
+        AssertSql("select _T0.KEY, _T0.VAL from PUBLIC.tbl1 as _T0", q => q.ToList());
+
+    [Test]
     public void TestSum() =>
         AssertSql("select sum (_T0.KEY) from PUBLIC.tbl1 as _T0", q => q.Sum(x => x.Key));
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -45,6 +45,10 @@ public class LinqSqlGenerationTests
         AssertSql("select _T0.KEY, _T0.VAL from PUBLIC.tbl1 as _T0", q => q.ToList());
 
     [Test]
+    public void TestSelectAllColumnsCustomNames() =>
+        AssertSql("select _T0.\"KEY\", _T0.\"VAL\" from PUBLIC.tbl1 as _T0", tbl => tbl.GetRecordView<PocoCustomNames>().AsQueryable().ToList());
+
+    [Test]
     public void TestSum() =>
         AssertSql("select sum (_T0.KEY) from PUBLIC.tbl1 as _T0", q => q.Sum(x => x.Key));
 
@@ -131,13 +135,16 @@ public class LinqSqlGenerationTests
         _server.Dispose();
     }
 
-    private void AssertSql(string expectedSql, Func<IQueryable<Poco>, object?> query)
+    private void AssertSql(string expectedSql, Func<IQueryable<Poco>, object?> query) =>
+        AssertSql(expectedSql, t => query(t.GetRecordView<Poco>().AsQueryable()));
+
+    private void AssertSql(string expectedSql, Func<ITable, object?> query)
     {
         _server.LastSql = string.Empty;
 
         try
         {
-            query(_table.GetRecordView<Poco>().AsQueryable());
+            query(_table);
         }
         catch (Exception)
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Tests.Linq;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Ignite.Sql;
@@ -45,8 +46,16 @@ public class LinqSqlGenerationTests
         AssertSql("select _T0.KEY, _T0.VAL from PUBLIC.tbl1 as _T0", q => q.ToList());
 
     [Test]
+    public void TestSelectAllColumnsOneColumnPoco() =>
+        AssertSql(
+            "select _T0.KEY from PUBLIC.tbl1 as _T0",
+            tbl => tbl.GetRecordView<OneColumnPoco>().AsQueryable().ToList());
+
+    [Test]
     public void TestSelectAllColumnsCustomNames() =>
-        AssertSql("select _T0.\"KEY\", _T0.\"VAL\" from PUBLIC.tbl1 as _T0", tbl => tbl.GetRecordView<PocoCustomNames>().AsQueryable().ToList());
+        AssertSql(
+            "select _T0.\"KEY\", _T0.\"VAL\" from PUBLIC.tbl1 as _T0",
+            tbl => tbl.GetRecordView<PocoCustomNames>().AsQueryable().ToList());
 
     [Test]
     public void TestSum() =>
@@ -155,4 +164,8 @@ public class LinqSqlGenerationTests
 
         Assert.AreEqual(expectedSql, _server.LastSql);
     }
+
+    // ReSharper disable once NotAccessedPositionalProperty.Local
+    [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Query tests.")]
+    private record OneColumnPoco(long Key);
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Poco.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Poco.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Tests.Table
 {
     using System;
+    using System.ComponentModel.DataAnnotations.Schema;
 
     /// <summary>
     /// Test user object.
@@ -28,8 +29,10 @@ namespace Apache.Ignite.Tests.Table
 
         public string? Val { get; set; }
 
+        [NotMapped]
         public Guid UnmappedId { get; set; }
 
+        [NotMapped]
         public string? UnmappedStr { get; set; }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/PocoCustomNames.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/PocoCustomNames.cs
@@ -31,7 +31,9 @@ public class PocoCustomNames
     [Column("VAL")]
     public string? Name { get; set; }
 
+    [NotMapped]
     public Guid UnmappedId { get; set; }
 
+    [NotMapped]
     public string? UnmappedStr { get; set; }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
@@ -20,6 +20,8 @@
 #pragma warning disable SA1306, SA1401, CS0649, CS0169, CA1823, CA1812
 namespace Apache.Ignite.Tests.Table.Serialization
 {
+    using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
     using Internal.Table.Serialization;
@@ -33,7 +35,7 @@ namespace Apache.Ignite.Tests.Table.Serialization
         [Test]
         public void TestGetAllFieldsIncludesPrivatePublicAndInherited()
         {
-            var fields = typeof(Derived).GetAllFields().Select(f => f.Name).OrderBy(x => x).ToArray();
+            var fields = ReflectionUtilsGetAllFields(typeof(Derived)).Select(f => f.Name).OrderBy(x => x).ToArray();
 
             var expected = new[]
             {
@@ -60,7 +62,7 @@ namespace Apache.Ignite.Tests.Table.Serialization
         [Test]
         public void TestCleanFieldNameReturnsPropertyNameForBackingField()
         {
-            var fieldNames = typeof(Derived).GetAllFields().Select(f => ReflectionUtilsCleanFieldName(f.Name)).ToArray();
+            var fieldNames = ReflectionUtilsGetAllFields(typeof(Derived)).Select(f => ReflectionUtilsCleanFieldName(f.Name)).ToArray();
 
             CollectionAssert.Contains(fieldNames, nameof(Base.BaseProp));
             CollectionAssert.Contains(fieldNames, nameof(BaseTwo.BaseTwoProp));
@@ -82,6 +84,10 @@ namespace Apache.Ignite.Tests.Table.Serialization
         private static string? ReflectionUtilsCleanFieldName(string name) =>
             typeof(ReflectionUtils).GetMethod("CleanFieldName", BindingFlags.Static | BindingFlags.NonPublic)!
                 .Invoke(null, new object[] { name }) as string;
+
+        private static IEnumerable<FieldInfo> ReflectionUtilsGetAllFields(Type type) =>
+            (IEnumerable<FieldInfo>)typeof(ReflectionUtils).GetMethod("GetAllFields", BindingFlags.Static | BindingFlags.NonPublic)!
+                .Invoke(null, new object[] { type })!;
 
         private class Base
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
@@ -68,14 +68,12 @@ namespace Apache.Ignite.Tests.Table.Serialization
         }
 
         [Test]
-        public void TestGetFieldByColumnNameReturnsNullForNotMappedProperty()
-        {
-        }
+        public void TestGetFieldByColumnNameReturnsNullForNotMappedProperty() =>
+            Assert.IsNull(typeof(Derived).GetFieldByColumnName("NotMappedProp"));
 
         [Test]
-        public void TestGetFieldByColumnNameReturnsNullForNotMappedField()
-        {
-        }
+        public void TestGetFieldByColumnNameReturnsNullForNotMappedField() =>
+            Assert.IsNull(typeof(Derived).GetFieldByColumnName("NotMappedFld"));
 
         [Test]
         public void TestGetFieldByColumnNameThrowsExceptionForDuplicateColumnName()
@@ -98,6 +96,7 @@ namespace Apache.Ignite.Tests.Table.Serialization
                 "<BasePropCustomColumnName>k__BackingField",
                 "<BaseTwoProp>k__BackingField",
                 "<DerivedProp>k__BackingField",
+                "<NotMappedProp>k__BackingField",
                 "BaseFieldCustomColumnName",
                 "BaseFieldInternal",
                 "BaseFieldPrivate",
@@ -110,7 +109,8 @@ namespace Apache.Ignite.Tests.Table.Serialization
                 "DerivedFieldInternal",
                 "DerivedFieldPrivate",
                 "DerivedFieldProtected",
-                "DerivedFieldPublic"
+                "DerivedFieldPublic",
+                "NotMappedFld"
             };
 
             CollectionAssert.AreEqual(expected, fields);
@@ -160,6 +160,12 @@ namespace Apache.Ignite.Tests.Table.Serialization
 
             [Column("FldCol")]
             public int BaseFieldCustomColumnName;
+
+            [NotMapped]
+            public int NotMappedFld;
+
+            [NotMapped]
+            public int NotMappedProp { get; set; }
         }
 
         private class BaseTwo : Base
@@ -180,6 +186,23 @@ namespace Apache.Ignite.Tests.Table.Serialization
             private int DerivedFieldPrivate;
 
             public int DerivedProp { get; set; }
+        }
+
+        private class DuplicateColumn1
+        {
+            public int MyCol { get; set; }
+
+            [Column("MyCol")]
+            public int MyCol2 { get; set; }
+        }
+
+        private class DuplicateColumn2
+        {
+            [Column("MyCol")]
+            public int MyCol1 { get; set; }
+
+            [Column("MyCol")]
+            public int MyCol2 { get; set; }
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
@@ -33,33 +33,51 @@ namespace Apache.Ignite.Tests.Table.Serialization
     public class ReflectionUtilsTests
     {
         [Test]
+        public void TestGetFieldByColumnNameReturnsFieldByName()
+        {
+            var res = typeof(Derived).GetFieldByColumnName("BaseFieldPublic");
+
+            Assert.AreEqual("BaseFieldPublic", res!.Name);
+        }
+
+        [Test]
+        public void TestGetFieldByColumnNameReturnsFieldByPropertyName()
+        {
+            var res = typeof(Derived).GetFieldByColumnName("BaseProp");
+
+            Assert.AreEqual("<BaseProp>k__BackingField", res!.Name);
+        }
+
+        [Test]
+        public void TestGetFieldByColumnNameReturnsFieldByColumnAttributeName()
+        {
+            Assert.IsNull(typeof(Derived).GetFieldByColumnName("foo"));
+        }
+
+        [Test]
         public void TestGetFieldByColumnNameReturnsNullForNonMatchingName()
         {
-
+            Assert.IsNull(typeof(Derived).GetFieldByColumnName("foo"));
         }
 
         [Test]
         public void TestGetFieldByColumnNameReturnsNullForNotMappedProperty()
         {
-
         }
 
         [Test]
         public void TestGetFieldByColumnNameReturnsNullForNotMappedField()
         {
-
         }
 
         [Test]
         public void TestGetFieldByColumnNameThrowsExceptionForDuplicateColumnName()
         {
-
         }
 
         [Test]
         public void TestGetColumns()
         {
-
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-// ReSharper disable InconsistentNaming
-// ReSharper disable UnusedMember.Local
+// ReSharper disable InconsistentNaming, UnusedMember.Local
 #pragma warning disable SA1306, SA1401, CS0649, CS0169, CA1823, CA1812, SA1201
 namespace Apache.Ignite.Tests.Table.Serialization
 {
@@ -82,6 +81,21 @@ namespace Apache.Ignite.Tests.Table.Serialization
         [Test]
         public void TestGetColumns()
         {
+            var columns = typeof(Columns).GetColumns().ToArray();
+
+            Assert.AreEqual(4, columns.Length);
+
+            Assert.AreEqual("Col1", columns[0].Name);
+            Assert.IsFalse(columns[0].HasColumnNameAttribute);
+
+            Assert.AreEqual("Column 2", columns[1].Name);
+            Assert.IsTrue(columns[1].HasColumnNameAttribute);
+
+            Assert.AreEqual("Col3", columns[2].Name);
+            Assert.IsFalse(columns[2].HasColumnNameAttribute);
+
+            Assert.AreEqual("Column 4", columns[3].Name);
+            Assert.IsTrue(columns[3].HasColumnNameAttribute);
         }
 
         [Test]
@@ -202,6 +216,22 @@ namespace Apache.Ignite.Tests.Table.Serialization
 
             [Column("MyCol")]
             public int MyCol2 { get; set; }
+        }
+
+        private class Columns
+        {
+            public int Col1;
+
+            [Column("Column 2")]
+            public int Col2;
+
+            public int Col3 { get; set; }
+
+            [Column("Column 4")]
+            public int Col4 { get; set; }
+
+            [NotMapped]
+            public int Col5 { get; set; }
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
@@ -33,6 +33,36 @@ namespace Apache.Ignite.Tests.Table.Serialization
     public class ReflectionUtilsTests
     {
         [Test]
+        public void TestGetFieldByColumnNameReturnsNullForNonMatchingName()
+        {
+
+        }
+
+        [Test]
+        public void TestGetFieldByColumnNameReturnsNullForNotMappedProperty()
+        {
+
+        }
+
+        [Test]
+        public void TestGetFieldByColumnNameReturnsNullForNotMappedField()
+        {
+
+        }
+
+        [Test]
+        public void TestGetFieldByColumnNameThrowsExceptionForDuplicateColumnName()
+        {
+
+        }
+
+        [Test]
+        public void TestGetColumns()
+        {
+
+        }
+
+        [Test]
         public void TestGetAllFieldsIncludesPrivatePublicAndInherited()
         {
             var fields = ReflectionUtilsGetAllFields(typeof(Derived)).Select(f => f.Name).OrderBy(x => x).ToArray();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
@@ -17,11 +17,12 @@
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedMember.Local
-#pragma warning disable SA1306, SA1401, CS0649, CS0169, CA1823, CA1812
+#pragma warning disable SA1306, SA1401, CS0649, CS0169, CA1823, CA1812, SA1201
 namespace Apache.Ignite.Tests.Table.Serialization
 {
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations.Schema;
     using System.Linq;
     using System.Reflection;
     using Internal.Table.Serialization;
@@ -36,7 +37,6 @@ namespace Apache.Ignite.Tests.Table.Serialization
         public void TestGetFieldByColumnNameReturnsFieldByName()
         {
             var res = typeof(Derived).GetFieldByColumnName("BaseFieldPublic");
-
             Assert.AreEqual("BaseFieldPublic", res!.Name);
         }
 
@@ -44,14 +44,21 @@ namespace Apache.Ignite.Tests.Table.Serialization
         public void TestGetFieldByColumnNameReturnsFieldByPropertyName()
         {
             var res = typeof(Derived).GetFieldByColumnName("BaseProp");
-
             Assert.AreEqual("<BaseProp>k__BackingField", res!.Name);
         }
 
         [Test]
         public void TestGetFieldByColumnNameReturnsFieldByColumnAttributeName()
         {
-            Assert.IsNull(typeof(Derived).GetFieldByColumnName("foo"));
+            var res = typeof(Derived).GetFieldByColumnName("FldCol");
+            Assert.AreEqual("BaseFieldCustomColumnName", res!.Name);
+        }
+
+        [Test]
+        public void TestGetFieldByColumnNameReturnsFieldByPropertyColumnAttributeName()
+        {
+            var res = typeof(Derived).GetFieldByColumnName("PropCol");
+            Assert.AreEqual("<BasePropCustomColumnName>k__BackingField", res!.Name);
         }
 
         [Test]
@@ -88,8 +95,10 @@ namespace Apache.Ignite.Tests.Table.Serialization
             var expected = new[]
             {
                 "<BaseProp>k__BackingField",
+                "<BasePropCustomColumnName>k__BackingField",
                 "<BaseTwoProp>k__BackingField",
                 "<DerivedProp>k__BackingField",
+                "BaseFieldCustomColumnName",
                 "BaseFieldInternal",
                 "BaseFieldPrivate",
                 "BaseFieldProtected",
@@ -145,6 +154,12 @@ namespace Apache.Ignite.Tests.Table.Serialization
             private int BaseFieldPrivate;
 
             public int BaseProp { get; set; }
+
+            [Column("PropCol")]
+            public int BasePropCustomColumnName { get; set; }
+
+            [Column("FldCol")]
+            public int BaseFieldCustomColumnName;
         }
 
         private class BaseTwo : Base

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
@@ -21,6 +21,7 @@
 namespace Apache.Ignite.Tests.Table.Serialization
 {
     using System.Linq;
+    using System.Reflection;
     using Internal.Table.Serialization;
     using NUnit.Framework;
 
@@ -59,7 +60,7 @@ namespace Apache.Ignite.Tests.Table.Serialization
         [Test]
         public void TestCleanFieldNameReturnsPropertyNameForBackingField()
         {
-            var fieldNames = typeof(Derived).GetAllFields().Select(f => ReflectionUtils.CleanFieldName(f.Name)).ToArray();
+            var fieldNames = typeof(Derived).GetAllFields().Select(f => ReflectionUtilsCleanFieldName(f.Name)).ToArray();
 
             CollectionAssert.Contains(fieldNames, nameof(Base.BaseProp));
             CollectionAssert.Contains(fieldNames, nameof(BaseTwo.BaseTwoProp));
@@ -75,8 +76,12 @@ namespace Apache.Ignite.Tests.Table.Serialization
         [TestCase("<AnonTypeProp>i__Field", "AnonTypeProp")]
         public void TestCleanFieldName(string name, string expected)
         {
-            Assert.AreEqual(expected, ReflectionUtils.CleanFieldName(name));
+            Assert.AreEqual(expected, ReflectionUtilsCleanFieldName(name));
         }
+
+        private static string? ReflectionUtilsCleanFieldName(string name) =>
+            typeof(ReflectionUtils).GetMethod("CleanFieldName", BindingFlags.Static | BindingFlags.NonPublic)!
+                .Invoke(null, new object[] { name }) as string;
 
         private class Base
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
@@ -34,38 +34,24 @@ namespace Apache.Ignite.Tests.Table.Serialization
     public class ReflectionUtilsTests
     {
         [Test]
-        public void TestGetFieldByColumnNameReturnsFieldByName()
-        {
-            var res = typeof(Derived).GetFieldByColumnName("BaseFieldPublic");
-            Assert.AreEqual("BaseFieldPublic", res!.Name);
-        }
+        public void TestGetFieldByColumnNameReturnsFieldByName() =>
+            Assert.AreEqual("BaseFieldPublic", typeof(Derived).GetFieldByColumnName("BaseFieldPublic")!.Name);
 
         [Test]
-        public void TestGetFieldByColumnNameReturnsFieldByPropertyName()
-        {
-            var res = typeof(Derived).GetFieldByColumnName("BaseProp");
-            Assert.AreEqual("<BaseProp>k__BackingField", res!.Name);
-        }
+        public void TestGetFieldByColumnNameReturnsFieldByPropertyName() =>
+            Assert.AreEqual("<BaseProp>k__BackingField", typeof(Derived).GetFieldByColumnName("BaseProp")!.Name);
 
         [Test]
-        public void TestGetFieldByColumnNameReturnsFieldByColumnAttributeName()
-        {
-            var res = typeof(Derived).GetFieldByColumnName("FldCol");
-            Assert.AreEqual("BaseFieldCustomColumnName", res!.Name);
-        }
+        public void TestGetFieldByColumnNameReturnsFieldByColumnAttributeName() =>
+            Assert.AreEqual("BaseFieldCustomColumnName", typeof(Derived).GetFieldByColumnName("FldCol")!.Name);
 
         [Test]
-        public void TestGetFieldByColumnNameReturnsFieldByPropertyColumnAttributeName()
-        {
-            var res = typeof(Derived).GetFieldByColumnName("PropCol");
-            Assert.AreEqual("<BasePropCustomColumnName>k__BackingField", res!.Name);
-        }
+        public void TestGetFieldByColumnNameReturnsFieldByPropertyColumnAttributeName() =>
+            Assert.AreEqual("<BasePropCustomColumnName>k__BackingField", typeof(Derived).GetFieldByColumnName("PropCol")!.Name);
 
         [Test]
-        public void TestGetFieldByColumnNameReturnsNullForNonMatchingName()
-        {
+        public void TestGetFieldByColumnNameReturnsNullForNonMatchingName() =>
             Assert.IsNull(typeof(Derived).GetFieldByColumnName("foo"));
-        }
 
         [Test]
         public void TestGetFieldByColumnNameReturnsNullForNotMappedProperty() =>
@@ -78,6 +64,19 @@ namespace Apache.Ignite.Tests.Table.Serialization
         [Test]
         public void TestGetFieldByColumnNameThrowsExceptionForDuplicateColumnName()
         {
+            var ex1 = Assert.Throws<IgniteClientException>(() => typeof(DuplicateColumn1).GetFieldByColumnName("foo"));
+            var ex2 = Assert.Throws<IgniteClientException>(() => typeof(DuplicateColumn2).GetFieldByColumnName("foo"));
+
+            var expected1 = "Column 'MyCol' maps to more than one field of type " +
+                            "Apache.Ignite.Tests.Table.Serialization.ReflectionUtilsTests+DuplicateColumn1: " +
+                            "Int32 <MyCol2>k__BackingField and Int32 <MyCol>k__BackingField";
+
+            var expected2 = "Column 'MyCol' maps to more than one field of type " +
+                            "Apache.Ignite.Tests.Table.Serialization.ReflectionUtilsTests+DuplicateColumn2: " +
+                            "Int32 <MyCol2>k__BackingField and Int32 <MyCol1>k__BackingField";
+
+            Assert.AreEqual(expected1, ex1!.Message);
+            Assert.AreEqual(expected2, ex2!.Message);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/DEVNOTES.md
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/DEVNOTES.md
@@ -1,0 +1,7 @@
+# Apache Ignite LINQ provider
+
+TODO: 
+* Mapping behavior considerations, examples.
+* Differences from Ignite 2.x
+* Inspiration from EF Core
+* Async approach

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/DEVNOTES.md
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/DEVNOTES.md
@@ -1,7 +1,22 @@
 # Apache Ignite LINQ provider
 
-TODO: 
-* Mapping behavior considerations, examples.
-* Differences from Ignite 2.x
-* Inspiration from EF Core
-* Async approach
+Translates C# LINQ expressions into Ignite-specific SQL.
+
+## Async
+
+LINQ provider uses underlying `Sql` API, which is fully async. While users can call sync methods like `ToList()`, `First()`, `Sum()`, etc, this will lead to thread blocking, which is not ideal for scalability.
+
+* Recommended approach is to use `ToResultSetAsync()` async extension method.
+* Later we should also provide `ToListAsync()`, `FirstAsync()`, `SumAsync()` and other extension methods (IGNITE-18084, inspired by EF Core).
+
+## User Type Mapping
+
+TODO: Explain schema issues, see comments in code.
+
+## Differences with Ignite 2.x provider
+
+This provider is a port of existing Ignite 2.x code. Major differences are:
+
+* Underlying async API (see above).
+* Fully integrated into core .NET client (as opposed to an extension in 2.x). Entry points are `IRecordView.AsQueryable` and `IKeyValueView.AsQueryable`. Record and KV views do not implement `IEnumerable` and/or `IQueryable` to avoid any confusing behavior.
+* Supports transactions.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/DEVNOTES.md
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/DEVNOTES.md
@@ -2,6 +2,7 @@
 
 Translates C# LINQ expressions into Ignite-specific SQL.
 
+
 ## Async
 
 LINQ provider uses underlying `Sql` API, which is fully async. While users can call sync methods like `ToList()`, `First()`, `Sum()`, etc, this will lead to thread blocking, which is not ideal for scalability.
@@ -9,17 +10,20 @@ LINQ provider uses underlying `Sql` API, which is fully async. While users can c
 * Recommended approach is to use `ToResultSetAsync()` async extension method.
 * Later we should also provide `ToListAsync()`, `FirstAsync()`, `SumAsync()` and other extension methods (IGNITE-18084, inspired by EF Core).
 
+
 ## User Type Mapping
 
 There are two way to map columns to user type members:
 1. Load schema and map only matching columns.
-   - GOOD: Potentially nicer to the user, allows unmapped members in user types.
-   - BAD: Requires loading schema (worse perf, worse complexity).
+   - GOOD: Potentially nicer to the user, allows unmapped members in user types without extra steps, more flexible with updated schemas.
+   - BAD: Requires loading schema before query translation (worse perf, worse complexity).
    - BAD: Can't cache metadata and delegates per type (worse perf, worse complexity).
    - BAD: Obstacle for compiled queries, because updated schema won't be picked up.
 2. Do not load schema, map all object columns.
    - GOOD: Simpler, faster.
-   - BAD: Requires all columns to be mapped (unless we support NotMappedAttribute - IGNITE-18149).
+   - BAD: All columns are mapped by default, unmapped columns should be explicitly excluded with `NotMappedAttribute` (IGNITE-18149).
+
+We take the second approach for the sake of performance, simplicity and clarity.
 
 
 ## Differences with Ignite 2.x provider

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/DEVNOTES.md
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/DEVNOTES.md
@@ -11,7 +11,16 @@ LINQ provider uses underlying `Sql` API, which is fully async. While users can c
 
 ## User Type Mapping
 
-TODO: Explain schema issues, see comments in code.
+There are two way to map columns to user type members:
+1. Load schema and map only matching columns.
+   - GOOD: Potentially nicer to the user, allows unmapped members in user types.
+   - BAD: Requires loading schema (worse perf, worse complexity).
+   - BAD: Can't cache metadata and delegates per type (worse perf, worse complexity).
+   - BAD: Obstacle for compiled queries, because updated schema won't be picked up.
+2. Do not load schema, map all object columns.
+   - GOOD: Simpler, faster.
+   - BAD: Requires all columns to be mapped (unless we support NotMappedAttribute - IGNITE-18149).
+
 
 ## Differences with Ignite 2.x provider
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/DEVNOTES.md
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/DEVNOTES.md
@@ -26,6 +26,15 @@ There are two way to map columns to user type members:
 We take the second approach for the sake of performance, simplicity and clarity.
 
 
+### Type Member to Column Mapping
+
+1. The mapping logic is based on **fields** only.
+2. Backing fields for [automatic properties](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/auto-implemented-properties) get the column name from the property or its attributes.
+3. When `[Column("CustomName")]` attribute is present with non-zero `Name`, we use the specified name as it is, in quoted form: `select TABLE_NAME."CustomName" from ...`
+4. Otherwise, uppercase type member name is used without quotes (case-insensitive): `select TABLE_NAME.FIELDNAME from ...`
+5. Fields and properties with `[NotMapped]` attribute are ignored.
+
+
 ## Differences with Ignite 2.x provider
 
 This provider is a port of existing Ignite 2.x code. Major differences are:

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -227,6 +227,15 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
         else
         {
             // TODO IGNITE-18138 Avoid over-fetching, select only mapped columns.
+            // There are two way to do that:
+            // 1. Load schema and map only matching columns.
+            //    + Potentially nicer to the user, allows unmapped members in user types.
+            //    - Requires loading schema (worse perf, worse complexity).
+            //    - Can't cache metadata and delegates per type (worse perf, worse complexity).
+            //    - Obstacle for compiled queries.
+            // 2. Do not load schema, map all object columns.
+            //    + Simpler, faster.
+            //    - Requires all columns to be mapped (unless we support some kind of Ignore attribute).
             // Count, sum, max, min expect a single field or *
             // var format = _includeAllFields || _useStar
             //     ? "{0}.*, {0}._KEY, {0}._VAL"

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -235,7 +235,7 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
             //    - Obstacle for compiled queries.
             // 2. Do not load schema, map all object columns.
             //    + Simpler, faster.
-            //    - Requires all columns to be mapped (unless we support some kind of Ignore attribute).
+            //    - Requires all columns to be mapped (unless we support NotMappedAttribute - IGNITE-18149).
             // Count, sum, max, min expect a single field or *
             // var format = _includeAllFields || _useStar
             //     ? "{0}.*, {0}._KEY, {0}._VAL"

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -216,11 +216,11 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
         if (joinClause != null && ExpressionWalker.GetIgniteQueryable(expression, false) == null)
         {
             var tableName = Aliases.GetTableAlias(expression);
-            var fieldname = Aliases.GetFieldAlias(expression);
+            var fieldName = Aliases.GetFieldAlias(expression);
 
-            ResultBuilder.AppendFormat(CultureInfo.InvariantCulture, "{0}.{1}", tableName, fieldname);
+            ResultBuilder.AppendFormat(CultureInfo.InvariantCulture, "{0}.{1}", tableName, fieldName);
         }
-        else if (joinClause != null && joinClause.InnerSequence is SubQueryExpression)
+        else if (joinClause is { InnerSequence: SubQueryExpression })
         {
             var subQueryExpression = (SubQueryExpression) joinClause.InnerSequence;
             base.Visit(subQueryExpression.QueryModel.SelectClause.Selector);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
@@ -209,6 +209,6 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// <param name="Field">Corresponding field.</param>
         /// <param name="HasColumnNameAttribute">Whether corresponding field or property has <see cref="ColumnAttribute"/>
         /// with <see cref="ColumnAttribute.Name"/> set.</param>
-        public record ColumnInfo(string Name, FieldInfo Field, bool HasColumnNameAttribute);
+        internal record ColumnInfo(string Name, FieldInfo Field, bool HasColumnNameAttribute);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
@@ -45,34 +45,6 @@ namespace Apache.Ignite.Internal.Table.Serialization
         private static readonly ConcurrentDictionary<Type, IReadOnlyDictionary<string, FieldInfo>> FieldsByColumnNameCache = new();
 
         /// <summary>
-        /// Gets all fields from the type, including non-public and inherited.
-        /// </summary>
-        /// <param name="type">Type.</param>
-        /// <returns>Fields.</returns>
-        public static IEnumerable<FieldInfo> GetAllFields(this Type type)
-        {
-            if (type.IsPrimitive)
-            {
-                yield break;
-            }
-
-            const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public |
-                                       BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
-
-            var t = type;
-
-            while (t != null)
-            {
-                foreach (var field in t.GetFields(flags))
-                {
-                    yield return field;
-                }
-
-                t = t.BaseType;
-            }
-        }
-
-        /// <summary>
         /// Gets the field by column name. Ignores case, handles <see cref="ColumnAttribute"/>.
         /// </summary>
         /// <param name="type">Type.</param>
@@ -81,7 +53,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         public static FieldInfo? GetFieldByColumnName(this Type type, string name)
         {
             // ReSharper disable once HeapView.CanAvoidClosure, ConvertClosureToMethodGroup
-            return FieldsByColumnNameCache.GetOrAdd(type, t => GetFieldsByColumnName(t)).TryGetValue(name, out var fieldInfo)
+            return FieldsByColumnNameCache.GetOrAdd(type, static t => GetFieldsByColumnName(t)).TryGetValue(name, out var fieldInfo)
                 ? fieldInfo
                 : null;
 
@@ -104,6 +76,34 @@ namespace Apache.Ignite.Internal.Table.Serialization
                 }
 
                 return res;
+            }
+        }
+
+        /// <summary>
+        /// Gets all fields from the type, including non-public and inherited.
+        /// </summary>
+        /// <param name="type">Type.</param>
+        /// <returns>Fields.</returns>
+        private static IEnumerable<FieldInfo> GetAllFields(this Type type)
+        {
+            if (type.IsPrimitive)
+            {
+                yield break;
+            }
+
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public |
+                                       BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+
+            var t = type;
+
+            while (t != null)
+            {
+                foreach (var field in t.GetFields(flags))
+                {
+                    yield return field;
+                }
+
+                t = t.BaseType;
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
@@ -83,11 +83,11 @@ namespace Apache.Ignite.Internal.Table.Serialization
                         continue;
                     }
 
-                    if (res.TryGetValue(columnInfo.Name, out var existingField))
+                    if (res.TryGetValue(columnInfo.Name, out var existingColInfo))
                     {
                         throw new IgniteClientException(
                             ErrorGroups.Client.Configuration,
-                            $"Column '{columnInfo.Name}' maps to more than one field of type {type}: {field} and {existingField}");
+                            $"Column '{columnInfo.Name}' maps to more than one field of type {type}: {field} and {existingColInfo.Field}");
                     }
 
                     res.Add(columnInfo.Name, columnInfo);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
@@ -112,7 +112,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// </summary>
         /// <param name="memberInfo">Member.</param>
         /// <returns>Clean name.</returns>
-        public static string GetCleanName(this MemberInfo memberInfo) => CleanFieldName(memberInfo.Name);
+        private static string GetCleanName(this MemberInfo memberInfo) => CleanFieldName(memberInfo.Name);
 
         /// <summary>
         /// Gets column name for the specified field: uses <see cref="ColumnAttribute"/> when available,
@@ -120,7 +120,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// </summary>
         /// <param name="fieldInfo">Member.</param>
         /// <returns>Clean name.</returns>
-        public static string GetColumnName(this FieldInfo fieldInfo)
+        private static string GetColumnName(this FieldInfo fieldInfo)
         {
             if (fieldInfo.GetCustomAttribute<ColumnAttribute>() is { Name: { } columnAttributeName })
             {
@@ -145,7 +145,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// </summary>
         /// <param name="fieldName">Field name to clean.</param>
         /// <returns>Resulting field name.</returns>
-        public static string CleanFieldName(string fieldName)
+        private static string CleanFieldName(string fieldName)
         {
             // C# auto property backing field (<MyProperty>k__BackingField)
             // or anonymous type backing field (<MyProperty>i__Field):
@@ -170,6 +170,6 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// <param name="expression">Expression.</param>
         /// <typeparam name="T">Argument type.</typeparam>
         /// <returns>Corresponding MethodInfo.</returns>
-        public static MethodInfo GetMethodInfo<T>(Expression<Func<T>> expression) => ((MethodCallExpression)expression.Body).Method;
+        private static MethodInfo GetMethodInfo<T>(Expression<Func<T>> expression) => ((MethodCallExpression)expression.Body).Method;
     }
 }


### PR DESCRIPTION
* When generating `SELECT` clause, instead of `*`, emit only mapped column names. For example, if a table has 10 columns, but LINQ expression uses a type with 5 properties, only select those 5 columns.
* Handle `[NotMapped]` attribute to allow more control over column mapping.
* Add DEVNOTES to Linq directory with some technical details.