### PR TITLE
IGNITE-18123 .NET: LINQ: Improve Skip and Take (offset / limit) support

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -113,6 +113,22 @@ public partial class LinqSqlGenerationTests
                 .ToList());
 
     [Test]
+    public void TestOffsetLimitFirst() =>
+        AssertSql(
+            "select _T0.KEY, _T0.VAL " +
+            "from PUBLIC.tbl1 as _T0 " +
+            "limit 1 offset ?",
+            q => q.Skip(2).Take(3).First());
+
+    [Test]
+    public void TestOffsetLimitSingle() =>
+        AssertSql(
+            "select _T0.KEY, _T0.VAL " +
+            "from PUBLIC.tbl1 as _T0 " +
+            "limit 2 offset ?",
+            q => q.Skip(2).Take(3).Single());
+
+    [Test]
     [Ignore("IGNITE-18131 Distinct support")]
     public void TestSelectOrderDistinct() =>
         AssertSql(

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -129,6 +129,26 @@ public partial class LinqSqlGenerationTests
             q => q.Skip(2).Take(3).Single());
 
     [Test]
+    public void TestOffsetMultipleNotSupported()
+    {
+        // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+        var ex = Assert.Throws<NotSupportedException>(
+            () => _table.GetRecordView<Poco>().AsQueryable().Skip(1).Skip(2).ToList());
+
+        Assert.AreEqual("Multiple Skip operators on the same subquery are not supported.", ex!.Message);
+    }
+
+    [Test]
+    public void TestLimitMultipleNotSupported()
+    {
+        // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+        var ex = Assert.Throws<NotSupportedException>(
+            () => _table.GetRecordView<Poco>().AsQueryable().Take(1).Take(2).ToList());
+
+        Assert.AreEqual("Multiple Take operators on the same subquery are not supported.", ex!.Message);
+    }
+
+    [Test]
     [Ignore("IGNITE-18131 Distinct support")]
     public void TestSelectOrderDistinct() =>
         AssertSql(

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -226,14 +226,23 @@ public partial class LinqTests : IgniteTestsBase
     [Test]
     public void TestOrderBySkipTakeBeforeSelect()
     {
-        List<long> res = PocoView.AsQueryable()
+        var query = PocoView.AsQueryable()
             .OrderByDescending(x => x.Key)
             .Skip(1)
             .Take(2)
-            .Select(x => x.Key)
-            .ToList();
+            .Select(x => x.Key);
+
+        List<long> res = query.ToList();
 
         Assert.AreEqual(new long[] { 8, 7 }, res);
+
+        StringAssert.Contains(
+            "select _T0.KEY from (" +
+            "select _T1.KEY, _T1.VAL " +
+            "from PUBLIC.TBL1 as _T1 " +
+            "order by (_T1.KEY) desc " +
+            "limit ? offset ?) as _T0",
+            query.ToString());
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -224,7 +224,6 @@ public partial class LinqTests : IgniteTestsBase
     }
 
     [Test]
-    [Ignore("IGNITE-18123 LINQ: Skip and Take (offset / limit) support")]
     public void TestOrderBySkipTakeBeforeSelect()
     {
         List<long> res = PocoView.AsQueryable()

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -222,7 +222,26 @@ public partial class LinqTests : IgniteTestsBase
 
         Assert.AreEqual(new long[] { 7, 8, 9 }, res);
 
-        // TODO: Remove limit workaround?
+        StringAssert.Contains(
+            "select _T0.KEY from PUBLIC.TBL1 as _T0 " +
+            "order by (_T0.KEY) asc " +
+            "offset ?",
+            query.ToString());
+    }
+
+    [Test]
+    public void TestSkipMultiple()
+    {
+        var query = PocoView.AsQueryable()
+            .OrderBy(x => x.Key)
+            .Select(x => x.Key)
+            .Skip(5)
+            .Skip(3);
+
+        List<long> res = query.ToList();
+
+        Assert.AreEqual(new long[] { 8, 9 }, res);
+
         StringAssert.Contains(
             "select _T0.KEY from PUBLIC.TBL1 as _T0 " +
             "order by (_T0.KEY) asc " +
@@ -249,6 +268,25 @@ public partial class LinqTests : IgniteTestsBase
     }
 
     [Test]
+    public void TestTakeMultiple()
+    {
+        var query = PocoView.AsQueryable()
+            .OrderBy(x => x.Key)
+            .Take(2)
+            .Take(5);
+
+        List<Poco> res = query.ToList();
+
+        Assert.AreEqual(new long[] { 0, 1 }, res.Select(x => x.Key));
+
+        StringAssert.Contains(
+            "select _T0.KEY, _T0.VAL from PUBLIC.TBL1 as _T0 " +
+            "order by (_T0.KEY) asc " +
+            "limit ?",
+            query.ToString());
+    }
+
+    [Test]
     public void TestOrderBySkipTake()
     {
         var query = PocoView.AsQueryable()
@@ -260,6 +298,26 @@ public partial class LinqTests : IgniteTestsBase
         List<long> res = query.ToList();
 
         Assert.AreEqual(new long[] { 8, 7 }, res);
+
+        StringAssert.Contains(
+            "select _T0.KEY from PUBLIC.TBL1 as _T0 " +
+            "order by (_T0.KEY) desc " +
+            "limit ? offset ?",
+            query.ToString());
+    }
+
+    [Test]
+    public void TestSkipTakeFirst()
+    {
+        var query = PocoView.AsQueryable()
+            .OrderByDescending(x => x.Key)
+            .Select(x => x.Key)
+            .Skip(1)
+            .Take(2);
+
+        long res = query.First();
+
+        Assert.AreEqual(8, res);
 
         StringAssert.Contains(
             "select _T0.KEY from PUBLIC.TBL1 as _T0 " +

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -226,7 +226,7 @@ public partial class LinqTests : IgniteTestsBase
         StringAssert.Contains(
             "select _T0.KEY from PUBLIC.TBL1 as _T0 " +
             "order by (_T0.KEY) asc " +
-            "limit 2147483640 offset ?",
+            "offset ?",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -230,50 +230,11 @@ public partial class LinqTests : IgniteTestsBase
     }
 
     [Test]
-    public void TestSkipMultiple()
-    {
-        var query = PocoView.AsQueryable()
-            .OrderBy(x => x.Key)
-            .Select(x => x.Key)
-            .Skip(5)
-            .Skip(3);
-
-        List<long> res = query.ToList();
-
-        Assert.AreEqual(new long[] { 8, 9 }, res);
-
-        StringAssert.Contains(
-            "select _T0.KEY from PUBLIC.TBL1 as _T0 " +
-            "order by (_T0.KEY) asc " +
-            "offset ?",
-            query.ToString());
-    }
-
-    [Test]
     public void TestTake()
     {
         var query = PocoView.AsQueryable()
             .OrderBy(x => x.Key)
             .Take(2);
-
-        List<Poco> res = query.ToList();
-
-        Assert.AreEqual(new long[] { 0, 1 }, res.Select(x => x.Key));
-
-        StringAssert.Contains(
-            "select _T0.KEY, _T0.VAL from PUBLIC.TBL1 as _T0 " +
-            "order by (_T0.KEY) asc " +
-            "limit ?",
-            query.ToString());
-    }
-
-    [Test]
-    public void TestTakeMultiple()
-    {
-        var query = PocoView.AsQueryable()
-            .OrderBy(x => x.Key)
-            .Take(2)
-            .Take(5);
 
         List<Poco> res = query.ToList();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -211,16 +211,61 @@ public partial class LinqTests : IgniteTestsBase
     }
 
     [Test]
+    public void TestSkip()
+    {
+        var query = PocoView.AsQueryable()
+            .OrderBy(x => x.Key)
+            .Select(x => x.Key)
+            .Skip(7);
+
+        List<long> res = query.ToList();
+
+        Assert.AreEqual(new long[] { 7, 8, 9 }, res);
+
+        // TODO: Remove limit workaround?
+        StringAssert.Contains(
+            "select _T0.KEY from PUBLIC.TBL1 as _T0 " +
+            "order by (_T0.KEY) asc " +
+            "limit 2147483640 offset ?",
+            query.ToString());
+    }
+
+    [Test]
+    public void TestTake()
+    {
+        var query = PocoView.AsQueryable()
+            .OrderBy(x => x.Key)
+            .Take(2);
+
+        List<Poco> res = query.ToList();
+
+        Assert.AreEqual(new long[] { 0, 1 }, res.Select(x => x.Key));
+
+        StringAssert.Contains(
+            "select _T0.KEY, _T0.VAL from PUBLIC.TBL1 as _T0 " +
+            "order by (_T0.KEY) asc " +
+            "limit ?",
+            query.ToString());
+    }
+
+    [Test]
     public void TestOrderBySkipTake()
     {
-        List<long> res = PocoView.AsQueryable()
+        var query = PocoView.AsQueryable()
             .OrderByDescending(x => x.Key)
             .Select(x => x.Key)
             .Skip(1)
-            .Take(2)
-            .ToList();
+            .Take(2);
+
+        List<long> res = query.ToList();
 
         Assert.AreEqual(new long[] { 8, 7 }, res);
+
+        StringAssert.Contains(
+            "select _T0.KEY from PUBLIC.TBL1 as _T0 " +
+            "order by (_T0.KEY) desc " +
+            "limit ? offset ?",
+            query.ToString());
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/StringBuilderExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/StringBuilderExtensions.cs
@@ -38,4 +38,22 @@ internal static class StringBuilderExtensions
 
         return sb;
     }
+
+    /// <summary>
+    /// Appends a string to the string builder, ensuring that there is a whitespace character between existing and appended content.
+    /// </summary>
+    /// <param name="sb">String builder.</param>
+    /// <param name="str">String to append.</param>
+    /// <returns>Same instance for chaining.</returns>
+    public static StringBuilder AppendWithSpace(this StringBuilder sb, string str)
+    {
+        if (!char.IsWhiteSpace(sb[^1]))
+        {
+            sb.Append(' ');
+        }
+
+        sb.Append(str);
+
+        return sb;
+    }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -180,8 +180,8 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
     /** <inheritdoc /> */
     public override void VisitMainFromClause(MainFromClause fromClause, QueryModel queryModel)
     {
-        // TODO: Why does this produce invalid SQL sometimes?
-        if (fromClause.FromExpression is SubQueryExpression subQuery)
+        if (fromClause.FromExpression is SubQueryExpression subQuery &&
+            subQuery.QueryModel.ResultOperators.All(x => x is not GroupResultOperator))
         {
             _builder.Append("from (");
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -180,6 +180,7 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
     /** <inheritdoc /> */
     public override void VisitMainFromClause(MainFromClause fromClause, QueryModel queryModel)
     {
+        // GROUP BY is handled separately in ProcessGroupings and does not need to be handled here as SubQuery.
         if (fromClause.FromExpression is SubQueryExpression subQuery &&
             subQuery.QueryModel.ResultOperators.All(x => x is not GroupResultOperator))
         {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -180,9 +180,8 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
     /** <inheritdoc /> */
     public override void VisitMainFromClause(MainFromClause fromClause, QueryModel queryModel)
     {
-        // Special case for UNION subquery.
-        if (fromClause.FromExpression is SubQueryExpression subQuery &&
-            subQuery.QueryModel.ResultOperators.Any(x => x is UnionResultOperator))
+        // TODO: Why does this produce invalid SQL sometimes?
+        if (fromClause.FromExpression is SubQueryExpression subQuery)
         {
             _builder.Append("from (");
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -484,10 +484,20 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
             }
             else if (op is TakeResultOperator limit)
             {
+                if (limitExpr != null)
+                {
+                    throw new NotSupportedException("Multiple Take operators on the same subquery are not supported.");
+                }
+
                 limitExpr = limit.Count;
             }
             else if (op is SkipResultOperator offset)
             {
+                if (offsetExpr != null)
+                {
+                    throw new NotSupportedException("Multiple Skip operators on the same subquery are not supported.");
+                }
+
                 offsetExpr = offset.Count;
             }
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -467,30 +467,32 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
     /// </summary>
     private void ProcessSkipTake(QueryModel queryModel)
     {
-        // TODO Single loop
-        if (queryModel.ResultOperators.Any(static x => x is FirstResultOperator))
+        foreach (var op in queryModel.ResultOperators)
         {
-            _builder.Append("limit 1");
-            return;
-        }
+            if (op is FirstResultOperator)
+            {
+                _builder.AppendWithSpace("limit 1");
+                return;
+            }
 
-        if (queryModel.ResultOperators.Any(static x => x is SingleResultOperator))
-        {
-            // Will fail in IgniteQueryExecutor.ExecuteSingleInternalAsync if there is more than 1 row.
-            _builder.Append("limit 2");
-            return;
-        }
+            if (op is SingleResultOperator)
+            {
+                // Will fail in IgniteQueryExecutor.ExecuteSingleInternalAsync if there is more than 1 row.
+                _builder.AppendWithSpace("limit 2");
+                return;
+            }
 
-        if (queryModel.ResultOperators.OfType<TakeResultOperator>().FirstOrDefault() is { } limit)
-        {
-            _builder.Append("limit ");
-            BuildSqlExpression(limit.Count);
-        }
+            if (op is TakeResultOperator limit)
+            {
+                _builder.AppendWithSpace("limit ");
+                BuildSqlExpression(limit.Count);
+            }
 
-        if (queryModel.ResultOperators.OfType<SkipResultOperator>().FirstOrDefault() is { } offset)
-        {
-            _builder.AppendWithSpace("offset ");
-            BuildSqlExpression(offset.Count);
+            if (op is SkipResultOperator offset)
+            {
+                _builder.AppendWithSpace("offset ");
+                BuildSqlExpression(offset.Count);
+            }
         }
     }
 


### PR DESCRIPTION
* Fix subquery handling with `Skip` and `Take`.
* Remove H2-specific workaround.
* Allow combining `Skip` with `First` or `Single`.