### PR TITLE
IGNITE-18435 .NET: Add support for Enum mapping

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -631,21 +631,23 @@ public partial class LinqTests : IgniteTestsBase
             .Where(x => x.Val == TestEnum.B)
             .Select(x => new { x.Key, Res = x.Val });
 
-        StringAssert.Contains("where (_T0.INT8 IS DISTINCT FROM ?)", query.ToString());
+        StringAssert.Contains(
+            "select _T0.KEY, _T0.VAL from PUBLIC.TBL_INT32 as _T0 where (cast(_T0.VAL as int) IS NOT DISTINCT FROM ?), Parameters=3",
+            query.ToString());
 
         var res = query.ToList();
+        var resEnum = res[0].Res;
 
         Assert.AreEqual(3, res[0].Key);
-        Assert.AreEqual(TestEnum.B, res[0].Res);
+        Assert.AreEqual(TestEnum.B, resEnum);
         Assert.AreEqual(1, res.Count);
     }
 
     private enum TestEnum
     {
         None = 0,
-        A = 1,
-        B = 3,
-        C = 5
+        A = 100,
+        B = 300
     }
 
     private record PocoByte(sbyte Key, sbyte Val);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -33,6 +33,8 @@ using Table;
 /// </summary>
 [SuppressMessage("ReSharper", "PossibleLossOfFraction", Justification = "Tests")]
 [SuppressMessage("ReSharper", "NotAccessedPositionalProperty.Local", Justification = "Tests")]
