### PR TITLE
IGNITE-18196 .NET: LINQ: Add aggregates support

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -86,6 +86,12 @@ public class LinqSqlGenerationTests
         AssertSql("select not exists (select 1 from PUBLIC.tbl1 as _T0 where not (_T0.KEY > ?))", q => q.All(x => x.Key > 10));
 
     [Test]
+    public void TestAllWithWhere() =>
+        AssertSql(
+            "select not exists (select 1 from PUBLIC.tbl1 as _T0 where not (_T0.KEY > ?))",
+            q => q.Where(x => x.Val != "1").All(x => x.Key > 10));
+
+    [Test]
     public void TestAny() =>
         AssertSql("select exists (select 1 from PUBLIC.tbl1 as _T0 where (_T0.KEY > ?))", q => q.Any(x => x.Key > 10));
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -158,19 +158,21 @@ public class LinqSqlGenerationTests
     private void AssertSql(string expectedSql, Func<ITable, object?> query)
     {
         _server.LastSql = string.Empty;
+        Exception? ex = null;
 
         try
         {
             query(_table);
         }
-        catch (Exception)
+        catch (Exception e)
         {
             // Ignore.
             // Result deserialization may fail because FakeServer returns one column always.
             // We are only interested in the generated SQL.
+            ex = e;
         }
 
-        Assert.AreEqual(expectedSql, _server.LastSql);
+        Assert.AreEqual(expectedSql, _server.LastSql, ex?.ToString());
     }
 
     // ReSharper disable once NotAccessedPositionalProperty.Local

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -83,11 +83,11 @@ public class LinqSqlGenerationTests
 
     [Test]
     public void TestAll() =>
-        AssertSql("select distinct _T0.VAL from PUBLIC.tbl1 as _T0", q => q.All(x => x.Key > 10));
+        AssertSql("select not exists (select 1 from PUBLIC.tbl1 as _T0 where not (_T0.KEY > ?))", q => q.All(x => x.Key > 10));
 
     [Test]
-    public void TestAny() => // TODO Can we use a better approach than COUNT?
-        AssertSql("select count (*) from PUBLIC.tbl1 as _T0 where (_T0.KEY > ?)", q => q.Any(x => x.Key > 10));
+    public void TestAny() =>
+        AssertSql("select exists (select 1 from PUBLIC.tbl1 as _T0 where (_T0.KEY > ?))", q => q.Any(x => x.Key > 10));
 
     [Test]
     public void TestSelectOrderByOffsetLimit() =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -184,7 +184,7 @@ public class LinqSqlGenerationTests
             ex = e;
         }
 
-        Assert.AreEqual(expectedSql, _server.LastSql, ex?.ToString());
+        Assert.AreEqual(expectedSql, _server.LastSql, string.IsNullOrEmpty(_server.LastSql) ? ex?.ToString() : null);
     }
 
     // ReSharper disable once NotAccessedPositionalProperty.Local

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -83,7 +83,9 @@ public class LinqSqlGenerationTests
 
     [Test]
     public void TestAll() =>
-        AssertSql("select not exists (select 1 from PUBLIC.tbl1 as _T0 where not (_T0.KEY > ?))", q => q.All(x => x.Key > 10));
+        AssertSql(
+            "select not exists (select 1 from (select * from PUBLIC.tbl1 as _T0) where not ((_T0.KEY > ?)))",
+            q => q.All(x => x.Key > 10));
 
     [Test]
     public void TestAllWithWhere() =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -82,6 +82,14 @@ public class LinqSqlGenerationTests
         AssertSql("select distinct _T0.VAL from PUBLIC.tbl1 as _T0", q => q.Select(x => x.Val).Distinct().ToArray());
 
     [Test]
