### PR TITLE
IGNITE-18110 Modernize Gradle cache usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,12 @@ allprojects {
     tasks.withType(Javadoc) {
         options.addStringOption('bottom', javadocFooter())
     }
+
+    //Temporary hack to disable caching of Test tasks.
+    //https://github.com/gradle/gradle/issues/9210
+    tasks.withType(Test).configureEach {
+        outputs.upToDateWhen { false }
+    }
 }
 
 subprojects {

--- a/buildscripts/java-core.gradle
+++ b/buildscripts/java-core.gradle
@@ -48,7 +48,6 @@ processResources {
     }
 }
 
-
 pmdMain {
     enabled = true
 }
@@ -76,7 +75,11 @@ tasks.withType(Checkstyle) {
                 "org/apache/ignite/raft/jraft/**/*"]
     reports {
         xml.required = false
-        html.required = true
+        html {
+            required = true
+            outputLocation = file("$rootDir/build/reports/checkstyle/${project.name}.html")
+        }
+
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,6 @@
 org.gradle.configureondemand=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
-org.gradle.caching=true
 
 #signing.keyId=*INSERT KEY HERE LAST 8 CHARS*
 #signing.password=*INSERT PASSWORD HERE*

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* Disable build cache for test tasks
* Move build cache enabling to CI
* Specify path to checkstyle report generation

https://issues.apache.org/jira/browse/IGNITE-18110