### PR TITLE
IGNITE-18156 Sql. Extend SQL grammar with CREATE/DROP ZONE statement.

### DIFF
--- a/modules/sql-engine/src/main/codegen/config.fmpp
+++ b/modules/sql-engine/src/main/codegen/config.fmpp
@@ -38,6 +38,7 @@ data: {
       "org.apache.ignite.internal.sql.engine.sql.IgniteSqlCreateTableOption",
       "org.apache.ignite.internal.sql.engine.sql.IgniteSqlCreateZone",
       "org.apache.ignite.internal.sql.engine.sql.IgniteSqlCreateZoneOption",
+      "org.apache.ignite.internal.sql.engine.sql.IgniteSqlCreateZoneOptionEnum",
       "org.apache.ignite.internal.sql.engine.sql.IgniteSqlDropIndex",
       "org.apache.ignite.internal.sql.engine.sql.IgniteSqlDropZone",
       "org.apache.ignite.internal.sql.engine.sql.IgniteSqlIntervalTypeNameSpec",
@@ -56,6 +57,13 @@ data: {
 #     "KEY_TYPE" // already presented in Calcite
       "TREE"
       "HASH"
+      "PARTITIONS"
+      "REPLICAS"
+      "AFFINITY_FUNCTION"
+      "DATA_NODES_FILTER"
+      "DATA_NODES_AUTO_ADJUST"
+      "DATA_NODES_AUTO_ADJUST_SCALE_UP"
+      "DATA_NODES_AUTO_ADJUST_SCALE_DOWN"
     ]
 
     # List of non-reserved keywords to add;
@@ -549,6 +557,13 @@ data: {
       "WRITE"
       "YEAR"
       "ZONE"
+      "PARTITIONS"
+      "REPLICAS"
+      "AFFINITY_FUNCTION"
+      "DATA_NODES_FILTER"
+      "DATA_NODES_AUTO_ADJUST"
+      "DATA_NODES_AUTO_ADJUST_SCALE_UP"
+      "DATA_NODES_AUTO_ADJUST_SCALE_DOWN"
     ]
 
     # List of non-reserved keywords to add;

--- a/modules/sql-engine/src/main/codegen/config.fmpp
+++ b/modules/sql-engine/src/main/codegen/config.fmpp
@@ -56,7 +56,6 @@ data: {
 #     "KEY_TYPE" // already presented in Calcite
       "TREE"
       "HASH"
-#      "ZONE"
     ]
 
     # List of non-reserved keywords to add;

--- a/modules/sql-engine/src/main/codegen/config.fmpp
+++ b/modules/sql-engine/src/main/codegen/config.fmpp
@@ -36,7 +36,10 @@ data: {
       "org.apache.ignite.internal.sql.engine.sql.IgniteSqlCreateTable",
       "org.apache.ignite.internal.sql.engine.sql.IgniteSqlCreateIndex",
       "org.apache.ignite.internal.sql.engine.sql.IgniteSqlCreateTableOption",
+      "org.apache.ignite.internal.sql.engine.sql.IgniteSqlCreateZone",
+      "org.apache.ignite.internal.sql.engine.sql.IgniteSqlCreateZoneOption",
       "org.apache.ignite.internal.sql.engine.sql.IgniteSqlDropIndex",
+      "org.apache.ignite.internal.sql.engine.sql.IgniteSqlDropZone",
       "org.apache.ignite.internal.sql.engine.sql.IgniteSqlIntervalTypeNameSpec",
       "org.apache.ignite.internal.sql.engine.sql.IgniteSqlIndexType",
       "org.apache.calcite.sql.ddl.SqlDdlNodes",
@@ -53,6 +56,7 @@ data: {
 #     "KEY_TYPE" // already presented in Calcite
       "TREE"
       "HASH"
+#      "ZONE"
     ]
 
     # List of non-reserved keywords to add;
@@ -584,7 +588,8 @@ data: {
     # Example: "SqlCreateForeignSchema".
     createStatementParserMethods: [
       "SqlCreateTable",
-      "SqlCreateIndex"
+      "SqlCreateIndex",
+      "SqlCreateZone"
     ]
 
     # List of methods for parsing extensions to "DROP" calls.
@@ -592,7 +597,8 @@ data: {
     # Example: "SqlDropSchema".
     dropStatementParserMethods: [
       "SqlDropTable",
-      "SqlDropIndex"
+      "SqlDropIndex",
+      "SqlDropZone"
     ]
 
     # List of methods for parsing extensions to "DROP" calls.

--- a/modules/sql-engine/src/main/codegen/includes/parserImpls.ftl
+++ b/modules/sql-engine/src/main/codegen/includes/parserImpls.ftl
@@ -161,65 +161,6 @@ SqlNodeList TableElementList() :
     }
 }
 
-SqlCreate SqlCreateZone(Span s, boolean replace) :
-{
-        final boolean ifNotExists;
-        final SqlIdentifier id;
-        SqlNodeList optionList = null;
-}
-{
-    <ZONE>
-        ifNotExists = IfNotExistsOpt()
-        id = CompoundIdentifier()
-    [
-        <WITH> { s.add(this); } optionList = CreateZoneOptionList()
-    ]
-    {
-        return new IgniteSqlCreateZone(s.end(this), ifNotExists, id, optionList);
-    }
-}
-
-void CreateZoneOption(List<SqlNode> list) :
-{
-    final Span s;
-    final SqlIdentifier key;
-    final SqlNode val;
-}
-{
-    key = SimpleIdentifier() { s = span(); }
-    <EQ>
-    val = Literal()
-    {
-        list.add(new IgniteSqlCreateZoneOption(key, val, s.end(this)));
-    }
-}
-
-SqlNodeList CreateZoneOptionList() :
-{
-    List<SqlNode> list = new ArrayList<SqlNode>();
-    final Span s = Span.of();
-}
-{
-    CreateZoneOption(list)
-    (
-        <COMMA> { s.add(this); } CreateZoneOption(list)
-    )*
-    {
-        return new SqlNodeList(list, s.end(this));
-    }
-}
-
-SqlDrop SqlDropZone(Span s, boolean replace) :
-{
-    final boolean ifExists;
-    final SqlIdentifier zoneId;
-}
-{
-    <ZONE> ifExists = IfExistsOpt() zoneId = CompoundIdentifier() {
-        return new IgniteSqlDropZone(s.end(this), ifExists, zoneId);
-    }
-}
-
 SqlCreate SqlCreateTable(Span s, boolean replace) :
 {
     final boolean ifNotExists;
@@ -482,4 +423,103 @@ SqlNode SqlAlterTable() :
 {
 < NEGATE: "!" >
 |   < TILDE: "~" >
+}
+
+SqlCreate SqlCreateZone(Span s, boolean replace) :
+{
+        final boolean ifNotExists;
+        final SqlIdentifier id;
+        SqlNodeList optionList = null;
+}
+{
+    <ZONE>
+        ifNotExists = IfNotExistsOpt()
+        id = CompoundIdentifier()
+    [
+        <WITH> { s.add(this); } optionList = CreateZoneOptionList()
+    ]
+    {
+        return new IgniteSqlCreateZone(s.end(this), ifNotExists, id, optionList);
+    }
+}
+
+SqlNodeList CreateZoneOptionList() :
+{
+    List<SqlNode> list = new ArrayList<SqlNode>();
+    final Span s = Span.of();
+}
+{
+    CreateZoneOption(list)
+    (
+        <COMMA> { s.add(this); } CreateZoneOption(list)
+    )*
+    {
+        return new SqlNodeList(list, s.end(this));
+    }
+}
+
+void CreateZoneOption(List<SqlNode> list) :
+{
+    final Span s;
+    final SqlLiteral key;
+    final SqlNode val;
+}
+{
+    key = CreateZoneOptionKey() { s = span(); }
+    <EQ>
+    val = Literal()
+    {
+        list.add(new IgniteSqlCreateZoneOption(key, val, s.end(this)));
+    }
+}
+
+SqlLiteral CreateZoneOptionKey() :
+{
+}
+{
+    <PARTITIONS>
+    {
+        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.PARTITIONS, getPos());
+    }
+|
+    <REPLICAS>
+    {
+        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.REPLICAS, getPos());
+    }
+|
+    <AFFINITY_FUNCTION>
+    {
+        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.AFFINITY_FUNCTION, getPos());
+    }
+|
+    <DATA_NODES_FILTER>
+    {
+        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_FILTER, getPos());
+    }
+|
+    <DATA_NODES_AUTO_ADJUST>
+    {
+        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST, getPos());
+    }
+|
+    <DATA_NODES_AUTO_ADJUST_SCALE_UP>
+    {
+        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST_SCALE_UP, getPos());
+    }
+|
+    <DATA_NODES_AUTO_ADJUST_SCALE_DOWN>
+    {
+        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST_SCALE_DOWN, getPos());
+    }
+}
+
+SqlDrop SqlDropZone(Span s, boolean replace) :
+{
+    final boolean ifExists;
+    final SqlIdentifier zoneId;
+}
+{
+    <ZONE> ifExists = IfExistsOpt() zoneId = CompoundIdentifier() {
+        return new IgniteSqlDropZone(s.end(this), ifExists, zoneId);
+    }
 }

