### PR TITLE
IGNITE-18131 .NET: LINQ: Improve Distinct support

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.KvView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.KvView.cs
@@ -42,7 +42,7 @@ public partial class LinqSqlGenerationTests
     [Test]
     public void TestSelectTwoColumnsKv() =>
         AssertSqlKv(
-            "select (_T0.KEY + ?), _T0.VAL from PUBLIC.tbl1 as _T0",
+            "select (_T0.KEY + ?) as KEY, _T0.VAL from PUBLIC.tbl1 as _T0",
             q => q.Select(x => new { Key = x.Key.Key + 1, x.Value.Val }).ToList());
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -149,7 +149,6 @@ public partial class LinqSqlGenerationTests
     }
 
     [Test]
-    [Ignore("IGNITE-18131 Distinct support")]
     public void TestSelectOrderDistinct() =>
         AssertSql(
             "select distinct _T0.KEY, (_T0.KEY + ?) from PUBLIC.tbl1 as _T0 order by ((_T0.KEY + ?)) asc",

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -101,7 +101,7 @@ public partial class LinqSqlGenerationTests
     [Test]
     public void TestSelectOrderByOffsetLimit() =>
         AssertSql(
-            "select _T0.KEY, _T0.VAL, (_T0.KEY + ?) " +
+            "select _T0.KEY, _T0.VAL, (_T0.KEY + ?) as KEY2 " +
             "from PUBLIC.tbl1 as _T0 " +
             "order by ((_T0.KEY + ?)) asc, (_T0.VAL) desc " +
             "limit ? offset ?",
@@ -151,7 +151,7 @@ public partial class LinqSqlGenerationTests
     [Test]
     public void TestSelectOrderDistinct() =>
         AssertSql(
-            "select distinct _T0.KEY, (_T0.KEY + ?) from PUBLIC.tbl1 as _T0 order by ((_T0.KEY + ?)) asc",
+            "select * from (select distinct _T0.KEY, (_T0.KEY + ?) as KEY2 from PUBLIC.tbl1 as _T0) as _T1 order by (_T1.KEY2) asc",
             q => q.Select(x => new { x.Key, Key2 = x.Key + 1})
                 .Distinct()
                 .OrderBy(x => x.Key2)
@@ -245,8 +245,8 @@ public partial class LinqSqlGenerationTests
     [Test]
     public void TestUnion() =>
         AssertSql(
-            "select (_T0.KEY + ?), _T0.VAL from PUBLIC.tbl1 as _T0 " +
-            "union (select (_T1.KEY + ?), _T1.VAL from PUBLIC.tbl1 as _T1)",
+            "select (_T0.KEY + ?) as KEY, _T0.VAL from PUBLIC.tbl1 as _T0 " +
+            "union (select (_T1.KEY + ?) as KEY, _T1.VAL from PUBLIC.tbl1 as _T1)",
             q => q.Select(x => new { Key = x.Key + 1, x.Val })
                 .Union(q.Select(x => new { Key = x.Key + 100, x.Val }))
                 .ToList());
@@ -254,8 +254,8 @@ public partial class LinqSqlGenerationTests
     [Test]
     public void TestIntersect() =>
         AssertSql(
-            "select (_T0.KEY + ?), concat(_T0.VAL, ?) from PUBLIC.tbl1 as _T0 " +
-            "intersect (select (_T1.KEY + ?), concat(_T1.VAL, ?) from PUBLIC.tbl1 as _T1)",
+            "select (_T0.KEY + ?) as KEY, concat(_T0.VAL, ?) as VAL from PUBLIC.tbl1 as _T0 " +
+            "intersect (select (_T1.KEY + ?) as KEY, concat(_T1.VAL, ?) as VAL from PUBLIC.tbl1 as _T1)",
             q => q.Select(x => new { Key = x.Key + 1, Val = x.Val + "_" })
                 .Intersect(q.Select(x => new { Key = x.Key + 100, Val = x.Val + "!" }))
                 .ToList());

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
@@ -110,7 +110,7 @@ public partial class LinqTests
         Assert.AreEqual(2, res[2].Max);
 
         StringAssert.Contains(
-            "select _T0.KEY, count(*), sum(_T0.KEY), avg(_T0.KEY), min(_T0.KEY), max(_T0.KEY) " +
+            "select _T0.KEY, count(*) as COUNT, sum(_T0.KEY) as SUM, avg(_T0.KEY) as AVG, min(_T0.KEY) as MIN, max(_T0.KEY) as MAX " +
             "from PUBLIC.TBL_INT32 as _T0 " +
             "group by (_T0.KEY) " +
             "order by (_T0.KEY) asc",

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
@@ -49,8 +49,8 @@ public partial class LinqTests
         Assert.AreEqual(900d / 2000, res[0].Double);
 
         StringAssert.Contains(
-            "select cast(_T0.VAL as tinyint), cast(_T0.VAL as smallint), cast(_T0.VAL as bigint), " +
-            "(cast(_T0.VAL as real) / ?), (cast(_T0.VAL as double) / ?) " +
+            "select cast(_T0.VAL as tinyint) as BYTE, cast(_T0.VAL as smallint) as SHORT, cast(_T0.VAL as bigint) as LONG, " +
+            "(cast(_T0.VAL as real) / ?) as FLOAT, (cast(_T0.VAL as double) / ?) as DOUBLE " +
             "from PUBLIC.TBL_INT32 as _T0 " +
             "order by (cast(_T0.VAL as bigint)) desc",
             query.ToString());

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
@@ -83,7 +83,7 @@ public partial class LinqTests
         Assert.AreEqual(4.0d, res[1].Avg);
 
         StringAssert.Contains(
-            "select _T0.VAL, count(*), sum(cast(_T0.KEY as int)), avg(cast(_T0.KEY as int)) " +
+            "select _T0.VAL, count(*) as COUNT, sum(cast(_T0.KEY as int)) as SUM, avg(cast(_T0.KEY as int)) as AVG " +
             "from PUBLIC.TBL_INT8 as _T0 " +
             "group by (_T0.VAL) " +
             "order by (_T0.VAL) asc",

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
@@ -179,7 +179,7 @@ public partial class LinqTests
         Assert.AreEqual(900, res[0].MaxPrice);
 
         StringAssert.Contains(
-            "select _T0.VAL, max(_T1.VAL) " +
+            "select _T0.VAL, max(_T1.VAL) as MAXPRICE " +
             "from PUBLIC.TBL1 as _T0 " +
             "inner join PUBLIC.TBL_INT32 as _T1 on (cast(_T1.KEY as bigint) = _T0.KEY) " +
             "group by (_T0.VAL) " +

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
@@ -140,7 +140,7 @@ public partial class LinqTests
         Assert.AreEqual(10, res.Count);
 
         StringAssert.Contains(
-            "select _T0.VAL, count(*) " +
+            "select _T0.VAL, count(*) as COUNT " +
             "from PUBLIC.TBL1 as _T1 " +
             "inner join PUBLIC.TBL_INT32 as _T0 on (cast(_T0.KEY as bigint) = _T1.KEY) " +
             "group by (_T0.VAL) " +

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.UnionIntersectExcept.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.UnionIntersectExcept.cs
@@ -89,7 +89,7 @@ public partial class LinqTests
         CollectionAssert.AreEquivalent(new[] { 4, 9 }, res.Select(x => x.Key));
 
         StringAssert.Contains(
-            "select cast(_T0.KEY as int) " +
+            "select cast(_T0.KEY as int) as KEY " +
             "from PUBLIC.TBL_INT8 as _T0 " +
             "where (cast(_T0.KEY as int) > ?) " +
             "union (select _T1.KEY from PUBLIC.TBL_INT32 as _T1 where ((_T1.KEY > ?) and (_T1.KEY < ?)))",
@@ -152,8 +152,8 @@ public partial class LinqTests
         CollectionAssert.AreEquivalent(new[] { 7, 8, 9 }, res.Select(x => x.Id));
 
         StringAssert.Contains(
-            "select _T0.KEY as ID from PUBLIC.TBL_INT64 as _T0 where (_T0.KEY > ?) " +
-            "except (select _T1.KEY as ID from PUBLIC.TBL1 as _T1 where (_T1.KEY < ?))",
+            "select _T0.KEY from PUBLIC.TBL_INT64 as _T0 where (_T0.KEY > ?) " +
+            "except (select _T1.KEY from PUBLIC.TBL1 as _T1 where (_T1.KEY < ?))",
             query.ToString());
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.UnionIntersectExcept.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.UnionIntersectExcept.cs
@@ -152,8 +152,8 @@ public partial class LinqTests
         CollectionAssert.AreEquivalent(new[] { 7, 8, 9 }, res.Select(x => x.Id));
 
         StringAssert.Contains(
-            "select _T0.KEY from PUBLIC.TBL_INT64 as _T0 where (_T0.KEY > ?) " +
-            "except (select _T1.KEY from PUBLIC.TBL1 as _T1 where (_T1.KEY < ?))",
+            "select _T0.KEY as ID from PUBLIC.TBL_INT64 as _T0 where (_T0.KEY > ?) " +
+            "except (select _T1.KEY as ID from PUBLIC.TBL1 as _T1 where (_T1.KEY < ?))",
             query.ToString());
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -382,9 +382,9 @@ public partial class LinqTests : IgniteTestsBase
         var res = query.ToList();
 
         Assert.AreEqual(4, res.Count);
-        Assert.AreEqual(14, res[0].Id);
+        Assert.AreEqual(13, res[0].Id);
 
-        StringAssert.Contains("select distinct (cast(_T0.VAL as int) + ?), _T0.VAL from PUBLIC.TBL_INT8 as _T0", query.ToString());
+        StringAssert.Contains("select distinct (cast(_T0.VAL as int) + ?) as F0, _T0.VAL as F1 from PUBLIC.TBL_INT8 as _T0 order by ( F0) desc", query.ToString());
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -369,12 +369,28 @@ public partial class LinqTests : IgniteTestsBase
     }
 
     [Test]
-    public void TestDistinctProjectionWithOrderBy()
+    public void TestDistinctAfterOrderBy()
     {
         var query = PocoByteView.AsQueryable()
             .Select(x => new { Id = x.Val + 10, V = x.Val })
             .OrderByDescending(x => x.Id)
             .Distinct();
+
+        var res = query.ToList();
+
+        Assert.AreEqual(4, res.Count);
+        Assert.AreEqual(14, res[0].Id);
+
+        StringAssert.Contains("select distinct (cast(_T0.VAL as int) + ?), _T0.VAL from PUBLIC.TBL_INT8 as _T0", query.ToString());
+    }
+
+    [Test]
+    public void TestDistinctBeforeOrderBy()
+    {
+        var query = PocoByteView.AsQueryable()
+            .Select(x => new { Id = x.Val + 10, V = x.Val })
+            .Distinct()
+            .OrderByDescending(x => x.Id);
 
         var res = query.ToList();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -328,6 +328,20 @@ public partial class LinqTests : IgniteTestsBase
     }
 
     [Test]
+    public void TestDistinctSimple()
+    {
+        var query = PocoByteView.AsQueryable()
+            .Select(x => x.Val)
+            .Distinct();
+
+        List<sbyte> res = query.ToList();
+
+        CollectionAssert.AreEquivalent(new[] { 0, 1, 2, 3 }, res);
+
+        StringAssert.Contains("select distinct _T0.VAL from PUBLIC.TBL_INT8 as _T0", query.ToString());
+    }
+
+    [Test]
     public void TestCustomColumnNameMapping()
     {
         var res = Table.GetRecordView<PocoCustomNames>().AsQueryable()

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -288,6 +288,7 @@ public partial class LinqTests : IgniteTestsBase
     }
 
     [Test]
+    [Ignore("IGNITE-18311")]
     public void TestOrderBySkipTakeBeforeSelect()
     {
         var query = PocoView.AsQueryable()

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -377,15 +377,19 @@ public partial class LinqTests : IgniteTestsBase
     {
         var query = PocoByteView.AsQueryable()
             .Select(x => new { Id = x.Val + 10, V = x.Val })
-            .OrderByDescending(x => x.Id)
+            .OrderByDescending(x => x.V)
             .Distinct();
 
         var res = query.ToList();
 
         Assert.AreEqual(4, res.Count);
-        Assert.AreEqual(14, res[0].Id);
+        Assert.AreEqual(13, res[0].Id);
 
-        StringAssert.Contains("select distinct (cast(_T0.VAL as int) + ?), _T0.VAL from PUBLIC.TBL_INT8 as _T0", query.ToString());
+        StringAssert.Contains(
+            "select distinct (cast(_T0.VAL as int) + ?) as ID, _T0.VAL " +
+            "from PUBLIC.TBL_INT8 as _T0 " +
+            "order by (_T0.VAL) desc",
+            query.ToString());
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -367,7 +367,7 @@ public partial class LinqTests : IgniteTestsBase
         Assert.AreEqual(4, res.Count);
 
         StringAssert.Contains(
-            "select distinct (cast(_T0.VAL as int) + ?) as ID, _T0.VAL as V " +
+            "select distinct (cast(_T0.VAL as int) + ?) as ID, _T0.VAL " +
             "from PUBLIC.TBL_INT8 as _T0",
             query.ToString());
     }
@@ -407,7 +407,7 @@ public partial class LinqTests : IgniteTestsBase
 
         StringAssert.Contains(
             "select * from " +
-            "(select distinct (cast(_T0.VAL as int) + ?) as ID, _T0.VAL as V from PUBLIC.TBL_INT8 as _T0) as _T1 " +
+            "(select distinct (cast(_T0.VAL as int) + ?) as ID, _T0.VAL from PUBLIC.TBL_INT8 as _T0) as _T1 " +
             "order by (_T1.ID) desc",
             query.ToString());
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -351,7 +351,7 @@ public partial class LinqTests : IgniteTestsBase
 
         Assert.AreEqual(10, res.Count);
 
-        StringAssert.Contains("select distinct  _T0.KEY, _T0.VAL from PUBLIC.TBL_INT8 as _T0", query.ToString());
+        StringAssert.Contains("select distinct _T0.KEY, _T0.VAL from PUBLIC.TBL_INT8 as _T0", query.ToString());
     }
 
     [Test]
@@ -365,7 +365,10 @@ public partial class LinqTests : IgniteTestsBase
 
         Assert.AreEqual(4, res.Count);
 
-        StringAssert.Contains("select distinct (cast(_T0.VAL as int) + ?), _T0.VAL from PUBLIC.TBL_INT8 as _T0", query.ToString());
+        StringAssert.Contains(
+            "select distinct (cast(_T0.VAL as int) + ?) as ID, _T0.VAL as V " +
+            "from PUBLIC.TBL_INT8 as _T0",
+            query.ToString());
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -382,9 +382,9 @@ public partial class LinqTests : IgniteTestsBase
         var res = query.ToList();
 
         Assert.AreEqual(4, res.Count);
-        Assert.AreEqual(13, res[0].Id);
+        Assert.AreEqual(14, res[0].Id);
 
-        StringAssert.Contains("select distinct (cast(_T0.VAL as int) + ?) as F0, _T0.VAL as F1 from PUBLIC.TBL_INT8 as _T0 order by ( F0) desc", query.ToString());
+        StringAssert.Contains("select distinct (cast(_T0.VAL as int) + ?), _T0.VAL from PUBLIC.TBL_INT8 as _T0", query.ToString());
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -328,7 +328,7 @@ public partial class LinqTests : IgniteTestsBase
     }
 
     [Test]
-    public void TestDistinctSimple()
+    public void TestDistinctOneField()
     {
         var query = PocoByteView.AsQueryable()
             .Select(x => x.Val)
@@ -339,6 +339,49 @@ public partial class LinqTests : IgniteTestsBase
         CollectionAssert.AreEquivalent(new[] { 0, 1, 2, 3 }, res);
 
         StringAssert.Contains("select distinct _T0.VAL from PUBLIC.TBL_INT8 as _T0", query.ToString());
+    }
+
+    [Test]
+    public void TestDistinctEntireObject()
+    {
+        var query = PocoByteView.AsQueryable()
+            .Distinct();
+
+        List<PocoByte> res = query.ToList();
+
+        Assert.AreEqual(10, res.Count);
+
+        StringAssert.Contains("select distinct  _T0.KEY, _T0.VAL from PUBLIC.TBL_INT8 as _T0", query.ToString());
+    }
+
+    [Test]
+    public void TestDistinctProjection()
+    {
+        var query = PocoByteView.AsQueryable()
+            .Select(x => new { Id = x.Val + 10, V = x.Val })
+            .Distinct();
+
+        var res = query.ToList();
+
+        Assert.AreEqual(4, res.Count);
+
+        StringAssert.Contains("select distinct (cast(_T0.VAL as int) + ?), _T0.VAL from PUBLIC.TBL_INT8 as _T0", query.ToString());
+    }
+
+    [Test]
+    public void TestDistinctProjectionWithOrderBy()
+    {
+        var query = PocoByteView.AsQueryable()
+            .Select(x => new { Id = x.Val + 10, V = x.Val })
+            .OrderByDescending(x => x.Id)
+            .Distinct();
+
+        var res = query.ToList();
+
+        Assert.AreEqual(4, res.Count);
+        Assert.AreEqual(14, res[0].Id);
+
+        StringAssert.Contains("select distinct (cast(_T0.VAL as int) + ?), _T0.VAL from PUBLIC.TBL_INT8 as _T0", query.ToString());
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -395,9 +395,13 @@ public partial class LinqTests : IgniteTestsBase
         var res = query.ToList();
 
         Assert.AreEqual(4, res.Count);
-        Assert.AreEqual(14, res[0].Id);
+        Assert.AreEqual(13, res[0].Id);
 
-        StringAssert.Contains("select distinct (cast(_T0.VAL as int) + ?), _T0.VAL from PUBLIC.TBL_INT8 as _T0", query.ToString());
+        StringAssert.Contains(
+            "select * from " +
+            "(select distinct (cast(_T0.VAL as int) + ?) as ID, _T0.VAL as V from PUBLIC.TBL_INT8 as _T0) as _T1 " +
+            "order by (_T1.ID) desc",
+            query.ToString());
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/AliasDictionary.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/AliasDictionary.cs
@@ -105,6 +105,31 @@ internal sealed class AliasDictionary
     }
 
     /// <summary>
+    /// Gets or creates an alias for the specified expression.
+    /// </summary>
+    /// <param name="expression">Expression.</param>
+    /// <returns>Alias.</returns>
+    public string GetOrCreateExpressionAlias(Expression expression)
+    {
+        if (!_fieldAliases.TryGetValue(expression, out var alias))
+        {
+            alias = "F" + _fieldAliasIndex++;
+
+            _fieldAliases[expression] = alias;
+        }
+
+        return alias;
+    }
+
+    /// <summary>
+    /// Gets an alias for the specified expression, or null if it does not exist.
+    /// </summary>
+    /// <param name="expression">Expression.</param>
+    /// <returns>Alias or null.</returns>
+    public string? TryGetExpressionAlias(Expression expression) =>
+        _fieldAliases.TryGetValue(expression, out var alias) ? alias : null;
+
+    /// <summary>
     /// Appends as clause.
     /// </summary>
     /// <param name="builder">Builder.</param>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/AliasDictionary.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/AliasDictionary.cs
@@ -105,31 +105,6 @@ internal sealed class AliasDictionary
     }
 
     /// <summary>
-    /// Gets or creates an alias for the specified expression.
-    /// </summary>
-    /// <param name="expression">Expression.</param>
-    /// <returns>Alias.</returns>
-    public string GetOrCreateExpressionAlias(Expression expression)
-    {
-        if (!_fieldAliases.TryGetValue(expression, out var alias))
-        {
-            alias = "F" + _fieldAliasIndex++;
-
-            _fieldAliases[expression] = alias;
-        }
-
-        return alias;
-    }
-
-    /// <summary>
-    /// Gets an alias for the specified expression, or null if it does not exist.
-    /// </summary>
-    /// <param name="expression">Expression.</param>
-    /// <returns>Alias or null.</returns>
-    public string? TryGetExpressionAlias(Expression expression) =>
-        _fieldAliases.TryGetValue(expression, out var alias) ? alias : null;
-
-    /// <summary>
     /// Appends as clause.
     /// </summary>
     /// <param name="builder">Builder.</param>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -325,7 +325,7 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
             var param = expression.Members?[i];
             if (param != null && param.Name != (arg as MemberExpression)?.Member.Name)
             {
-                ResultBuilder.AppendWithSpace("as ").Append(param.Name.ToUpperInvariant());
+                ResultBuilder.AppendWithSpace("as ").Append(Aliases.GetOrCreateExpressionAlias(arg));
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -321,8 +321,8 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
 
             Visit(arg);
 
+            // When projection uses a different field name, or projection comes from a complex expression, append an alias.
             var param = expression.Members?[i];
-
             if (param != null && param.Name != (arg as MemberExpression)?.Member.Name)
             {
                 ResultBuilder.AppendWithSpace("as ").Append(param.Name.ToUpperInvariant());

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -321,9 +321,9 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
 
             Visit(arg);
 
-            // When projection uses a different field name, or projection comes from a complex expression, append an alias.
+            // When projection uses projection comes from a complex expression, append an alias.
             var param = expression.Members?[i];
-            if (param != null && param.Name != (arg as MemberExpression)?.Member.Name)
+            if (param != null && arg is not MemberExpression)
             {
                 ResultBuilder.AppendWithSpace("as ").Append(param.Name.ToUpperInvariant());
             }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -327,7 +327,7 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
             // TODO: This won't work with custom column names though? Or we can retrieve that from attributes?
             if (param != null && param.Name != (arg as MemberExpression)?.Member.Name)
             {
-                ResultBuilder.Append(" as ").Append(param.Name.ToUpperInvariant());
+                ResultBuilder.AppendWithSpace("as ").Append(param.Name.ToUpperInvariant());
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -325,7 +325,7 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
             var param = expression.Members?[i];
             if (param != null && param.Name != (arg as MemberExpression)?.Member.Name)
             {
-                ResultBuilder.AppendWithSpace("as ").Append(Aliases.GetOrCreateExpressionAlias(arg));
+                ResultBuilder.AppendWithSpace("as ").Append(param.Name.ToUpperInvariant());
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -323,8 +323,6 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
 
             var param = expression.Members?[i];
 
-            // TODO: Somehow don't append if param name is same as arg name.
-            // TODO: This won't work with custom column names though? Or we can retrieve that from attributes?
             if (param != null && param.Name != (arg as MemberExpression)?.Member.Name)
             {
                 ResultBuilder.AppendWithSpace("as ").Append(param.Name.ToUpperInvariant());

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -646,13 +646,6 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
     /// </summary>
     private void BuildSqlExpression(Expression expression, bool useStar = false, bool includeAllFields = false, bool visitSubqueryModel = false)
     {
-        if (Aliases.TryGetExpressionAlias(expression) is { } alias)
-        {
-            Builder.AppendWithSpace(alias);
-        }
-        else
-        {
-            new IgniteQueryExpressionVisitor(this, useStar, includeAllFields, visitSubqueryModel).Visit(expression);
-        }
+        new IgniteQueryExpressionVisitor(this, useStar, includeAllFields, visitSubqueryModel).Visit(expression);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -646,6 +646,13 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
     /// </summary>
     private void BuildSqlExpression(Expression expression, bool useStar = false, bool includeAllFields = false, bool visitSubqueryModel = false)
     {
-        new IgniteQueryExpressionVisitor(this, useStar, includeAllFields, visitSubqueryModel).Visit(expression);
+        if (Aliases.TryGetExpressionAlias(expression) is { } alias)
+        {
+            Builder.AppendWithSpace(alias);
+        }
+        else
+        {
+            new IgniteQueryExpressionVisitor(this, useStar, includeAllFields, visitSubqueryModel).Visit(expression);
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -186,7 +186,7 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
         {
             _builder.Append("from (");
 
-            VisitQueryModel(subQuery.QueryModel);
+            VisitQueryModel(subQuery.QueryModel, includeAllFields: true);
 
             _builder.TrimEnd()
                 .Append(") as ")


### PR DESCRIPTION
* Use column alias when projecting a complex expression into a new type to support some `.Distinct` use cases.
* Add more tests.