### PR TITLE
IGNITE-18215 .NET: LINQ: Fix GroupBy with complex expression

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -260,7 +260,6 @@ public partial class LinqSqlGenerationTests
     }
 
     [Test]
-    [Ignore("IGNITE-18215 Group by calculated value")]
     public void TestGroupBySubQuery()
     {
         AssertSql(

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -263,7 +263,7 @@ public partial class LinqSqlGenerationTests
     public void TestGroupBySubQuery()
     {
         AssertSql(
-            "select (_T0.KEY + ?) as _G0, count (*)  from PUBLIC.tbl1 as _T0 group by G0",
+            "select (_T0.KEY + ?) as _G0, count(*) as COUNT from PUBLIC.tbl1 as _T0 group by (_G0)",
             q => q.Select(x => new { x.Key, Key2 = x.Key + 1 })
                 .GroupBy(x => x.Key2)
                 .Select(g => new { g.Key, Count = g.Count() })

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -263,7 +263,7 @@ public partial class LinqSqlGenerationTests
     public void TestGroupBySubQuery()
     {
         AssertSql(
-            "select (_T0.KEY + ?) as _G0, count(*) as COUNT from PUBLIC.tbl1 as _T0 group by (_G0)",
+            "select (_T0.KEY + ?) as _G0, count(*) as COUNT from PUBLIC.tbl1 as _T0 group by _G0",
             q => q.Select(x => new { x.Key, Key2 = x.Key + 1 })
                 .GroupBy(x => x.Key2)
                 .Select(g => new { g.Key, Count = g.Count() })

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -149,7 +149,7 @@ public partial class LinqSqlGenerationTests
         AssertSql(
             "select _T0.KEY, _T0.VAL, (_T0.KEY + ?) as KEY2 " +
             "from PUBLIC.tbl1 as _T0 " +
-            "order by ((_T0.KEY + ?)) asc, (_T0.VAL) desc " +
+            "order by (_T0.KEY + ?) asc, _T0.VAL desc " +
             "limit ? offset ?",
             q => q.Select(x => new { x.Key, x.Val, Key2 = x.Key + 1})
                 .OrderBy(x => x.Key2)
@@ -229,7 +229,7 @@ public partial class LinqSqlGenerationTests
     [Test]
     public void TestSelectOrderDistinct() =>
         AssertSql(
-            "select * from (select distinct _T0.KEY, (_T0.KEY + ?) as KEY2 from PUBLIC.tbl1 as _T0) as _T1 order by (_T1.KEY2) asc",
+            "select * from (select distinct _T0.KEY, (_T0.KEY + ?) as KEY2 from PUBLIC.tbl1 as _T0) as _T1 order by _T1.KEY2 asc",
             q => q.Select(x => new { x.Key, Key2 = x.Key + 1})
                 .Distinct()
                 .OrderBy(x => x.Key2)

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
@@ -151,10 +151,10 @@ public partial class LinqTests
         Assert.AreEqual(2, res[2].Max);
 
         StringAssert.Contains(
-            "select _T0.KEY, count(*) as COUNT, sum(_T0.KEY) as SUM, avg(_T0.KEY) as AVG, min(_T0.KEY) as MIN, max(_T0.KEY) as MAX " +
+            "select _T0.KEY as _G0, count(*) as COUNT, sum(_T0.KEY) as SUM, avg(_T0.KEY) as AVG, min(_T0.KEY) as MIN, max(_T0.KEY) as MAX " +
             "from PUBLIC.TBL_INT32 as _T0 " +
-            "group by (_T0.KEY) " +
-            "order by (_T0.KEY) asc",
+            "group by _G0 " +
+            "order by (_G0) asc",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Aggregate.cs
@@ -154,7 +154,7 @@ public partial class LinqTests
             "select _T0.KEY as _G0, count(*) as COUNT, sum(_T0.KEY) as SUM, avg(_T0.KEY) as AVG, min(_T0.KEY) as MIN, max(_T0.KEY) as MAX " +
             "from PUBLIC.TBL_INT32 as _T0 " +
             "group by _G0 " +
-            "order by (_G0) asc",
+            "order by _G0 asc",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
@@ -82,7 +82,7 @@ public partial class LinqTests
             "select _T0.KEY, _T0.VAL, _T1.VAL " +
             "from PUBLIC.TBL_FLOAT as _T0 " +
             "inner join PUBLIC.TBL_INT8 as _T1 on (cast(_T1.KEY as real) = _T0.KEY) " +
-            "order by (_T0.KEY) desc",
+            "order by _T0.KEY desc",
             query.ToString());
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
@@ -52,7 +52,7 @@ public partial class LinqTests
             "select cast(_T0.VAL as tinyint) as BYTE, cast(_T0.VAL as smallint) as SHORT, cast(_T0.VAL as bigint) as LONG, " +
             "(cast(_T0.VAL as real) / ?) as FLOAT, (cast(_T0.VAL as double) / ?) as DOUBLE " +
             "from PUBLIC.TBL_INT32 as _T0 " +
-            "order by (cast(_T0.VAL as bigint)) desc",
+            "order by cast(_T0.VAL as bigint) desc",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
@@ -91,7 +91,6 @@ public partial class LinqTests
     }
 
     [Test]
-    [Ignore("IGNITE-18215 Group by calculated value")]
     public void TestGroupBySubQuery()
     {
         var query = PocoByteView.AsQueryable()

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
@@ -110,8 +110,8 @@ public partial class LinqTests
         StringAssert.Contains(
             "select (cast(_T0.VAL as int) * ?) as _G0, count(*) as COUNT " +
             "from PUBLIC.TBL_INT8 as _T0 " +
-            "group by _G0 " +
-            "order by _G0 asc",
+            "group by (_G0) " +
+            "order by (_G0) asc",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
@@ -111,7 +111,7 @@ public partial class LinqTests
             "select (cast(_T0.VAL as int) * ?) as _G0, count(*) as COUNT " +
             "from PUBLIC.TBL_INT8 as _T0 " +
             "group by (_G0) " +
-            "order by (_G0) asc",
+            "order by _G0 asc",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
@@ -40,7 +40,7 @@ public partial class LinqTests
         Assert.AreEqual(new[] { 0, 1, 2, 3 }, res);
 
         StringAssert.Contains(
-            "select _T0.VAL as _G0" +
+            "select _T0.VAL as _G0 " +
             "from PUBLIC.TBL_INT8 as _T0 " +
             "group by _G0 " +
             "order by (_G0) asc",

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
@@ -110,8 +110,8 @@ public partial class LinqTests
         StringAssert.Contains(
             "select (cast(_T0.VAL as int) * ?) as _G0, count(*) as COUNT " +
             "from PUBLIC.TBL_INT8 as _T0 " +
-            "group by (_G0) " +
-            "order by (_G0) asc",
+            "group by _G0 " +
+            "order by _G0 asc",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
@@ -43,7 +43,7 @@ public partial class LinqTests
             "select _T0.VAL as _G0 " +
             "from PUBLIC.TBL_INT8 as _T0 " +
             "group by _G0 " +
-            "order by (_G0) asc",
+            "order by _G0 asc",
             query.ToString());
     }
 
@@ -64,7 +64,7 @@ public partial class LinqTests
             "select _T0.KEY " +
             "from PUBLIC.TBL_INT8 as _T0 " +
             "group by (_T0.VAL, _T0.KEY) " +
-            "order by (_T0.KEY) asc",
+            "order by _T0.KEY asc",
             query.ToString());
     }
 
@@ -86,7 +86,7 @@ public partial class LinqTests
             "select _T0.VAL, count(*) as COUNT, sum(cast(_T0.KEY as int)) as SUM, avg(cast(_T0.KEY as int)) as AVG " +
             "from PUBLIC.TBL_INT8 as _T0 " +
             "group by (_T0.VAL) " +
-            "order by (_T0.VAL) asc",
+            "order by _T0.VAL asc",
             query.ToString());
     }
 
@@ -111,7 +111,7 @@ public partial class LinqTests
             "select (cast(_T0.VAL as int) * ?) as _G0, count(*) as COUNT " +
             "from PUBLIC.TBL_INT8 as _T0 " +
             "group by _G0 " +
-            "order by (_G0) asc",
+            "order by _G0 asc",
             query.ToString());
     }
 
@@ -142,11 +142,11 @@ public partial class LinqTests
         Assert.AreEqual(10, res.Count);
 
         StringAssert.Contains(
-            "select _T0.VAL, count(*) as COUNT " +
+            "select _T0.VAL as _G0, count(*) as COUNT " +
             "from PUBLIC.TBL1 as _T1 " +
             "inner join PUBLIC.TBL_INT32 as _T0 on (cast(_T0.KEY as bigint) = _T1.KEY) " +
-            "group by (_T0.VAL) " +
-            "order by (_T0.VAL) asc",
+            "group by _G0 " +
+            "order by _G0 asc",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
@@ -83,10 +83,10 @@ public partial class LinqTests
         Assert.AreEqual(4.0d, res[1].Avg);
 
         StringAssert.Contains(
-            "select _T0.VAL, count(*) as COUNT, sum(cast(_T0.KEY as int)) as SUM, avg(cast(_T0.KEY as int)) as AVG " +
+            "select _T0.VAL as _G0, count(*) as COUNT, sum(cast(_T0.KEY as int)) as SUM, avg(cast(_T0.KEY as int)) as AVG " +
             "from PUBLIC.TBL_INT8 as _T0 " +
-            "group by (_T0.VAL) " +
-            "order by _T0.VAL asc",
+            "group by _G0 " +
+            "order by _G0 asc",
             query.ToString());
     }
 
@@ -181,11 +181,11 @@ public partial class LinqTests
         Assert.AreEqual(900, res[0].MaxPrice);
 
         StringAssert.Contains(
-            "select _T0.VAL, max(_T1.VAL) as MAXPRICE " +
+            "select _T0.VAL as _G0, max(_T1.VAL) as MAXPRICE " +
             "from PUBLIC.TBL1 as _T0 " +
             "inner join PUBLIC.TBL_INT32 as _T1 on (cast(_T1.KEY as bigint) = _T0.KEY) " +
-            "group by (_T0.VAL) " +
-            "order by (max(_T1.VAL)) desc",
+            "group by _G0 " +
+            "order by max(_T1.VAL) desc",
             query.ToString());
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
@@ -101,14 +101,17 @@ public partial class LinqTests
 
         var res = query.ToList();
 
-        Assert.AreEqual(1, res[1].Key);
+        Assert.AreEqual(10, res[1].Key);
         Assert.AreEqual(3, res[1].Count);
 
+        Assert.AreEqual(20, res[2].Key);
+        Assert.AreEqual(3, res[2].Count);
+
         StringAssert.Contains(
-            "select (_T0.VAL * ?) as _G0, count (*)  " +
+            "select (cast(_T0.VAL as int) * ?) as _G0, count(*) as COUNT " +
             "from PUBLIC.TBL_INT8 as _T0 " +
-            "group by _G0 " +
-            "order by _G0 asc",
+            "group by (_G0) " +
+            "order by (_G0) asc",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.GroupBy.cs
@@ -40,10 +40,10 @@ public partial class LinqTests
         Assert.AreEqual(new[] { 0, 1, 2, 3 }, res);
 
         StringAssert.Contains(
-            "select _T0.VAL " +
+            "select _T0.VAL as _G0" +
             "from PUBLIC.TBL_INT8 as _T0 " +
-            "group by (_T0.VAL) " +
-            "order by (_T0.VAL) asc",
+            "group by _G0 " +
+            "order by (_G0) asc",
             query.ToString());
     }
 
@@ -110,8 +110,8 @@ public partial class LinqTests
         StringAssert.Contains(
             "select (cast(_T0.VAL as int) * ?) as _G0, count(*) as COUNT " +
             "from PUBLIC.TBL_INT8 as _T0 " +
-            "group by (_G0) " +
-            "order by _G0 asc",
+            "group by _G0 " +
+            "order by (_G0) asc",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Join.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Join.cs
@@ -85,7 +85,7 @@ public partial class LinqTests
             "from PUBLIC.TBL1 as _T0 " +
             "inner join PUBLIC.TBL_INT32 as _T1 on (cast(_T1.KEY as bigint) = _T0.KEY) " +
             "where (_T0.KEY > ?) " +
-            "order by (_T0.KEY) asc " +
+            "order by _T0.KEY asc " +
             "limit ?",
             joinQuery.ToString());
     }
@@ -159,7 +159,7 @@ public partial class LinqTests
             "from PUBLIC.TBL1 as _T0 " +
             "inner join PUBLIC.TBL_INT32 as _T1 on (cast(_T1.KEY as bigint) = _T0.KEY) " +
             "where (_T1.KEY > ?) " +
-            "order by (_T1.KEY) asc",
+            "order by _T1.KEY asc",
             joinQuery.ToString());
     }
 
