### PR TITLE
IGNITE-18280 Fix dependencies in Gradle packaging tasks

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -62,7 +62,7 @@ For all the commands going forward:
    ```
 7. Create ZIP, DEB, RPM packages, .NET and C++ client, sign them and create checksums:
    ```
-   ./gradlew prepareRelease
+   ./gradlew -PprepareRelease prepareRelease
    ```
 8. Copy all packages along with checksums and signatures to the development distribution directory:
    ```

--- a/modules/platforms/build.gradle
+++ b/modules/platforms/build.gradle
@@ -73,11 +73,11 @@ task createChecksums(type: Checksum) {
     dependsOn zipCppClient, zipNuGet
 
     inputFiles.from zipCppClient.outputs.files, zipNuGet.outputs.files
-    outputDirectory = file("$buildDir/distributions")
     checksumAlgorithm = Checksum.Algorithm.SHA512
 }
 
-signing {
+// Explicitly create task so that the resulting artifact is not added to the configuration
+tasks.register('signArtifacts', Sign) {
     sign zipNuGet
     sign zipCppClient
 }
@@ -89,8 +89,13 @@ configurations {
     }
 }
 
-artifacts {
-    platformsRelease(file("$buildDir/distributions")) {
-        builtBy createChecksums, signZipNuGet, signZipCppClient
+if (project.hasProperty('prepareRelease')) {
+    artifacts {
+        platformsRelease(file("$buildDir/distributions")) {
+            builtBy signArtifacts
+        }
+        platformsRelease(file("$buildDir/checksums")) {
+            builtBy createChecksums
+        }
     }
 }

--- a/packaging/build.gradle
+++ b/packaging/build.gradle
@@ -31,19 +31,17 @@ configurations {
     cliArtifacts
     cliZip
     dbZip
-    cliRelease
-    dbRelease
-    platformsRelease
+    release
 }
 
 dependencies {
-    dbArtifacts(project(':ignite-runner'))
-    cliArtifacts(project(':ignite-cli'))
-    cliZip(project(path: ':packaging-cli', configuration: 'cliZip'))
-    dbZip(project(path: ':packaging-db', configuration: 'dbZip'))
-    cliRelease(project(path: ':packaging-cli', configuration: 'cliRelease'))
-    dbRelease(project(path: ':packaging-db', configuration: 'dbRelease'))
-    platformsRelease(project(path: ':platforms', configuration: 'platformsRelease'))
+    dbArtifacts project(':ignite-runner')
+    cliArtifacts project(':ignite-cli')
+    cliZip project(path: ':packaging-cli', configuration: 'cliZip')
+    dbZip project(path: ':packaging-db', configuration: 'dbZip')
+    release project(path: ':packaging-cli', configuration: 'cliRelease')
+    release project(path: ':packaging-db', configuration: 'dbRelease')
+    release project(path: ':platforms', configuration: 'platformsRelease')
 }
 
 // Task that generates start script for cli
@@ -68,10 +66,10 @@ def tokens = [
 ]
 
 task replaceVars(type: Copy) {
-    from("$rootDir/packaging/common")
-    from("$rootDir/packaging/docker/docker-entrypoint.sh")
+    from "$rootDir/packaging/common"
+    from "$rootDir/packaging/docker/docker-entrypoint.sh"
     filter(ReplaceTokens, tokens: tokens)
-    into("$buildDir/docker")
+    into "$buildDir/docker"
 }
 
 docker {
@@ -81,7 +79,7 @@ docker {
     copySpec.into 'dist', {
         into('') {
             fileMode 0755
-            from("$buildDir/docker/docker-entrypoint.sh")
+            from "$buildDir/docker/docker-entrypoint.sh"
         }
         into('db') {
             into('') {
@@ -91,32 +89,32 @@ docker {
                         includeEmptyDirs = true
                     }
                 }
-                from("$rootDir/LICENSE")
-                from("$rootDir/NOTICE")
-                from("$rootDir/assembly/README.md")
+                from "$rootDir/LICENSE"
+                from "$rootDir/NOTICE"
+                from "$rootDir/assembly/README.md"
             }
             into('etc') {
-                from('config/ignite-config.conf')
-                from('docker/ignite.java.util.logging.properties')
+                from 'config/ignite-config.conf'
+                from 'docker/ignite.java.util.logging.properties'
             }
             into('lib') {
-                from(configurations.dbArtifacts)
-                from("$buildDir/docker/$tokens.BOOTSTRAP_FILE_NAME")
-                from("$buildDir/docker/$tokens.SETUP_JAVA_FILE_NAME")
+                from configurations.dbArtifacts
+                from "$buildDir/docker/$tokens.BOOTSTRAP_FILE_NAME"
+                from "$buildDir/docker/$tokens.SETUP_JAVA_FILE_NAME"
             }
         }
         into('cli') {
             into('') {
-                from("$rootDir/LICENSE")
-                from("$rootDir/NOTICE")
-                from("$rootDir/assembly/README.md")
+                from "$rootDir/LICENSE"
+                from "$rootDir/NOTICE"
+                from "$rootDir/assembly/README.md"
             }
             into('bin') {
                 fileMode 0755
-                from(cliStartScript)
+                from cliStartScript
             }
             into('lib') {
-                from(configurations.cliArtifacts)
+                from configurations.cliArtifacts
             }
         }
     }
@@ -150,7 +148,6 @@ task createChecksums(type: Checksum) {
     dependsOn allDistZip, allSrcZip
 
     inputFiles.from allDistZip.outputs.files, allSrcZip.outputs.files
-    outputDirectory = file("$buildDir/distributions")
     checksumAlgorithm = Checksum.Algorithm.SHA512
 }
 
@@ -161,16 +158,16 @@ task signAllSrcZip(type: Sign) {
     sign allSrcZip.outputs.files.singleFile
 }
 
-signing {
+// Explicitly create task so that the resulting artifact is not added to the configuration
+tasks.register('signAllDistZip', Sign) {
     sign allDistZip
 }
 
-task prepareRelease(type: Copy) {
-    from configurations.cliRelease
-    from configurations.dbRelease
-    from configurations.platformsRelease
+tasks.register('prepareRelease', Copy) {
+    from configurations.release
     dependsOn createChecksums, signAllSrcZip, signAllDistZip
     from file("$buildDir/distributions")
+    from file("$buildDir/checksums")
     include '*.zip', '*.asc', '*.sha512'
     include '*.rpm', '*.deb', '*.changes'
     into file("$buildDir/release")

--- a/packaging/cli/build.gradle
+++ b/packaging/cli/build.gradle
@@ -52,7 +52,6 @@ task createChecksums(type: Checksum) {
     dependsOn distZip
 
     inputFiles.from distZip.outputs.files
-    outputDirectory = file("$buildDir/distributions")
     checksumAlgorithm = Checksum.Algorithm.SHA512
 }
 
@@ -64,12 +63,11 @@ def zipTokens = tokens + [
 ]
 
 task replaceScriptVarsZip(type: Copy) {
-    from("start.sh")
+    from 'start.sh'
     filter(ReplaceTokens, tokens: zipTokens)
-    fileMode 0755
-    into("$buildDir/zip")
+    into "$buildDir/zip"
     rename {
-        "ignite3"
+        'ignite3'
     }
 }
 
@@ -90,9 +88,6 @@ task windowsCliStartScript(type: Copy) {
     into "$buildDir/windows"
 }
 
-distTar.dependsOn replaceScriptVarsZip, windowsCliStartScript
-distZip.dependsOn replaceScriptVarsZip, windowsCliStartScript
-
 distributions {
     main {
         distributionBaseName = 'ignite3-cli'
@@ -105,9 +100,9 @@ distributions {
             into('bin') {
                 duplicatesStrategy= DuplicatesStrategy.EXCLUDE
                 from configurations.cliScripts
-                from "$buildDir/zip/ignite3"
-                from "$buildDir/windows"
-                fileMode = 0755
+                from replaceScriptVarsZip
+                from windowsCliStartScript
+                fileMode 0755
             }
             into('lib') {
                 from configurations.cliArtifacts
@@ -129,7 +124,8 @@ artifacts {
     cliZip(distZip)
 }
 
-signing {
+// Explicitly create task so that the resulting artifact is not added to the configuration
+tasks.register('signCliZip', Sign) {
     sign configurations.cliZip
 }
 
@@ -141,26 +137,14 @@ def linuxTokens = tokens + [
 ]
 
 task replaceScriptVarsLinux(type: Copy) {
-    from("start.sh")
+    from 'start.sh'
+    from 'postInstall.sh'
     filter(ReplaceTokens, tokens: linuxTokens)
-    fileMode 0755
-    into("$buildDir/linux")
-    rename {
-        "ignite3"
-    }
+    into "$buildDir/linux"
 }
-
-task replacePostInstallScriptVars(type: Copy) {
-    from("postInstall.sh")
-    filter(ReplaceTokens, tokens: linuxTokens)
-    into("${buildDir}")
-}
-
-buildRpm.dependsOn replaceScriptVarsLinux, replacePostInstallScriptVars
-buildDeb.dependsOn replaceScriptVarsLinux, replacePostInstallScriptVars
-
 
 buildDeb {
+    dependsOn replaceScriptVarsLinux
     signingKeyId = project.findProperty("signing.keyId")
     signingKeyPassphrase = project.findProperty("signing.password")
     signingKeyRingFile = project.hasProperty("signing.secretKeyRingFile") ? file(project.property("signing.secretKeyRingFile")) : null
@@ -172,6 +156,8 @@ buildDeb {
 }
 
 buildRpm {
+    dependsOn replaceScriptVarsLinux
+
     into("/etc/bash_completion.d/") {
         from configurations.cliScripts
         fileMode 0755
@@ -188,8 +174,11 @@ ospackage {
     user 'root'
 
     into(linuxTokens.INSTALL_DIR) {
-        from("$buildDir/linux/ignite3")
-        fileMode = 0755
+        from "$buildDir/linux/ignite3"
+        fileMode 0755
+        rename {
+            'ignite3'
+        }
     }
 
     into(linuxTokens.LIB_DIR) {
@@ -197,7 +186,7 @@ ospackage {
         from "$rootDir/packaging/common/setup-java.sh"
     }
 
-    postInstall file("${buildDir}/postInstall.sh")
+    postInstall file("$buildDir/linux/postInstall.sh")
 }
 
 configurations {
@@ -207,8 +196,13 @@ configurations {
     }
 }
 
-artifacts {
-    cliRelease(file("$buildDir/distributions")) {
-        builtBy createChecksums, signCliZip, buildDeb, buildRpm
+if (project.hasProperty('prepareRelease')) {
+    artifacts {
+        cliRelease(file("$buildDir/distributions")) {
+            builtBy signCliZip, buildDeb, buildRpm
+        }
+        cliRelease(file("$buildDir/checksums")) {
+            builtBy createChecksums
+        }
     }
 }

--- a/packaging/db/build.gradle
+++ b/packaging/db/build.gradle
@@ -56,13 +56,13 @@ def zipStartScriptTokens = tokens + [
 ]
 
 task replaceZipScriptVars(type: Copy) {
-    from("$rootDir/packaging/common")
-    from("$rootDir/packaging/zip")
-    from("$rootDir/packaging/db/ignite.java.util.logging.properties")
+    from "$rootDir/packaging/common"
+    from "$rootDir/packaging/zip"
+    from "$rootDir/packaging/db/ignite.java.util.logging.properties"
 
     filter(ReplaceTokens, tokens: zipStartScriptTokens)
 
-    into("$buildDir/zip/")
+    into "$buildDir/zip/"
 }
 
 distributions {
@@ -79,35 +79,35 @@ distributions {
                 }
             }
             into('') {
-                from("$rootDir/LICENSE")
-                from("$rootDir/NOTICE")
-                from("$rootDir/assembly/README.md")
+                from "$rootDir/LICENSE"
+                from "$rootDir/NOTICE"
+                from "$rootDir/assembly/README.md"
             }
             into('etc') {
-                from("$buildDir/zip/${zipStartScriptTokens.VARS_FILE_NAME}")
-                from("$rootDir/packaging/config/ignite-config.conf")
-                from("$buildDir/zip/ignite.java.util.logging.properties")
+                from "$buildDir/zip/${zipStartScriptTokens.VARS_FILE_NAME}"
+                from "$rootDir/packaging/config/ignite-config.conf"
+                from "$buildDir/zip/ignite.java.util.logging.properties"
             }
             into('bin') {
                 fileMode 0755
-                from("$buildDir/zip/ignite3db")
+                from "$buildDir/zip/ignite3db"
             }
             into('lib') {
                 from configurations.dbArtifacts
-                from("$buildDir/zip/${zipStartScriptTokens.BOOTSTRAP_FILE_NAME}")
-                from("$buildDir/zip/${zipStartScriptTokens.SETUP_JAVA_FILE_NAME}")
+                from "$buildDir/zip/${zipStartScriptTokens.BOOTSTRAP_FILE_NAME}"
+                from "$buildDir/zip/${zipStartScriptTokens.SETUP_JAVA_FILE_NAME}"
             }
         }
     }
 }
 
 distZip.dependsOn replaceZipScriptVars
+distTar.dependsOn replaceZipScriptVars
 
 task createChecksums(type: Checksum) {
     dependsOn distZip
 
     inputFiles.from distZip.outputs.files
-    outputDirectory = file("$buildDir/distributions")
     checksumAlgorithm = Checksum.Algorithm.SHA512
 }
 
@@ -123,7 +123,8 @@ artifacts {
     dbZip(distZip)
 }
 
-signing {
+// Explicitly create task so that the resulting artifact is not added to the configuration
+tasks.register('signDbZip', Sign) {
     sign configurations.dbZip
 }
 
@@ -144,23 +145,23 @@ def packageTokens = tokens + [
 
 
 task replacePackageScriptVars(type: Copy) {
-    from("${rootDir}/packaging/linux")
-    from("${rootDir}/packaging/db/ignite.java.util.logging.properties")
-    from("$rootDir/packaging/common")
+    from "$rootDir/packaging/linux"
+    from "$rootDir/packaging/db/ignite.java.util.logging.properties"
+    from "$rootDir/packaging/common"
     filter(ReplaceTokens, tokens: packageTokens)
-    into("${buildDir}/linux")
+    into "$buildDir/linux"
 }
 
 buildRpm {
     dependsOn replacePackageScriptVars
     configurationFile = "/etc/ignite3/vars.env"
 
-    installUtils file("${buildDir}/linux/service/vars.env")
-    installUtils file("${buildDir}/linux/common.sh")
-    preInstall file("${buildDir}/linux/preInstall.sh")
-    postInstall file("${buildDir}/linux/postInstall.sh")
-    preUninstall file("${buildDir}/linux/rpm/preUninstall.sh")
-    postUninstall file("${buildDir}/linux/rpm/postUninstall.sh")
+    installUtils file("$buildDir/linux/service/vars.env")
+    installUtils file("$buildDir/linux/common.sh")
+    preInstall file("$buildDir/linux/preInstall.sh")
+    postInstall file("$buildDir/linux/postInstall.sh")
+    preUninstall file("$buildDir/linux/rpm/preUninstall.sh")
+    postUninstall file("$buildDir/linux/rpm/postUninstall.sh")
 }
 
 buildDeb {
@@ -170,12 +171,12 @@ buildDeb {
     dependsOn replacePackageScriptVars
     configurationFile = "/etc/ignite3/vars.env"
 
-    installUtils file("${buildDir}/linux/service/vars.env")
-    installUtils file("${buildDir}/linux/common.sh")
-    preInstall file("${buildDir}/linux/preInstall.sh")
-    postInstall file("${buildDir}/linux/postInstall.sh")
-    preUninstall file("${buildDir}/linux/deb/preUninstall.sh")
-    postUninstall file("${buildDir}/linux/deb/postUninstall.sh")
+    installUtils file("$buildDir/linux/service/vars.env")
+    installUtils file("$buildDir/linux/common.sh")
+    preInstall file("$buildDir/linux/preInstall.sh")
+    postInstall file("$buildDir/linux/postInstall.sh")
+    preUninstall file("$buildDir/linux/deb/preUninstall.sh")
+    postUninstall file("$buildDir/linux/deb/postUninstall.sh")
 }
 
 ospackage {
@@ -188,28 +189,28 @@ ospackage {
     os LINUX
 
     into(packageTokens.INSTALL_DIR) {
-        into("") {
-            from "${buildDir}/linux/service/ignite3db.service"
-            from "${buildDir}/linux/service/ignite3db.conf"
-            from("${buildDir}/linux/start.sh") {
+        into('') {
+            from "$buildDir/linux/service/ignite3db.service"
+            from "$buildDir/linux/service/ignite3db.conf"
+            from("$buildDir/linux/start.sh") {
                 fileMode 0755
             }
         }
 
-        into("lib") {
+        into('lib') {
             from configurations.dbArtifacts
-            from("$buildDir/linux/${zipStartScriptTokens.BOOTSTRAP_FILE_NAME}")
-            from("$buildDir/linux/${zipStartScriptTokens.SETUP_JAVA_FILE_NAME}")
+            from "$buildDir/linux/${zipStartScriptTokens.BOOTSTRAP_FILE_NAME}"
+            from "$buildDir/linux/${zipStartScriptTokens.SETUP_JAVA_FILE_NAME}"
         }
 
-        into("etc") {
+        into('etc') {
             fileType CONFIG
-            from "${buildDir}/linux/service/vars.env"
-            from "${buildDir}/linux/ignite.java.util.logging.properties"
-            from "${rootDir}/packaging/config/ignite-config.conf"
+            from "$buildDir/linux/service/vars.env"
+            from "$buildDir/linux/ignite.java.util.logging.properties"
+            from "$rootDir/packaging/config/ignite-config.conf"
         }
 
-        into("etc") {
+        into('etc') {
             from sourceSets.main.resources
         }
     }
@@ -224,8 +225,13 @@ configurations {
     }
 }
 
-artifacts {
-    dbRelease(file("$buildDir/distributions")) {
-        builtBy createChecksums, signDbZip, buildDeb, buildRpm
+if (project.hasProperty('prepareRelease')) {
+    artifacts {
+        dbRelease(file("$buildDir/distributions")) {
+            builtBy signDbZip, buildDeb, buildRpm
+        }
+        dbRelease(file("$buildDir/checksums")) {
+            builtBy createChecksums
+        }
     }
 }


### PR DESCRIPTION
* Fix dependencies to get rid of Gradle warnings.
* Do not assembly release artifacts (such as .NET binaries) during regular build.

This fix properly declares dependencies between packaging tasks so that Gradle can optimize them correctly and don't complain.
Also this adds a property check for adding release artifacts. The reason is that adding an artifact to the configuration automatically adds a dependency to the `assemble` task so running `gradlew build` always produces artifacts intended only for the release.

https://issues.apache.org/jira/browse/IGNITE-18280

