### PR TITLE
IGNITE-18071 Add client-side heartbeat timeout

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -12,8 +12,8 @@
     <inspection_tool class="AccessToStaticFieldLockedOnInstance" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoredClasses">
         <set>
-          <option value="org.apache.ignite.lang.ByteArray" />
           <option value="org.apache.ignite.internal.logger.IgniteLogger" />
+          <option value="org.apache.ignite.lang.ByteArray" />
         </set>
       </option>
     </inspection_tool>
@@ -255,7 +255,6 @@
     <inspection_tool class="AndroidLintMenuTitle" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="AndroidLintMergeMarker" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="AndroidLintMergeRootFrame" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="AndroidLintMinSdkTooLow" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintMipmapIcons" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintMissingApplicationIcon" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintMissingBackupPin" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -312,7 +311,6 @@
     <inspection_tool class="AndroidLintRecycle" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintRecyclerView" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintReferenceType" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="AndroidLintRegistered" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintRelativeOverlap" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintRequiredSize" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="AndroidLintResAuto" enabled="false" level="ERROR" enabled_by_default="false" />
@@ -371,7 +369,6 @@
     <inspection_tool class="AndroidLintUnknownId" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="AndroidLintUnknownIdInLayout" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintUnlocalizedSms" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="AndroidLintUnpackedNativeCode" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintUnprotectedSMSBroadcastReceiver" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintUnsafeDynamicallyLoadedCode" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintUnsafeNativeCodeLocation" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -439,7 +436,7 @@
     <inspection_tool class="AssignmentToStaticFieldFromInstanceMethod" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="AssignmentToSuperclassField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="AutoCloseableResource" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="METHOD_MATCHER_CONFIG" value="java.util.Formatter,format,java.io.Writer,append,com.google.common.base.Preconditions,checkNotNull,org.hibernate.Session,close,java.io.PrintWriter,printf,java.io.PrintStream,printf,org.apache.ignite.internal.metric.IndexPagesMetricsTest,createCache" />
+      <option name="METHOD_MATCHER_CONFIG" value="java.util.Formatter,format,java.io.Writer,append,com.google.common.base.Preconditions,checkNotNull,org.hibernate.Session,close,java.io.PrintWriter,printf,java.io.PrintStream,printf,org.apache.ignite.internal.metric.IndexPagesMetricsTest,createCache,org.apache.ignite.client.IgniteClient.Builder,build" />
     </inspection_tool>
     <inspection_tool class="AutoTupling" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="AwaitNotInLoop" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -1032,7 +1029,6 @@
       </option>
     </inspection_tool>
     <inspection_tool class="SuspiciousArrayCast" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousLiteralUnderscore" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousLocalesLanguages" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementDensity" enabled="true" level="WARNING" enabled_by_default="true">

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -255,6 +255,7 @@
     <inspection_tool class="AndroidLintMenuTitle" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="AndroidLintMergeMarker" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="AndroidLintMergeRootFrame" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AndroidLintMinSdkTooLow" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintMipmapIcons" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintMissingApplicationIcon" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintMissingBackupPin" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -311,6 +312,7 @@
     <inspection_tool class="AndroidLintRecycle" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintRecyclerView" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintReferenceType" enabled="false" level="ERROR" enabled_by_default="false" />
+    <inspection_tool class="AndroidLintRegistered" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintRelativeOverlap" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintRequiredSize" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="AndroidLintResAuto" enabled="false" level="ERROR" enabled_by_default="false" />
@@ -369,6 +371,7 @@
     <inspection_tool class="AndroidLintUnknownId" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="AndroidLintUnknownIdInLayout" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintUnlocalizedSms" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AndroidLintUnpackedNativeCode" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintUnprotectedSMSBroadcastReceiver" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintUnsafeDynamicallyLoadedCode" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="AndroidLintUnsafeNativeCodeLocation" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -436,7 +439,7 @@
     <inspection_tool class="AssignmentToStaticFieldFromInstanceMethod" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="AssignmentToSuperclassField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="AutoCloseableResource" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="METHOD_MATCHER_CONFIG" value="java.util.Formatter,format,java.io.Writer,append,com.google.common.base.Preconditions,checkNotNull,org.hibernate.Session,close,java.io.PrintWriter,printf,java.io.PrintStream,printf,org.apache.ignite.internal.metric.IndexPagesMetricsTest,createCache,org.apache.ignite.client.IgniteClient.Builder,build" />
