### PR TITLE
IGNITE-18609 .NET: Add ContainsKey method to Record API

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
@@ -584,5 +584,18 @@ namespace Apache.Ignite.Tests.Table
             Assert.AreEqual(tuple["Time"], res["Time"]);
             Assert.AreEqual(tuple["DateTime"], res["DateTime"]);
         }
+
+        [Test]
+        public async Task TestContainsKey()
+        {
+            var keyTuple = GetTuple(1);
+            var tuple = GetTuple(1, "foo");
+
+            await TupleView.UpsertAsync(null, tuple);
+
+            Assert.IsTrue(await TupleView.ContainsKeyAsync(null, keyTuple));
+            Assert.IsTrue(await TupleView.ContainsKeyAsync(null, tuple));
+            Assert.IsFalse(await TupleView.ContainsKeyAsync(null, GetTuple(-128)));
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
@@ -782,6 +782,19 @@ namespace Apache.Ignite.Tests.Table
                 ex!.Message);
         }
 
+        [Test]
+        public async Task TestContainsKey()
+        {
+            var keyPoco = GetPoco(1);
+            var poco = GetPoco(1, "foo");
+
+            await PocoView.UpsertAsync(null, poco);
+
+            Assert.IsTrue(await PocoView.ContainsKeyAsync(null, keyPoco));
+            Assert.IsTrue(await PocoView.ContainsKeyAsync(null, poco));
+            Assert.IsFalse(await PocoView.ContainsKeyAsync(null, GetPoco(-128)));
+        }
+
         // ReSharper disable once NotAccessedPositionalProperty.Local
         private record UnsupportedByteType(byte Int8);
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
@@ -18,7 +18,6 @@
 namespace Apache.Ignite.Tests.Transactions
 {
     using System;
-    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Threading.Tasks;
     using System.Transactions;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
@@ -72,7 +72,7 @@ internal sealed class KeyValueView<TK, TV> : IKeyValueView<TK, TV>
 
     /// <inheritdoc/>
     public async Task<bool> ContainsAsync(ITransaction? transaction, TK key) =>
-        await _recordView.ContainsKey(transaction, ToKv(key)).ConfigureAwait(false);
+        await _recordView.ContainsAsync(transaction, ToKv(key)).ConfigureAwait(false);
 
     /// <inheritdoc/>
     public async Task PutAsync(ITransaction? transaction, TK key, TV val) =>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
@@ -72,7 +72,7 @@ internal sealed class KeyValueView<TK, TV> : IKeyValueView<TK, TV>
 
     /// <inheritdoc/>
     public async Task<bool> ContainsAsync(ITransaction? transaction, TK key) =>
-        await _recordView.ContainsAsync(transaction, ToKv(key)).ConfigureAwait(false);
+        await _recordView.ContainsKeyAsync(transaction, ToKv(key)).ConfigureAwait(false);
 
     /// <inheritdoc/>
     public async Task PutAsync(ITransaction? transaction, TK key, TV val) =>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -105,7 +105,7 @@ namespace Apache.Ignite.Internal.Table
         }
 
         /// <inheritdoc/>
