### PR TITLE
IGNITE-18147 Disable environment lookup for micronaut

### DIFF
--- a/modules/rest/src/main/java/org/apache/ignite/internal/rest/RestComponent.java
+++ b/modules/rest/src/main/java/org/apache/ignite/internal/rest/RestComponent.java
@@ -17,6 +17,8 @@
 
 package org.apache.ignite.internal.rest;
 
+import static io.micronaut.context.env.Environment.BARE_METAL;
+
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.http.server.exceptions.ServerStartupException;
 import io.micronaut.openapi.annotation.OpenAPIInclude;
@@ -104,7 +106,10 @@ public class RestComponent implements IgniteComponent {
         for (int portCandidate = desiredPort; portCandidate <= desiredPort + portRange; portCandidate++) {
             try {
                 port = portCandidate;
-                context = buildMicronautContext(portCandidate).start();
+                context = buildMicronautContext(portCandidate)
+                        .deduceEnvironment(false)
+                        .environments(BARE_METAL)
+                        .start();
                 LOG.info("REST protocol started successfully");
                 return;
             } catch (ApplicationStartupException e) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-18147

Micronaut used to look up the environment. It caused dns resolving and if it was slow, then the startup of the application was slow. Now this behaviour is disabled by default.