+    public void TestAll() =>
+        AssertSql("select distinct _T0.VAL from PUBLIC.tbl1 as _T0", q => q.All(x => x.Key > 10));
+
+    [Test]
+    public void TestAny() => // TODO Can we use a better approach than COUNT?
+        AssertSql("select count (*) from PUBLIC.tbl1 as _T0 where (_T0.KEY > ?)", q => q.Any(x => x.Key > 10));
+
+    [Test]
     public void TestSelectOrderByOffsetLimit() =>
         AssertSql(
             "select _T0.KEY, _T0.VAL, (_T0.KEY + ?) " +

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -127,7 +127,7 @@ public class LinqSqlGenerationTests
         _server.LastSqlTimeoutMs = null;
         _server.LastSqlPageSize = null;
 
-        _ = _table.GetRecordView<Poco>().AsQueryable().Select(x => x.Key).ToArray();
+        _ = _table.GetRecordView<Poco>().AsQueryable().Select(x => (int)x.Key).ToArray();
 
         Assert.AreEqual(SqlStatement.DefaultTimeout.TotalMilliseconds, _server.LastSqlTimeoutMs);
         Assert.AreEqual(SqlStatement.DefaultPageSize, _server.LastSqlPageSize);
@@ -139,7 +139,7 @@ public class LinqSqlGenerationTests
         _server.LastSqlTimeoutMs = null;
         _server.LastSqlPageSize = null;
 
-        _ = _table.GetRecordView<Poco>().AsQueryable(options: new(TimeSpan.FromSeconds(25), 128)).Select(x => x.Key).ToArray();
+        _ = _table.GetRecordView<Poco>().AsQueryable(options: new(TimeSpan.FromSeconds(25), 128)).Select(x => (int)x.Key).ToArray();
 
         Assert.AreEqual(25000, _server.LastSqlTimeoutMs);
         Assert.AreEqual(128, _server.LastSqlPageSize);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -84,13 +84,13 @@ public class LinqSqlGenerationTests
     [Test]
     public void TestAll() =>
         AssertSql(
-            "select not exists (select 1 from (select * from PUBLIC.tbl1 as _T0) where not ((_T0.KEY > ?)))",
+            "select not exists (select 1 from PUBLIC.tbl1 as _T0 where not (_T0.KEY > ?))",
             q => q.All(x => x.Key > 10));
 
     [Test]
     public void TestAllWithWhere() =>
         AssertSql(
-            "select not exists (select 1 from PUBLIC.tbl1 as _T0 where not (_T0.KEY > ?))",
+            "select not exists (select 1 from PUBLIC.tbl1 as _T0 where (_T0.VAL IS DISTINCT FROM ?) and not (_T0.KEY > ?))",
             q => q.Where(x => x.Val != "1").All(x => x.Key > 10));
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
@@ -94,4 +94,18 @@ public partial class LinqTests
 
         Assert.AreEqual(3, res);
     }