--- a/modules/sql-engine/src/main/codegen/includes/parserImpls.ftl
+++ b/modules/sql-engine/src/main/codegen/includes/parserImpls.ftl
@@ -188,11 +188,7 @@ void CreateZoneOption(List<SqlNode> list) :
 {
     key = SimpleIdentifier() { s = span(); }
     <EQ>
-    (
-        val = Literal()
-    |
-        val = SimpleIdentifier()
-    )
+    val = Literal()
     {
         list.add(new IgniteSqlCreateZoneOption(key, val, s.end(this)));
     }

--- a/modules/sql-engine/src/main/codegen/includes/parserImpls.ftl
+++ b/modules/sql-engine/src/main/codegen/includes/parserImpls.ftl
@@ -179,7 +179,7 @@ SqlCreate SqlCreateZone(Span s, boolean replace) :
     }
 }
 
-void CreateZoneOption(Set<SqlNode> list) :
+void CreateZoneOption(List<SqlNode> list) :
 {
     final Span s;
     final SqlIdentifier key;
@@ -200,7 +200,7 @@ void CreateZoneOption(Set<SqlNode> list) :
 
 SqlNodeList CreateZoneOptionList() :
 {
-    Set<SqlNode> list = new HashSet<SqlNode>();
+    List<SqlNode> list = new ArrayList<SqlNode>();
     final Span s = Span.of();
 }
 {
@@ -219,7 +219,7 @@ SqlDrop SqlDropZone(Span s, boolean replace) :
     final SqlIdentifier zoneId;
 }
 {
-    <ZONE> ifExists = IfExistsOpt() zoneId = SimpleIdentifier() {
+    <ZONE> ifExists = IfExistsOpt() zoneId = CompoundIdentifier() {
         return new IgniteSqlDropZone(s.end(this), ifExists, zoneId);
     }
 }

--- a/modules/sql-engine/src/main/codegen/includes/parserImpls.ftl
+++ b/modules/sql-engine/src/main/codegen/includes/parserImpls.ftl
@@ -460,78 +460,66 @@ SqlNodeList CreateZoneOptionList() :
 
 void CreateZoneOption(List<SqlNode> list) :
 {
-    final Span s = Span.of();
+    final Span s;
     final SqlLiteral key;
     final SqlNode val;
 }
 {
     (
         (
-            <PARTITIONS>
-            {
-                key = SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.PARTITIONS, getPos());
-            }
+            key = CreateNumericZoneOptionKey() { s = span(); }
             <EQ>
             val = NumericLiteral()
         )
-    |
+        |
         (
-            <REPLICAS>
-            {
-                key = SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.REPLICAS, getPos());
-            }
-            <EQ>
-            val = NumericLiteral()
-        )
-    |
-        (
-            <AFFINITY_FUNCTION>
-            {
-                key = SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.AFFINITY_FUNCTION, getPos());
-            }
+            key = CreateStringZoneOptionKey() { s = span(); }
             <EQ>
             val = StringLiteral()
-        )
-    |
-        (
-            <DATA_NODES_FILTER>
-            {
-                key = SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_FILTER, getPos());
-            }
-            <EQ>
-            val = StringLiteral()
-        )
-    |
-        (
-            <DATA_NODES_AUTO_ADJUST>
-            {
-                key = SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST, getPos());
-            }
-            <EQ>
-            val = NumericLiteral()
-        )
-    |
-        (
-            <DATA_NODES_AUTO_ADJUST_SCALE_UP>
-            {
-                key = SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST_SCALE_UP, getPos());
-            }
-            <EQ>
-            val = NumericLiteral()
-        )
-    |
-        (
-            <DATA_NODES_AUTO_ADJUST_SCALE_DOWN>
-            {
-                key = SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST_SCALE_DOWN, getPos());
-            }
-            <EQ>
-            val = NumericLiteral()
         )
     )
     {
         list.add(new IgniteSqlCreateZoneOption(key, val, s.end(this)));
     }
+}
+
+SqlLiteral CreateNumericZoneOptionKey() :
+{
+}
+{
+    <PARTITIONS>
+    {
+        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.PARTITIONS, getPos());
+    }
+|
+    <REPLICAS>
+    {
+        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.REPLICAS, getPos());
+    }
+|
+    <DATA_NODES_AUTO_ADJUST>
+    {
+        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST, getPos());
+    }
+|
+    <DATA_NODES_AUTO_ADJUST_SCALE_UP>
+    {
+        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST_SCALE_UP, getPos());
+    }
+|
+    <DATA_NODES_AUTO_ADJUST_SCALE_DOWN>
+    {
+        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST_SCALE_DOWN, getPos());
+    }
+}
+
+SqlLiteral CreateStringZoneOptionKey() :
+{
+}
+{
+    <AFFINITY_FUNCTION> { return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.AFFINITY_FUNCTION, getPos()); }
+|
+    <DATA_NODES_FILTER> { return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_FILTER, getPos()); }
 }
 
 SqlDrop SqlDropZone(Span s, boolean replace) :

