### PR TITLE
IGNITE-18618 .NET: Increase default SocketTimeout to 30 seconds

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
@@ -96,7 +96,7 @@ namespace Apache.Ignite
         /// <para />
         /// -1 means infinite timeout.
         /// </summary>
-        [DefaultValue(typeof(TimeSpan), "00:00:05")]
+        [DefaultValue(typeof(TimeSpan), "00:00:30")]
         public TimeSpan SocketTimeout { get; set; } = DefaultSocketTimeout;
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
@@ -37,7 +37,7 @@ namespace Apache.Ignite
         /// <summary>
         /// Default socket timeout.
         /// </summary>
-        public static readonly TimeSpan DefaultSocketTimeout = TimeSpan.FromSeconds(5);
+        public static readonly TimeSpan DefaultSocketTimeout = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// Default heartbeat interval.


### PR DESCRIPTION
5 seconds was way too small, no matter test or prod.

`SocketTimeout` applies to initial handshake and to heartbeat messages. Connection is closed if a handshake or heartbeat response was not received within the specified time.