### PR TITLE
IGNITE-18614 .NET: Fix test data cleanup

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -61,7 +61,13 @@ public partial class LinqTests : IgniteTestsBase
     [OneTimeSetUp]
     public async Task InsertData()
     {
-        foreach (var tableName in new[] { TableName, TableDateTimeName, TableDoubleName, TableFloatName, TableDecimalName })
+        var tableNames = new[]
+        {
+            TableName, TableDateTimeName, TableDoubleName, TableFloatName, TableDecimalName, TableInt8Name,
+            TableInt16Name, TableInt32Name, TableInt64Name
+        };
+
+        foreach (var tableName in tableNames)
         {
             await Client.Sql.ExecuteAsync(null, "delete from " + tableName);
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -61,6 +61,11 @@ public partial class LinqTests : IgniteTestsBase
     [OneTimeSetUp]
     public async Task InsertData()
     {
+        foreach (var tableName in new[] { TableName, TableDateTimeName, TableDoubleName, TableFloatName, TableDecimalName })
+        {
+            await Client.Sql.ExecuteAsync(null, "delete from " + tableName);
+        }
+
         PocoByteView = (await Client.Tables.GetTableAsync(TableInt8Name))!.GetRecordView<PocoByte>();
         PocoShortView = (await Client.Tables.GetTableAsync(TableInt16Name))!.GetRecordView<PocoShort>();
         PocoIntView = (await Client.Tables.GetTableAsync(TableInt32Name))!.GetRecordView<PocoInt>();


### PR DESCRIPTION
Clean up existing table data to ensure that the same test node can be reused for multiple test runs.