--- a/modules/sql-engine/src/main/codegen/includes/parserImpls.ftl
+++ b/modules/sql-engine/src/main/codegen/includes/parserImpls.ftl
@@ -460,56 +460,77 @@ SqlNodeList CreateZoneOptionList() :
 
 void CreateZoneOption(List<SqlNode> list) :
 {
-    final Span s;
+    final Span s = Span.of();
     final SqlLiteral key;
     final SqlNode val;
 }
 {
-    key = CreateZoneOptionKey() { s = span(); }
-    <EQ>
-    val = Literal()
+    (
+        (
+            <PARTITIONS>
+            {
+                key = SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.PARTITIONS, getPos());
+            }
+            <EQ>
+            val = NumericLiteral()
+        )
+    |
+        (
+            <REPLICAS>
+            {
+                key = SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.REPLICAS, getPos());
+            }
+            <EQ>
+            val = NumericLiteral()
+        )
+    |
+        (
+            <AFFINITY_FUNCTION>
+            {
+                key = SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.AFFINITY_FUNCTION, getPos());
+            }
+            <EQ>
+            val = StringLiteral()
+        )
+    |
+        (
+            <DATA_NODES_FILTER>
+            {
+                key = SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_FILTER, getPos());
+            }
+            <EQ>
+            val = StringLiteral()
+        )
+    |
+        (
+            <DATA_NODES_AUTO_ADJUST>
+            {
+                key = SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST, getPos());
+            }
+            <EQ>
+            val = NumericLiteral()
+        )
+    |
+        (
+            <DATA_NODES_AUTO_ADJUST_SCALE_UP>
+            {
+                key = SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST_SCALE_UP, getPos());
+            }
+            <EQ>
+            val = NumericLiteral()
+        )
+    |
+        (
+            <DATA_NODES_AUTO_ADJUST_SCALE_DOWN>
+            {
+                key = SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST_SCALE_DOWN, getPos());
+            }
+            <EQ>
+            val = NumericLiteral()
+        )
+    )
     {
         list.add(new IgniteSqlCreateZoneOption(key, val, s.end(this)));
-    }
-}
-
-SqlLiteral CreateZoneOptionKey() :
-{
-}
-{
-    <PARTITIONS>
-    {
-        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.PARTITIONS, getPos());
-    }
-|
-    <REPLICAS>
-    {
-        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.REPLICAS, getPos());
-    }
-|
-    <AFFINITY_FUNCTION>
-    {
-        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.AFFINITY_FUNCTION, getPos());
-    }
-|
-    <DATA_NODES_FILTER>
-    {
-        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_FILTER, getPos());
-    }
-|
-    <DATA_NODES_AUTO_ADJUST>
-    {
-        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST, getPos());
-    }
-|
-    <DATA_NODES_AUTO_ADJUST_SCALE_UP>
-    {
-        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST_SCALE_UP, getPos());
-    }
-|
-    <DATA_NODES_AUTO_ADJUST_SCALE_DOWN>
-    {
-        return SqlLiteral.createSymbol(IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST_SCALE_DOWN, getPos());
     }
 }
 

--- a/modules/sql-engine/src/main/codegen/includes/parserImpls.ftl
+++ b/modules/sql-engine/src/main/codegen/includes/parserImpls.ftl
@@ -161,6 +161,71 @@ SqlNodeList TableElementList() :
     }
 }
 
+SqlCreate SqlCreateZone(Span s, boolean replace) :
+{
+        final boolean ifNotExists;
+        final SqlIdentifier id;
+        SqlNodeList optionList = null;
+}
+{
+    <ZONE>
+        ifNotExists = IfNotExistsOpt()
+        id = CompoundIdentifier()
+    [
+        <WITH> { s.add(this); } optionList = CreateZoneOptionList()
+    ]
+    {
+        return new IgniteSqlCreateZone(s.end(this), ifNotExists, id, optionList);
+    }
+}
+
+void CreateZoneOption(List<SqlNode> list) :
+{
+    final Span s;
+    final SqlIdentifier key;
+    final SqlNode val;
+}
+{
+    key = SimpleIdentifier() { s = span(); }
+    <EQ>
+    (
+        val = SimpleIdentifier()
+    |
+        val = Literal()
+    )
+    {
+        IgniteSqlCreateZoneOption.validate(list, key, getPos());
+
+        list.add(new IgniteSqlCreateZoneOption(key, val, s.end(this)));
+    }
+}
+
+SqlNodeList CreateZoneOptionList() :
+{
+    List<SqlNode> list = new ArrayList<SqlNode>();
+    final Span s = Span.of();
+}
+{
+    CreateZoneOption(list)
+    (
+        <COMMA> { s.add(this); } CreateZoneOption(list)
+    )*
+    {
+        return new SqlNodeList(list, s.end(this));
+    }
+}
+
+SqlDrop SqlDropZone(Span s, boolean replace) :
+{
+    final boolean ifExists;
+    final SqlIdentifier zoneId;
+}
+{
+    <ZONE> ifExists = IfExistsOpt() zoneId = SimpleIdentifier() {
+        return new IgniteSqlDropZone(s.end(this), ifExists, zoneId);
+    }
+}
+
 SqlCreate SqlCreateTable(Span s, boolean replace) :
 {
     final boolean ifNotExists;

--- a/modules/sql-engine/src/main/codegen/includes/parserImpls.ftl
+++ b/modules/sql-engine/src/main/codegen/includes/parserImpls.ftl
@@ -179,7 +179,7 @@ SqlCreate SqlCreateZone(Span s, boolean replace) :
     }
 }
 