@@ -292,7 +292,7 @@ public partial class LinqTests
             "select _T0.KEY, _T1.KEY, _T1.VAL " +
             "from PUBLIC.TBL1 as _T0 " +
             "left outer join (select * from PUBLIC.TBL_STRING as _T2 ) as _T1 on (_T1.VAL = _T0.VAL) " +
-            "order by (_T0.KEY) asc",
+            "order by _T0.KEY asc",
             joinQuery.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.KvView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.KvView.cs
@@ -196,10 +196,10 @@ public partial class LinqTests
         Assert.AreEqual(2, res[2].Max);
 
         StringAssert.Contains(
-            "select _T0.KEY, count(*) as COUNT, sum(_T0.KEY) as SUM, avg(_T0.KEY) as AVG, min(_T0.KEY) as MIN, max(_T0.KEY) as MAX " +
+            "select _T0.KEY as _G0, count(*) as COUNT, sum(_T0.KEY) as SUM, avg(_T0.KEY) as AVG, min(_T0.KEY) as MIN, max(_T0.KEY) as MAX " +
             "from PUBLIC.TBL1 as _T0 " +
-            "group by (_T0.KEY) " +
-            "order by (_T0.KEY) asc",
+            "group by _G0 " +
+            "order by (_G0) asc",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.KvView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.KvView.cs
@@ -47,7 +47,7 @@ public partial class LinqTests
             "select _T0.KEY, _T0.VAL " +
             "from PUBLIC.TBL1 as _T0 " +
             "where ((_T0.KEY > ?) and (_T0.VAL IS DISTINCT FROM ?)) " +
-            "order by (_T0.KEY) asc",
+            "order by _T0.KEY asc",
             query.ToString());
     }
 
