### PR TITLE
IGNITE-18627 .NET: Fix empty result set handling in IgniteDbDataReader

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/IgniteDbDataReaderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/IgniteDbDataReaderTests.cs
@@ -661,6 +661,7 @@ public class IgniteDbDataReaderTests : IgniteTestsBase
 
         Assert.IsFalse(readRes);
         Assert.AreEqual(14, reader.FieldCount);
+        Assert.IsFalse(reader.HasRows);
     }
 
     private async Task<IgniteDbDataReader> ExecuteReader()

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/IgniteDbDataReaderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/IgniteDbDataReaderTests.cs
@@ -555,12 +555,13 @@ public class IgniteDbDataReaderTests : IgniteTestsBase
     }
 
     [Test]
+    [SuppressMessage("Performance", "CA1849:Call async methods when in an async method", Justification = "Testing sync method.")]
     public async Task TestNextResult()
     {
         await using var reader = await ExecuteReader();
 
-        Assert.Throws<NotSupportedException>(() => reader.NextResult());
-        Assert.ThrowsAsync<NotSupportedException>(() => reader.NextResultAsync());
+        Assert.IsFalse(reader.NextResult());
+        Assert.IsFalse(await reader.NextResultAsync());
     }
 
     [Test]
@@ -641,7 +642,7 @@ public class IgniteDbDataReaderTests : IgniteTestsBase
         dt.Load(reader);
 
         Assert.AreEqual(14, dt.Columns.Count);
-        Assert.AreEqual(9, dt.Rows.Count);
+        Assert.AreEqual(0, dt.Rows.Count);
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/IgniteDbDataReaderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/IgniteDbDataReaderTests.cs
@@ -637,7 +637,6 @@ public class IgniteDbDataReaderTests : IgniteTestsBase
     {
         await using var reader = await Client.Sql.ExecuteReaderAsync(null, "SELECT * FROM TBL_ALL_COLUMNS_SQL WHERE KEY > 100");
 
-        // This calls GetSchemaTable underneath.
         var dt = new DataTable();
         dt.Load(reader);
 
@@ -661,6 +660,7 @@ public class IgniteDbDataReaderTests : IgniteTestsBase
         bool readRes = await reader.ReadAsync();
 
         Assert.IsFalse(readRes);
+        Assert.AreEqual(14, reader.FieldCount);
     }
 
     private async Task<IgniteDbDataReader> ExecuteReader()

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/IgniteDbDataReaderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/IgniteDbDataReaderTests.cs
@@ -49,7 +49,8 @@ public class IgniteDbDataReaderTests : IgniteTestsBase
     [OneTimeSetUp]
     public async Task InsertTestData()
     {
-        await Client.Sql.ExecuteAsync(null, "delete from TBL_ALL_COLUMNS_SQL");
+        await Client.Sql.ExecuteAsync(null, $"delete from {TableAllColumnsSqlName}");
+        await Client.Sql.ExecuteAsync(null, $"delete from {TableName}");
 
         var pocoAllColumns1 = new PocoAllColumnsSqlNullable(
             Key: 1,

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSet.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSet.cs
@@ -78,6 +78,7 @@ namespace Apache.Ignite.Internal.Sql
             if (HasRowSet)
             {
                 _buffer = buf.Slice(reader.Consumed);
+                HasRows = reader.ReadArrayHeader() > 0;
             }
             else
             {
@@ -111,6 +112,11 @@ namespace Apache.Ignite.Internal.Sql
         /// Gets a value indicating whether this instance is disposed.
         /// </summary>
         internal bool IsDisposed => (_resourceId == null || _resourceClosed) && _bufferReleased > 0;
+
+        /// <summary>
+        /// Gets a value indicating whether this result set has any rows in it.
+        /// </summary>
+        internal bool HasRows { get; }
 
         /// <inheritdoc/>
         public async ValueTask<List<T>> ToListAsync() =>

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbDataReader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbDataReader.cs
@@ -77,7 +77,7 @@ public sealed class IgniteDbDataReader : DbDataReader, IDbColumnSchemaGenerator
     public override int RecordsAffected => checked((int)_resultSet.AffectedRows);
 
     /// <inheritdoc/>
-    public override bool HasRows => _resultSet.HasRowSet;
+    public override bool HasRows => _resultSet.HasRows;
 
     /// <inheritdoc/>
     public override bool IsClosed => _resultSet.IsDisposed;


### PR DESCRIPTION
* Fix `IndexOutOfRangeException` when reading empty result set
* Fix `HasRows` to return false for empty result set
* Fix `NextResult` to return false instead of throwing exception