### PR TITLE
IGNITE-18613 .NET: Balance requests across connections

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Tests.Compute
 {
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using Internal.Proto;
@@ -95,18 +96,16 @@ namespace Apache.Ignite.Tests.Compute
             // ReSharper disable once AccessToDisposedClosure
             TestUtils.WaitForCondition(() => client.GetConnections().Count == 2, 5000);
 
+            var nodeNames = new HashSet<string>();
+
             for (int i = 0; i < 100; i++)
             {
                 var node = i % 2 == 0 ? server1.Node : server2.Node;
-
                 var res = await client.Compute.ExecuteAsync<string>(nodes: new[] { node }, jobClassName: string.Empty);
-
-                // Every third request goes to a different node due to a combination of retry and round-robin logic.
-                if ((i - 4) % 3 != 0)
-                {
-                    Assert.AreEqual(node.Name, res, $"Iteration {i}");
-                }
+                nodeNames.Add(res);
             }
+
+            CollectionAssert.AreEquivalent(new[] { "s1", "s2" }, nodeNames);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
@@ -101,7 +101,11 @@ namespace Apache.Ignite.Tests.Compute
 
                 var res = await client.Compute.ExecuteAsync<string>(nodes: new[] { node }, jobClassName: string.Empty);
 
-                Assert.AreEqual(node.Name, res);
+                // Every third request goes to a different node due to a combination of retry and round-robin logic.
+                if ((i - 4) % 3 != 0)
+                {
+                    Assert.AreEqual(node.Name, res, $"Iteration {i}");
+                }
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessTests.cs
@@ -68,14 +68,9 @@ public class PartitionAwarenessTests
     {
         using var client = await GetClient();
         var recordView = (await client.Tables.GetTableAsync(FakeServer.ExistingTableName))!.GetRecordView<int>();
-        var (defaultServer, _) = GetServerPair();
 
         // Warm up.
         await recordView.UpsertAsync(null, 1);
-
-        Assert.AreEqual(
-            new[] { ClientOp.TableGet, ClientOp.SchemasGet, ClientOp.PartitionAssignmentGet },
-            defaultServer.ClientOps.Take(3));
 
         // Check.
         await AssertOpOnNode(async () => await recordView.UpsertAsync(null, 1), ClientOp.TupleUpsert, _server2, _server1);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/RequestBalancingTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/RequestBalancingTests.cs
@@ -45,18 +45,20 @@ public class RequestBalancingTests
         // ReSharper disable once AccessToDisposedClosure
         TestUtils.WaitForCondition(() => client.GetConnections().Count == 3, 5000);
 
-        for (var i = 0; i < 5; i++)
+        for (var i = 0; i < 10; i++)
         {
             await client.Tables.GetTablesAsync();
             await client.Tables.GetTableAsync(FakeServer.ExistingTableName);
         }
 
+        // All servers get their share of requests.
         foreach (var server in new[] { server1, server2, server3 })
         {
             CollectionAssert.Contains(server.ClientOps, ClientOp.TableGet, server.Node.Name);
             CollectionAssert.Contains(server.ClientOps, ClientOp.TablesGet, server.Node.Name);
         }
 
-        Assert.AreEqual(10, server1.ClientOps.Count + server2.ClientOps.Count + server3.ClientOps.Count);
+        // Total number of requests across all servers.
+        Assert.AreEqual(20, server1.ClientOps.Count + server2.ClientOps.Count + server3.ClientOps.Count);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/RequestBalancingTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/RequestBalancingTests.cs
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests;
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests request balancing across active connections.
+/// When client is connected to multiple nodes, requests will use all available connections in a round-robin fashion
+/// (unless an operation is tied to a specific connection, like a transaction or a cursor).
+/// </summary>
+public class RequestBalancingTests
+{
+    [Test]
+    public async Task TestRequestsAreRoundRobinBalanced()
+    {
+        await Task.Delay(1);
+        Assert.Fail("TODO");
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -117,6 +117,7 @@ namespace Apache.Ignite.Internal
 
             // Because this call is not awaited, execution of the current method continues before the call is completed.
             // Secondary connections are established in the background.
+            // TODO IGNITE-18808 Do this periodically.
             _ = socket.ConnectAllSockets();
 
             return socket;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -123,35 +123,6 @@ namespace Apache.Ignite.Internal
         /// Performs an in-out operation.
         /// </summary>
         /// <param name="clientOp">Client op code.</param>
-        /// <param name="tx">Transaction.</param>
-        /// <param name="request">Request data.</param>
-        /// <param name="preferredNode">Preferred node.</param>
-        /// <returns>Response data.</returns>
-        public async Task<PooledBuffer> DoOutInOpAsync(
-            ClientOp clientOp,
-            Transaction? tx,
-            PooledArrayBuffer? request = null,
-            PreferredNode preferredNode = default)
-        {
-            if (tx == null)
-            {
-                // Use failover socket with reconnect and retry behavior.
-                return await DoOutInOpAsync(clientOp, request, preferredNode).ConfigureAwait(false);
-            }
-
-            if (tx.FailoverSocket != this)
-            {
-                throw new IgniteClientException(ErrorGroups.Client.Connection, "Specified transaction belongs to a different IgniteClient instance.");
-            }
-
-            // Use tx-specific socket without retry and failover.
-            return await tx.Socket.DoOutInOpAsync(clientOp, request).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Performs an in-out operation.
-        /// </summary>
-        /// <param name="clientOp">Client op code.</param>
         /// <param name="request">Request data.</param>
         /// <param name="preferredNode">Preferred node.</param>
         /// <returns>Response data and socket.</returns>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -302,7 +302,7 @@ namespace Apache.Ignite.Internal
                         continue;
                     }
 
-                    tasks.Add(ConnectAsync(endpoint));
+                    tasks.Add(ConnectAsync(endpoint).AsTask());
                 }
 
                 await Task.WhenAll(tasks).ConfigureAwait(false);
@@ -366,7 +366,7 @@ namespace Apache.Ignite.Internal
         /// <summary>
         /// Connects to the given endpoint.
         /// </summary>
-        private async Task<ClientSocket> ConnectAsync(SocketEndpoint endpoint)
+        private async ValueTask<ClientSocket> ConnectAsync(SocketEndpoint endpoint)
         {
             if (endpoint.Socket?.IsDisposed == false)
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -38,7 +38,7 @@ namespace Apache.Ignite.Internal
     internal sealed class ClientFailoverSocket : IDisposable
     {
         /** Current global endpoint index for Round-robin. */
-        private static long _endPointIndex;
+        private static long _globalEndPointIndex;
 
         /** Logger. */
         private readonly IIgniteLogger? _logger;
@@ -71,6 +71,9 @@ namespace Apache.Ignite.Internal
 
         /** Cluster id from the first handshake. */
         private Guid? _clusterId;
+
+        /** Local index for round-robin balancing within this FailoverSocket. */
+        private long _endPointIndex = Interlocked.Increment(ref _globalEndPointIndex);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ClientFailoverSocket"/> class.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -396,8 +396,12 @@ namespace Apache.Ignite.Internal.Table
             ClientOp clientOp,
             Transaction? tx,
             PooledArrayBuffer? request = null,
-            PreferredNode preferredNode = default) =>
-            await _table.Socket.DoOutInOpAsync(clientOp, tx, request, preferredNode).ConfigureAwait(false);
+            PreferredNode preferredNode = default)
+        {
+            var (buf, _) = await _table.Socket.DoOutInOpAndGetSocketAsync(clientOp, tx, request, preferredNode).ConfigureAwait(false);
+
+            return buf;
+        }
 
         private async Task<PooledBuffer> DoRecordOutOpAsync(
             ClientOp op,


### PR DESCRIPTION
When .NET client is connected to more than one server node, send requests to different connections in a round-robin fashion instead of using the same default connection every time.