-void CreateZoneOption(List<SqlNode> list) :
+void CreateZoneOption(Set<SqlNode> list) :
 {
     final Span s;
     final SqlIdentifier key;
@@ -189,20 +189,18 @@ void CreateZoneOption(List<SqlNode> list) :
     key = SimpleIdentifier() { s = span(); }
     <EQ>
     (
-        val = SimpleIdentifier()
-    |
         val = Literal()
+    |
+        val = SimpleIdentifier()
     )
     {
-        IgniteSqlCreateZoneOption.validate(list, key, getPos());
-
         list.add(new IgniteSqlCreateZoneOption(key, val, s.end(this)));
     }
 }
 
 SqlNodeList CreateZoneOptionList() :
 {
-    List<SqlNode> list = new ArrayList<SqlNode>();
+    Set<SqlNode> list = new HashSet<SqlNode>();
     final Span s = Span.of();
 }
 {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZone.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZone.java
@@ -41,7 +41,7 @@ public class IgniteSqlCreateZone extends SqlCreate {
 
     private static final SqlOperator OPERATOR = new SqlSpecialOperator("CREATE ZONE", SqlKind.OTHER);
 
-    /** Creates a SqlCreateTable. */
+    /** Creates a SqlCreateZone. */
     public IgniteSqlCreateZone(
             SqlParserPos pos,
             boolean ifNotExists,
@@ -80,14 +80,14 @@ public class IgniteSqlCreateZone extends SqlCreate {
     }
 
     /**
-     * Get name of the table.
+     * Get name of the distributed zone.
      */
     public SqlIdentifier name() {
         return name;
     }
 
     /**
-     * Get list of the specified options to create table with.
+     * Get list of the specified options to create distributed zone with.
      */
     public SqlNodeList createOptionList() {
         return createOptionList;

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZone.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZone.java
@@ -80,14 +80,14 @@ public class IgniteSqlCreateZone extends SqlCreate {
     }
 
     /**
-     * Get name of the distributed zone.
+     * Get name of the distribution zone.
      */
     public SqlIdentifier name() {
         return name;
     }
 
     /**
-     * Get list of the specified options to create distributed zone with.
+     * Get list of the specified options to create distribution zone with.
      */
     public SqlNodeList createOptionList() {
         return createOptionList;

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZone.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZone.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.sql;
+
+import java.util.List;
+import java.util.Objects;
+import org.apache.calcite.sql.SqlCreate;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Parse tree for {@code CREATE ZONE} statement with Ignite specific features.
+ */
+public class IgniteSqlCreateZone extends SqlCreate {
+    private final SqlIdentifier name;
+
+    private final @Nullable SqlNodeList createOptionList;
+
+    private static final SqlOperator OPERATOR = new SqlSpecialOperator("CREATE ZONE", SqlKind.OTHER);
+
+    /** Creates a SqlCreateTable. */
+    public IgniteSqlCreateZone(
+            SqlParserPos pos,
+            boolean ifNotExists,
+            SqlIdentifier name,
+            @Nullable SqlNodeList createOptionList
+    ) {
+        super(OPERATOR, pos, false, ifNotExists);
+
+        this.name = Objects.requireNonNull(name, "name");
+        this.createOptionList = createOptionList;
+    }
+
+    /** {@inheritDoc} */
+    @SuppressWarnings("nullness")
+    @Override
+    public List<SqlNode> getOperandList() {
+        return ImmutableNullableList.of(name, createOptionList);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+        writer.keyword("CREATE");
+        writer.keyword("ZONE");
+        if (ifNotExists) {
+            writer.keyword("IF NOT EXISTS");
+        }
+
+        name.unparse(writer, leftPrec, rightPrec);
+
+        if (createOptionList != null) {
+            writer.keyword("WITH");
+
+            createOptionList.unparse(writer, 0, 0);
+        }
+    }
+
+    /**
+     * Get name of the table.
+     */
+    public SqlIdentifier name() {
+        return name;
+    }
+
+    /**
+     * Get list of the specified options to create table with.
+     */
+    public SqlNodeList createOptionList() {
+        return createOptionList;
+    }
+
+    /**
+     * Get whether the IF NOT EXISTS is specified.
+     */
+    public boolean ifNotExists() {
+        return ifNotExists;
+    }
+}

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZoneOption.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZoneOption.java
@@ -31,7 +31,7 @@ import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.util.Litmus;
 
-/** An AST node representing option to create zone with. */
+/** An AST node representing option to create distributed zone with. */
 public class IgniteSqlCreateZoneOption extends SqlCall {
     private static final SqlOperator OPERATOR =
             new SqlSpecialOperator("ZoneOption", SqlKind.OTHER);
@@ -42,7 +42,7 @@ public class IgniteSqlCreateZoneOption extends SqlCall {
     /** Option value. */
     private final SqlNode value;
 
-    /** Creates IgniteSqlCreateZoneOption. */
+    /** Creates {@link IgniteSqlCreateZoneOption}. */
     public IgniteSqlCreateZoneOption(SqlIdentifier key, SqlNode value, SqlParserPos pos) {
         super(pos);
 

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZoneOption.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZoneOption.java
@@ -31,7 +31,7 @@ import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.util.Litmus;
 
-/** An AST node representing option to create distributed zone with. */
+/** An AST node representing option to create distribution zone with. */
 public class IgniteSqlCreateZoneOption extends SqlCall {
     private static final SqlOperator OPERATOR =
             new SqlSpecialOperator("ZoneOption", SqlKind.OTHER);

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZoneOption.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZoneOption.java
@@ -19,8 +19,8 @@ package org.apache.ignite.internal.sql.engine.sql;
 
 import java.util.List;
 import org.apache.calcite.sql.SqlCall;
-import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -37,13 +37,13 @@ public class IgniteSqlCreateZoneOption extends SqlCall {
             new SqlSpecialOperator("ZoneOption", SqlKind.OTHER);
 
     /** Option key. */
-    private final SqlIdentifier key;
+    private final SqlLiteral key;
 
     /** Option value. */
     private final SqlNode value;
 
     /** Creates {@link IgniteSqlCreateZoneOption}. */
-    public IgniteSqlCreateZoneOption(SqlIdentifier key, SqlNode value, SqlParserPos pos) {
+    public IgniteSqlCreateZoneOption(SqlLiteral key, SqlNode value, SqlParserPos pos) {
         super(pos);
 
         this.key = key;
@@ -106,7 +106,7 @@ public class IgniteSqlCreateZoneOption extends SqlCall {
     /**
      * Get option's key.
      */
-    public SqlIdentifier key() {
+    public SqlLiteral key() {
         return key;
     }
 

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZoneOption.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZoneOption.java
@@ -25,7 +25,6 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
-import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.util.SqlVisitor;
 import org.apache.calcite.sql.validate.SqlValidator;
@@ -81,32 +80,6 @@ public class IgniteSqlCreateZoneOption extends SqlCall {
     @Override
     public void validate(SqlValidator validator, SqlValidatorScope scope) {
         throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Validation.
-     *
-     * @param nodes Sql nodes list.
-     * @param key Current sql node key.
-     * @param pos Parser position.
-     */
-    public static void validate(List<SqlNode> nodes, SqlNode key, SqlParserPos pos) {
-        String strKey = ((SqlIdentifier) key).getSimple();
-        String autoAdjust = "DATA_NODES_AUTO_ADJUST";
-
-        if (!strKey.startsWith(autoAdjust)) {
-            return;
-        }
-
-        boolean searchAutoAdjust = !autoAdjust.equals(strKey);
-
-        for (SqlNode node : nodes) {
-            String nodeKey = ((IgniteSqlCreateZoneOption) node).key().getSimple();
-
-            if (searchAutoAdjust ? nodeKey.equals(autoAdjust) : nodeKey.startsWith(autoAdjust)) {
-                throw new RuntimeException(new SqlParseException("Encountered \"" + strKey + "\"", pos, null, null, null));
-            }
-        }
     }
 
     /** {@inheritDoc} */

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZoneOption.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZoneOption.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.sql;
+
+import java.util.List;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.util.SqlVisitor;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql.validate.SqlValidatorScope;
+import org.apache.calcite.util.Litmus;
+
+/** An AST node representing option to create zone with. */
+public class IgniteSqlCreateZoneOption extends SqlCall {
+    private static final SqlOperator OPERATOR =
+            new SqlSpecialOperator("ZoneOption", SqlKind.OTHER);
+
+    /** Option key. */
+    private final SqlIdentifier key;
+
+    /** Option value. */
+    private final SqlNode value;
+
+    /** Creates IgniteSqlCreateZoneOption. */
+    public IgniteSqlCreateZoneOption(SqlIdentifier key, SqlNode value, SqlParserPos pos) {
+        super(pos);
+
+        this.key = key;
+        this.value = value;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public SqlOperator getOperator() {
+        return OPERATOR;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<SqlNode> getOperandList() {
+        return List.of(key, value);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public SqlNode clone(SqlParserPos pos) {
+        return new IgniteSqlCreateZoneOption(key, value, pos);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+        key.unparse(writer, leftPrec, rightPrec);
+        writer.keyword("=");
+        value.unparse(writer, leftPrec, rightPrec);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void validate(SqlValidator validator, SqlValidatorScope scope) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Validation.
+     *
+     * @param nodes Sql nodes list.
+     * @param key Current sql node key.
+     * @param pos Parser position.
+     */
+    public static void validate(List<SqlNode> nodes, SqlNode key, SqlParserPos pos) {
+        String strKey = ((SqlIdentifier) key).getSimple();
+        String autoAdjust = "DATA_NODES_AUTO_ADJUST";
+
+        if (!strKey.startsWith(autoAdjust)) {
+            return;
+        }
+
+        boolean searchAutoAdjust = !autoAdjust.equals(strKey);
+
+        for (SqlNode node : nodes) {
+            String nodeKey = ((IgniteSqlCreateZoneOption) node).key().getSimple();
+
+            if (searchAutoAdjust ? nodeKey.equals(autoAdjust) : nodeKey.startsWith(autoAdjust)) {
+                throw new RuntimeException(new SqlParseException("Encountered \"" + strKey + "\"", pos, null, null, null));
+            }
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <R> R accept(SqlVisitor<R> visitor) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equalsDeep(SqlNode node, Litmus litmus) {
+        if (!(node instanceof IgniteSqlCreateZoneOption)) {
+            return litmus.fail("{} != {}", this, node);
+        }
+
+        IgniteSqlCreateZoneOption that = (IgniteSqlCreateZoneOption) node;
+        if (key != that.key) {
+            return litmus.fail("{} != {}", this, node);
+        }
+
+        return value.equalsDeep(that.value, litmus);
+    }
+
+    /**
+     * Get option's key.
+     */
+    public SqlIdentifier key() {
+        return key;
+    }
+
+    /**
+     * Get option's value.
+     */
+    public SqlNode value() {
+        return value;
+    }
+}

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZoneOptionEnum.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZoneOptionEnum.java
@@ -18,7 +18,7 @@
 package org.apache.ignite.internal.sql.engine.sql;
 
 /**
- * Enumerates the Ignite specific options for CREATE ZONE statement.
+ * Enumerates the options for CREATE ZONE statement.
  */
 public enum IgniteSqlCreateZoneOptionEnum {
     /** Number of partitions. */

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZoneOptionEnum.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateZoneOptionEnum.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.sql;
+
+/**
+ * Enumerates the Ignite specific options for CREATE ZONE statement.
+ */
+public enum IgniteSqlCreateZoneOptionEnum {
+    /** Number of partitions. */
+    PARTITIONS,
+
+    /** Number of replicas. */
+    REPLICAS,
+
+    /** Affinity function name. */
+    AFFINITY_FUNCTION,
+
+    /** An expression to filter data nodes. */
+    DATA_NODES_FILTER,
+
+    /** Data nodes auto adjust timeout. */
+    DATA_NODES_AUTO_ADJUST,
+
+    /** Data nodes scale up auto adjust timeout. */
+    DATA_NODES_AUTO_ADJUST_SCALE_UP,
+
+    /** Data nodes scale down auto adjust timeout. */
+    DATA_NODES_AUTO_ADJUST_SCALE_DOWN
+}

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlDropZone.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlDropZone.java
@@ -33,21 +33,22 @@ import org.apache.calcite.util.ImmutableNullableList;
  * Parse tree for {@code DROP ZONE} statement.
  */
 public class IgniteSqlDropZone extends SqlDrop {
-    /** Index name. */
-    private final SqlIdentifier zoneName;
+    /** Zone name. */
+    private final SqlIdentifier name;
 
     /** Sql operator. */
     private static final SqlOperator OPERATOR = new SqlSpecialOperator("DROP ZONE", SqlKind.OTHER);
 
     /** Constructor. */
-    public IgniteSqlDropZone(SqlParserPos pos, boolean ifExists, SqlIdentifier zoneName) {
+    public IgniteSqlDropZone(SqlParserPos pos, boolean ifExists, SqlIdentifier name) {
         super(OPERATOR, pos, ifExists);
-        this.zoneName = Objects.requireNonNull(zoneName, "zone name");
+
+        this.name = Objects.requireNonNull(name, "zone name");
     }
 
     /** {@inheritDoc} */
     @Override public List<SqlNode> getOperandList() {
-        return ImmutableNullableList.of(zoneName);
+        return ImmutableNullableList.of(name);
     }
 
     /** {@inheritDoc} */
@@ -58,11 +59,11 @@ public class IgniteSqlDropZone extends SqlDrop {
             writer.keyword("IF EXISTS");
         }
 
-        zoneName.unparse(writer, leftPrec, rightPrec);
+        name.unparse(writer, leftPrec, rightPrec);
     }
 
-    public SqlIdentifier zoneName() {
-        return zoneName;
+    public SqlIdentifier name() {
+        return name;
     }
 
     public boolean ifExists() {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlDropZone.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlDropZone.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.sql;
+
+import java.util.List;
+import java.util.Objects;
+import org.apache.calcite.sql.SqlDrop;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+/**
+ * Parse tree for {@code DROP ZONE} statement.
+ */
+public class IgniteSqlDropZone extends SqlDrop {
+    /** Index name. */
+    private final SqlIdentifier zoneName;
+
+    /** Sql operator. */
+    private static final SqlOperator OPERATOR = new SqlSpecialOperator("DROP ZONE", SqlKind.OTHER);
+
+    /** Constructor. */
+    public IgniteSqlDropZone(SqlParserPos pos, boolean ifExists, SqlIdentifier zoneName) {
+        super(OPERATOR, pos, ifExists);
+        this.zoneName = Objects.requireNonNull(zoneName, "zone name");
+    }
+
+    /** {@inheritDoc} */
+    @Override public List<SqlNode> getOperandList() {
+        return ImmutableNullableList.of(zoneName);
+    }
+
+    /** {@inheritDoc} */
+    @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+        writer.keyword(getOperator().getName()); // "DROP ..."
+
+        if (ifExists) {
+            writer.keyword("IF EXISTS");
+        }
+
+        zoneName.unparse(writer, leftPrec, rightPrec);
+    }
+
+    public SqlIdentifier zoneName() {
+        return zoneName;
+    }
+
+    public boolean ifExists() {
+        return ifExists;
+    }
+}

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/AbstractDdlParserTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/AbstractDdlParserTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.sql;
+
+import java.util.function.Predicate;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.ignite.internal.generated.query.calcite.sql.IgniteSqlParserImpl;
+import org.hamcrest.CustomMatcher;
+import org.hamcrest.Matcher;
+
+/**
+ * Common methods to verify parsing of the DDL command.
+ */
+public abstract class AbstractDdlParserTest {
+    /**
+     * Parses a given statement and returns a resulting AST.
+     *
+     * @param stmt Statement to parse.
+     * @return An AST.
+     */
+    protected SqlNode parse(String stmt) throws SqlParseException {
+        SqlParser parser = SqlParser.create(stmt, SqlParser.config().withParserFactory(IgniteSqlParserImpl.FACTORY));
+
+        return parser.parseStmt();
+    }
+
+    /**
+     * Matcher to verify that an object of the expected type and matches the given predicate.
+     *
+     * @param desc Description for this matcher.
+     * @param cls  Expected class to verify the object is instance of.
+     * @param pred Addition check that would be applied to the object.
+     * @return {@code true} in case the object if instance of the given class and matches the predicat.
+     */
+    protected <T> Matcher<T> ofTypeMatching(String desc, Class<T> cls, Predicate<T> pred) {
+        return new CustomMatcher<T>(desc) {
+            /** {@inheritDoc} */
+            @Override
+            public boolean matches(Object item) {
+                return item != null && cls.isAssignableFrom(item.getClass()) && pred.test((T) item);
+            }
+        };
+    }
+}

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
@@ -126,13 +126,13 @@ public class SqlDdlZoneParserTest extends AbstractDdlParserTest {
 
         IgniteSqlDropZone dropZone = (IgniteSqlDropZone) node;
 
-        assertThat(dropZone.zoneName().names, is(List.of("TEST_ZONE")));
+        assertThat(dropZone.name().names, is(List.of("TEST_ZONE")));
         assertFalse(dropZone.ifExists());
 
         // Fully qualified name.
         dropZone = ((IgniteSqlDropZone) parse("drop zone public.test_zone"));
 
-        assertThat(dropZone.zoneName().names, is(List.of("PUBLIC", "TEST_ZONE")));
+        assertThat(dropZone.name().names, is(List.of("PUBLIC", "TEST_ZONE")));
     }
 
     /**

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
@@ -84,7 +84,7 @@ public class SqlDdlZoneParserTest extends AbstractDdlParserTest {
                 "create zone test_zone with "
                         + "replicas=2, "
                         + "partitions=3, "
-                        + "data_nodes_filter=nodes_filter, "
+                        + "data_nodes_filter='(\"US\" || \"EU\") && \"SSD\"', "
                         + "affinity_function=test_Affinity, "
                         + "data_nodes_auto_adjust=1, "
                         + "data_nodes_auto_adjust_scale_up=2, "
@@ -98,7 +98,7 @@ public class SqlDdlZoneParserTest extends AbstractDdlParserTest {
         assertThatZoneOptionPresent(optList, "REPLICAS", 2);
         assertThatZoneOptionPresent(optList, "PARTITIONS", 3);
         assertThatZoneOptionPresent(optList, "AFFINITY_FUNCTION", "TEST_AFFINITY");
-        assertThatZoneOptionPresent(optList, "DATA_NODES_FILTER", "NODES_FILTER");
+        assertThatZoneOptionPresent(optList, "DATA_NODES_FILTER", "(\"US\" || \"EU\") && \"SSD\"");
         assertThatZoneOptionPresent(optList, "DATA_NODES_AUTO_ADJUST", 1);
 
         SqlPrettyWriter w = new SqlPrettyWriter();
@@ -107,7 +107,7 @@ public class SqlDdlZoneParserTest extends AbstractDdlParserTest {
         assertThat(w.toString(), equalTo("CREATE ZONE \"TEST_ZONE\" WITH "
                 + "\"REPLICAS\" = 2, "
                 + "\"PARTITIONS\" = 3, "
-                + "\"DATA_NODES_FILTER\" = \"NODES_FILTER\", "
+                + "\"DATA_NODES_FILTER\" = '(\"US\" || \"EU\") && \"SSD\"', "
                 + "\"AFFINITY_FUNCTION\" = \"TEST_AFFINITY\", "
                 + "\"DATA_NODES_AUTO_ADJUST\" = 1, "
                 + "\"DATA_NODES_AUTO_ADJUST_SCALE_UP\" = 2, "

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.sql;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Objects;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.pretty.SqlPrettyWriter;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test suite to verify parsing of the DDL "ZONE" commands.
+ */
+public class SqlDdlZoneParserTest extends AbstractDdlParserTest {
+    /**
+     * Parse simple CREATE ZONE statement.
+     */
+    @Test
+    public void createZoneMoOptions() throws SqlParseException {
+        // Simple name.
+        IgniteSqlCreateZone createZone = parseCreateZone("create zone test_zone");
+
+        assertThat(createZone.name().names, is(List.of("TEST_ZONE")));
+        assertFalse(createZone.ifNotExists());
+        assertNull(createZone.createOptionList());
+
+        // Fully qualified name.
+        createZone = parseCreateZone("create zone public.test_zone");
+        assertThat(createZone.name().names, is(List.of("PUBLIC", "TEST_ZONE")));
+
+        // Quoted identifier.
+        createZone = parseCreateZone("create zone \"public\".\"test_Zone\"");
+        assertThat(createZone.name().names, is(List.of("public", "test_Zone")));
+
+        createZone = parseCreateZone("create zone \"public-test_Zone\"");
+        assertThat(createZone.name().names, is(List.of("public-test_Zone")));
+    }
+
+    /**
+     * Parse CREATE ZONE IF NOT EXISTS statement.
+     */
+    @Test
+    public void createZoneIfNotExists() throws SqlParseException {
+        IgniteSqlCreateZone createZone = parseCreateZone("create zone if not exists test_zone");
+
+        assertTrue(createZone.ifNotExists());
+        assertNull(createZone.createOptionList());
+    }
+
+    /**
+     * Parse CREATE ZONE WITH ... statement.
+     */
+    @Test
+    public void createZoneWithOptions() throws SqlParseException {
+        IgniteSqlCreateZone createZone = parseCreateZone(
+                "create zone test_zone with "
+                        + "replicas=2, "
+                        + "partitions=3, "
+                        + "data_nodes_filter=nodes_filter, "
+                        + "affinity_function=test_Affinity, "
+                        + "data_nodes_auto_adjust=1, "
+                        + "data_nodes_auto_adjust_scale_up=2, "
+                        + "data_nodes_auto_adjust_scale_down=3"
+        );
+
+        assertNotNull(createZone.createOptionList());
+
+        List<SqlNode> optList = createZone.createOptionList().getList();
+
+        assertThatZoneOptionPresent(optList, "REPLICAS", 2);
+        assertThatZoneOptionPresent(optList, "PARTITIONS", 3);
+        assertThatZoneOptionPresent(optList, "AFFINITY_FUNCTION", "TEST_AFFINITY");
+        assertThatZoneOptionPresent(optList, "DATA_NODES_FILTER", "NODES_FILTER");
+        assertThatZoneOptionPresent(optList, "DATA_NODES_AUTO_ADJUST", 1);
+
+        SqlPrettyWriter w = new SqlPrettyWriter();
+        createZone.unparse(w, 0, 0);
+
+        assertThat(w.toString(), equalTo("CREATE ZONE \"TEST_ZONE\" WITH "
+                + "\"REPLICAS\" = 2, "
+                + "\"PARTITIONS\" = 3, "
+                + "\"DATA_NODES_FILTER\" = \"NODES_FILTER\", "
+                + "\"AFFINITY_FUNCTION\" = \"TEST_AFFINITY\", "
+                + "\"DATA_NODES_AUTO_ADJUST\" = 1, "
+                + "\"DATA_NODES_AUTO_ADJUST_SCALE_UP\" = 2, "
+                + "\"DATA_NODES_AUTO_ADJUST_SCALE_DOWN\" = 3"));
+    }
+
+    /**
+     * Parsing DROP ZONE statement.
+     */
+    @Test
+    public void dropZone() throws SqlParseException {
+        // Simple name.
+        SqlNode node = parse("drop zone test_zone");
+
+        assertThat(node, instanceOf(IgniteSqlDropZone.class));
+
+        IgniteSqlDropZone dropZone = (IgniteSqlDropZone) node;
+
+        assertThat(dropZone.zoneName().names, is(List.of("TEST_ZONE")));
+        assertFalse(dropZone.ifExists());
+
+        // Fully qualified name.
+        dropZone = ((IgniteSqlDropZone) parse("drop zone public.test_zone"));
+
+        assertThat(dropZone.zoneName().names, is(List.of("PUBLIC", "TEST_ZONE")));
+    }
+
+    /**
+     * Parsing DROP ZONE IF EXISTS statement.
+     */
+    @Test
+    public void dropZoneIfExists() throws SqlParseException {
+        IgniteSqlDropZone dropZone = (IgniteSqlDropZone) parse("drop zone if exists test_zone");
+
+        assertTrue(dropZone.ifExists());
+
+        SqlPrettyWriter w = new SqlPrettyWriter();
+        dropZone.unparse(w, 0, 0);
+
+        assertThat(w.toString(), equalTo("DROP ZONE IF EXISTS \"TEST_ZONE\""));
+    }
+
+    /**
+     * Parse CREATE ZONE statement.
+     *
+     * @param stmt Create zone query.
+     * @return {@link org.apache.calcite.sql.SqlCreate SqlCreate} node.
+     */
+    private IgniteSqlCreateZone parseCreateZone(String stmt) throws SqlParseException {
+        SqlNode node = parse(stmt);
+
+        assertThat(node, instanceOf(IgniteSqlCreateZone.class));
+
+        return (IgniteSqlCreateZone) node;
+    }
+
+    private void assertThatZoneOptionPresent(List<SqlNode> optionList, String option, Object expVal) {
+        assertThat(optionList, Matchers.hasItem(ofTypeMatching(
+                option + "=" + expVal,
+                IgniteSqlCreateZoneOption.class,
+                opt -> {
+                    if (opt.key().getSimple().equals(option)) {
+                        if (opt.value() instanceof SqlLiteral) {
+                            return Objects.equals(expVal, ((SqlLiteral) opt.value()).getValueAs(expVal.getClass()));
+                        }
+
+                        if (opt.value() instanceof SqlIdentifier) {
+                            return Objects.equals(expVal, ((SqlIdentifier) opt.value()).getSimple());
+                        }
+                    }
+
+                    return false;
+                }
+        )));
+    }
+}

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import org.apache.calcite.sql.SqlLiteral;
@@ -118,8 +119,18 @@ public class SqlDdlZoneParserTest extends AbstractDdlParserTest {
      * Parse CREATE ZONE WITH unknown option.
      */
     @Test
-    public void createZoneWithUnknownOptions() {
+    public void createZoneWithInvalidOptions() {
+        // Unknown option.
         assertThrows(SqlParseException.class, () -> parseCreateZone("create zone test_zone with foo=bar"));
+
+        // Invalid option type.
+        List<String> optNames = Arrays.asList("PARTITIONS", "REPLICAS", "AFFINITY_FUNCTION", "DATA_NODES_FILTER", "DATA_NODES_AUTO_ADJUST",
+                "DATA_NODES_AUTO_ADJUST_SCALE_UP", "DATA_NODES_AUTO_ADJUST_SCALE_DOWN");
+
+        for (String optName : optNames) {
+            assertThrows(SqlParseException.class,
+                    () -> parseCreateZone(String.format("create zone test_zone with %s=bar", optName)));
+        }
     }
 
     /**

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
@@ -124,12 +124,19 @@ public class SqlDdlZoneParserTest extends AbstractDdlParserTest {
         assertThrows(SqlParseException.class, () -> parseCreateZone("create zone test_zone with foo=bar"));
 
         // Invalid option type.
-        List<String> optNames = Arrays.asList("PARTITIONS", "REPLICAS", "AFFINITY_FUNCTION", "DATA_NODES_FILTER", "DATA_NODES_AUTO_ADJUST",
+        List<String> numericOptNames = Arrays.asList("PARTITIONS", "REPLICAS", "DATA_NODES_AUTO_ADJUST",
                 "DATA_NODES_AUTO_ADJUST_SCALE_UP", "DATA_NODES_AUTO_ADJUST_SCALE_DOWN");
 
-        for (String optName : optNames) {
+        for (String optName : numericOptNames) {
             assertThrows(SqlParseException.class,
-                    () -> parseCreateZone(String.format("create zone test_zone with %s=bar", optName)));
+                    () -> parseCreateZone(String.format("create zone test_zone with %s='bar'", optName)));
+        }
+
+        List<String> stringOptNames = Arrays.asList("AFFINITY_FUNCTION", "DATA_NODES_FILTER");
+
+        for (String optName : stringOptNames) {
+            assertThrows(SqlParseException.class,
+                    () -> parseCreateZone(String.format("create zone test_zone with %s=1", optName)));
         }
     }
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
@@ -85,7 +85,7 @@ public class SqlDdlZoneParserTest extends AbstractDdlParserTest {
                         + "replicas=2, "
                         + "partitions=3, "
                         + "data_nodes_filter='(\"US\" || \"EU\") && \"SSD\"', "
-                        + "affinity_function=test_Affinity, "
+                        + "affinity_function='test_Affinity', "
                         + "data_nodes_auto_adjust=1, "
                         + "data_nodes_auto_adjust_scale_up=2, "
                         + "data_nodes_auto_adjust_scale_down=3"
@@ -97,7 +97,7 @@ public class SqlDdlZoneParserTest extends AbstractDdlParserTest {
 
         assertThatZoneOptionPresent(optList, "REPLICAS", 2);
         assertThatZoneOptionPresent(optList, "PARTITIONS", 3);
-        assertThatZoneOptionPresent(optList, "AFFINITY_FUNCTION", "TEST_AFFINITY");
+        assertThatZoneOptionPresent(optList, "AFFINITY_FUNCTION", "test_Affinity");
         assertThatZoneOptionPresent(optList, "DATA_NODES_FILTER", "(\"US\" || \"EU\") && \"SSD\"");
         assertThatZoneOptionPresent(optList, "DATA_NODES_AUTO_ADJUST", 1);
 
@@ -108,7 +108,7 @@ public class SqlDdlZoneParserTest extends AbstractDdlParserTest {
                 + "\"REPLICAS\" = 2, "
                 + "\"PARTITIONS\" = 3, "
                 + "\"DATA_NODES_FILTER\" = '(\"US\" || \"EU\") && \"SSD\"', "
-                + "\"AFFINITY_FUNCTION\" = \"TEST_AFFINITY\", "
+                + "\"AFFINITY_FUNCTION\" = 'test_Affinity', "
                 + "\"DATA_NODES_AUTO_ADJUST\" = 1, "
                 + "\"DATA_NODES_AUTO_ADJUST_SCALE_UP\" = 2, "
                 + "\"DATA_NODES_AUTO_ADJUST_SCALE_DOWN\" = 3"));

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
@@ -96,11 +96,11 @@ public class SqlDdlZoneParserTest extends AbstractDdlParserTest {
 
         List<SqlNode> optList = createZone.createOptionList().getList();
 
-        assertThatZoneOptionPresent(optList, "REPLICAS", 2);
-        assertThatZoneOptionPresent(optList, "PARTITIONS", 3);
-        assertThatZoneOptionPresent(optList, "AFFINITY_FUNCTION", "test_Affinity");
-        assertThatZoneOptionPresent(optList, "DATA_NODES_FILTER", "(\"US\" || \"EU\") && \"SSD\"");
-        assertThatZoneOptionPresent(optList, "DATA_NODES_AUTO_ADJUST", 1);
+        assertThatZoneOptionPresent(optList, IgniteSqlCreateZoneOptionEnum.REPLICAS, 2);
+        assertThatZoneOptionPresent(optList, IgniteSqlCreateZoneOptionEnum.PARTITIONS, 3);
+        assertThatZoneOptionPresent(optList, IgniteSqlCreateZoneOptionEnum.AFFINITY_FUNCTION, "test_Affinity");
+        assertThatZoneOptionPresent(optList, IgniteSqlCreateZoneOptionEnum.DATA_NODES_FILTER, "(\"US\" || \"EU\") && \"SSD\"");
+        assertThatZoneOptionPresent(optList, IgniteSqlCreateZoneOptionEnum.DATA_NODES_AUTO_ADJUST, 1);
 
         SqlPrettyWriter w = new SqlPrettyWriter();
         createZone.unparse(w, 0, 0);
@@ -190,12 +190,12 @@ public class SqlDdlZoneParserTest extends AbstractDdlParserTest {
         return (IgniteSqlCreateZone) node;
     }
 
-    private void assertThatZoneOptionPresent(List<SqlNode> optionList, String option, Object expVal) {
+    private void assertThatZoneOptionPresent(List<SqlNode> optionList, IgniteSqlCreateZoneOptionEnum name, Object expVal) {
         assertThat(optionList, Matchers.hasItem(ofTypeMatching(
-                option + "=" + expVal,
+                name + "=" + expVal,
                 IgniteSqlCreateZoneOption.class,
                 opt -> {
-                    if (option.equals(opt.key().toValue())) {
+                    if (name == opt.key().symbolValue(IgniteSqlCreateZoneOptionEnum.class)) {
                         if (opt.value() instanceof SqlLiteral) {
                             return Objects.equals(expVal, ((SqlLiteral) opt.value()).getValueAs(expVal.getClass()));
                         }

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/sql/SqlDdlZoneParserTest.java
@@ -121,22 +121,22 @@ public class SqlDdlZoneParserTest extends AbstractDdlParserTest {
     @Test
     public void createZoneWithInvalidOptions() {
         // Unknown option.
-        assertThrows(SqlParseException.class, () -> parseCreateZone("create zone test_zone with foo=bar"));
+        assertThrows(SqlParseException.class, () -> parseCreateZone("create zone test_zone with foo='bar'"));
 
         // Invalid option type.
+        String query = "create zone test_zone with %s=%s";
+
         List<String> numericOptNames = Arrays.asList("PARTITIONS", "REPLICAS", "DATA_NODES_AUTO_ADJUST",
                 "DATA_NODES_AUTO_ADJUST_SCALE_UP", "DATA_NODES_AUTO_ADJUST_SCALE_DOWN");
 
         for (String optName : numericOptNames) {
-            assertThrows(SqlParseException.class,
-                    () -> parseCreateZone(String.format("create zone test_zone with %s='bar'", optName)));
+            assertThrows(SqlParseException.class, () -> parseCreateZone(String.format(query, optName, "'bar'")));
         }
 
         List<String> stringOptNames = Arrays.asList("AFFINITY_FUNCTION", "DATA_NODES_FILTER");
 
         for (String optName : stringOptNames) {
-            assertThrows(SqlParseException.class,
-                    () -> parseCreateZone(String.format("create zone test_zone with %s=1", optName)));
+            assertThrows(SqlParseException.class, () -> parseCreateZone(String.format(query, optName, "1")));
         }
     }
 


### PR DESCRIPTION
Basic SQL grammar to CREATE/DROP distributed zones.

It was decided not to overload the parser with complex validation logic of command options (it should be implemented somewhere near the conversion level).

Thus, currently the parser is not responsible for invalid (unknown) options, invalid option invariants, and duplicates.