### PR TITLE
IGNITE-18818 .NET: Improve locking granularity in ClientFailoverSocket

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Program.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Program.cs
@@ -24,6 +24,6 @@ internal static class Program
 {
     private static void Main()
     {
-        BenchmarkRunner.Run<TableGetBenchmarks>();
+        BenchmarkRunner.Run<TableGetMultiThreadedBenchmarks>();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Program.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Program.cs
@@ -18,12 +18,12 @@
 namespace Apache.Ignite.Benchmarks;
 
 using BenchmarkDotNet.Running;
-using Sql;
+using Table;
 
 internal static class Program
 {
     private static void Main()
     {
-        BenchmarkRunner.Run<ResultSetBenchmarks>();
+        BenchmarkRunner.Run<TableGetBenchmarks>();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TableGetBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TableGetBenchmarks.cs
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Benchmarks.Table;
+
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Tests;
+
+public class TableGetBenchmarks
+{
+    private FakeServer _server = null!;
+    private IIgniteClient _client = null!;
+
+    [GlobalSetup]
+    public async Task GlobalSetup()
+    {
+        _server = new FakeServer();
+        _client = await IgniteClient.StartAsync(new IgniteClientConfiguration(_server.Endpoint));
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        _client.Dispose();
+        _server.Dispose();
+    }
+
+    [Benchmark]
+    public async Task TableGet()
+    {
+        await _client.Tables.GetTableAsync(FakeServer.ExistingTableName);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TableGetBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TableGetBenchmarks.cs
@@ -21,6 +21,15 @@ using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Tests;
 
+/// <summary>
+/// Measures simple operation on a fake server - retrieve table id by name. Indicates overall networking performance.
+/// <para />
+/// Results on i9-12900H, .NET SDK 6.0.405, Ubuntu 22.04:
+/// |   Method |     Mean |    Error |   StdDev | Allocated |
+/// |--------- |---------:|---------:|---------:|----------:|
+/// | TableGet | 24.22 us | 0.347 us | 0.308 us |      2 KB |.
+/// </summary>
+[MemoryDiagnoser]
 public class TableGetBenchmarks
 {
     private FakeServer _server = null!;

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TableGetMultiThreadedBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TableGetMultiThreadedBenchmarks.cs
@@ -40,6 +40,7 @@ public class TableGetMultiThreadedBenchmarks
     private List<FakeServer> _servers = null!;
     private IIgniteClient _client = null!;
 
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global, MemberCanBePrivate.Global (benchmark parameter).
     [Params(1, 2, 4)]
     public int ServerCount { get; set; }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TableGetMultiThreadedBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TableGetMultiThreadedBenchmarks.cs
@@ -28,9 +28,12 @@ using Tests;
 /// Measures simple operation on a fake server - retrieve table id by name from multiple threads.
 /// <para />
 /// Results on i9-12900H, .NET SDK 6.0.405, Ubuntu 22.04:
-/// TODO.
+/// |   Method | ServerCount |     Mean |     Error |    StdDev |
+/// |--------- |------------ |---------:|----------:|----------:|
+/// | TableGet |           1 | 1.520 ms | 0.0304 ms | 0.0406 ms |
+/// | TableGet |           2 | 1.266 ms | 0.0250 ms | 0.0560 ms |
+/// | TableGet |           4 | 1.010 ms | 0.0202 ms | 0.0421 ms |.
 /// </summary>
-[MemoryDiagnoser]
 public class TableGetMultiThreadedBenchmarks
 {
     [SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Reviewed.")]
@@ -57,5 +60,5 @@ public class TableGetMultiThreadedBenchmarks
 
     [Benchmark]
     public void TableGet() =>
-        Parallel.For(1, 1000, _ => _client.Tables.GetTableAsync(FakeServer.ExistingTableName).GetAwaiter().GetResult());
+        Parallel.For(1, 100, _ => _client.Tables.GetTableAsync(FakeServer.ExistingTableName).GetAwaiter().GetResult());
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TableGetMultiThreadedBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TableGetMultiThreadedBenchmarks.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Benchmarks.Table;
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -44,10 +45,18 @@ public class TableGetMultiThreadedBenchmarks
     [Params(1, 2, 4)]
     public int ServerCount { get; set; }
 
+    // ReSharper disable once UnusedAutoPropertyAccessor.Global, MemberCanBePrivate.Global (benchmark parameter).
+    [Params(0, 10)]
+    public int ServerOperationDelayMs { get; set; }
+
     [GlobalSetup]
     public async Task GlobalSetup()
     {
-        _servers = Enumerable.Range(0, ServerCount).Select(_ => new FakeServer()).ToList();
+        var operationDelay = TimeSpan.FromMilliseconds(ServerOperationDelayMs);
+
+        _servers = Enumerable.Range(0, ServerCount)
+            .Select(_ => new FakeServer { OperationDelay = operationDelay })
+            .ToList();
 
         _client = await IgniteClient.StartAsync(new IgniteClientConfiguration(_servers.Select(s => s.Endpoint).ToArray()));
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ClientFailoverSocketTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ClientFailoverSocketTests.cs
@@ -27,7 +27,6 @@ using NUnit.Framework;
 /// </summary>
 public class ClientFailoverSocketTests
 {
-    // TODO: Test that disposed socket throws exception
     [Test]
     public async Task TestBackgroundConnectionProcessDoesNotBlockOperations()
     {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ClientFailoverSocketTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ClientFailoverSocketTests.cs
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests;
+
+using Internal;
+
+/// <summary>
+/// Tests for <see cref="ClientFailoverSocket"/>.
+/// </summary>
+public class ClientFailoverSocketTests
+{
+    // TODO: Test that socket can be used while connections are established in background
+    // TODO: Test that disposed socket throws exception
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -101,6 +101,8 @@ namespace Apache.Ignite.Tests
 
         public TimeSpan HandshakeDelay { get; set; }
 
+        public TimeSpan OperationDelay { get; set; }
+
         public TimeSpan HeartbeatDelay { get; set; }
 
         public int Port => ((IPEndPoint)_listener.LocalEndPoint!).Port;
@@ -462,6 +464,11 @@ namespace Apache.Ignite.Tests
                 {
                     msgSize = ReceiveMessageSize(handler);
                     using var msg = ReceiveBytes(handler, msgSize);
+
+                    if (OperationDelay > TimeSpan.Zero)
+                    {
+                        Thread.Sleep(OperationDelay);
+                    }
 
                     if (_shouldDropConnection(++requestCount))
                     {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -290,6 +290,7 @@ namespace Apache.Ignite.Internal
                 return;
             }
 
+            // TODO: Locking is too strict, we can connect to multiple endpoints in parallel?
             await _socketLock.WaitAsync().ConfigureAwait(false);
 
             var tasks = new List<Task>(_endpoints.Count);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -290,15 +290,12 @@ namespace Apache.Ignite.Internal
                 return;
             }
 
-            // TODO: Locking is too strict, we can connect to multiple endpoints in parallel?
-            await _socketLock.WaitAsync().ConfigureAwait(false);
-
-            var tasks = new List<Task>(_endpoints.Count);
-
-            _logger?.Debug("Establishing secondary connections...");
-
             try
             {
+                var tasks = new List<Task>(_endpoints.Count);
+
+                _logger?.Debug("Establishing secondary connections...");
+
                 foreach (var endpoint in _endpoints)
                 {
                     if (endpoint.Socket?.IsDisposed == false)
@@ -314,10 +311,6 @@ namespace Apache.Ignite.Internal
             catch (Exception e)
             {
                 _logger?.Warn(e, "Error while trying to establish secondary connections: " + e.Message);
-            }
-            finally
-            {
-                _socketLock.Release();
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -124,6 +124,14 @@ namespace Apache.Ignite.Internal
         }
 
         /// <summary>
+        /// Resets global endpoint index.
+        /// </summary>
+        public static void ResetGlobalEndpointIndex()
+        {
+            _globalEndPointIndex = 0;
+        }
+
+        /// <summary>
         /// Performs an in-out operation.
         /// </summary>
         /// <param name="clientOp">Client op code.</param>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -228,7 +228,7 @@ namespace Apache.Ignite.Internal
                 .ToList()!;
 
         /// <summary>
-        /// Gets the primary socket. Reconnects if necessary.
+        /// Gets a socket. Reconnects if necessary.
         /// </summary>
         /// <param name="preferredNode">Preferred node.</param>
         /// <returns>Client socket.</returns>
@@ -238,6 +238,7 @@ namespace Apache.Ignite.Internal
             Justification = "Any connection exception should be handled.")]
         private async ValueTask<ClientSocket> GetSocketAsync(PreferredNode preferredNode = default)
         {
+            // TODO: This locking is too strict, we can do better.
             await _socketLock.WaitAsync().ConfigureAwait(false);
 
             try

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -124,12 +124,9 @@ namespace Apache.Ignite.Internal
         }
 
         /// <summary>
-        /// Resets global endpoint index.
+        /// Resets global endpoint index. For testing purposes only (to make behavior deterministic).
         /// </summary>
-        public static void ResetGlobalEndpointIndex()
-        {
-            _globalEndPointIndex = 0;
-        }
+        public static void ResetGlobalEndpointIndex() => _globalEndPointIndex = 0;
 
         /// <summary>
         /// Performs an in-out operation.


### PR DESCRIPTION
* Take `_socketLock` only when a reconnect is required to avoid blocking operations on healthy channels.
* Add benchmarks to measure networking performance and client scaling on multiple connections.