+
+    [Test]
+    public void TestAll()
+    {
+        Assert.IsFalse(PocoView.AsQueryable().All(x => x.Key > 5));
+        Assert.IsTrue(PocoView.AsQueryable().All(x => x.Key < 500));
+    }
+
+    [Test]
+    public void TestAny()
+    {
+        Assert.IsFalse(PocoView.AsQueryable().Any(x => x.Key > 500));
+        Assert.IsTrue(PocoView.AsQueryable().Any(x => x.Key < 5));
+    }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
@@ -41,8 +41,8 @@ public partial class LinqTests
     {
         Assert.AreEqual(12, PocoByteView.AsQueryable().Sum(x => x.Val));
         Assert.AreEqual(90, PocoShortView.AsQueryable().Sum(x => x.Val));
-        Assert.AreEqual(45, PocoIntView.AsQueryable().Sum(x => x.Val));
-        Assert.AreEqual(45, PocoLongView.AsQueryable().Sum(x => x.Val));
+        Assert.AreEqual(4500, PocoIntView.AsQueryable().Sum(x => x.Val));
+        Assert.AreEqual(90, PocoLongView.AsQueryable().Sum(x => x.Val));
         Assert.AreEqual(45, PocoFloatView.AsQueryable().Sum(x => x.Val));
         Assert.AreEqual(45, PocoDecimalView.AsQueryable().Sum(x => x.Val));
         Assert.AreEqual(45, PocoDoubleView.AsQueryable().Sum(x => x.Val));

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
@@ -39,8 +39,49 @@ public partial class LinqTests
     [Test]
     public void TestSumAllTypes()
     {
-        // TODO: All types
-        Assert.AreEqual(45, PocoView.AsQueryable().Sum(x => x.Key));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Sum(x => x.Int8));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Sum(x => x.Int16));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Sum(x => x.Int32));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Sum(x => x.Int64));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Sum(x => x.Float));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Sum(x => x.Double));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Sum(x => x.Decimal));
+    }
+
+    [Test]
+    public void TestMinAllTypes()
+    {
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Min(x => x.Int8));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Min(x => x.Int16));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Min(x => x.Int32));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Min(x => x.Int64));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Min(x => x.Float));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Min(x => x.Double));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Min(x => x.Decimal));
+    }
+
+    [Test]
+    public void TestMaxAllTypes()
+    {
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Max(x => x.Int8));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Max(x => x.Int16));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Max(x => x.Int32));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Max(x => x.Int64));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Max(x => x.Float));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Max(x => x.Double));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Max(x => x.Decimal));
+    }
+
+    [Test]
+    public void TestAverageAllTypes()
+    {
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Average(x => x.Int8));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Average(x => x.Int16));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Average(x => x.Int32));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Average(x => x.Int64));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Average(x => x.Float));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Average(x => x.Double));
+        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Average(x => x.Decimal));
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
@@ -39,7 +39,8 @@ public partial class LinqTests
     [Test]
     public void TestSumAllTypes()
     {
-        Assert.AreEqual(1, PocoView.AsQueryable().Sum(x => x.Key));
+        // TODO: All types
+        Assert.AreEqual(45, PocoView.AsQueryable().Sum(x => x.Key));
     }
 
     [Test]
@@ -100,6 +101,9 @@ public partial class LinqTests
     {
         Assert.IsFalse(PocoView.AsQueryable().All(x => x.Key > 5));
         Assert.IsTrue(PocoView.AsQueryable().All(x => x.Key < 500));
+
+        // Additional Where.
+        Assert.IsTrue(PocoView.AsQueryable().Where(x => x.Key > 8).All(x => x.Key > 5));
     }
 
     [Test]
