### PR TITLE
IGNITE-18092 Fix zip distribution name providing to sign and checksum tasks

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,15 +33,16 @@ For all the commands going forward:
    git tag -a {version}-rc{rc} -m "{version}-rc{rc}"
    git push --tags
    ```
-3. Setup properties in gradle.properties  
-   You can specify it in project gradle.property but DO NOT FORGET revert it before push.
-   Better place is gradle.properties in HOME dir, read about it https://docs.gradle.org/current/userguide/build_environment.html
+3. Setup properties in gradle.properties.
+   You can specify it in project gradle.properties but DO NOT FORGET to revert it before push.
+   Better place is gradle.properties in HOME dir, you can read about it here
+   https://docs.gradle.org/current/userguide/build_environment.html
    ```
    signing.keyId=*INSERT KEY HERE LAST 8 CHARS*
    signing.password=*INSERT PASSWORD HERE*
    signing.secretKeyRingFile=*INSERT KEY RING ABSOLUTE PATH HERE*
    ```
-   For generate secret key ring file please use follow command
+   To generate a secret key ring file use the following command
    ```
    gpg --keyring secring.gpg --export-secret-keys > ~/.gnupg/secring.gpg
    ```
@@ -59,71 +60,21 @@ For all the commands going forward:
    rm -rf {dist.dev}/{version}-rc{rc}
    mkdir {dist.dev}/{version}-rc{rc}
    ```
-7. Create a signed src zip:
+7. Create ZIP, DEB, RPM packages, .NET and C++ client, sign them and create checksums:
    ```
-   ./gradlew buildAndSignAllSrcZip
+   ./gradlew prepareRelease
    ```
-8. Copy src zip with checksums and signatures
+8. Copy all packages along with checksums and signatures to the development distribution directory:
    ```
-   cp packaging/build/distributions/apache-ignite-{version}-src.zip \
-   packaging/build/distributions/ignite3-{version}.zip.asc \ 
-   packaging/build/distributions/ignite3-{version}.zip.sha512 \
-   {dist.dev}/{version}-rc{rc}
+   cp packaging/build/release/* {dist.dev}/{version}-rc{rc}
    ```
-9. Create zip distributions 
-   ```
-   ./gradlew allDistZip
-   ```
-10. Sign zip distributions
-    ```
-    ./gradlew signAllDistZip signCliZip signDbZip
-    ```
-11. Copy ZIP packages along with checksums and signatures to the development distribution directory:
-    ```
-    cp packaging/build/distributions/ignite3-{version}.zip \
-    packaging/build/distributions/ignite3-{version}.zip.asc \
-    packaging/build/distributions/ignite3-{version}.zip.sha512 \
-    packaging/build/db/distributions/ignite3db-{version}.zip \
-    packaging/build/db/distributions/ignite3db-{version}.zip.asc \
-    packaging/build/db/distributions/ignite3db-{version}.zip.sha512 \
-    packaging/build/cli/distributions/ignite3cli-{version}.zip \
-    packaging/build/cli/distributions/ignite3cli-{version}.zip.asc \
-    packaging/build/cli/distributions/ignite3cli-{version}.zip.sha512 \
-    /Users/vkulichenko/GridGain/dist-dev/{version}-rc{rc}
-    ```
-12. Create DEB\RPM distributions, they will be signed 
-   ```
-   ./gradlew buildDeb buildRpm
-   ```
-13. Copy DEB\RPM packages to the development distribution directory:
-   ```
-   cp packaging/db/build/distributions/*.deb packaging/db/build/distributions/*.changes \
-   packaging/db/build/distributions/*.rpm \
-   packaging/cli/build/distributions/*.deb packaging/cli/build/distributions/*.changes \
-   packaging/cli/build/distributions/*.rpm \
-   {dist.dev}/{version}-rc{rc}
-   ```
-14. Create Dotnet and C++ clients 
-   ```
-   ./gradlew buildAndSignCppClient buildAndSignNuGetZip
-   ```
-15. Copy zip with checksums and signatures
-   ```
-   cp modules/platforms/build/distributions/apache-ignite-{version}-cpp.zip \
-   modules/platforms/build/distributions/apache-ignite-{version}-cpp.zip.asc \ 
-   modules/platforms/build/distributions/apache-ignite-{version}-cpp.zip.sha512 \  
-   modules/platforms/build/distributions/apache-ignite-{version}-nuget.zip \
-   modules/platforms/build/distributions/apache-ignite-{version}-nuget.zip.asc \ 
-   modules/platforms/build/distributions/apache-ignite-{version}-nuget.zip.sha512 \ 
-   {dist.dev}/{version}-rc{rc}
-   ```
-16. Commit ZIP and DEB\RPM packages:
+9. Commit ZIP and DEB\RPM packages:
    ```
    cd {dist.dev}
    svn add {version}-rc{rc}
    svn commit -m “Apache Ignite {version} RC{rc}”
    ```
-17. Put the release on a vote on the developers mailing list.
+10. Put the release on a vote on the developers mailing list.
 
 ## Finalizing the Release
 