@@ -71,7 +71,7 @@ public partial class LinqTests
             "select _T0.KEY, _T0.VAL " +
             "from PUBLIC.TBL1 as _T0 " +
             "where ((_T0.KEY > ?) and (_T0.VAL IS DISTINCT FROM ?)) " +
-            "order by (_T0.KEY) asc",
+            "order by _T0.KEY asc",
             query.ToString());
     }
 
@@ -90,7 +90,7 @@ public partial class LinqTests
         StringAssert.Contains(
             "select _T0.KEY from PUBLIC.TBL1 as _T0 " +
             "where (_T0.KEY > ?) " +
-            "order by (_T0.KEY) asc",
+            "order by _T0.KEY asc",
             query.ToString());
     }
 
@@ -109,7 +109,7 @@ public partial class LinqTests
         StringAssert.Contains(
             "select _T0.VAL from PUBLIC.TBL1 as _T0 " +
             "where (_T0.VAL IS DISTINCT FROM ?) " +
-            "order by (_T0.VAL) asc",
+            "order by _T0.VAL asc",
             query.ToString());
     }
 
@@ -128,7 +128,7 @@ public partial class LinqTests
         StringAssert.Contains(
             "select _T0.VAL from PUBLIC.TBL1 as _T0 " +
             "where (_T0.VAL IS DISTINCT FROM ?) " +
-            "order by (_T0.VAL) asc",
+            "order by _T0.VAL asc",
             query.ToString());
     }
 
