### PR TITLE
IGNITE-18650 Fix NullPointerException in TableManager.assignments

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
@@ -20,12 +20,18 @@ package org.apache.ignite.internal.runner.app.client;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.client.IgniteClientConnectionException;
 import org.apache.ignite.internal.testframework.WorkDirectoryExtension;
+import org.apache.ignite.lang.ErrorGroups;
+import org.apache.ignite.lang.ErrorGroups.Client;
+import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.network.ClusterNode;
+import org.apache.ignite.sql.Session;
 import org.apache.ignite.table.RecordView;
 import org.apache.ignite.table.Table;
 import org.apache.ignite.table.Tuple;
@@ -71,5 +77,18 @@ public class ItThinClientConnectionTest extends ItAbstractThinClientTest {
                 assertThat(nodes.get(0).name(), startsWith("itcct_n_"));
             }
         }
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    void testAccessDroppedTableThrowsTableDoesNotExistsError() {
+        Session session = client().sql().createSession();
+        session.execute(null, "CREATE TABLE IF NOT EXISTS DELME (key INTEGER PRIMARY KEY)");
+
+        var table = client().tables().table("DELME");
+        session.execute(null, "DROP TABLE DELME");
+
+        IgniteException ex = assertThrows(IgniteException.class, () -> table.recordView(Integer.class).delete(null, 1));
+        assertEquals(Client.TABLE_ID_NOT_FOUND_ERR, ex.code());
     }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
@@ -25,9 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.apache.ignite.client.IgniteClient;
-import org.apache.ignite.client.IgniteClientConnectionException;
 import org.apache.ignite.internal.testframework.WorkDirectoryExtension;
-import org.apache.ignite.lang.ErrorGroups;
 import org.apache.ignite.lang.ErrorGroups.Client;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.network.ClusterNode;

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
@@ -87,6 +87,6 @@ public class ItThinClientConnectionTest extends ItAbstractThinClientTest {
         session.execute(null, "DROP TABLE DELME");
 
         IgniteException ex = assertThrows(IgniteException.class, () -> table.recordView(Integer.class).delete(null, 1));
-        assertEquals(Client.TABLE_ID_NOT_FOUND_ERR, ex.code());
+        assertEquals(Client.TABLE_ID_NOT_FOUND_ERR, ex.code(), ex.getMessage());
     }
 }

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/IgniteTablesInternal.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/IgniteTablesInternal.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.lang.NodeStoppingException;
 import org.apache.ignite.table.manager.IgniteTables;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Internal tables facade provides low-level methods for table operations.
@@ -86,6 +87,7 @@ public interface IgniteTablesInternal extends IgniteTables {
      * @param tableId Unique id of a table.
      * @return List of the current assignments.
      */
+    @Nullable
     List<String> assignments(UUID tableId) throws NodeStoppingException;
 
     /**

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
@@ -1049,7 +1049,13 @@ public class TableManager extends Producer<TableEvent, TableEventParameters> imp
             throw new NodeStoppingException();
         }
         try {
-            return table(tableId).internalTable().assignments();
+            TableImpl table = table(tableId);
+
+            if (table == null) {
+                return null;
+            }
+
+            return table.internalTable().assignments();
         } finally {
             busyLock.leaveBusy();
         }


### PR DESCRIPTION
Fix NullPointerException when assignments are requested for a table that no longer exists.