### PR TITLE
IGNITE-18340 Gradle build doesn't produce OpenAPI spec

### DIFF
--- a/modules/rest/build.gradle
+++ b/modules/rest/build.gradle
@@ -39,3 +39,8 @@ dependencies {
     testImplementation project(':ignite-configuration')
     testImplementation libs.slf4j.jdk14
 }
+
+compileJava {
+    options.fork = true
+    options.forkOptions.jvmArgs += '-Dmicronaut.openapi.config.file=openapi/openapi.properties'
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-18340

Pass a compiler argument to the annotation processor.