@@ -166,7 +166,7 @@ public partial class LinqTests
             "select _T0.KEY, _T0.VAL, _T1.KEY, _T1.VAL from PUBLIC.TBL1 as _T0 " +
             "inner join (select * from PUBLIC.TBL1 as _T2 where (_T2.KEY > ?) ) as _T1 on (_T1.KEY = _T0.KEY) " +
             "where (_T0.KEY > ?) " +
-            "order by (_T0.KEY) asc",
+            "order by _T0.KEY asc",
             query.ToString());
     }
 
@@ -199,7 +199,7 @@ public partial class LinqTests
             "select _T0.KEY as _G0, count(*) as COUNT, sum(_T0.KEY) as SUM, avg(_T0.KEY) as AVG, min(_T0.KEY) as MIN, max(_T0.KEY) as MAX " +
             "from PUBLIC.TBL1 as _T0 " +
             "group by _G0 " +
-            "order by (_G0) asc",
+            "order by _G0 asc",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.UnionIntersectExcept.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.UnionIntersectExcept.cs
@@ -68,7 +68,7 @@ public partial class LinqTests
             "select * from " +
             "(select _T0.KEY from PUBLIC.TBL_INT64 as _T0 where (_T0.KEY > ?) " +
             "union (select _T1.KEY from PUBLIC.TBL1 as _T1 where (_T1.KEY < ?))) as _T2 " +
