### PR TITLE
IGNITE-18626 .NET: Fix nullable result handling in LINQ

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Buffers/ByteArrayPoolTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Buffers/ByteArrayPoolTests.cs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#if DEBUG
 namespace Apache.Ignite.Tests.Buffers
 {
     using System;
@@ -37,3 +38,4 @@ namespace Apache.Ignite.Tests.Buffers
         }
     }
 }
+#endif

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/ResultSelector.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/ResultSelector.cs
@@ -245,7 +245,7 @@ internal static class ResultSelector
                         // Create nullable with default non-zero value.
                         var local = il.DeclareLocal(underlyingType);
                         il.Emit(OpCodes.Ldloca_S, local);
-                        il.Emit(OpCodes.Initobj, targetType); // Load default value into local.
+                        il.Emit(OpCodes.Initobj, underlyingType); // Load default value into local.
                         il.Emit(OpCodes.Ldloc, local); // Load local value onto stack for constructor call.
                         il.Emit(OpCodes.Newobj, targetType.GetConstructor(new[] { underlyingType })!);
                     }


### PR DESCRIPTION
Fix `System.AccessViolationException` when reading nullable value types in LINQ.

No new tests: existing tests cover the use case, but the bug could only be reproduced in Release mode on Linux, or in any mode without a debugger on Windows.

Release mode test run step added to TC: https://ci.ignite.apache.org/buildConfiguration/ApacheIgnite3xGradle_Test_RunNetTests?branch=pull%2F1477&buildTypeTab=overview&mode=builds