+[SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Tests")]
+[SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:Elements should appear in the correct order", Justification = "Tests")]
 public partial class LinqTests : IgniteTestsBase
 {
     private const int Count = 10;
@@ -42,6 +44,8 @@ public partial class LinqTests : IgniteTestsBase
     private IRecordView<PocoShort> PocoShortView { get; set; } = null!;
 
     private IRecordView<PocoInt> PocoIntView { get; set; } = null!;
+
+    private IRecordView<PocoIntEnum> PocoIntEnumView { get; set; } = null!;
 
     private IRecordView<PocoLong> PocoLongView { get; set; } = null!;
 
@@ -59,6 +63,7 @@ public partial class LinqTests : IgniteTestsBase
         PocoByteView = (await Client.Tables.GetTableAsync(TableInt8Name))!.GetRecordView<PocoByte>();
         PocoShortView = (await Client.Tables.GetTableAsync(TableInt16Name))!.GetRecordView<PocoShort>();
         PocoIntView = (await Client.Tables.GetTableAsync(TableInt32Name))!.GetRecordView<PocoInt>();
+        PocoIntEnumView = (await Client.Tables.GetTableAsync(TableInt32Name))!.GetRecordView<PocoIntEnum>();
         PocoLongView = (await Client.Tables.GetTableAsync(TableInt64Name))!.GetRecordView<PocoLong>();
         PocoFloatView = (await Client.Tables.GetTableAsync(TableFloatName))!.GetRecordView<PocoFloat>();
         PocoDoubleView = (await Client.Tables.GetTableAsync(TableDoubleName))!.GetRecordView<PocoDouble>();
@@ -619,6 +624,30 @@ public partial class LinqTests : IgniteTestsBase
         Assert.AreEqual(10, res.Count);
     }
 
+    [Test]
+    public void TestFilterAndSelectEnumColumn()
+    {
+        var query = PocoIntEnumView.AsQueryable()
+            .Where(x => x.Val == TestEnum.B)
+            .Select(x => new { x.Key, Res = x.Val });
+
+        StringAssert.Contains("where (_T0.INT8 IS DISTINCT FROM ?)", query.ToString());
+
+        var res = query.ToList();
+
+        Assert.AreEqual(3, res[0].Key);
+        Assert.AreEqual(TestEnum.B, res[0].Res);
+        Assert.AreEqual(1, res.Count);
+    }
+
+    private enum TestEnum
+    {
+        None = 0,
+        A = 1,
+        B = 3,
+        C = 5
+    }
+
     private record PocoByte(sbyte Key, sbyte Val);
 
     private record PocoShort(short Key, short Val);
@@ -634,4 +663,6 @@ public partial class LinqTests : IgniteTestsBase
     private record PocoDecimal(decimal Key, decimal Val);
 
     private record PocoString(string Key, string Val);
+
+    private record PocoIntEnum(int Key, TestEnum Val);
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -35,6 +35,7 @@ using Table;
 [SuppressMessage("ReSharper", "NotAccessedPositionalProperty.Local", Justification = "Tests")]
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Tests")]
 [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:Elements should appear in the correct order", Justification = "Tests")]
+[SuppressMessage("ReSharper", "UnusedMember.Local", Justification = "Tests")]
 public partial class LinqTests : IgniteTestsBase
 {
     private const int Count = 10;

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/PocoEnums.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/PocoEnums.cs
@@ -19,19 +19,42 @@ namespace Apache.Ignite.Tests.Table;
 
 using System.Diagnostics.CodeAnalysis;
 
-/// <summary>
-/// Test user object.
-/// </summary>
-[SuppressMessage("Microsoft.Naming", "CA1720:AvoidTypeNamesInParameters", Justification = "POCO mapping.")]
-[SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Justification = "POCO mapping.")]
-[SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "POCO mapping.")]
-public record PocoEnums(long Key, TestEnum Int32);
-
 [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:Elements should appear in the correct order", Justification = "Tests.")]
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Tests.")]
-public enum TestEnum
+[SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Tests.")]
+[SuppressMessage("Design", "CA1008:Enums should have zero value", Justification = "Tests.")]
+[SuppressMessage("Design", "CA1028:Enum Storage should be Int32", Justification = "Tests.")]
+public static class PocoEnums
 {
-    None = 0,
-    Foo = 1,
-    BarBaz = 3
+    public record PocoIntEnum(long Key, IntEnum Int32);
+
+    public record PocoShortEnum(long Key, ShortEnum Int16);
+
+    public record PocoLongEnum(long Key, LongEnum Int64);
+
+    public record PocoByteEnum(long Key, ByteEnum Int8);
+
+    public enum IntEnum : int
+    {
+        Foo = 1,
+        Bar = 3
+    }
+
+    public enum ShortEnum : short
+    {
+        Foo = 1,
+        Bar = 3
+    }
+
+    public enum LongEnum : long
+    {
+        Foo = 1,
+        Bar = 3
+    }
+
+    public enum ByteEnum : sbyte
+    {
+        Foo = 1,
+        Bar = 3
+    }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/PocoEnums.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/PocoEnums.cs
@@ -34,6 +34,8 @@ public static class PocoEnums
 
     public record PocoByteEnum(long Key, ByteEnum Int8);
 
+    public record PocoUnsignedByteEnum(long Key, UnsignedByteEnum Int8);
+
     public enum IntEnum : int
     {
         Foo = 1,
@@ -53,6 +55,12 @@ public static class PocoEnums
     }
 
     public enum ByteEnum : sbyte
+    {
+        Foo = 1,
+        Bar = 3
+    }
+
+    public enum UnsignedByteEnum : byte
     {
         Foo = 1,
         Bar = 3

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/PocoEnums.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/PocoEnums.cs
@@ -25,13 +25,7 @@ using System.Diagnostics.CodeAnalysis;
 [SuppressMessage("Microsoft.Naming", "CA1720:AvoidTypeNamesInParameters", Justification = "POCO mapping.")]
 [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Justification = "POCO mapping.")]
 [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "POCO mapping.")]
-public record PocoEnums(
-    long Key,
-    TestEnum? Str,
-    TestEnum Int8,
-    TestEnum Int16,
-    TestEnum Int32,
-    TestEnum Int64);
+public record PocoEnums(long Key, TestEnum Int32);
 
 [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:Elements should appear in the correct order", Justification = "Tests.")]
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Tests.")]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/PocoEnums.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/PocoEnums.cs
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests.Table;
+
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Test user object.
+/// </summary>
+[SuppressMessage("Microsoft.Naming", "CA1720:AvoidTypeNamesInParameters", Justification = "POCO mapping.")]
+[SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Justification = "POCO mapping.")]
+[SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "POCO mapping.")]
+public record PocoEnums(
+    long Key,
+    TestEnum? Str,
+    TestEnum Int8,
+    TestEnum Int16,
+    TestEnum Int32,
+    TestEnum Int64);
+
+[SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:Elements should appear in the correct order", Justification = "Tests.")]
+[SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Tests.")]
+public enum TestEnum
+{
+    None = 0,
+    Foo = 1,
+    BarBaz = 3
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/PocoEnums.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/PocoEnums.cs
@@ -36,7 +36,7 @@ public static class PocoEnums
 
     public record PocoUnsignedByteEnum(long Key, UnsignedByteEnum Int8);
 
-    public enum IntEnum : int
+    public enum IntEnum
     {
         Foo = 1,
         Bar = 3

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
@@ -25,6 +25,7 @@ namespace Apache.Ignite.Tests.Table
     using System.Threading.Tasks;
     using NodaTime;
     using NUnit.Framework;
+    using NUnit.Framework.Internal;
 
     /// <summary>
     /// Tests for POCO view.
@@ -737,23 +738,24 @@ namespace Apache.Ignite.Tests.Table
         [Test]
         public async Task TestNumericEnumMapping()
         {
-            var table = await Client.Tables.GetTableAsync(TableAllColumnsName);
-            var view = table!.GetRecordView<PocoEnums>();
+            // TODO: Test incompatible underlying types.
+            // TODO: Test integer values that are not in enum.
+            await Test(new PocoEnums.PocoIntEnum(1, PocoEnums.IntEnum.Foo));
+            await Test(new PocoEnums.PocoByteEnum(1, PocoEnums.ByteEnum.Foo));
+            await Test(new PocoEnums.PocoShortEnum(1, PocoEnums.ShortEnum.Foo));
+            await Test(new PocoEnums.PocoLongEnum(1, PocoEnums.LongEnum.Foo));
 
-            var poco = new PocoEnums(1, TestEnum.Foo);
-            await view.UpsertAsync(null, poco);
+            async Task Test<T>(T val)
+                where T : notnull
+            {
+                var table = await Client.Tables.GetTableAsync(TableAllColumnsName);
+                var view = table!.GetRecordView<T>();
 
-            var res = await view.GetAsync(null, poco);
-            Assert.AreEqual(poco, res.Value);
-        }
+                await view.UpsertAsync(null, val);
 
-        [Test]
-        public async Task TestStringEnumMapping()
-        {
-            var table = await Client.Tables.GetTableAsync(TableAllColumnsName);
-            var pocoView = table!.GetRecordView<PocoEnums>();
-
-            Assert.Fail("TODO");
+                var res = await view.GetAsync(null, val);
+                Assert.AreEqual(val, res.Value);
+            }
         }
 
         // ReSharper disable once NotAccessedPositionalProperty.Local

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
@@ -25,7 +25,6 @@ namespace Apache.Ignite.Tests.Table
     using System.Threading.Tasks;
     using NodaTime;
     using NUnit.Framework;
-    using NUnit.Framework.Internal;
 
     /// <summary>
     /// Tests for POCO view.

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
@@ -736,6 +736,12 @@ namespace Apache.Ignite.Tests.Table
             await Test(new PocoEnums.PocoShortEnum(1, (PocoEnums.ShortEnum)102));
             await Test(new PocoEnums.PocoLongEnum(1, (PocoEnums.LongEnum)103));
 
+            // Default values.
+            await Test(new PocoEnums.PocoIntEnum(1, default));
+            await Test(new PocoEnums.PocoByteEnum(1, default));
+            await Test(new PocoEnums.PocoShortEnum(1, default));
+            await Test(new PocoEnums.PocoLongEnum(1, default));
+
             async Task Test<T>(T val)
                 where T : notnull
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
@@ -740,7 +740,7 @@ namespace Apache.Ignite.Tests.Table
             var table = await Client.Tables.GetTableAsync(TableAllColumnsName);
             var view = table!.GetRecordView<PocoEnums>();
 
-            var poco = new PocoEnums(1, TestEnum.None, TestEnum.Foo, TestEnum.BarBaz, TestEnum.Foo, TestEnum.BarBaz);
+            var poco = new PocoEnums(1, TestEnum.Foo);
             await view.UpsertAsync(null, poco);
 
             var res = await view.GetAsync(null, poco);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
@@ -734,6 +734,28 @@ namespace Apache.Ignite.Tests.Table
                 ex!.Message);
         }
 
+        [Test]
+        public async Task TestNumericEnumMapping()
+        {
+            var table = await Client.Tables.GetTableAsync(TableAllColumnsName);
+            var view = table!.GetRecordView<PocoEnums>();
+
+            var poco = new PocoEnums(1, TestEnum.None, TestEnum.Foo, TestEnum.BarBaz, TestEnum.Foo, TestEnum.BarBaz);
+            await view.UpsertAsync(null, poco);
+
+            var res = await view.GetAsync(null, poco);
+            Assert.AreEqual(poco, res.Value);
+        }
+
+        [Test]
+        public async Task TestStringEnumMapping()
+        {
+            var table = await Client.Tables.GetTableAsync(TableAllColumnsName);
+            var pocoView = table!.GetRecordView<PocoEnums>();
+
+            Assert.Fail("TODO");
+        }
+
         // ReSharper disable once NotAccessedPositionalProperty.Local
         private record UnsupportedByteType(byte Int8);
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/BinaryTupleMethods.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/BinaryTupleMethods.cs
@@ -176,34 +176,36 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// <summary>
         /// Gets the write method.
         /// </summary>
-        /// <param name="valueType">Type of the value to write.</param>
+        /// <param name="type">Type of the value to write.</param>
         /// <returns>Write method for the specified value type.</returns>
-        public static MethodInfo GetWriteMethod(Type valueType) =>
-            WriteMethods.TryGetValue(valueType, out var method) ? method : throw GetUnsupportedTypeException(valueType);
+        public static MethodInfo GetWriteMethod(Type type) =>
+            WriteMethods.TryGetValue(Unwrap(type), out var method) ? method : throw GetUnsupportedTypeException(type);
 
         /// <summary>
         /// Gets the write method.
         /// </summary>
-        /// <param name="valueType">Type of the value to write.</param>
+        /// <param name="type">Type of the value to write.</param>
         /// <returns>Write method for the specified value type.</returns>
-        public static MethodInfo? GetWriteMethodOrNull(Type valueType) => WriteMethods.GetValueOrDefault(valueType);
+        public static MethodInfo? GetWriteMethodOrNull(Type type) => WriteMethods.GetValueOrDefault(Unwrap(type));
 
         /// <summary>
         /// Gets the read method.
         /// </summary>
-        /// <param name="valueType">Type of the value to read.</param>
+        /// <param name="type">Type of the value to read.</param>
         /// <returns>Read method for the specified value type.</returns>
-        public static MethodInfo GetReadMethod(Type valueType) =>
-            ReadMethods.TryGetValue(valueType, out var method) ? method : throw GetUnsupportedTypeException(valueType);
+        public static MethodInfo GetReadMethod(Type type) =>
+            ReadMethods.TryGetValue(Unwrap(type), out var method) ? method : throw GetUnsupportedTypeException(type);
 
         /// <summary>
         /// Gets the read method.
         /// </summary>
-        /// <param name="valueType">Type of the value to read.</param>
+        /// <param name="type">Type of the value to read.</param>
         /// <returns>Read method for the specified value type.</returns>
-        public static MethodInfo? GetReadMethodOrNull(Type valueType) => ReadMethods.GetValueOrDefault(valueType);
+        public static MethodInfo? GetReadMethodOrNull(Type type) => ReadMethods.GetValueOrDefault(Unwrap(type));
 
         private static IgniteClientException GetUnsupportedTypeException(Type valueType) =>
             new(ErrorGroups.Client.Configuration, "Unsupported type: " + valueType);
+
+        private static Type Unwrap(Type type) => type.IsEnum ? Enum.GetUnderlyingType(type) : type;
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/BinaryTupleMethods.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/BinaryTupleMethods.cs
@@ -206,6 +206,6 @@ namespace Apache.Ignite.Internal.Table.Serialization
         private static IgniteClientException GetUnsupportedTypeException(Type valueType) =>
             new(ErrorGroups.Client.Configuration, "Unsupported type: " + valueType);
 
-        private static Type Unwrap(Type type) => type.IsEnum ? Enum.GetUnderlyingType(type) : type;
+        private static Type Unwrap(Type type) => type.UnwrapEnum();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ILGeneratorExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ILGeneratorExtensions.cs
@@ -66,6 +66,11 @@ internal static class ILGeneratorExtensions
             return;
         }
 
+        if (to.IsEnum)
+        {
+            to = to.GetEnumUnderlyingType();
+        }
+
         if (!from.IsValueType || !to.IsValueType)
         {
             EmitConvertTo(il, from, to, columnName);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
@@ -502,7 +502,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
             var columnType = column.Type.ToType();
 
             var fieldType = Nullable.GetUnderlyingType(fieldInfo.FieldType) ?? fieldInfo.FieldType;
-            fieldType = fieldType.IsEnum ? Enum.GetUnderlyingType(fieldType) : fieldType;
+            fieldType = fieldType.UnwrapEnum();
 
             if (fieldType != columnType)
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
@@ -500,11 +500,13 @@ namespace Apache.Ignite.Internal.Table.Serialization
         private static void ValidateFieldType(FieldInfo fieldInfo, Column column)
         {
             var columnType = column.Type.ToType();
+
             var fieldType = Nullable.GetUnderlyingType(fieldInfo.FieldType) ?? fieldInfo.FieldType;
+            fieldType = fieldType.IsEnum ? Enum.GetUnderlyingType(fieldType) : fieldType;
 
             if (fieldType != columnType)
             {
-                var message = $"Can't map field '{fieldInfo.DeclaringType?.Name}.{fieldInfo.Name}' of type '{fieldType}' " +
+                var message = $"Can't map field '{fieldInfo.DeclaringType?.Name}.{fieldInfo.Name}' of type '{fieldInfo.FieldType}' " +
                               $"to column '{column.Name}' of type '{columnType}' - types do not match.";
 
                 throw new IgniteClientException(ErrorGroups.Client.Configuration, message);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
@@ -86,6 +86,13 @@ namespace Apache.Ignite.Internal.Table.Serialization
             type is { IsGenericType: true } && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>);
 
         /// <summary>
+        /// Gets the underlying enum type, if applicable. Otherwise, returns the type itself.
+        /// </summary>
+        /// <param name="type">Type to unwrap.</param>
+        /// <returns>Underlying type when enum; type itself otherwise.</returns>
+        public static Type UnwrapEnum(this Type type) => type.IsEnum ? Enum.GetUnderlyingType(type) : type;
+
+        /// <summary>
         /// Gets a map of fields by column name.
         /// </summary>
         /// <param name="type">Type to get the map for.</param>


### PR DESCRIPTION
* Map integer columns (int8, int16, int32, int64) to .NET enums.
* Includes support in `RecordView`, `KeyValueView`, and LINQ.