@@ -107,5 +111,8 @@ public partial class LinqTests
     {
         Assert.IsFalse(PocoView.AsQueryable().Any(x => x.Key > 500));
         Assert.IsTrue(PocoView.AsQueryable().Any(x => x.Key < 5));
+
+        // Additional Where.
+        Assert.IsFalse(PocoView.AsQueryable().Where(x => x.Key > 7).Any(x => x.Key < 5));
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests.Linq;
+
+using System.Linq;
+using NUnit.Framework;
+
+/// <summary>
+/// Linq aggregate tests.
+/// </summary>
+public partial class LinqTests
+{
+    [Test]
+    public void TestFilteredSum()
+    {
+        long res = PocoView.AsQueryable()
+            .Where(x => x.Key < 3)
+            .Select(x => x.Key)
+            .Sum();
+
+        Assert.AreEqual(3, res);
+    }
+
+    [Test]
+    public void TestSumAllTypes()
+    {
+        Assert.AreEqual(1, PocoView.AsQueryable().Sum(x => x.Key));
+    }
+
+    [Test]
+    public void TestGroupByAllAggregates()
+    {
+        var query = PocoIntView.AsQueryable()
+            .GroupBy(x => x.Key)
+            .Select(x => new
+            {
+                x.Key,
+                Count = x.Count(),
+                Sum = x.Sum(a => a.Key),
+                Avg = x.Average(a => a.Key),
+                Min = x.Min(a => a.Key),
+                Max = x.Max(a => a.Key)
+            })
+            .OrderBy(x => x.Key);
+
+        var res = query.ToList();
+
+        Assert.AreEqual(2, res[2].Key);
+        Assert.AreEqual(1, res[2].Count);
+        Assert.AreEqual(2, res[2].Sum);
+        Assert.AreEqual(2, res[2].Avg);
+        Assert.AreEqual(2, res[2].Min);
+        Assert.AreEqual(2, res[2].Max);
+
+        StringAssert.Contains(
+            "select _T0.KEY, _T1.VAL " +
+            "from PUBLIC.TBL_INT32 as _T0 " +
+            "left outer join (select * from PUBLIC.TBL_INT16 as _T2 ) as _T1 " +
+            "on (_T1.KEY = _T0.KEY)",
+            query.ToString());
+    }
+
+    [Test]
+    public void TestCount()
+    {
+        int res = PocoView
+            .AsQueryable()
+            .Count(x => x.Key < 3);
+
+        Assert.AreEqual(3, res);
+    }
+
+    [Test]
+    public void TestLongCount()
+    {
+        long res = PocoView
+            .AsQueryable()
+            .LongCount(x => x.Key < 3);
+
+        Assert.AreEqual(3, res);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
@@ -63,19 +63,25 @@ public partial class LinqTests
     [Test]
     public void TestMax()
     {
-        Assert.Fail("TODO");
+        Assert.AreEqual(3, PocoByteView.AsQueryable().Max(x => x.Val));
+        Assert.AreEqual(18, PocoShortView.AsQueryable().Max(x => x.Val));
+        Assert.AreEqual(900, PocoIntView.AsQueryable().Max(x => x.Val));
+        Assert.AreEqual(18, PocoLongView.AsQueryable().Max(x => x.Val));
+        Assert.AreEqual(9.0f, PocoFloatView.AsQueryable().Max(x => x.Val));
+        Assert.AreEqual(9m, PocoDecimalView.AsQueryable().Max(x => x.Val));
+        Assert.AreEqual(9.0d, PocoDoubleView.AsQueryable().Max(x => x.Val));
     }
 
     [Test]
-    public void TestAverageAllTypes()
+    public void TestAverage()
     {
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Average(x => x.Int8));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Average(x => x.Int16));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Average(x => x.Int32));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Average(x => x.Int64));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Average(x => x.Float));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Average(x => x.Double));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Average(x => x.Decimal));
+        Assert.AreEqual(1.0d, PocoByteView.AsQueryable().Average(x => x.Val));
+        Assert.AreEqual(9.0d, PocoShortView.AsQueryable().Average(x => x.Val));
+        Assert.AreEqual(450d, PocoIntView.AsQueryable().Average(x => x.Val));
+        Assert.AreEqual(9.0d, PocoLongView.AsQueryable().Average(x => x.Val));
+        Assert.AreEqual(4.5f, PocoFloatView.AsQueryable().Average(x => x.Val));
+        Assert.AreEqual(4.5m, PocoDecimalView.AsQueryable().Average(x => x.Val));
+        Assert.AreEqual(4.5d, PocoDoubleView.AsQueryable().Average(x => x.Val));
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
@@ -37,39 +37,33 @@ public partial class LinqTests
     }
 
     [Test]
-    public void TestSumAllTypes()
+    public void TestSum()
     {
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Sum(x => x.Int8));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Sum(x => x.Int16));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Sum(x => x.Int32));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Sum(x => x.Int64));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Sum(x => x.Float));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Sum(x => x.Double));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Sum(x => x.Decimal));
+        Assert.AreEqual(12, PocoByteView.AsQueryable().Sum(x => x.Val));
+        Assert.AreEqual(90, PocoShortView.AsQueryable().Sum(x => x.Val));
+        Assert.AreEqual(45, PocoIntView.AsQueryable().Sum(x => x.Val));
+        Assert.AreEqual(45, PocoLongView.AsQueryable().Sum(x => x.Val));
+        Assert.AreEqual(45, PocoFloatView.AsQueryable().Sum(x => x.Val));
+        Assert.AreEqual(45, PocoDecimalView.AsQueryable().Sum(x => x.Val));
+        Assert.AreEqual(45, PocoDoubleView.AsQueryable().Sum(x => x.Val));
     }
 
     [Test]
