### PR TITLE
IGNITE-18212 Fix parsing error on GROUP BY with alias

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItAggregatesTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItAggregatesTest.java
@@ -64,6 +64,18 @@ public class ItAggregatesTest extends AbstractBasicIntegrationTest {
                 .returns(15d, 1L)
                 .check();
 
+        // same query, but grouping by alias
+        assertQuery("select salary as sal, count(name) from person group by sal order by salary")
+                .returns(10d, 3L)
+                .returns(15d, 1L)
+                .check();
+
+        // same query, but grouping by ordinal
+        assertQuery("select salary, count(name) from person group by 1 order by salary")
+                .returns(10d, 3L)
+                .returns(15d, 1L)
+                .check();
+
         assertQuery("select salary, count(*) from person group by salary order by salary")
                 .returns(10d, 3L)
                 .returns(15d, 2L)

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItAggregatesTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItAggregatesTest.java
@@ -65,15 +65,32 @@ public class ItAggregatesTest extends AbstractBasicIntegrationTest {
                 .check();
 
         // same query, but grouping by alias
-        assertQuery("select salary as sal, count(name) from person group by sal order by salary")
+        assertQuery("select salary as sal, count(name) from person group by sal order by sal")
                 .returns(10d, 3L)
                 .returns(15d, 1L)
                 .check();
 
         // same query, but grouping by ordinal
-        assertQuery("select salary, count(name) from person group by 1 order by salary")
+        assertQuery("select salary, count(name) from person group by 1 order by 1")
                 .returns(10d, 3L)
                 .returns(15d, 1L)
+                .check();
+
+        assertQuery("select salary * salary / 5, count(name) from person group by (salary * salary / 5) order by (salary * salary / 5)")
+                .returns(20d, 3L)
+                .returns(45d, 1L)
+                .check();
+
+        // same query, but grouping by alias
+        assertQuery("select (salary * salary / 5) as sal, count(name) from person group by sal order by sal")
+                .returns(20d, 3L)
+                .returns(45d, 1L)
+                .check();
+
+        // same query, but grouping by ordinal
+        assertQuery("select salary * salary / 5, count(name) from person group by 1 order by 1")
+                .returns(20d, 3L)
+                .returns(45d, 1L)
                 .check();
 
         assertQuery("select salary, count(*) from person group by salary order by salary")

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlConformance.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlConformance.java
@@ -38,4 +38,16 @@ public class IgniteSqlConformance extends SqlAbstractConformance {
     public boolean isBangEqualAllowed() {
         return true;
     }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isGroupByAlias() {
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isGroupByOrdinal() {
+        return true;
+    }
 }


### PR DESCRIPTION
Enable `isGroupByAlias` and `isGroupByOrdinal` in SQL conformance.