-            "order by (_T2.KEY) asc",
+            "order by _T2.KEY asc",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -312,7 +312,7 @@ public partial class LinqTests : IgniteTestsBase
 
         StringAssert.Contains(
             "select _T0.KEY from PUBLIC.TBL1 as _T0 " +
-            "order by (_T0.KEY) desc " +
+            "order by _T0.KEY desc " +
             "limit ? offset ?",
             query.ToString());
     }
@@ -355,7 +355,7 @@ public partial class LinqTests : IgniteTestsBase
             "select _T0.KEY from (" +
             "select _T1.KEY, _T1.VAL " +
             "from PUBLIC.TBL1 as _T1 " +
-            "order by (_T1.KEY) desc " +
+            "order by _T1.KEY desc " +
             "limit ? offset ?) as _T0",
             query.ToString());
     }
@@ -379,7 +379,7 @@ public partial class LinqTests : IgniteTestsBase
             "select _T0.DECIMAL, _T0.DOUBLE " +
             "from PUBLIC.TBL_ALL_COLUMNS_SQL as _T0 " +
             "where (_T0.KEY < ?) " +
-            "order by (_T0.KEY) asc, (_T0.INT8) desc, (_T0.INT16) asc",
+            "order by _T0.KEY asc, _T0.INT8 desc, _T0.INT16 asc",
             query.ToString());
     }
 
@@ -461,7 +461,7 @@ public partial class LinqTests : IgniteTestsBase
         StringAssert.Contains(
             "select distinct (cast(_T0.VAL as int) + ?) as ID, _T0.VAL " +
             "from PUBLIC.TBL_INT8 as _T0 " +
-            "order by (_T0.VAL) desc",
+            "order by _T0.VAL desc",
             query.ToString());
     }
 
@@ -481,7 +481,7 @@ public partial class LinqTests : IgniteTestsBase
         StringAssert.Contains(
             "select * from " +
             "(select distinct (cast(_T0.VAL as int) + ?) as ID, _T0.VAL from PUBLIC.TBL_INT8 as _T0) as _T1 " +
-            "order by (_T1.ID) desc",
+            "order by _T1.ID desc",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -274,7 +274,7 @@ public partial class LinqTests : IgniteTestsBase
 
         StringAssert.Contains(
             "select _T0.KEY from PUBLIC.TBL1 as _T0 " +
-            "order by (_T0.KEY) asc " +
+            "order by _T0.KEY asc " +
             "offset ?",
             query.ToString());
     }
@@ -292,7 +292,7 @@ public partial class LinqTests : IgniteTestsBase
 
         StringAssert.Contains(
             "select _T0.KEY, _T0.VAL from PUBLIC.TBL1 as _T0 " +
-            "order by (_T0.KEY) asc " +
+            "order by _T0.KEY asc " +
             "limit ?",
             query.ToString());
     }