-        public async Task<bool> ContainsAsync(ITransaction? transaction, T key)
+        public async Task<bool> ContainsKeyAsync(ITransaction? transaction, T key)
         {
             IgniteArgumentCheck.NotNull(key, nameof(key));
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -77,6 +77,23 @@ namespace Apache.Ignite.Internal.Table
         public Sql Sql => _sql;
 
         /// <inheritdoc/>
+        public IQueryable<T> AsQueryable(ITransaction? transaction = null, QueryableOptions? options = null)
+        {
+            var executor = new IgniteQueryExecutor(_sql, transaction, options);
+            var provider = new IgniteQueryProvider(IgniteQueryParser.Instance, executor, _table.Name);
+
+            if (typeof(T).IsKeyValuePair())
+            {
+                throw new NotSupportedException(
+                    $"Can't use {typeof(KeyValuePair<,>)} for LINQ queries: " +
+                    $"it is reserved for {typeof(IKeyValueView<,>)}.{nameof(IKeyValueView<int, int>.AsQueryable)}. " +
+                    "Use a custom type instead.");
+            }
+
+            return new IgniteQueryable<T>(provider);
+        }
+
+        /// <inheritdoc/>
         public async Task<Option<T>> GetAsync(ITransaction? transaction, T key)
         {
             IgniteArgumentCheck.NotNull(key, nameof(key));
@@ -85,6 +102,23 @@ namespace Apache.Ignite.Internal.Table
             var resSchema = await _table.ReadSchemaAsync(resBuf).ConfigureAwait(false);
 
             return _ser.ReadValue(resBuf, resSchema, key);
+        }
+
+        /// <summary>
+        /// Determines if the table contains an entry for the specified key.
+        /// </summary>
+        /// <param name="transaction">Transaction.</param>
+        /// <param name="key">Key.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// The task result contains a value indicating whether a record with the specified key exists in the table.
+        /// </returns>
+        public async Task<bool> ContainsAsync(ITransaction? transaction, T key)
+        {
+            IgniteArgumentCheck.NotNull(key, nameof(key));
+
+            using var resBuf = await DoRecordOutOpAsync(ClientOp.TupleContainsKey, transaction, key, keyOnly: true).ConfigureAwait(false);
+            return resBuf.GetReader().ReadBoolean();
         }
 
         /// <inheritdoc/>
@@ -297,23 +331,6 @@ namespace Apache.Ignite.Internal.Table
         public async Task<IList<T>> DeleteAllExactAsync(ITransaction? transaction, IEnumerable<T> records) =>
             await DeleteAllAsync(transaction, records, exact: true).ConfigureAwait(false);
 
-        /// <inheritdoc/>
-        public IQueryable<T> AsQueryable(ITransaction? transaction = null, QueryableOptions? options = null)
-        {
-            var executor = new IgniteQueryExecutor(_sql, transaction, options);
-            var provider = new IgniteQueryProvider(IgniteQueryParser.Instance, executor, _table.Name);
-
-            if (typeof(T).IsKeyValuePair())
-            {
-                throw new NotSupportedException(
-                    $"Can't use {typeof(KeyValuePair<,>)} for LINQ queries: " +
-                    $"it is reserved for {typeof(IKeyValueView<,>)}.{nameof(IKeyValueView<int, int>.AsQueryable)}. " +
-                    "Use a custom type instead.");
-            }
-
-            return new IgniteQueryable<T>(provider);
-        }
-
         /// <summary>
         /// Deletes multiple records. If one or more keys do not exist, other records are still deleted.
         /// </summary>
@@ -324,7 +341,7 @@ namespace Apache.Ignite.Internal.Table
         /// A <see cref="Task"/> representing the asynchronous operation.
         /// The task result contains records from <paramref name="records"/> that did not exist.
         /// </returns>
-        public async Task<IList<T>> DeleteAllAsync(ITransaction? transaction, IEnumerable<T> records, bool exact) =>
+        internal async Task<IList<T>> DeleteAllAsync(ITransaction? transaction, IEnumerable<T> records, bool exact) =>
             await DeleteAllAsync(
                 transaction,
                 records,
@@ -347,7 +364,7 @@ namespace Apache.Ignite.Internal.Table
         /// A <see cref="Task"/> representing the asynchronous operation.
         /// The task result contains records from <paramref name="records"/> that did not exist.
         /// </returns>
-        public async Task<TRes> DeleteAllAsync<TRes>(
+        internal async Task<TRes> DeleteAllAsync<TRes>(
             ITransaction? transaction,
             IEnumerable<T> records,
             Func<int, TRes> resultFactory,
@@ -381,23 +398,6 @@ namespace Apache.Ignite.Internal.Table
                 keyOnly: !exact,
                 resultFactory: resultFactory,
                 addAction: addAction);
-        }
-
-        /// <summary>
-        /// Determines if the table contains an entry for the specified key.
-        /// </summary>
-        /// <param name="transaction">Transaction.</param>
-        /// <param name="key">Key.</param>
-        /// <returns>
-        /// A <see cref="Task"/> representing the asynchronous operation.
-        /// The task result contains a value indicating whether a record with the specified key exists in the table.
-        /// </returns>
-        internal async Task<bool> ContainsKey(ITransaction? transaction, T key)
-        {
-            IgniteArgumentCheck.NotNull(key, nameof(key));
-
-            using var resBuf = await DoRecordOutOpAsync(ClientOp.TupleContainsKey, transaction, key, keyOnly: true).ConfigureAwait(false);
-            return resBuf.GetReader().ReadBoolean();
         }
 
         private async Task<PooledBuffer> DoOutInOpAsync(

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -104,15 +104,7 @@ namespace Apache.Ignite.Internal.Table
             return _ser.ReadValue(resBuf, resSchema, key);
         }
 
-        /// <summary>
-        /// Determines if the table contains an entry for the specified key.
-        /// </summary>
-        /// <param name="transaction">Transaction.</param>
-        /// <param name="key">Key.</param>
-        /// <returns>
-        /// A <see cref="Task"/> representing the asynchronous operation.
-        /// The task result contains a value indicating whether a record with the specified key exists in the table.
-        /// </returns>
+        /// <inheritdoc/>
         public async Task<bool> ContainsAsync(ITransaction? transaction, T key)
         {
             IgniteArgumentCheck.NotNull(key, nameof(key));

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IKeyValueView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IKeyValueView.cs
@@ -60,7 +60,7 @@ public interface IKeyValueView<TK, TV>
     /// Determines if the table contains an entry for the specified key.
     /// </summary>
     /// <param name="transaction">The transaction or <c>null</c> to auto commit.</param>
-    /// <param name="key">Keys.</param>
+    /// <param name="key">Key.</param>
     /// <returns>
     /// A <see cref="Task"/> representing the asynchronous operation.
     /// The task result is <c>true</c> if a value exists for the specified key, and <c>false</c> otherwise.

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IRecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IRecordView.cs
@@ -50,7 +50,7 @@ namespace Apache.Ignite.Table
         /// A <see cref="Task"/> representing the asynchronous operation.
         /// The task result is <c>true</c> if a value exists for the specified key, and <c>false</c> otherwise.
         /// </returns>
-        Task<bool> ContainsAsync(ITransaction? transaction, T key);
+        Task<bool> ContainsKeyAsync(ITransaction? transaction, T key);
 
         /// <summary>
         /// Gets multiple records by keys.

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IRecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IRecordView.cs
@@ -42,6 +42,17 @@ namespace Apache.Ignite.Table
         Task<Option<T>> GetAsync(ITransaction? transaction, T key);
 
         /// <summary>
+        /// Determines if the table contains an entry for the specified key.
+        /// </summary>
+        /// <param name="transaction">The transaction or <c>null</c> to auto commit.</param>
+        /// <param name="key">A record with key columns set.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// The task result is <c>true</c> if a value exists for the specified key, and <c>false</c> otherwise.
+        /// </returns>
+        Task<bool> ContainsAsync(ITransaction? transaction, T key);
+
+        /// <summary>
         /// Gets multiple records by keys.
         /// </summary>
         /// <param name="transaction">The transaction or <c>null</c> to auto commit.</param>


### PR DESCRIPTION
* `IRecordView` does not have `Contains`, and `KeyValueView` has one. Add the missing method. 
* Use `ContainsKey` name to stress the fact that only key part of the record is checked (which is evident from the signature in `KeyValueView`, but not in `RecordView`).