### PR TITLE
IGNITE-18555 .NET: Enable Gradle daemon in tests

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -124,7 +124,7 @@ namespace Apache.Ignite.Tests
         {
             var file = TestUtils.IsWindows ? "cmd.exe" : "/bin/bash";
             var opts = Environment.GetEnvironmentVariable(GradleOptsEnvVar);
-            var command = $"{GradlePath} {GradleCommandExec} " + opts;
+            var command = $"{GradlePath} {GradleCommandExec} {opts}";
 
             Log("Executing command: " + command);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -31,11 +31,13 @@ namespace Apache.Ignite.Tests
     /// </summary>
     public sealed class JavaServer : IDisposable
     {
+        private const string GradleOptsEnvVar = "IGNITE_DOTNET_GRADLE_OPTS";
+
         private const int DefaultClientPort = 10942;
 
         private const int ConnectTimeoutSeconds = 120;
 
-        private const string GradleCommandExec = ":ignite-runner:runnerPlatformTest --no-daemon"
+        private const string GradleCommandExec = ":ignite-runner:runnerPlatformTest"
           + " -x compileJava -x compileTestFixturesJava -x compileIntegrationTestJava -x compileTestJava --parallel";
 
          /** Full path to Gradle binary. */
@@ -121,6 +123,10 @@ namespace Apache.Ignite.Tests
         private static Process CreateProcess()
         {
             var file = TestUtils.IsWindows ? "cmd.exe" : "/bin/bash";
+            var opts = Environment.GetEnvironmentVariable(GradleOptsEnvVar);
+            var command = $"{GradlePath} {GradleCommandExec} " + opts;
+
+            Log("Executing command: " + command);
 
             var process = new Process
             {
@@ -130,7 +136,7 @@ namespace Apache.Ignite.Tests
                     ArgumentList =
                     {
                         TestUtils.IsWindows ? "/c" : "-c",
-                        $"{GradlePath} {GradleCommandExec}"
+                        command
                     },
                     CreateNoWindow = true,
                     UseShellExecute = false,
@@ -139,6 +145,7 @@ namespace Apache.Ignite.Tests
                     RedirectStandardError = true
                 }
             };
+
             return process;
         }
 


### PR DESCRIPTION
* `--no-daemon` removed to speed up local test execution
* `IGNITE_DOTNET_GRADLE_OPTS` env var added to TC to keep the existing behavior: https://ci.ignite.apache.org/admin/editBuildParams.html?id=buildType:ApacheIgnite3xGradle_Test_RunNetTests