@@ -332,7 +332,7 @@ public partial class LinqTests : IgniteTestsBase
 
         StringAssert.Contains(
             "select _T0.KEY from PUBLIC.TBL1 as _T0 " +
-            "order by (_T0.KEY) desc " +
+            "order by _T0.KEY desc " +
             "limit ? offset ?",
             query.ToString());
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -361,6 +361,29 @@ public partial class LinqTests : IgniteTestsBase
     }
 
     [Test]
+    public void TestOrderByMultiple()
+    {
+        var query = PocoAllColumnsSqlView.AsQueryable()
+            .Where(x => x.Key < 10)
+            .OrderBy(x => x.Key)
+            .ThenByDescending(x => x.Int8)
+            .ThenBy(x => x.Int16)
+            .Select(x => new { x.Decimal, x.Double });
+
+        var res = query.ToList();
+
+        Assert.AreEqual(6.5d, res[0].Double);
+        Assert.AreEqual(7.7m, res[0].Decimal);
+
+        StringAssert.Contains(
+            "select _T0.DECIMAL, _T0.DOUBLE " +
+            "from PUBLIC.TBL_ALL_COLUMNS_SQL as _T0 " +
+            "where (_T0.KEY < ?) " +
+            "order by (_T0.KEY) asc, (_T0.INT8) desc, (_T0.INT16) asc",
+            query.ToString());
+    }
+
+    [Test]
     public void TestContains()
     {
         var keys = new long[] { 4, 2 };

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/AliasDictionary.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/AliasDictionary.cs
@@ -25,6 +25,7 @@ using System.Linq.Expressions;
 using System.Text;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ResultOperators;
 
 /// <summary>
 /// Alias dictionary.
@@ -36,7 +37,7 @@ internal sealed class AliasDictionary
     private readonly Dictionary<Expression, string> _fieldAliases = new();
 
     /** */
-    private readonly Dictionary<Expression, string> _groupByAliases = new();
+    private readonly Dictionary<GroupResultOperator, string> _groupByAliases = new();
 
     /** */
     private readonly Stack<Dictionary<IQuerySource, string>> _stack = new();
@@ -108,20 +109,20 @@ internal sealed class AliasDictionary
     }
 
     /// <summary>
-    /// Gets the GROUP BY member alias.
+    /// Gets or creates the GROUP BY member alias.
     /// </summary>
-    /// <param name="expression">Expression.</param>
+    /// <param name="op">Group operator.</param>
     /// <returns>Alias.</returns>
-    public (string Alias, bool Created) GetOrCreateGroupByMemberAlias(Expression expression)
+    public (string Alias, bool Created) GetOrCreateGroupByMemberAlias(GroupResultOperator op)
     {
-        if (_groupByAliases.TryGetValue(expression, out var alias))
+        if (_groupByAliases.TryGetValue(op, out var alias))
         {
             return (alias, false);
         }
 
         alias = "_G" + _groupByAliases.Count;
 
-        _groupByAliases[expression] = alias;
+        _groupByAliases[op] = alias;
 
         return (alias, true);
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/AliasDictionary.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/AliasDictionary.cs
@@ -36,6 +36,9 @@ internal sealed class AliasDictionary
     private readonly Dictionary<Expression, string> _fieldAliases = new();
 
     /** */
+    private readonly Dictionary<Expression, string> _groupByAliases = new();
+
+    /** */
     private readonly Stack<Dictionary<IQuerySource, string>> _stack = new();
 
     /** */
@@ -102,6 +105,25 @@ internal sealed class AliasDictionary
         var referenceExpression = ExpressionWalker.GetQuerySourceReference(expression)!;
 
         return GetFieldAlias(referenceExpression);
+    }
+
+    /// <summary>
+    /// Gets the GROUP BY member alias.
+    /// </summary>
+    /// <param name="expression">Expression.</param>
+    /// <returns>Alias.</returns>
+    public (string Alias, bool Created) GetOrCreateGroupByMemberAlias(Expression expression)
+    {
+        if (_groupByAliases.TryGetValue(expression, out var alias))
+        {
+            return (alias, false);
+        }
+
+        alias = "_G" + _groupByAliases.Count;
+
+        _groupByAliases[expression] = alias;
+
+        return (alias, true);
     }
 
     /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -677,8 +677,7 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
             return false;
         }
 
