### PR TITLE
IGNITE-18815 C++ Tx sync rollback on destruction

### DIFF
--- a/modules/platforms/cpp/ignite/client/detail/transaction/transaction_impl.h
+++ b/modules/platforms/cpp/ignite/client/detail/transaction/transaction_impl.h
@@ -59,8 +59,14 @@ public:
         , m_state(state::OPEN)
         , m_connection(std::move(connection)) {}
 
+    /**
+     * Destructor.
+     *
+     * It is important to rollback transaction synchronously on destruction to
+     * avoid conflicts if the same data is accessed after transaction is destructed.
+     */
     ~transaction_impl() {
-        rollback_async([](auto) {});
+        sync<void>([this](auto callback) { rollback_async(std::move(callback)); });
     }
 
     /**

--- a/modules/platforms/cpp/ignite/client/transaction/transaction.h
+++ b/modules/platforms/cpp/ignite/client/transaction/transaction.h
@@ -59,7 +59,7 @@ public:
      * Rollbacks the transaction.
      */
     IGNITE_API void rollback() {
-        return sync<void>([this](auto callback) { rollback_async(std::move(callback)); });
+        sync<void>([this](auto callback) { rollback_async(std::move(callback)); });
     }
 
     /**


### PR DESCRIPTION
Transactions now rolled back synchronously on destruction.
No new tests as existing tests cover this case.