-    public void TestMinAllTypes()
+    public void TestMin()
     {
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Min(x => x.Int8));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Min(x => x.Int16));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Min(x => x.Int32));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Min(x => x.Int64));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Min(x => x.Float));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Min(x => x.Double));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Min(x => x.Decimal));
+        Assert.AreEqual(0, PocoByteView.AsQueryable().Min(x => x.Val));
+        Assert.AreEqual(0, PocoShortView.AsQueryable().Min(x => x.Val));
+        Assert.AreEqual(0, PocoIntView.AsQueryable().Min(x => x.Val));
+        Assert.AreEqual(0, PocoLongView.AsQueryable().Min(x => x.Val));
+        Assert.AreEqual(0, PocoFloatView.AsQueryable().Min(x => x.Val));
+        Assert.AreEqual(0, PocoDecimalView.AsQueryable().Min(x => x.Val));
+        Assert.AreEqual(0, PocoDoubleView.AsQueryable().Min(x => x.Val));
     }
 
     [Test]
-    public void TestMaxAllTypes()
+    public void TestMax()
     {
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Max(x => x.Int8));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Max(x => x.Int16));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Max(x => x.Int32));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Max(x => x.Int64));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Max(x => x.Float));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Max(x => x.Double));
-        Assert.AreEqual(45, PocoAllColumnsView.AsQueryable().Max(x => x.Decimal));
+        Assert.Fail("TODO");
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
@@ -69,10 +69,10 @@ public partial class LinqTests
         Assert.AreEqual(2, res[2].Max);
 
         StringAssert.Contains(
-            "select _T0.KEY, _T1.VAL " +
+            "select _T0.KEY, count (*) , sum (_T0.KEY) , avg (_T0.KEY) , min (_T0.KEY) , max (_T0.KEY)  " +
             "from PUBLIC.TBL_INT32 as _T0 " +
-            "left outer join (select * from PUBLIC.TBL_INT16 as _T2 ) as _T1 " +
-            "on (_T1.KEY = _T0.KEY)",
+            "group by (_T0.KEY) " +
+            "order by (_T0.KEY) asc",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -44,6 +44,12 @@ public partial class LinqTests : IgniteTestsBase
 
     private IRecordView<PocoLong> PocoLongView { get; set; } = null!;
 
+    private IRecordView<PocoFloat> PocoFloatView { get; set; } = null!;
+
+    private IRecordView<PocoDouble> PocoDoubleView { get; set; } = null!;
+
+    private IRecordView<PocoDecimal> PocoDecimalView { get; set; } = null!;
+
     [OneTimeSetUp]
     public async Task InsertData()
     {
@@ -51,6 +57,9 @@ public partial class LinqTests : IgniteTestsBase
         PocoShortView = (await Client.Tables.GetTableAsync(TableInt16Name))!.GetRecordView<PocoShort>();
         PocoIntView = (await Client.Tables.GetTableAsync(TableInt32Name))!.GetRecordView<PocoInt>();
         PocoLongView = (await Client.Tables.GetTableAsync(TableInt64Name))!.GetRecordView<PocoLong>();
+        PocoFloatView = (await Client.Tables.GetTableAsync(TableFloatName))!.GetRecordView<PocoFloat>();
+        PocoDoubleView = (await Client.Tables.GetTableAsync(TableDoubleName))!.GetRecordView<PocoDouble>();
+        PocoDecimalView = (await Client.Tables.GetTableAsync(TableDecimalName))!.GetRecordView<PocoDecimal>();
 
         for (int i = 0; i < Count; i++)
         {
@@ -60,6 +69,10 @@ public partial class LinqTests : IgniteTestsBase
             await PocoShortView.UpsertAsync(null, new PocoShort((short)(i * 2), (short)(i * 2)));
             await PocoIntView.UpsertAsync(null, new PocoInt(i, i * 100));
             await PocoLongView.UpsertAsync(null, new PocoLong(i, i * 2));
+
+            await PocoFloatView.UpsertAsync(null, new(i, i));
+            await PocoDoubleView.UpsertAsync(null, new(i, i));
+            await PocoDecimalView.UpsertAsync(null, new(i, i));
         }
     }
 
@@ -308,4 +321,10 @@ public partial class LinqTests : IgniteTestsBase
     private record PocoInt(int Key, int Val);
 
     private record PocoLong(long Key, long Val);
+
+    private record PocoFloat(float Key, float Val);
+
+    private record PocoDouble(double Key, double Val);
+
+    private record PocoDecimal(decimal Key, decimal Val);
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -263,7 +263,7 @@ public partial class LinqTests : IgniteTestsBase
 
         var tx = await client.Transactions.BeginAsync();
         var tbl = await client.Tables.GetTableAsync(FakeServer.ExistingTableName);
-        var pocoView = tbl!.GetRecordView<Poco>();
+        var pocoView = tbl!.GetRecordView<PocoInt>();
 
         _ = pocoView.AsQueryable(tx).Select(x => x.Key).ToArray();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -194,37 +194,6 @@ public partial class LinqTests : IgniteTestsBase
     }
 
     [Test]