-        // TODO: use grpBy as key?
-        var (alias, aliasCreated) = Aliases.GetOrCreateGroupByMemberAlias(grpBy.KeySelector);
+        var (alias, aliasCreated) = Aliases.GetOrCreateGroupByMemberAlias(grpBy);
 
         if (aliasCreated)
         {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -677,7 +677,18 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
             return false;
         }
 
-        Visit(grpBy.KeySelector);
+        // TODO: use grpBy as key?
+        var (alias, aliasCreated) = Aliases.GetOrCreateGroupByMemberAlias(grpBy.KeySelector);
+
+        if (aliasCreated)
+        {
+            Visit(grpBy.KeySelector);
+            ResultBuilder.Append(" as ").Append(alias);
+        }
+        else
+        {
+            ResultBuilder.Append(alias);
+        }
 
         return true;
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -110,6 +110,7 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
                 _builder.Append(", ");
             }
 
+            // TODO: Remove unnecessary parenthesis.
             _builder.Append('(');
 
             BuildSqlExpression(ordering.Expression);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -110,12 +110,7 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
                 _builder.Append(", ");
             }
 
-            // TODO: Remove unnecessary parenthesis.
-            _builder.Append('(');
-
             BuildSqlExpression(ordering.Expression);
-
-            _builder.TrimEnd().Append(')');
 
             _builder.Append(ordering.OrderingDirection == OrderingDirection.Asc ? " asc" : " desc");
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -566,6 +566,7 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
         }
         else
         {
+            // This GroupBy member was processed before (it is a part of SELECT or something else), use alias.
             _builder.Append(alias);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -112,7 +112,7 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
 
             BuildSqlExpression(ordering.Expression);
 
-            _builder.Append(ordering.OrderingDirection == OrderingDirection.Asc ? " asc" : " desc");
+            _builder.AppendWithSpace(ordering.OrderingDirection == OrderingDirection.Asc ? "asc" : "desc");
         }
 
         _builder.Append(' ');

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -552,21 +552,24 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
         }
 
         // Append grouping
-        _builder.Append("group by (");
+        _builder.Append("group by ");
 
         var (alias, aliasCreated) = Aliases.GetOrCreateGroupByMemberAlias(groupBy);
 
         if (aliasCreated)
         {
+            // This GroupBy member was not processed before, build full SQL expression.
+            // Do not append "AS alias" here, because we are inside GROUP BY clause already.
+            _builder.Append('(');
             BuildSqlExpression(groupBy.KeySelector);
-            _builder.Append(" as ").Append(alias);
+            _builder.Append(')');
         }
         else
         {
             _builder.Append(alias);
         }
 
-        _builder.Append(") ");
+        _builder.Append(' ');
 
         return true;
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryModelVisitor.cs
@@ -554,7 +554,17 @@ internal sealed class IgniteQueryModelVisitor : QueryModelVisitorBase
         // Append grouping
         _builder.Append("group by (");
 
-        BuildSqlExpression(groupBy.KeySelector);
+        var (alias, aliasCreated) = Aliases.GetOrCreateGroupByMemberAlias(groupBy);
+
+        if (aliasCreated)
+        {
+            BuildSqlExpression(groupBy.KeySelector);
+            _builder.Append(" as ").Append(alias);
+        }
+        else
+        {
+            _builder.Append(alias);
+        }
 
         _builder.Append(") ");
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/Sql.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/Sql.cs
@@ -137,6 +137,17 @@ namespace Apache.Ignite.Internal.Sql
                     "Invalid query, check inner exceptions for details: " + statement.Query,
                     e);
             }