@@ -145,4 +96,3 @@ Perform the following actions ONLY after the vote is successful and closed.
    svn add {version}
    svn commit -m “Apache Ignite {version}”
    ```
-   

--- a/modules/platforms/build.gradle
+++ b/modules/platforms/build.gradle
@@ -48,7 +48,7 @@ task buildNuGet(type: Exec) {
 }
 
 task zipNuGet(type: Zip) {
-    archiveName "apache-ignite-${project.version}-nuget.zip"
+    archiveFileName = "apache-ignite-${project.version}-nuget.zip"
 
     from ("$buildDir/nupkg") {
         include "*.nupkg"
@@ -59,7 +59,7 @@ task zipNuGet(type: Zip) {
 }
 
 task zipCppClient(type: Zip) {
-    archiveName "apache-ignite-${project.version}-cpp.zip"
+    archiveFileName = "apache-ignite-${project.version}-cpp.zip"
 
     from ("$projectDir/cpp") {
         exclude "CMakeFiles"
@@ -71,18 +71,26 @@ task zipCppClient(type: Zip) {
 
 task createChecksums(type: Checksum) {
     dependsOn zipCppClient, zipNuGet
-    //TODO: remove distribution name hard code IGNITE-18092
-    files = files("${buildDir}/distributions/apache-ignite-${project.version}-cpp.zip",
-            "${buildDir}/distributions/apache-ignite-${project.version}-nuget.zip")
-    outputDir = new File("${buildDir}/distributions")
-    algorithm = Checksum.Algorithm.SHA512
+
+    inputFiles.from zipCppClient.outputs.files, zipNuGet.outputs.files
+    outputDirectory = file("$buildDir/distributions")
+    checksumAlgorithm = Checksum.Algorithm.SHA512
 }
 
-task buildAndSignNuGetZip(type: Sign) {
+signing {
     sign zipNuGet
+    sign zipCppClient
 }
 
-task buildAndSignCppClient(type: Sign) {
-    dependsOn createChecksums
-    sign zipCppClient
+configurations {
+    platformsRelease {
+        canBeConsumed = true
+        canBeResolved = false
+    }
+}
+
+artifacts {
+    platformsRelease(file("$buildDir/distributions")) {
+        builtBy createChecksums, signZipNuGet, signZipCppClient
+    }
 }

--- a/packaging/build.gradle
+++ b/packaging/build.gradle
@@ -23,23 +23,25 @@ plugins {
     alias(libs.plugins.checksum)
 }
 
-import org.gradle.crypto.checksum.Checksum
 import org.apache.tools.ant.filters.ReplaceTokens
+import org.gradle.crypto.checksum.Checksum
 
 configurations {
     dbArtifacts
-    cliArtifacts
-    cliScripts
     cliZip
     dbZip
+    cliRelease
+    dbRelease
+    platformsRelease
 }
 
 dependencies {
     dbArtifacts(project(':ignite-runner'))
-    cliArtifacts(project(':ignite-cli'))
-    cliScripts(project(path: ':ignite-cli', configuration: 'cliScripts'))
     cliZip(project(path: ':packaging-cli', configuration: 'cliZip'))
     dbZip(project(path: ':packaging-db', configuration: 'dbZip'))
+    cliRelease(project(path: ':packaging-cli', configuration: 'cliRelease'))
+    dbRelease(project(path: ':packaging-db', configuration: 'dbRelease'))
+    platformsRelease(project(path: ':platforms', configuration: 'platformsRelease'))
 }
 
 def tokens = [
@@ -104,37 +106,43 @@ task allDistZip(type: Zip) {
     }
 }
 
-task createDistZipChecksums(type: Checksum) {
-    //TODO: remove distribution name hard code IGNITE-18092
-    files = files(files("${buildDir}/distributions/ignite3-${project.version}.zip"))
-    outputDir = new File("${buildDir}/distributions")
-    algorithm = Checksum.Algorithm.SHA512
-}
-
-task createSrcZipChecksums(type: Checksum) {
-    //TODO: remove distribution name hard code IGNITE-18092
-    files = files(files("${buildDir}/distributions/apache-ignite-${project.version}-src.zip"))
-    outputDir = new File("${buildDir}/distributions")
-    algorithm = Checksum.Algorithm.SHA512
-}
-
-allDistZip.finalizedBy(createDistZipChecksums)
-
 task allSrcZip(type: Exec) {
     workingDir rootDir
 
+    def outFile = "$buildDir/distributions/apache-ignite-${project.version}-src.zip"
     commandLine "git", "archive",
             "--prefix=apache-ignite-${project.version}-src",
-            "-o", "$buildDir/distributions/apache-ignite-${project.version}-src.zip",
+            "-o", outFile,
             "HEAD"
+    outputs.file outFile
 }
 
-task buildAndSignAllSrcZip(type: Sign) {
-    dependsOn allSrcZip, createSrcZipChecksums
+task createChecksums(type: Checksum) {
+    dependsOn allDistZip, allSrcZip
 
-    sign file("$buildDir/distributions/apache-ignite-${project.version}-src.zip")
+    inputFiles.from allDistZip.outputs.files, allSrcZip.outputs.files
+    outputDirectory = file("$buildDir/distributions")
+    checksumAlgorithm = Checksum.Algorithm.SHA512
+}
+
+// Need to create a separate task since signing single file doesn't automatically create a task
+task signAllSrcZip(type: Sign) {
+    dependsOn allSrcZip
+
+    sign allSrcZip.outputs.files.singleFile
 }
 
 signing {
     sign allDistZip
+}
+
+task prepareRelease(type: Copy) {
+    from configurations.cliRelease
+    from configurations.dbRelease
+    from configurations.platformsRelease
+    dependsOn createChecksums, signAllSrcZip, signAllDistZip
+    from file("$buildDir/distributions")
+    include '*.zip', '*.asc', '*.sha512'
+    include '*.rpm', '*.deb', '*.changes'
+    into file("$buildDir/release")
 }

--- a/packaging/cli/build.gradle
+++ b/packaging/cli/build.gradle
@@ -49,14 +49,12 @@ def tokens = [
 ]
 
 task createChecksums(type: Checksum) {
-    //TODO: remove distribution name hard code IGNITE-18092
-    files = files(file("${buildDir}/distributions/ignite3-cli-${project.version}.zip"))
-    outputDir = new File("${buildDir}/distributions")
-    algorithm = Checksum.Algorithm.SHA512
-}
+    dependsOn distZip
 
-distTar.finalizedBy(createChecksums)
-distZip.finalizedBy(createChecksums)
+    inputFiles.from distZip.outputs.files
+    outputDirectory = file("$buildDir/distributions")
+    checksumAlgorithm = Checksum.Algorithm.SHA512
+}
 
 
 // ZIP packaging
@@ -81,7 +79,7 @@ task cliStartScript(type: CreateStartScripts) {
     mainClass = "org.apache.ignite.internal.cli.Main"
     // forms a classpath string that will be passed to exec "java -cp <classpath> .."
     // it is expected to locate the "lib" dir together with "bin"
-    classpath = files(new File("../lib/${project(':ignite-cli').name}-${project(':ignite-cli').version}.jar"), new File("../lib/*"))
+    classpath = files(new File("../lib/*"))
     outputDir = file "$buildDir/scripts"
     applicationName = 'ignite3'
 }
@@ -128,15 +126,12 @@ configurations {
 }
 
 artifacts {
-    cliZip(distZip) {
-        builtBy(distZip)
-    }
+    cliZip(distZip)
 }
 
 signing {
     sign configurations.cliZip
 }
-
 
 // DEB/RPM packaging
 
@@ -203,4 +198,17 @@ ospackage {
     }
 
     postInstall file("${buildDir}/postInstall.sh")
+}
+
+configurations {
+    cliRelease {
+        canBeConsumed = true
+        canBeResolved = false
+    }
+}
+
+artifacts {
+    cliRelease(file("$buildDir/distributions")) {
+        builtBy createChecksums, signCliZip, buildDeb, buildRpm
+    }
 }

--- a/packaging/db/build.gradle
+++ b/packaging/db/build.gradle
@@ -23,13 +23,12 @@ plugins {
     alias(libs.plugins.checksum)
 }
 
+import org.apache.tools.ant.filters.ReplaceTokens
 import org.gradle.crypto.checksum.Checksum
 
 configurations {
     dbArtifacts
 }
-
-import org.apache.tools.ant.filters.ReplaceTokens
 
 dependencies {
     dbArtifacts(project(':ignite-runner'))
@@ -105,15 +104,12 @@ distributions {
 distZip.dependsOn replaceZipScriptVars
 
 task createChecksums(type: Checksum) {
-    //TODO: remove distribution name hard code IGNITE-18092
-    files = files(file("${buildDir}/distributions/ignite3-db-${project.version}.zip"))
-    outputDir = new File("${buildDir}/distributions")
-    algorithm = Checksum.Algorithm.SHA512
+    dependsOn distZip
+
+    inputFiles.from distZip.outputs.files
+    outputDirectory = file("$buildDir/distributions")
+    checksumAlgorithm = Checksum.Algorithm.SHA512
 }
-
-distTar.finalizedBy(createChecksums)
-distZip.finalizedBy(createChecksums)
-
 
 // Expose zip artifacts to be consumed by others
 configurations {
@@ -124,9 +120,7 @@ configurations {
 }
 
 artifacts {
-    dbZip(distZip) {
-        builtBy(distZip)
-    }
+    dbZip(distZip)
 }
 
 signing {
@@ -221,4 +215,17 @@ ospackage {
     }
     link "/etc/ignite3db", "${packageTokens.INSTALL_DIR}/etc/"
     link "/opt/ignite3db", "${packageTokens.INSTALL_DIR}"
+}
+
+configurations {
+    dbRelease {
+        canBeConsumed = true
+        canBeResolved = false
+    }
+}
+
+artifacts {
+    dbRelease(file("$buildDir/distributions")) {
+        builtBy createChecksums, signDbZip, buildDeb, buildRpm
+    }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-18092

This also combines most of the tasks needed to release into one `prepareRelease` task, which copies artifacts to one directory.