+      <option name="METHOD_MATCHER_CONFIG" value="java.util.Formatter,format,java.io.Writer,append,com.google.common.base.Preconditions,checkNotNull,org.hibernate.Session,close,java.io.PrintWriter,printf,java.io.PrintStream,printf,org.apache.ignite.internal.metric.IndexPagesMetricsTest,createCache" />
     </inspection_tool>
     <inspection_tool class="AutoTupling" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="AwaitNotInLoop" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -1029,6 +1032,7 @@
       </option>
     </inspection_tool>
     <inspection_tool class="SuspiciousArrayCast" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousLiteralUnderscore" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousLocalesLanguages" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementDensity" enabled="true" level="WARNING" enabled_by_default="true">

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -12,8 +12,8 @@
     <inspection_tool class="AccessToStaticFieldLockedOnInstance" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoredClasses">
         <set>
-          <option value="org.apache.ignite.internal.logger.IgniteLogger" />
           <option value="org.apache.ignite.lang.ByteArray" />
+          <option value="org.apache.ignite.internal.logger.IgniteLogger" />
         </set>
       </option>
     </inspection_tool>

--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
@@ -19,6 +19,7 @@ package org.apache.ignite.client;
 
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_CONNECT_TIMEOUT;
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_HEARTBEAT_INTERVAL;
+import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_HEARTBEAT_TIMEOUT;
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_RECONNECT_THROTTLING_PERIOD;
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_RECONNECT_THROTTLING_RETRIES;
 import static org.apache.ignite.internal.client.ClientUtils.sync;
@@ -34,6 +35,7 @@ import org.apache.ignite.internal.client.IgniteClientConfigurationImpl;
 import org.apache.ignite.internal.client.TcpIgniteClient;
 import org.apache.ignite.lang.LoggerFactory;
 import org.apache.ignite.network.ClusterNode;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Ignite client entry point.