-    public void TestCount()
-    {
-        int res = PocoView
-            .AsQueryable()
-            .Count(x => x.Key < 3);
-
-        Assert.AreEqual(3, res);
-    }
-
-    [Test]
-    public void TestLongCount()
-    {
-        long res = PocoView
-            .AsQueryable()
-            .LongCount(x => x.Key < 3);
-
-        Assert.AreEqual(3, res);
-    }
-
-    [Test]
-    public void TestSum()
-    {
-        long res = PocoView.AsQueryable()
-            .Where(x => x.Key < 3)
-            .Select(x => x.Key)
-            .Sum();
-
-        Assert.AreEqual(3, res);
-    }
-
-    [Test]
     public void TestOrderBySkipTake()
     {
         List<long> res = PocoView.AsQueryable()

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
@@ -122,6 +122,16 @@ namespace Apache.Ignite.Tests.Sql
         }
 
         [Test]
+        public async Task TestExists()
+        {
+            await using var resultSet = await Client.Sql.ExecuteAsync(null, "SELECT EXISTS (SELECT 1 FROM TEST WHERE ID > 1)");
+            var rows = await resultSet.ToListAsync();
+
+            Assert.AreEqual(1, rows.Count);
+            Assert.AreEqual(true, rows[0][0]);
+        }
+
+        [Test]
         public async Task TestEnumerateMultiplePages()
         {
             var statement = new SqlStatement("SELECT ID, VAL FROM TEST ORDER BY VAL", pageSize: 4);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/StringBuilderExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/StringBuilderExtensions.cs
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Internal.Common;
+
+using System.Text;
+
+/// <summary>
+/// Extension methods for <see cref="StringBuilder"/> class.
+/// </summary>
+internal static class StringBuilderExtensions
+{
+    /// <summary>
+    /// Removes all the trailing white-space characters from the current string builder.
+    /// </summary>
+    /// <param name="sb">String builder.</param>
+    /// <returns>Same instance for chaining.</returns>
+    public static StringBuilder TrimEnd(this StringBuilder sb)
+    {
+        while (sb.Length > 0 && char.IsWhiteSpace(sb[^1]))
+        {
+            sb.Length--;
+        }
+
+        return sb;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExecutor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExecutor.cs
@@ -149,9 +149,7 @@ internal sealed class IgniteQueryExecutor : IQueryExecutor
 
         if (columns.Count == 1)
         {
-            // TODO: Get rid of ChangeType
-            return (IReadOnlyList<IColumnMetadata> cols, ref BinaryTupleReader reader) =>
-                (T)Convert.ChangeType(Sql.ReadColumnValue(ref reader, cols[0], 0)!, typeof(T), CultureInfo.InvariantCulture);
+            return (IReadOnlyList<IColumnMetadata> cols, ref BinaryTupleReader reader) => (T)Sql.ReadColumnValue(ref reader, cols[0], 0)!;
         }
 
         // TODO: IGNITE-18136 Replace reflection with emitted delegates.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExecutor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExecutor.cs
@@ -149,6 +149,7 @@ internal sealed class IgniteQueryExecutor : IQueryExecutor
 
         if (columns.Count == 1)
         {
+            // TODO: Get rid of ChangeType
             return (IReadOnlyList<IColumnMetadata> cols, ref BinaryTupleReader reader) =>
                 (T)Convert.ChangeType(Sql.ReadColumnValue(ref reader, cols[0], 0)!, typeof(T), CultureInfo.InvariantCulture);
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -344,10 +344,6 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
                 _builder.Append("count (");
                 parenCount++;
             }
-            else if (op is AllResultOperator or AnyResultOperator)
-            {
-                _builder.Append('1');
-            }
             else if (op is SumResultOperator)
             {
                 _builder.Append("sum (");

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -230,26 +230,14 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
         //     VisitUpdateAllOperator(queryModel);
         // }
         // else
-        if (queryModel.ResultOperators.Count == 1 && queryModel.ResultOperators[0] is AnyResultOperator)
+        if (queryModel.ResultOperators.Count == 1 && queryModel.ResultOperators[0] is AnyResultOperator or AllResultOperator)
         {
-            // SELECT
-            _builder.Append("select exists (select 1 ");
-
-            // FROM ... WHERE ... JOIN ...
-            base.VisitQueryModel(queryModel);
-
-            // UNION ...
-            ProcessResultOperatorsEnd(queryModel);
-
-            _builder.TrimEnd().Append(')');
-        }
-        else if (queryModel.ResultOperators.Count == 1 && queryModel.ResultOperators[0] is AllResultOperator)
-        {
-            // TODO: Combine with the above?
             // All is different from Any: it always has a predicate inside.
             // We use NOT EXISTS with reverted predicate to implement All.
             // Reverted predicate is added in VisitBodyClauses.
-            _builder.Append("select not exists (select 1 ");
+            _builder.Append(queryModel.ResultOperators[0] is AllResultOperator
+                ? "select not exists (select 1 "
+                : "select exists (select 1 ");
 
             // FROM ... WHERE ... JOIN ...
             base.VisitQueryModel(queryModel);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -232,6 +232,8 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
     {
         _aliases.Push(copyAliases);
 
+        // TODO: Handle Any as SELECT EXISTS (SELECT 1 ...)
+        // TODO: Handle All as SELECT NOT EXISTS (SELECT 1 ...)
         // TODO: IGNITE-18137 DML
         // var lastResultOp = queryModel.ResultOperators.LastOrDefault();
         // if (lastResultOp is RemoveAllResultOperator)
@@ -323,10 +325,14 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
 
         foreach (var op in queryModel.ResultOperators.Reverse())
         {
-            if (op is CountResultOperator || op is AnyResultOperator || op is LongCountResultOperator)
+            if (op is CountResultOperator or LongCountResultOperator)
             {
                 _builder.Append("count (");
                 parenCount++;
+            }
+            else if (op is AllResultOperator or AnyResultOperator)
+            {
+                _builder.Append('1');
             }
             else if (op is SumResultOperator)
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -256,7 +256,7 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
             // UNION ...
             ProcessResultOperatorsEnd(queryModel);
 
-            _builder.Append(')');
+            _builder.TrimEnd().Append(')');
         }
         else
         {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -243,7 +243,7 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
 
             _builder.TrimEnd().Append(')');
         }
-        else if (queryModel.ResultOperators.Count == 1 && queryModel.ResultOperators[0] is AllResultOperator allOp)
+        else if (queryModel.ResultOperators.Count == 1 && queryModel.ResultOperators[0] is AllResultOperator)
         {
             // TODO: Combine with the above?
             // All is different from Any: it always has a predicate inside.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -245,7 +245,8 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
         }
         else if (queryModel.ResultOperators.Count == 1 && queryModel.ResultOperators[0] is AllResultOperator)
         {
-            // TODO: Combine with above?
+            // All is different from Any: it always has a predicate inside/
+
             // SELECT
             _builder.Append("select not exists (select 1 ");
 


### PR DESCRIPTION
* Add support and tests for Sum, Count, Min, Max, Average, Count, Any, All.
  * Ported 2.x code supports most of that, but Any and All had to be reworked to use SQL `EXISTS`.
* Fix result set type conversion logic.