### PR TITLE
IGNITE-18808 .NET: Reconnect all endpoints periodically in background

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ClientFailoverSocketTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ClientFailoverSocketTests.cs
@@ -40,7 +40,7 @@ public class ClientFailoverSocketTests
 
         var clientCfg = new IgniteClientConfiguration
         {
-            Endpoints = { server1.Endpoint, server2.Endpoint }
+            Endpoints = { server2.Endpoint, server1.Endpoint }
         };
 
         // First connection will go to server2, which does not have a delay.

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -117,7 +117,7 @@ namespace Apache.Ignite.Tests
 
         public long? LastSqlTxId { get; set; }
 
-        public bool DropConnections { get; set; }
+        public bool DropNewConnections { get; set; }
 
         public bool SendInvalidMagic { get; set; }
 
@@ -135,7 +135,7 @@ namespace Apache.Ignite.Tests
 
         public void ClearOps() => _ops?.Clear();
 
-        public void DropConnection() => _handler?.Dispose();
+        public void DropExistingConnection() => _handler?.Dispose();
 
         public void Dispose()
         {
@@ -433,7 +433,7 @@ namespace Apache.Ignite.Tests
             {
                 using Socket handler = _listener.Accept();
 
-                if (DropConnections)
+                if (DropNewConnections)
                 {
                     continue;
                 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -135,6 +135,8 @@ namespace Apache.Ignite.Tests
 
         public void ClearOps() => _ops?.Clear();
 
+        public void DropConnection() => _handler?.Dispose();
+
         public void Dispose()
         {
             lock (_disposeSyncRoot)

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServerGroup.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServerGroup.cs
@@ -58,4 +58,12 @@ public sealed class FakeServerGroup : IDisposable
             server.Dispose();
         }
     }
+
+    public void DropAllConnections()
+    {
+        foreach (var server in _servers)
+        {
+            server.DropConnection();
+        }
+    }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServerGroup.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServerGroup.cs
@@ -21,7 +21,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Internal;
 
 /// <summary>
 /// A group of fake servers.
@@ -35,8 +34,8 @@ public sealed class FakeServerGroup : IDisposable
         _servers = servers;
     }
 
-    public static FakeServerGroup Create(int count, Func<FakeServer> factory) =>
-        new(Enumerable.Range(1, count).Select(_ => factory()).ToList());
+    public static FakeServerGroup Create(int count, Func<int, FakeServer> factory) =>
+        new(Enumerable.Range(0, count).Select(factory).ToList());
 
     public async Task<IIgniteClient> ConnectClientAsync(IgniteClientConfiguration? cfg = null)
     {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServerGroup.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServerGroup.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Tests;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -33,6 +34,18 @@ public sealed class FakeServerGroup : IDisposable
     }
 
     public IReadOnlyList<FakeServer> Servers { get; }
+
+    [SuppressMessage("Design", "CA1044:Properties should not be write only", Justification = "Tests.")]
+    public bool DropNewConnections
+    {
+        set
+        {
+            foreach (var server in Servers)
+            {
+                server.DropNewConnections = value;
+            }
+        }
+    }
 
     public static FakeServerGroup Create(int count, Func<int, FakeServer> factory) =>
         new(Enumerable.Range(0, count).Select(factory).ToList());
@@ -59,11 +72,11 @@ public sealed class FakeServerGroup : IDisposable
         }
     }
 