@@ -86,10 +88,13 @@ public interface IgniteClient extends Ignite {
         /** Heartbeat interval. */
         private long heartbeatInterval = DFLT_HEARTBEAT_INTERVAL;
 
-        /** Retry policy. */
-        private RetryPolicy retryPolicy = new RetryReadPolicy();
+        /** Heartbeat timeout. */
+        private long heartbeatTimeout = DFLT_HEARTBEAT_TIMEOUT;
 
-        private LoggerFactory loggerFactory;
+        /** Retry policy. */
+        private @Nullable RetryPolicy retryPolicy = new RetryReadPolicy();
+
+        private @Nullable LoggerFactory loggerFactory;
 
         /**
          * Sets the addresses of Ignite server nodes within a cluster. An address can be an IP address or a hostname, with or without port.
@@ -116,7 +121,7 @@ public interface IgniteClient extends Ignite {
          * @param retryPolicy Retry policy.
          * @return This instance.
          */
-        public Builder retryPolicy(RetryPolicy retryPolicy) {
+        public Builder retryPolicy(@Nullable RetryPolicy retryPolicy) {
             this.retryPolicy = retryPolicy;
 
             return this;
@@ -241,6 +246,20 @@ public interface IgniteClient extends Ignite {
         }
 
         /**
+         * Sets the heartbeat message timeout, in milliseconds. Default is <code>5000</code>.
+         *
+         * <p>When a server does not respond to a heartbeat within the specified timeout, client will close the connection.
+         *
+         * @param heartbeatTimeout Heartbeat timeout.
+         * @return This instance.
+         */
+        public Builder heartbeatTimeout(long heartbeatTimeout) {
+            this.heartbeatTimeout = heartbeatTimeout;
+
+            return this;
+        }
+
+        /**
          * Builds the client.
          *
          * @return Ignite client.
@@ -263,6 +282,7 @@ public interface IgniteClient extends Ignite {
                     reconnectThrottlingRetries,
                     asyncContinuationExecutor,
                     heartbeatInterval,
+                    heartbeatTimeout,
                     retryPolicy,
                     loggerFactory
             );

--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
@@ -94,6 +94,7 @@ public interface IgniteClient extends Ignite {
         /** Retry policy. */
         private @Nullable RetryPolicy retryPolicy = new RetryReadPolicy();
 
+        /** Logger factory. */
         private @Nullable LoggerFactory loggerFactory;
 
         /**

--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConfiguration.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConfiguration.java
@@ -36,11 +36,11 @@ public interface IgniteClientConfiguration {
     /** Default socket connect timeout, in milliseconds. */
     int DFLT_CONNECT_TIMEOUT = 5000;
 
+    /** Default heartbeat timeout, in milliseconds. */
+    int DFLT_HEARTBEAT_TIMEOUT = 5000;
+
     /** Default heartbeat interval, in milliseconds. */
     int DFLT_HEARTBEAT_INTERVAL = 30_000;
-
-    /** Default operation retry limit. */
-    int DFLT_RETRY_LIMIT = 5;
 
     /** Default reconnect throttling period. */
     long DFLT_RECONNECT_THROTTLING_PERIOD = 30_000L;
@@ -120,6 +120,18 @@ public interface IgniteClientConfiguration {
      * @return Heartbeat interval.
      */
     public long heartbeatInterval();
+
+    /**
+     * Gets the heartbeat message timeout, in milliseconds. Default is <code>5000</code>.
+     *
+     * <p>When a server does not respond to a heartbeat within the specified timeout, client will close the connection.
+     *
+     * <p>When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
+     * to keep the connection alive and detect potential half-open state.
+     *
+     * @return Heartbeat interval.
+     */
+    public long heartbeatTimeout();
 
     /**
      * Returns the logger factory. This factory will be used to create a logger instance when needed.

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientUtils.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientUtils.java
@@ -17,11 +17,16 @@
 
 package org.apache.ignite.internal.client;
 
+import java.lang.System.Logger;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.apache.ignite.client.ClientOperationType;
+import org.apache.ignite.client.IgniteClientConfiguration;
 import org.apache.ignite.internal.client.proto.ClientOp;
+import org.apache.ignite.internal.logger.IgniteLogger;
+import org.apache.ignite.internal.logger.Loggers;
 import org.apache.ignite.lang.IgniteException;
+import org.apache.ignite.lang.LoggerFactory;
 
 /**
  * Client utilities.
@@ -177,5 +182,21 @@ public class ClientUtils {
             default:
                 throw new UnsupportedOperationException("Invalid op code: " + opCode);
         }
+    }
+
+    /**
+     * Gets a logger for the given class.
+     *
+     * @param cls Class.
+     * @return Logger.
+     */
+    public static <T> IgniteLogger logger(IgniteClientConfiguration cfg, Class<T> cls) {
+        var loggerFactory = cfg.loggerFactory() == null
+                ? (LoggerFactory) System::getLogger
+                : cfg.loggerFactory();
+
+        return loggerFactory == null
+                ? Loggers.voidLogger()
+                : Loggers.forClass(cls, loggerFactory);
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientUtils.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientUtils.java
@@ -17,7 +17,6 @@
 
 package org.apache.ignite.internal.client;
 
-import java.lang.System.Logger;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.apache.ignite.client.ClientOperationType;

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/IgniteClientConfigurationImpl.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/IgniteClientConfigurationImpl.java
@@ -49,6 +49,9 @@ public final class IgniteClientConfigurationImpl implements IgniteClientConfigur
     /** Heartbeat interval. */
     private final long heartbeatInterval;
 
+    /** Heartbeat timout. */
+    private final long heartbeatTimeout;
+
     /** Retry policy. */
     private final RetryPolicy retryPolicy;
 
@@ -64,6 +67,7 @@ public final class IgniteClientConfigurationImpl implements IgniteClientConfigur
      * @param reconnectThrottlingRetries Reconnect throttling retries.
      * @param asyncContinuationExecutor Async continuation executor.
      * @param heartbeatInterval Heartbeat message interval.
+     * @param heartbeatTimeout Heartbeat message timeout.
      * @param retryPolicy Retry policy.
      * @param loggerFactory Logger factory which will be used to create a logger instance for this this particular client when needed.
      */
@@ -75,8 +79,9 @@ public final class IgniteClientConfigurationImpl implements IgniteClientConfigur
             int reconnectThrottlingRetries,
             Executor asyncContinuationExecutor,
             long heartbeatInterval,
-            RetryPolicy retryPolicy,
-            LoggerFactory loggerFactory
+            long heartbeatTimeout,
+            @Nullable RetryPolicy retryPolicy,
+            @Nullable LoggerFactory loggerFactory
     ) {
         this.addressFinder = addressFinder;
 
@@ -88,6 +93,7 @@ public final class IgniteClientConfigurationImpl implements IgniteClientConfigur
         this.reconnectThrottlingRetries = reconnectThrottlingRetries;
         this.asyncContinuationExecutor = asyncContinuationExecutor;
         this.heartbeatInterval = heartbeatInterval;
+        this.heartbeatTimeout = heartbeatTimeout;
         this.retryPolicy = retryPolicy;
         this.loggerFactory = loggerFactory;
     }
@@ -132,6 +138,12 @@ public final class IgniteClientConfigurationImpl implements IgniteClientConfigur
     @Override
     public long heartbeatInterval() {
         return heartbeatInterval;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long heartbeatTimeout() {
+        return heartbeatTimeout;
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -114,10 +114,10 @@ public final class ReliableChannel implements AutoCloseable {
      * @param clientCfg Client config.
      */
     ReliableChannel(BiFunction<ClientChannelConfiguration, ClientConnectionMultiplexer, ClientChannel> chFactory,
-            IgniteClientConfiguration clientCfg, IgniteLogger log) {
+            IgniteClientConfiguration clientCfg) {
         this.clientCfg = Objects.requireNonNull(clientCfg, "clientCfg");
         this.chFactory = Objects.requireNonNull(chFactory, "chFactory");
-        this.log = Objects.requireNonNull(log, "log");
+        this.log = ClientUtils.logger(clientCfg, ReliableChannel.class);
 
         connMgr = new NettyClientConnectionMultiplexer();
         connMgr.start(clientCfg);

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -99,6 +99,9 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
     /** Connect timeout in milliseconds. */
     private final long connectTimeout;
 
+    /** Heartbeat timeout in milliseconds. */
+    private final long heartbeatTimeout;
+
     /** Heartbeat timer. */
     private final Timer heartbeatTimer;
 
@@ -124,6 +127,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
                 : cfg.clientConfiguration().asyncContinuationExecutor();
 
         connectTimeout = cfg.clientConfiguration().connectTimeout();
+        heartbeatTimeout = cfg.clientConfiguration().heartbeatTimeout();
 
         sock = connMgr.open(cfg.getAddress(), this, this);
 
@@ -514,7 +518,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
             try {
                 if (System.currentTimeMillis() - lastSendMillis > interval) {
                     serviceAsync(ClientOp.HEARTBEAT, null, null)
-                            .orTimeout(connectTimeout, TimeUnit.MILLISECONDS)
+                            .orTimeout(heartbeatTimeout, TimeUnit.MILLISECONDS)
                             .exceptionally(e -> {
                                 if (e instanceof TimeoutException) {
                                     log.warn("Heartbeat timeout, closing the channel");

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -23,7 +23,6 @@ import static org.apache.ignite.lang.ErrorGroups.Client.PROTOCOL_ERR;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
-import java.lang.System.Logger;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetSocketAddress;

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -526,16 +526,17 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
                     var fut = serviceAsync(ClientOp.HEARTBEAT, null, null);
 
                     if (connectTimeout > 0) {
-                        fut.orTimeout(heartbeatTimeout, TimeUnit.MILLISECONDS)
-                            .exceptionally(e -> {
-                                if (e instanceof TimeoutException) {
-                                    log.warn("Heartbeat timeout, closing the channel");
+                        fut
+                                .orTimeout(heartbeatTimeout, TimeUnit.MILLISECONDS)
+                                .exceptionally(e -> {
+                                    if (e instanceof TimeoutException) {
+                                        log.warn("Heartbeat timeout, closing the channel");
 
-                                    close((TimeoutException) e);
-                                }
+                                        close((TimeoutException) e);
+                                    }
 
-                                return null;
-                            });
+                                    return null;
+                                });
                     }
                 }
             } catch (Throwable ignored) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -514,9 +514,8 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
         @Override public void run() {
             try {
                 if (System.currentTimeMillis() - lastSendMillis > interval) {
-                    // TODO: Get timeout from config.
                     serviceAsync(ClientOp.HEARTBEAT, null, null)
-                            .orTimeout(100, TimeUnit.MILLISECONDS)
+                            .orTimeout(connectTimeout, TimeUnit.MILLISECONDS)
                             .exceptionally(e -> {
                                 if (e instanceof TimeoutException) {
                                     log.warn("Heartbeat timeout, closing the channel");

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -390,13 +390,14 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
         try {
             handshakeReq(ver);
 
+            // handshakeRes must be called even in case of timeout to release the buffer.
             var resFut = fut.thenAccept(res -> handshakeRes(res, ver));
 
             if (connectTimeout > 0) {
-                resFut = resFut.orTimeout(connectTimeout, TimeUnit.MILLISECONDS);
+                resFut.get(connectTimeout, TimeUnit.MILLISECONDS);
+            } else {
+                resFut.get();
             }
-
-            resFut.get();
         } catch (Throwable e) {
             throw IgniteException.wrap(e);
         }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpIgniteClient.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpIgniteClient.java
@@ -34,8 +34,6 @@ import org.apache.ignite.internal.client.sql.ClientSql;
 import org.apache.ignite.internal.client.table.ClientTables;
 import org.apache.ignite.internal.client.tx.ClientTransactions;
 import org.apache.ignite.internal.jdbc.proto.ClientMessage;
-import org.apache.ignite.internal.logger.Loggers;
-import org.apache.ignite.lang.LoggerFactory;
 import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.NetworkAddress;
 import org.apache.ignite.sql.IgniteSql;
@@ -88,13 +86,7 @@ public class TcpIgniteClient implements IgniteClient {
 
         this.cfg = cfg;
 
-        var loggerFactory = cfg.loggerFactory() == null
-                ? (LoggerFactory) System::getLogger
-                : cfg.loggerFactory();
-
-        var log = Loggers.forClass(TcpIgniteClient.class, loggerFactory);
-
-        ch = new ReliableChannel(chFactory, cfg, log);
+        ch = new ReliableChannel(chFactory, cfg);
         tables = new ClientTables(ch);
         transactions = new ClientTransactions(ch);
         compute = new ClientCompute(ch, tables);

--- a/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
@@ -136,7 +136,7 @@ public abstract class AbstractClientTest {
             Ignite ignite,
             String nodeName
     ) {
-        return new TestServer(port, portRange, idleTimeout, ignite, null, 0, nodeName, clusterId);
+        return new TestServer(port, portRange, idleTimeout, ignite, null, null, nodeName, clusterId);
     }
 
     /**

--- a/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
@@ -136,7 +136,7 @@ public abstract class AbstractClientTest {
             Ignite ignite,
             String nodeName
     ) {
-        return new TestServer(port, portRange, idleTimeout, ignite, null, nodeName, clusterId);
+        return new TestServer(port, portRange, idleTimeout, ignite, null, 0, nodeName, clusterId);
     }
 
     /**

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
@@ -176,9 +176,9 @@ public class ClientComputeTest {
 
         var clusterId = UUID.randomUUID();
 
-        server1 = new TestServer(10900, 10, 0, ignite, shouldDropConnection, "s1", clusterId);
-        server2 = new TestServer(10910, 10, 0, ignite, shouldDropConnection, "s2", clusterId);
-        server3 = new TestServer(10920, 10, 0, ignite, shouldDropConnection, "s3", clusterId);
+        server1 = new TestServer(10900, 10, 0, ignite, shouldDropConnection, 0, "s1", clusterId);
+        server2 = new TestServer(10910, 10, 0, ignite, shouldDropConnection, 0, "s2", clusterId);
+        server3 = new TestServer(10920, 10, 0, ignite, shouldDropConnection, 0, "s3", clusterId);
     }
 
     private Set<ClusterNode> getClusterNodes(String... names) {

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
@@ -176,9 +176,9 @@ public class ClientComputeTest {
 
         var clusterId = UUID.randomUUID();
 
-        server1 = new TestServer(10900, 10, 0, ignite, shouldDropConnection, 0, "s1", clusterId);
-        server2 = new TestServer(10910, 10, 0, ignite, shouldDropConnection, 0, "s2", clusterId);
-        server3 = new TestServer(10920, 10, 0, ignite, shouldDropConnection, 0, "s3", clusterId);
+        server1 = new TestServer(10900, 10, 0, ignite, shouldDropConnection, null, "s1", clusterId);
+        server2 = new TestServer(10910, 10, 0, ignite, shouldDropConnection, null, "s2", clusterId);
+        server3 = new TestServer(10920, 10, 0, ignite, shouldDropConnection, null, "s3", clusterId);
     }
 
     private Set<ClusterNode> getClusterNodes(String... names) {

--- a/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -21,7 +21,6 @@ import static org.apache.ignite.internal.testframework.IgniteTestUtils.assertThr
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.UUID;
@@ -29,7 +28,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import org.apache.ignite.client.IgniteClient.Builder;
 import org.apache.ignite.client.fakes.FakeIgnite;
-import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.lang.IgniteException;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;

--- a/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
@@ -88,7 +88,7 @@ public class HeartbeatTest {
 
             Builder builder = IgniteClient.builder()
                     .addresses("127.0.0.1:" + srvPort)
-                    .retryPolicy(new RetryLimitPolicy().retryLimit(0))
+                    .retryPolicy(new RetryLimitPolicy().retryLimit(1))
                     .heartbeatTimeout(30)
                     .reconnectThrottlingPeriod(5000)
                     .reconnectThrottlingRetries(0)

--- a/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
@@ -79,7 +79,6 @@ public class HeartbeatTest {
         }
     }
 
-
     @Test
     public void testHeartbeatTimeoutClosesConnection() throws Exception {
         Function<Integer, Integer> responseDelayFunc = requestCount -> requestCount > 1 ? 500 : 0;

--- a/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
@@ -75,4 +75,22 @@ public class HeartbeatTest {
             assertEquals("Negative delay.", ex.getMessage());
         }
     }
+
+
+    @Test
+    public void testHeartbeatTimeout() throws Exception {
+        try (var srv = new TestServer(10800, 10, 300, new FakeIgnite())) {
+            int srvPort = srv.port();
+
+            Builder builder = IgniteClient.builder()
+                    .addresses("127.0.0.1:" + srvPort)
+                    .heartbeatInterval(50);
+
+            try (var client = builder.build()) {
+                Thread.sleep(900);
+
+                assertEquals(0, client.tables().tables().size());
+            }
+        }
+    }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
@@ -20,6 +20,7 @@ package org.apache.ignite.client;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.UUID;
 import org.apache.ignite.client.IgniteClient.Builder;
 import org.apache.ignite.client.fakes.FakeIgnite;
 import org.junit.jupiter.api.Test;
@@ -78,12 +79,14 @@ public class HeartbeatTest {
 
 
     @Test
-    public void testHeartbeatTimeout() throws Exception {
-        try (var srv = new TestServer(10800, 10, 300, new FakeIgnite())) {
+    public void testHeartbeatTimeoutClosesConnection() throws Exception {
+        try (var srv = new TestServer(10800, 10, 300, new FakeIgnite(), x -> false, x -> x > 1 ? 500 : 0, null, UUID.randomUUID())) {
             int srvPort = srv.port();
 
             Builder builder = IgniteClient.builder()
                     .addresses("127.0.0.1:" + srvPort)
+                    .retryPolicy(new RetryLimitPolicy().retryLimit(0))
+                    .connectTimeout(50)
                     .heartbeatInterval(50);
 
             try (var client = builder.build()) {

--- a/modules/client/src/test/java/org/apache/ignite/client/MultiClusterTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/MultiClusterTest.java
@@ -49,8 +49,8 @@ public class MultiClusterTest {
 
     @BeforeEach
     void setUp() {
-        server1 = new TestServer(10900, 10, 0, new FakeIgnite(), null, "s1", clusterId1);
-        server2 = new TestServer(10900, 10, 0, new FakeIgnite(), null, "s2", clusterId2);
+        server1 = new TestServer(10900, 10, 0, new FakeIgnite(), null, 0, "s1", clusterId1);
+        server2 = new TestServer(10900, 10, 0, new FakeIgnite(), null, 0, "s2", clusterId2);
     }
 
     @AfterEach
@@ -91,7 +91,7 @@ public class MultiClusterTest {
             client.tables().tables();
 
             server1.close();
-            server1 = new TestServer(10900, 10, 0, new FakeIgnite(), null, "s1", clusterId2);
+            server1 = new TestServer(10900, 10, 0, new FakeIgnite(), null, 0, "s1", clusterId2);
 
             IgniteClientConnectionException ex = (IgniteClientConnectionException) assertThrowsWithCause(
                     () -> client.tables().tables(), IgniteClientConnectionException.class, "Cluster ID mismatch");

--- a/modules/client/src/test/java/org/apache/ignite/client/MultiClusterTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/MultiClusterTest.java
@@ -49,8 +49,8 @@ public class MultiClusterTest {
 
     @BeforeEach
     void setUp() {
-        server1 = new TestServer(10900, 10, 0, new FakeIgnite(), null, 0, "s1", clusterId1);
-        server2 = new TestServer(10900, 10, 0, new FakeIgnite(), null, 0, "s2", clusterId2);
+        server1 = new TestServer(10900, 10, 0, new FakeIgnite(), null, null, "s1", clusterId1);
+        server2 = new TestServer(10900, 10, 0, new FakeIgnite(), null, null, "s2", clusterId2);
     }
 
     @AfterEach
@@ -91,7 +91,7 @@ public class MultiClusterTest {
             client.tables().tables();
 
             server1.close();
-            server1 = new TestServer(10900, 10, 0, new FakeIgnite(), null, 0, "s1", clusterId2);
+            server1 = new TestServer(10900, 10, 0, new FakeIgnite(), null, null, "s1", clusterId2);
 
             IgniteClientConnectionException ex = (IgniteClientConnectionException) assertThrowsWithCause(
                     () -> client.tables().tables(), IgniteClientConnectionException.class, "Cluster ID mismatch");

--- a/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
@@ -265,6 +265,6 @@ public class RetryPolicyTest {
         FakeIgnite ign = new FakeIgnite();
         ((FakeIgniteTables) ign.tables()).createTable("t");
 
-        server = new TestServer(10900, 10, 0, ign, shouldDropConnection, 0, null, UUID.randomUUID());
+        server = new TestServer(10900, 10, 0, ign, shouldDropConnection, null, null, UUID.randomUUID());
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
@@ -265,6 +265,6 @@ public class RetryPolicyTest {
         FakeIgnite ign = new FakeIgnite();
         ((FakeIgniteTables) ign.tables()).createTable("t");
 
-        server = new TestServer(10900, 10, 0, ign, shouldDropConnection, null, UUID.randomUUID());
+        server = new TestServer(10900, 10, 0, ign, shouldDropConnection, 0, null, UUID.randomUUID());
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
@@ -216,7 +216,7 @@ public class RetryPolicyTest {
     @Test
     public void testRetryReadPolicyAllOperationsSupported() throws IllegalAccessException {
         var plc = new RetryReadPolicy();
-        var cfg = new IgniteClientConfigurationImpl(null, null, 0, 0, 0, null, 0, null, null);
+        var cfg = new IgniteClientConfigurationImpl(null, null, 0, 0, 0, null, 0, 0, null, null);
 
         for (var op : ClientOperationType.values()) {
             var ctx = new RetryPolicyContextImpl(cfg, op, 0, null);

--- a/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
@@ -60,6 +60,9 @@ public class TestClientHandlerModule implements IgniteComponent {
     /** Connection drop condition. */
     private final Function<Integer, Boolean> shouldDropConnection;
 
+    /** Server response delay. */
+    private final long responseDelayMs;
+
     /** Cluster service. */
     private final ClusterService clusterService;
 
@@ -82,6 +85,7 @@ public class TestClientHandlerModule implements IgniteComponent {
      * @param registry Configuration registry.
      * @param bootstrapFactory Bootstrap factory.
      * @param shouldDropConnection Connection drop condition.
+     * @param responseDelayMs Response delay, in milliseconds.
      * @param clusterService Cluster service.
      * @param compute Compute.
      * @param clusterId Cluster id.
@@ -91,6 +95,7 @@ public class TestClientHandlerModule implements IgniteComponent {
             ConfigurationRegistry registry,
             NettyBootstrapFactory bootstrapFactory,
             Function<Integer, Boolean> shouldDropConnection,
+            long responseDelayMs,
             ClusterService clusterService,
             IgniteCompute compute,
             UUID clusterId) {
@@ -102,6 +107,7 @@ public class TestClientHandlerModule implements IgniteComponent {
         this.registry = registry;
         this.bootstrapFactory = bootstrapFactory;
         this.shouldDropConnection = shouldDropConnection;
+        this.responseDelayMs = responseDelayMs;
         this.clusterService = clusterService;
         this.compute = compute;
         this.clusterId = clusterId;

--- a/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
@@ -74,7 +74,7 @@ public class TestServer implements AutoCloseable {
             long idleTimeout,
             Ignite ignite
     ) {
-        this(port, portRange, idleTimeout, ignite, null, null, UUID.randomUUID());
+        this(port, portRange, idleTimeout, ignite, null, 0, null, UUID.randomUUID());
     }
 
     /**
@@ -91,7 +91,8 @@ public class TestServer implements AutoCloseable {
             long idleTimeout,
             Ignite ignite,
             @Nullable Function<Integer, Boolean> shouldDropConnection,
-            String nodeName,
+            long responseDelayMs,
+            @Nullable String nodeName,
             UUID clusterId
     ) {
         cfg = new ConfigurationRegistry(
@@ -131,7 +132,15 @@ public class TestServer implements AutoCloseable {
                 compute.executeColocated(anyString(), any(), anyString(), any())).thenReturn(CompletableFuture.completedFuture(nodeName));
 
         module = shouldDropConnection != null
-                ? new TestClientHandlerModule(ignite, cfg, bootstrapFactory, shouldDropConnection, clusterService, compute, clusterId)
+                ? new TestClientHandlerModule(
+                        ignite,
+                        cfg,
+                        bootstrapFactory,
+                        shouldDropConnection,
+                        responseDelayMs,
+                        clusterService,
+                        compute,
+                        clusterId)
                 : new ClientHandlerModule(
                         ((FakeIgnite) ignite).queryEngine(),
                         (IgniteTablesInternal) ignite.tables(),

--- a/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
@@ -74,7 +74,7 @@ public class TestServer implements AutoCloseable {
             long idleTimeout,
             Ignite ignite
     ) {
-        this(port, portRange, idleTimeout, ignite, null, 0, null, UUID.randomUUID());
+        this(port, portRange, idleTimeout, ignite, null, null, null, UUID.randomUUID());
     }
 
     /**
@@ -91,7 +91,7 @@ public class TestServer implements AutoCloseable {
             long idleTimeout,
             Ignite ignite,
             @Nullable Function<Integer, Boolean> shouldDropConnection,
-            long responseDelayMs,
+            @Nullable Function<Integer, Integer> responseDelay,
             @Nullable String nodeName,
             UUID clusterId
     ) {
@@ -137,7 +137,7 @@ public class TestServer implements AutoCloseable {
                         cfg,
                         bootstrapFactory,
                         shouldDropConnection,
-                        responseDelayMs,
+                        responseDelay,
                         clusterService,
                         compute,
                         clusterId)


### PR DESCRIPTION
* Add `IgniteClientConfiguration.heartbeatTimeout`.
* Close connection when there is no response from server to heartbeat message within the specified timeout.
* Minor fixes - add nullable annotations, improve logger handling.
* Add test for `connectTimeout`.
* Fix Netty buffer leak in case of connect timeout.