+#if DEBUG
+            catch (IgniteException e)
+            {
+                if ((e.InnerException?.Message ?? e.Message).StartsWith("org.apache.calcite.", StringComparison.Ordinal))
+                {
+                    Console.WriteLine("SQL parsing failed: " + statement.Query);
+                }
+
+                throw;
+            }
+#endif
 
             PooledArrayBuffer Write()
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/Sql.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/Sql.cs
@@ -140,6 +140,8 @@ namespace Apache.Ignite.Internal.Sql
 #if DEBUG
             catch (IgniteException e)
             {
+                // TODO IGNITE-14865 Calcite error handling rework
+                // This should not happen, all parsing errors must be wrapped in SqlException.
                 if ((e.InnerException?.Message ?? e.Message).StartsWith("org.apache.calcite.", StringComparison.Ordinal))
                 {
                     Console.WriteLine("SQL parsing failed: " + statement.Query);

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -155,6 +155,8 @@ public class PlatformTestNodeRunner {
         System.out.println("THIN_CLIENT_PORTS=" + ports);
 
         long runTimeMinutes = getRunTimeMinutes();
+        System.out.println("Nodes will be active for " + runTimeMinutes + " minutes.");
+
         Thread.sleep(runTimeMinutes * 60_000);
         System.out.println("Exiting after " + runTimeMinutes + " minutes.");
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -290,8 +290,7 @@ public class PlatformTestNodeRunner {
 
         try {
             return Long.parseLong(runTimeMinutesFromEnv);
-        }
-        catch (Exception ignored) {
+        } catch (Exception ignored) {
             // No-op.
         }
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -57,6 +57,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Helper class for non-Java platform tests (.NET, C++, Python, ...). Starts nodes, populates tables and data for tests.
  */
+@SuppressWarnings("CallToSystemGetenv")
 public class PlatformTestNodeRunner {
     /** Test node name. */
     private static final String NODE_NAME = PlatformTestNodeRunner.class.getCanonicalName();
@@ -74,6 +75,9 @@ public class PlatformTestNodeRunner {
 
     /** Time to keep the node alive. */
     private static final int RUN_TIME_MINUTES = 30;
+
+    /** Time to keep the node alive - env var. */
+    private static final String RUN_TIME_MINUTES_ENV = "IGNITE_PLATFORM_TEST_NODE_RUNNER_RUN_TIME_MINUTES";
 
     /** Nodes bootstrap configuration. */
     private static final Map<String, String> nodesBootstrapCfg = Map.of(
@@ -150,9 +154,9 @@ public class PlatformTestNodeRunner {
 
         System.out.println("THIN_CLIENT_PORTS=" + ports);
 
-        Thread.sleep(RUN_TIME_MINUTES * 60_000);
-
-        System.out.println("Exiting after " + RUN_TIME_MINUTES + " minutes.");
+        long runTimeMinutes = getRunTimeMinutes();
+        Thread.sleep(runTimeMinutes * 60_000);
+        System.out.println("Exiting after " + runTimeMinutes + " minutes.");
 
         for (Ignite node : startedNodes) {
             IgnitionManager.stop(node.name());
@@ -268,6 +272,28 @@ public class PlatformTestNodeRunner {
      */
     private static int getPort(IgniteImpl node) {
         return node.clientAddress().port();
+    }
+
+    /**
+     * Gets run time limit, in minutes.
+     *
+     * @return Node run time limit, in minutes.
+     */
+    private static long getRunTimeMinutes() {
+        String runTimeMinutesFromEnv = System.getenv(RUN_TIME_MINUTES_ENV);
+
+        if (runTimeMinutesFromEnv == null) {
+            return RUN_TIME_MINUTES;
+        }
+
+        try {
+            return Long.parseLong(runTimeMinutesFromEnv);
+        }
+        catch (Exception ignored) {
+            // No-op.
+        }
+
+        return RUN_TIME_MINUTES;
     }
 
     /**


### PR DESCRIPTION
* When a complex expression (as opposed to a simple column name) is used in `GroupBy`, emit an alias to fix `Expression '_T0.VAL' is not being grouped` SQL parser error.

Extra:
* Remove redundant parenthesis in emitted SQL `ORDER BY`
* Add `TestOrderByMultiple`
* Make `PlatformTestNodeRunner` run time configurable through env var