-    public void DropAllConnections()
+    public void DropExistingConnections()
     {
         foreach (var server in Servers)
         {
-            server.DropConnection();
+            server.DropExistingConnection();
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServerGroup.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServerGroup.cs
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Internal;
+
+/// <summary>
+/// A group of fake servers.
+/// </summary>
+public sealed class FakeServerGroup : IDisposable
+{
+    private readonly IReadOnlyList<FakeServer> _servers;
+
+    public FakeServerGroup(IReadOnlyList<FakeServer> servers)
+    {
+        _servers = servers;
+    }
+
+    public static FakeServerGroup Create(int count, Func<FakeServer> factory) =>
+        new(Enumerable.Range(1, count).Select(_ => factory()).ToList());
+
+    public async Task<IIgniteClient> ConnectClientAsync(IgniteClientConfiguration? cfg = null)
+    {
+        cfg ??= new IgniteClientConfiguration();
+
+        cfg.Endpoints.Clear();
+
+        foreach (var server in _servers)
+        {
+            cfg.Endpoints.Add(server.Endpoint);
+        }
+
+        return await IgniteClient.StartAsync(cfg);
+    }
+
+    public void Dispose()
+    {
+        foreach (var server in _servers)
+        {
+            server.Dispose();
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServerGroup.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServerGroup.cs
@@ -27,12 +27,12 @@ using System.Threading.Tasks;
 /// </summary>
 public sealed class FakeServerGroup : IDisposable
 {
-    private readonly IReadOnlyList<FakeServer> _servers;
-
     public FakeServerGroup(IReadOnlyList<FakeServer> servers)
     {
-        _servers = servers;
+        Servers = servers;
     }
+
+    public IReadOnlyList<FakeServer> Servers { get; }
 
     public static FakeServerGroup Create(int count, Func<int, FakeServer> factory) =>
         new(Enumerable.Range(0, count).Select(factory).ToList());
@@ -43,7 +43,7 @@ public sealed class FakeServerGroup : IDisposable
 
         cfg.Endpoints.Clear();
 
-        foreach (var server in _servers)
+        foreach (var server in Servers)
         {
             cfg.Endpoints.Add(server.Endpoint);
         }
@@ -53,7 +53,7 @@ public sealed class FakeServerGroup : IDisposable
 
     public void Dispose()
     {
-        foreach (var server in _servers)
+        foreach (var server in Servers)
         {
             server.Dispose();
         }
@@ -61,7 +61,7 @@ public sealed class FakeServerGroup : IDisposable
 
     public void DropAllConnections()
     {
-        foreach (var server in _servers)
+        foreach (var server in Servers)
         {
             server.DropConnection();
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
@@ -80,8 +80,8 @@ namespace Apache.Ignite.Tests
         [Test]
         public void TestZeroOrNegativeHeartbeatIntervalThrows()
         {
-            Assert.ThrowsAsync<IgniteClientException>(async () => await ConnectAndGetLog(TimeSpan.Zero));
-            Assert.ThrowsAsync<IgniteClientException>(async () => await ConnectAndGetLog(TimeSpan.FromSeconds(-1)));
+            Assert.ThrowsAsync<IgniteClientConnectionException>(async () => await ConnectAndGetLog(TimeSpan.Zero));
+            Assert.ThrowsAsync<IgniteClientConnectionException>(async () => await ConnectAndGetLog(TimeSpan.FromSeconds(-1)));
         }
 
         private static async Task<string> ConnectAndGetLog(TimeSpan heartbeatInterval)

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessTests.cs
@@ -369,7 +369,11 @@ public class PartitionAwarenessTests
             }
         };
 
-        return await IgniteClient.StartAsync(cfg);
+        var client = await IgniteClient.StartAsync(cfg);
+
+        TestUtils.WaitForCondition(() => client.GetConnections().Count == 2);
+
+        return client;
     }
 
     // ReSharper disable NotAccessedPositionalProperty.Local

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -68,4 +68,17 @@ public class ReconnectTests
 
         Assert.DoesNotThrowAsync(async () => await client.Tables.GetTablesAsync());
     }
+
+    [Test]
+    public async Task TestDroppedConnectionIsRestoredOnDemand()
+    {
+        using var server = new FakeServer();
+        using var client = await server.ConnectClientAsync();
+
+        Assert.DoesNotThrowAsync(async () => await client.Tables.GetTablesAsync());
+
+        server.DropConnection();
+
+        Assert.DoesNotThrowAsync(async () => await client.Tables.GetTablesAsync());
+    }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -57,7 +57,7 @@ public class ReconnectTests
     {
         ClientFailoverSocket.ResetGlobalEndpointIndex();
 
-        using var servers = FakeServerGroup.Create(5, idx => new FakeServer { DropConnections = idx < 4 });
+        using var servers = FakeServerGroup.Create(10, idx => new FakeServer { DropConnections = idx < 9 });
         using var client = await servers.ConnectClientAsync();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -65,5 +65,7 @@ public class ReconnectTests
 
         using var servers = FakeServerGroup.Create(10, idx => new FakeServer { DropConnections = idx < 9 });
         using var client = await servers.ConnectClientAsync();
+
+        Assert.DoesNotThrowAsync(async () => await client.Tables.GetTablesAsync());
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -104,5 +104,7 @@ public class ReconnectTests
 
         // Connection is restored in background due to ReconnectInterval.
         TestUtils.WaitForCondition(() => client.GetConnections().Count > 0, 3000);
+
+        Assert.DoesNotThrowAsync(async () => await client.Tables.GetTablesAsync());
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests;
+
+/// <summary>
+/// Automatic reconnect tests.
+/// </summary>
+public class ReconnectTests
+{
+    // TODO: Test reconnect to one node
+    // TODO: Test reconnect to multiple nodes (all fail, some fail, etc)
+    // TODO: Test connection to a node that was not initially available (add FakeServer flag that rejects connections)
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Tests;
 
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 /// <summary>
@@ -37,8 +38,16 @@ public class ReconnectTests
     [Test]
     public void TestFailedInitialConnectionToAllServersThrowsException()
     {
-        using var servers = FakeServerGroup.Create(3, () => new FakeServer { DropConnections = true });
+        using var servers = FakeServerGroup.Create(3, _ => new FakeServer { DropConnections = true });
 
         var ex = Assert.ThrowsAsync<IgniteClientConnectionException>(async () => await servers.ConnectClientAsync());
+        StringAssert.StartsWith("Failed to connect to endpoint: 127.0.0.1:", ex!.Message);
+    }
+
+    [Test]
+    public async Task TestFailedInitialConnectionToSomeServersAndSuccessfulConnectionToOneDoesNotThrow()
+    {
+        using var servers = FakeServerGroup.Create(5, idx => new FakeServer { DropConnections = idx < 4 });
+        using var client = await servers.ConnectClientAsync();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -25,4 +25,6 @@ public class ReconnectTests
     // TODO: Test reconnect to one node
     // TODO: Test reconnect to multiple nodes (all fail, some fail, etc)
     // TODO: Test connection to a node that was not initially available (add FakeServer flag that rejects connections)
+    // TODO: Check that reconnect stops on dispose
+    // TODO: What happens if all nodes are lost? Do we just keep trying?
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -95,7 +95,7 @@ public class ReconnectTests
         servers.DropAllConnections();
 
         // Dropped connections are detected by heartbeat.
-        TestUtils.WaitForCondition(() => client.GetConnections().Count == 0, 500);
+        TestUtils.WaitForCondition(() => client.GetConnections().Count == 0, 3000);
 
         // Connections are restored in background due to ReconnectInterval.
         TestUtils.WaitForCondition(() => client.GetConnections().Count == 10, 3000);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -33,8 +33,12 @@ public class ReconnectTests
     // TODO: Check that reconnect stops on dispose
     // TODO: What happens if all nodes are lost? Do we just keep trying?
     [Test]
-    public void TestInvalidMagicFromAllServersThrowsException()
+    public void TestInvalidMagicThrowsException()
     {
+        using var server = new FakeServer { SendInvalidMagic = true };
+
+        var ex = Assert.ThrowsAsync<IgniteClientConnectionException>(async () => await server.ConnectClientAsync());
+        Assert.AreEqual("Invalid header", ex!.Message);
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -38,7 +38,9 @@ public class ReconnectTests
         using var server = new FakeServer { SendInvalidMagic = true };
 
         var ex = Assert.ThrowsAsync<IgniteClientConnectionException>(async () => await server.ConnectClientAsync());
-        Assert.AreEqual("Invalid header", ex!.Message);
+
+        StringAssert.StartsWith("Failed to connect to endpoint: 127.0.0.1:", ex!.Message);
+        StringAssert.StartsWith("Invalid magic bytes returned from the server", ex.InnerException!.Message);
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -153,6 +153,6 @@ public class ReconnectTests
         Assert.DoesNotThrowAsync(async () => await client.Tables.GetTablesAsync());
 
         // All connections are restored.
-        TestUtils.WaitForCondition(() => client.GetConnections().Count == 10);
+        TestUtils.WaitForCondition(() => client.GetConnections().Count == 10, 3000);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -17,6 +17,8 @@
 
 namespace Apache.Ignite.Tests;
 
+using NUnit.Framework;
+
 /// <summary>
 /// Automatic reconnect tests.
 /// </summary>
@@ -27,4 +29,16 @@ public class ReconnectTests
     // TODO: Test connection to a node that was not initially available (add FakeServer flag that rejects connections)
     // TODO: Check that reconnect stops on dispose
     // TODO: What happens if all nodes are lost? Do we just keep trying?
+    [Test]
+    public void TestInvalidMagicFromAllServersThrowsException()
+    {
+    }
+
+    [Test]
+    public void TestFailedInitialConnectionToAllServersThrowsException()
+    {
+        using var servers = FakeServerGroup.Create(3, () => new FakeServer { DropConnections = true });
+
+        var ex = Assert.ThrowsAsync<IgniteClientConnectionException>(async () => await servers.ConnectClientAsync());
+    }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -99,7 +99,10 @@ public class ReconnectTests
         Assert.AreEqual(1, client.GetConnections().Count);
         server.DropConnection();
 
+        // Dropped connection is detected by heartbeat.
         TestUtils.WaitForCondition(() => client.GetConnections().Count == 0, 500);
+
+        // Connection is restored in background due to ReconnectInterval.
         TestUtils.WaitForCondition(() => client.GetConnections().Count > 0, 3000);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/SocketTimeoutTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/SocketTimeoutTest.cs
@@ -41,7 +41,8 @@ public class SocketTimeoutTest
             SocketTimeout = TimeSpan.FromMilliseconds(50)
         };
 
-        Assert.ThrowsAsync<TimeoutException>(async () => await server.ConnectClientAsync(cfg));
+        var ex = Assert.ThrowsAsync<IgniteClientConnectionException>(async () => await server.ConnectClientAsync(cfg));
+        Assert.IsInstanceOf<TimeoutException>(ex?.InnerException);
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
@@ -45,6 +45,11 @@ namespace Apache.Ignite
         public static readonly TimeSpan DefaultHeartbeatInterval = TimeSpan.FromSeconds(30);
 
         /// <summary>
+        /// Default reconnect interval.
+        /// </summary>
+        public static readonly TimeSpan DefaultReconnectInterval = TimeSpan.FromSeconds(30);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="IgniteClientConfiguration"/> class.
         /// </summary>
         public IgniteClientConfiguration()
@@ -130,10 +135,21 @@ namespace Apache.Ignite
         /// When server-side idle timeout is not zero, effective heartbeat
         /// interval is set to <c>Min(HeartbeatInterval, IdleTimeout / 3)</c>.
         /// <para />
-        /// When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
+        /// When client connection is idle (no operations are performed), heartbeat messages are sent periodically
         /// to keep the connection alive and detect potential half-open state.
         /// </summary>
         [DefaultValue(typeof(TimeSpan), "00:00:30")]
         public TimeSpan HeartbeatInterval { get; set; } = DefaultHeartbeatInterval;
+
+        /// <summary>
+        /// Gets or sets the background reconnect interval.
+        /// <para />
+        /// Default is <see cref="DefaultReconnectInterval"/>. Set to <see cref="TimeSpan.Zero"/> to disable periodic reconnect.
+        /// <para />
+        /// Client repairs failed connections on demand (when a request is made). However, when multiple connections exist
+        /// (<see cref="Endpoints"/> contains addresses of multiple nodes), some of those connections may not TODO.
+        /// </summary>
+        [DefaultValue(typeof(TimeSpan), "00:00:30")]
+        public TimeSpan ReconnectInterval { get; set; } = DefaultReconnectInterval;
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
@@ -106,6 +106,11 @@ namespace Apache.Ignite
 
         /// <summary>
         /// Gets endpoints to connect to.
+        /// <para />
+        /// Providing addresses of multiple nodes in the cluster will improve performance:
+        /// Ignite will balance requests across all connections, and use partition awareness to send key-based requests
+        /// directly to the primary node.
+        /// <para />
         /// Examples of supported formats:
         ///  * 192.168.1.25 (default port is used, see <see cref="DefaultPort"/>).
         ///  * 192.168.1.25:780 (custom port)
@@ -146,8 +151,10 @@ namespace Apache.Ignite
         /// <para />
         /// Default is <see cref="DefaultReconnectInterval"/>. Set to <see cref="TimeSpan.Zero"/> to disable periodic reconnect.
         /// <para />
-        /// Client repairs failed connections on demand (when a request is made). However, when multiple connections exist
-        /// (<see cref="Endpoints"/> contains addresses of multiple nodes), some of those connections may not TODO.
+        /// Ignite balances requests across all healthy connections (when multiple endpoints are configured).
+        /// Ignite also repairs connections on demand (when a request is made).
+        /// However, "secondary" connections can be lost (due to network issues, or node restarts). This property controls how ofter Ignite
+        /// client will check all configured endpoints and try to reconnect them in case of failure.
         /// </summary>
         [DefaultValue(typeof(TimeSpan), "00:00:30")]
         public TimeSpan ReconnectInterval { get; set; } = DefaultReconnectInterval;

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
@@ -85,6 +85,7 @@ namespace Apache.Ignite
             Endpoints = other.Endpoints.ToList();
             RetryPolicy = other.RetryPolicy;
             HeartbeatInterval = other.HeartbeatInterval;
+            ReconnectInterval = other.ReconnectInterval;
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -227,11 +227,20 @@ namespace Apache.Ignite.Internal
         /// Gets active connections.
         /// </summary>
         /// <returns>Active connections.</returns>
-        public IEnumerable<ConnectionContext> GetConnections() =>
-            _endpoints
-                .Where(e => e.Socket is { IsDisposed: false, ConnectionContext: not null })
-                .Select(e => e.Socket!.ConnectionContext)
-                .ToList();
+        public IEnumerable<ConnectionContext> GetConnections()
+        {
+            var res = new List<ConnectionContext>(_endpoints.Count);
+
+            foreach (var endpoint in _endpoints)
+            {
+                if (endpoint.Socket is { IsDisposed: false, ConnectionContext: { } ctx })
+                {
+                    res.Add(ctx);
+                }
+            }
+
+            return res;
+        }
 
         /// <summary>
         /// Gets a socket. Reconnects if necessary.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -22,6 +22,7 @@ namespace Apache.Ignite.Internal
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
+    using System.IO;
     using System.Linq;
     using System.Net;
     using System.Net.Sockets;
@@ -349,7 +350,7 @@ namespace Apache.Ignite.Internal
                 {
                     return await ConnectAsync(endPoint).ConfigureAwait(false);
                 }
-                catch (SocketException e)
+                catch (IgniteClientConnectionException e) when (e.InnerException is SocketException or IOException)
                 {
                     errors ??= new List<Exception>();
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -114,7 +114,7 @@ namespace Apache.Ignite.Internal
         {
             var socket = new ClientFailoverSocket(configuration);
 
-            await socket.GetSocketAsync().ConfigureAwait(false);
+            await socket.GetNextSocketAsync().ConfigureAwait(false);
 
             // Because this call is not awaited, execution of the current method continues before the call is completed.
             // Secondary connections are established in the background.
@@ -350,7 +350,7 @@ namespace Apache.Ignite.Internal
                 {
                     return await ConnectAsync(endPoint).ConfigureAwait(false);
                 }
-                catch (IgniteClientConnectionException e) when (e.InnerException is SocketException or IOException)
+                catch (IgniteClientConnectionException e) when (e.GetBaseException() is SocketException or IOException)
                 {
                     errors ??= new List<Exception>();
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -229,9 +229,9 @@ namespace Apache.Ignite.Internal
         /// <returns>Active connections.</returns>
         public IEnumerable<ConnectionContext> GetConnections() =>
             _endpoints
-                .Select(e => e.Socket?.ConnectionContext)
-                .Where(ctx => ctx != null)
-                .ToList()!;
+                .Where(e => e.Socket is { IsDisposed: false, ConnectionContext: not null })
+                .Select(e => e.Socket!.ConnectionContext)
+                .ToList();
 
         /// <summary>
         /// Gets a socket. Reconnects if necessary.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -176,12 +176,12 @@ namespace Apache.Ignite.Internal
 
                 return new ClientSocket(stream, configuration, context, assignmentChangeCallback);
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 // ReSharper disable once MethodHasAsyncOverload
                 socket.Dispose();
 
-                throw;
+                throw new IgniteClientConnectionException(ErrorGroups.Client.Connection, "Failed to connect to endpoint: " + endPoint, e);
             }
         }
 


### PR DESCRIPTION
Before this change .NET client would repair a connection only on demand (when all connections are broken, or when partition awareness requests a specific connection). Therefore, some connections may be lost and never repaired, which negatively affects request balancing.

* Add `IgniteClientConfiguration.ReconnectInterval`.
* Run a background task that checks and repairs all endpoints periodically.

This works together with heartbeats (which detect broken connections).