### PR TITLE
IGNITE-18810 Java client: Balance requests across connections

### DIFF
--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
@@ -26,7 +26,6 @@ import java.nio.ByteBuffer;
 import java.util.BitSet;
 import java.util.UUID;
 import org.apache.ignite.internal.binarytuple.BinaryTupleBuilder;
-import org.msgpack.core.annotations.Nullable;
 
 /**
  * ByteBuf-based MsgPack implementation. Replaces {@link org.msgpack.core.MessagePacker} to avoid
@@ -170,7 +169,7 @@ public class ClientMessagePacker implements AutoCloseable {
      *
      * @param i the value to be written.
      */
-    public void packIntNullable(@Nullable Integer i) {
+    public void packIntNullable(Integer i) {
         if (i == null) {
             packNil();
         } else {
@@ -233,7 +232,7 @@ public class ClientMessagePacker implements AutoCloseable {
      *
      * @param v the value to be written.
      */
-    public void packLongNullable(@Nullable Long v) {
+    public void packLongNullable(Long v) {
         if (v == null) {
             packNil();
         } else {
@@ -270,7 +269,7 @@ public class ClientMessagePacker implements AutoCloseable {
      *
      * @param s the value to be written.
      */
-    public void packString(@Nullable String s) {
+    public void packString(String s) {
         assert !closed : "Packer is closed";
 
         if (s == null) {

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.util.BitSet;
 import java.util.UUID;
 import org.apache.ignite.internal.binarytuple.BinaryTupleBuilder;
+import org.msgpack.core.annotations.Nullable;
 
 /**
  * ByteBuf-based MsgPack implementation. Replaces {@link org.msgpack.core.MessagePacker} to avoid
@@ -169,7 +170,7 @@ public class ClientMessagePacker implements AutoCloseable {
      *
      * @param i the value to be written.
      */
-    public void packIntNullable(Integer i) {
+    public void packIntNullable(@Nullable Integer i) {
         if (i == null) {
             packNil();
         } else {
@@ -232,7 +233,7 @@ public class ClientMessagePacker implements AutoCloseable {
      *
      * @param v the value to be written.
      */
-    public void packLongNullable(Long v) {
+    public void packLongNullable(@Nullable Long v) {
         if (v == null) {
             packNil();
         } else {
@@ -269,7 +270,7 @@ public class ClientMessagePacker implements AutoCloseable {
      *
      * @param s the value to be written.
      */
-    public void packString(String s) {
+    public void packString(@Nullable String s) {
         assert !closed : "Packer is closed";
 
         if (s == null) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -726,26 +726,6 @@ public final class ReliableChannel implements AutoCloseable {
             return getOrCreateChannelAsync(false);
         }
 
-        private @Nullable ClientChannel getNow() {
-            if (close) {
-                return null;
-            }
-
-            var f = chFut;
-
-            if (f == null) {
-                return null;
-            }
-
-            var ch = ClientFutureUtils.getNowSafe(f);
-
-            if (ch == null || ch.closed()) {
-                return null;
-            }
-
-            return ch;
-        }
-
         /**
          * Get or create channel.
          */
@@ -825,6 +805,29 @@ public final class ReliableChannel implements AutoCloseable {
 
                 return chFut0;
             }
+        }
+
+        /**
+         * Get channel if connected, or null otherwise.
+         */
+        private @Nullable ClientChannel getNow() {
+            if (close) {
+                return null;
+            }
+
+            var f = chFut;
+
+            if (f == null) {
+                return null;
+            }
+
+            var ch = ClientFutureUtils.getNowSafe(f);
+
+            if (ch == null || ch.closed()) {
+                return null;
+            }
+
+            return ch;
         }
 
         /**

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -325,7 +325,7 @@ public final class ReliableChannel implements AutoCloseable {
      * On current channel failure.
      */
     private void onChannelFailure(ClientChannel ch) {
-        // There is nothing wrong if curChIdx was concurrently changed, since channel was closed by another thread
+        // There is nothing wrong if defaultChIdx was concurrently changed, since channel was closed by another thread
         // when current index was changed and no other wrong channel will be closed by current thread because
         // onChannelFailure checks channel binded to the holder before closing it.
         onChannelFailure(channels.get(defaultChIdx), ch);
@@ -496,7 +496,7 @@ public final class ReliableChannel implements AutoCloseable {
             int startIdx = curChIdx.incrementAndGet();
 
             for (int i = 0; i < channels.size(); i++) {
-                int nextIdx = (startIdx + i) % channels.size();
+                int nextIdx = Math.abs(startIdx + i) % channels.size();
 
                 ClientChannelHolder hld = channels.get(nextIdx);
                 ClientChannel ch = hld == null ? null : hld.getNow();

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -690,6 +690,26 @@ public final class ReliableChannel implements AutoCloseable {
             return getOrCreateChannelAsync(false);
         }
 
+        private @Nullable ClientChannel getNow() {
+            if (close) {
+                return null;
+            }
+
+            var f = chFut;
+
+            if (f == null) {
+                return null;
+            }
+
+            var ch = ClientFutureUtils.getNowSafe(f);
+
+            if (ch == null || ch.closed()) {
+                return null;
+            }
+
+            return ch;
+        }
+
         /**
          * Get or create channel.
          */
@@ -822,7 +842,7 @@ public final class ReliableChannel implements AutoCloseable {
                 return true;
             }
 
-            var ch = f.getNow(null);
+            var ch = ClientFutureUtils.getNowSafe(f);
 
             return ch != null && !ch.closed();
         }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -236,6 +236,7 @@ public final class ReliableChannel implements AutoCloseable {
     private CompletableFuture<ClientChannel> getChannelAsync(@Nullable String preferredNodeName, @Nullable String preferredNodeId) {
         ClientChannelHolder holder = null;
 
+        // 1. Preferred node connection.
         if (preferredNodeName != null) {
             holder = nodeChannelsByName.get(preferredNodeName);
         } else if (preferredNodeId != null) {
@@ -252,6 +253,14 @@ public final class ReliableChannel implements AutoCloseable {
             });
         }
 
+        // 2. Round-robin connection.
+        ClientChannel nextCh = getNextChannelWithoutReconnect();
+
+        if (nextCh != null) {
+            return CompletableFuture.completedFuture(nextCh);
+        }
+
+        // 3. Default connection (with reconnect if necessary).
         return getDefaultChannelAsync();
     }
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -219,7 +219,7 @@ public class ClientCompute implements IgniteCompute {
                     w.packObjectArrayAsBinaryTuple(args);
                 },
                 r -> (R) r.unpackObjectFromBinaryTuple(),
-                ClientTupleSerializer.getHashFunction(null, keyMapper, key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(null, keyMapper, key));
     }
 
     private static <R> CompletableFuture<R> executeColocatedTupleKey(
@@ -241,7 +241,7 @@ public class ClientCompute implements IgniteCompute {
                     w.packObjectArrayAsBinaryTuple(args);
                 },
                 r -> (R) r.unpackObjectFromBinaryTuple(),
-                ClientTupleSerializer.getHashFunction(null, key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(null, key));
     }
 
     private CompletableFuture<ClientTable> getTable(String tableName) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientSession.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientSession.java
@@ -78,7 +78,7 @@ public class ClientSession implements Session {
      * @param properties Properties.
      */
     @SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType")
-    public ClientSession(
+    ClientSession(
             ReliableChannel ch,
             @Nullable Integer defaultPageSize,
             @Nullable String defaultSchema,
@@ -160,7 +160,7 @@ public class ClientSession implements Session {
             w.out().packObjectArrayAsBinaryTuple(arguments);
         };
 
-        PayloadReader<AsyncResultSet<T>> payloadReader = r -> new ClientAsyncResultSet<T>(r.clientChannel(), r.in(), mapper);
+        PayloadReader<AsyncResultSet<T>> payloadReader = r -> new ClientAsyncResultSet<>(r.clientChannel(), r.in(), mapper);
 
         if (transaction != null) {
             //noinspection resource
@@ -290,7 +290,7 @@ public class ClientSession implements Session {
     /** {@inheritDoc} */
     @Override
     public SessionBuilder toBuilder() {
-        return null;
+        throw new UnsupportedOperationException("Not implemented yet.");
     }
 
     private void packProperties(PayloadOutputChannel w, Map<String, Object> props) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientSession.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientSession.java
@@ -141,6 +141,7 @@ public class ClientSession implements Session {
 
         ClientStatement clientStatement = (ClientStatement) statement;
 
+        // TODO: Use tx channel if present.
         return ch.serviceAsync(ClientOp.SQL_EXEC, w -> {
             writeTx(transaction, w);
 
@@ -155,7 +156,7 @@ public class ClientSession implements Session {
             w.out().packString(clientStatement.query());
 
             w.out().packObjectArrayAsBinaryTuple(arguments);
-        }, r -> new ClientAsyncResultSet(r.clientChannel(), r.in(), mapper));
+        }, r -> new ClientAsyncResultSet<T>(r.clientChannel(), r.in(), mapper));
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueBinaryView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueBinaryView.java
@@ -77,7 +77,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                 (s, w) -> ser.writeTuple(tx, key, s, w, true),
                 ClientTupleSerializer::readValueTuple,
                 null,
-                ClientTupleSerializer.getHashFunction(tx, key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -100,7 +100,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                 (s, w) -> ser.writeTuples(tx, keys, s, w, true),
                 ClientTupleSerializer::readKvTuplesNullable,
                 Collections.emptyMap(),
-                ClientTupleSerializer.getHashFunction(tx, keys.iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keys.iterator().next()));
     }
 
     /**
@@ -139,7 +139,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                 (s, w) -> ser.writeTuple(tx, key, s, w, true),
                 (s, r) -> IgniteUtils.nonNullOrElse(ClientTupleSerializer.readValueTuple(s, r), defaultValue),
                 null,
-                ClientTupleSerializer.getHashFunction(tx, key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -157,7 +157,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                 ClientOp.TUPLE_CONTAINS_KEY,
                 (s, w) -> ser.writeTuple(tx, key, s, w, true),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -175,7 +175,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                 ClientOp.TUPLE_UPSERT,
                 (s, w) -> ser.writeKvTuple(tx, key, val, s, w, false),
                 r -> null,
-                ClientTupleSerializer.getHashFunction(tx, key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -197,7 +197,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                 ClientOp.TUPLE_UPSERT_ALL,
                 (s, w) -> ser.writeKvTuples(tx, pairs, s, w),
                 r -> null,
-                ClientTupleSerializer.getHashFunction(tx, pairs.keySet().iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, pairs.keySet().iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -217,7 +217,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                 (s, w) -> ser.writeKvTuple(tx, key, val, s, w, false),
                 ClientTupleSerializer::readValueTuple,
                 null,
-                ClientTupleSerializer.getHashFunction(tx, key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, key));
     }
 
     /**
@@ -256,7 +256,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                 ClientOp.TUPLE_INSERT,
                 (s, w) -> ser.writeKvTuple(tx, key, val, s, w, false),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -280,7 +280,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                 ClientOp.TUPLE_DELETE,
                 (s, w) -> ser.writeTuple(tx, key, s, w, true),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -293,7 +293,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                 ClientOp.TUPLE_DELETE_EXACT,
                 (s, w) -> ser.writeKvTuple(tx, key, val, s, w, false),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -316,7 +316,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                 (s, w) -> ser.writeTuples(tx, keys, s, w, true),
                 (s, r) -> ClientTupleSerializer.readTuples(s, r, true),
                 Collections.emptyList(),
-                ClientTupleSerializer.getHashFunction(tx, keys.iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keys.iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -335,7 +335,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                 (s, w) -> ser.writeTuple(tx, key, s, w, true),
                 ClientTupleSerializer::readValueTuple,
                 null,
-                ClientTupleSerializer.getHashFunction(tx, key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, key));
     }
 
     /**
@@ -379,7 +379,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                 ClientOp.TUPLE_REPLACE,
                 (s, w) -> ser.writeKvTuple(tx, key, val, s, w, false),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -394,7 +394,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                     ser.writeKvTuple(tx, key, newVal, s, w, true);
                 },
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, key));
     }
 
     /** {@inheritDoc} */
@@ -414,7 +414,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                 (s, w) -> ser.writeKvTuple(tx, key, val, s, w, false),
                 ClientTupleSerializer::readValueTuple,
                 null,
-                ClientTupleSerializer.getHashFunction(tx, key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, key));
     }
 
     /**

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueView.java
@@ -97,7 +97,7 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                 (s, w) -> keySer.writeRec(tx, key, s, w, TuplePart.KEY),
                 (s, r) -> valSer.readRec(s, r, TuplePart.VAL),
                 null,
-                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -144,7 +144,7 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                 (s, w) -> keySer.writeRecs(tx, keys, s, w, TuplePart.KEY),
                 this::readGetAllResponse,
                 Collections.emptyMap(),
-                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), keys.iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keySer.mapper(), keys.iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -162,7 +162,7 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                 ClientOp.TUPLE_CONTAINS_KEY,
                 (s, w) -> keySer.writeRec(tx, key, s, w, TuplePart.KEY),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -180,7 +180,7 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                 ClientOp.TUPLE_UPSERT,
                 (s, w) -> writeKeyValue(s, w, tx, key, val),
                 r -> null,
-                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -209,7 +209,7 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                     }
                 },
                 r -> null,
-                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), pairs.keySet().iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keySer.mapper(), pairs.keySet().iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -229,7 +229,7 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                 (s, w) -> writeKeyValue(s, w, tx, key, val),
                 (s, r) -> valSer.readRec(s, r, TuplePart.VAL),
                 null,
-                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -259,7 +259,7 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                 ClientOp.TUPLE_INSERT,
                 (s, w) -> writeKeyValue(s, w, tx, key, val),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -283,7 +283,7 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                 ClientOp.TUPLE_DELETE,
                 (s, w) -> keySer.writeRec(tx, key, s, w, TuplePart.KEY),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -295,7 +295,7 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                 ClientOp.TUPLE_DELETE_EXACT,
                 (s, w) -> writeKeyValue(s, w, tx, key, val),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -318,7 +318,7 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                 (s, w) -> keySer.writeRecs(tx, keys, s, w, TuplePart.KEY),
                 (s, r) -> keySer.readRecs(s, r, false, TuplePart.KEY),
                 Collections.emptyList(),
-                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), keys.iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keySer.mapper(), keys.iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -337,7 +337,7 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                 (s, w) -> keySer.writeRec(tx, key, s, w, TuplePart.KEY),
                 (s, r) -> valSer.readRec(s, r, TuplePart.VAL),
                 null,
-                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -375,7 +375,7 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                 ClientOp.TUPLE_REPLACE,
                 (s, w) -> writeKeyValue(s, w, tx, key, val),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -391,7 +391,7 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                     writeKeyValueRaw(s, w, key, newVal);
                 },
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */
@@ -411,7 +411,7 @@ public class ClientKeyValueView<K, V> implements KeyValueView<K, V> {
                 (s, w) -> writeKeyValue(s, w, tx, key, val),
                 (s, r) -> valSer.readRec(s, r, TuplePart.VAL),
                 null,
-                ClientTupleSerializer.getHashFunction(tx, keySer.mapper(), key));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keySer.mapper(), key));
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordBinaryView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordBinaryView.java
@@ -72,7 +72,7 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
                 (s, w) -> ser.writeTuple(tx, keyRec, s, w, true),
                 (s, r) -> ClientTupleSerializer.readValueTuple(s, r, keyRec),
                 null,
-                ClientTupleSerializer.getHashFunction(tx, keyRec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keyRec));
     }
 
     /** {@inheritDoc} */
@@ -95,7 +95,7 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
                 (s, w) -> ser.writeTuples(tx, keyRecs, s, w, true),
                 ClientTupleSerializer::readTuplesNullable,
                 Collections.emptyList(),
-                ClientTupleSerializer.getHashFunction(tx, keyRecs.iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keyRecs.iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -113,7 +113,7 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
                 ClientOp.TUPLE_UPSERT,
                 (s, w) -> ser.writeTuple(tx, rec, s, w),
                 r -> null,
-                ClientTupleSerializer.getHashFunction(tx, rec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, rec));
     }
 
     /** {@inheritDoc} */
@@ -135,7 +135,7 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
                 ClientOp.TUPLE_UPSERT_ALL,
                 (s, w) -> ser.writeTuples(tx, recs, s, w, false),
                 r -> null,
-                ClientTupleSerializer.getHashFunction(tx, recs.iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, recs.iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -154,7 +154,7 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
                 (s, w) -> ser.writeTuple(tx, rec, s, w, false),
                 (s, r) -> ClientTupleSerializer.readValueTuple(s, r, rec),
                 null,
-                ClientTupleSerializer.getHashFunction(tx, rec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, rec));
     }
 
     /** {@inheritDoc} */
@@ -172,7 +172,7 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
                 ClientOp.TUPLE_INSERT,
                 (s, w) -> ser.writeTuple(tx, rec, s, w, false),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, rec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, rec));
     }
 
     /** {@inheritDoc} */
@@ -195,7 +195,7 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
                 (s, w) -> ser.writeTuples(tx, recs, s, w, false),
                 ClientTupleSerializer::readTuples,
                 Collections.emptyList(),
-                ClientTupleSerializer.getHashFunction(tx, recs.iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, recs.iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -219,7 +219,7 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
                 ClientOp.TUPLE_REPLACE,
                 (s, w) -> ser.writeTuple(tx, rec, s, w, false),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, rec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, rec));
     }
 
     /** {@inheritDoc} */
@@ -235,7 +235,7 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
                     ser.writeTuple(tx, newRec, s, w, false, true);
                 },
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, oldRec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, oldRec));
     }
 
     /** {@inheritDoc} */
@@ -254,7 +254,7 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
                 (s, w) -> ser.writeTuple(tx, rec, s, w, false),
                 (s, r) -> ClientTupleSerializer.readValueTuple(s, r, rec),
                 null,
-                ClientTupleSerializer.getHashFunction(tx, rec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, rec));
     }
 
     /** {@inheritDoc} */
@@ -272,7 +272,7 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
                 ClientOp.TUPLE_DELETE,
                 (s, w) -> ser.writeTuple(tx, keyRec, s, w, true),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, keyRec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keyRec));
     }
 
     /** {@inheritDoc} */
@@ -290,7 +290,7 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
                 ClientOp.TUPLE_DELETE_EXACT,
                 (s, w) -> ser.writeTuple(tx, rec, s, w, false),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, rec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, rec));
     }
 
     /** {@inheritDoc} */
@@ -309,7 +309,7 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
                 (s, w) -> ser.writeTuple(tx, keyRec, s, w, true),
                 (s, r) -> ClientTupleSerializer.readValueTuple(s, r, keyRec),
                 null,
-                ClientTupleSerializer.getHashFunction(tx, keyRec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keyRec));
     }
 
     /** {@inheritDoc} */
@@ -332,7 +332,7 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
                 (s, w) -> ser.writeTuples(tx, keyRecs, s, w, true),
                 (s, r) -> ClientTupleSerializer.readTuples(s, r, true),
                 Collections.emptyList(),
-                ClientTupleSerializer.getHashFunction(tx, keyRecs.iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, keyRecs.iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -355,7 +355,7 @@ public class ClientRecordBinaryView implements RecordView<Tuple> {
                 (s, w) -> ser.writeTuples(tx, recs, s, w, false),
                 ClientTupleSerializer::readTuples,
                 Collections.emptyList(),
-                ClientTupleSerializer.getHashFunction(tx, recs.iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, recs.iterator().next()));
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientRecordView.java
@@ -72,7 +72,7 @@ public class ClientRecordView<R> implements RecordView<R> {
                 (s, w) -> ser.writeRec(tx, keyRec, s, w, TuplePart.KEY),
                 (s, r) -> ser.readValRec(keyRec, s, r),
                 null,
-                ClientTupleSerializer.getHashFunction(tx, ser.mapper(), keyRec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, ser.mapper(), keyRec));
     }
 
     /** {@inheritDoc} */
@@ -95,7 +95,7 @@ public class ClientRecordView<R> implements RecordView<R> {
                 (s, w) -> ser.writeRecs(tx, keyRecs, s, w, TuplePart.KEY),
                 (s, r) -> ser.readRecs(s, r, true, TuplePart.KEY_AND_VAL),
                 Collections.emptyList(),
-                ClientTupleSerializer.getHashFunction(tx, ser.mapper(), keyRecs.iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, ser.mapper(), keyRecs.iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -113,7 +113,7 @@ public class ClientRecordView<R> implements RecordView<R> {
                 ClientOp.TUPLE_UPSERT,
                 (s, w) -> ser.writeRec(tx, rec, s, w, TuplePart.KEY_AND_VAL),
                 r -> null,
-                ClientTupleSerializer.getHashFunction(tx, ser.mapper(), rec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, ser.mapper(), rec));
     }
 
     /** {@inheritDoc} */
@@ -135,7 +135,7 @@ public class ClientRecordView<R> implements RecordView<R> {
                 ClientOp.TUPLE_UPSERT_ALL,
                 (s, w) -> ser.writeRecs(tx, recs, s, w, TuplePart.KEY_AND_VAL),
                 r -> null,
-                ClientTupleSerializer.getHashFunction(tx, ser.mapper(), recs.iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, ser.mapper(), recs.iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -154,7 +154,7 @@ public class ClientRecordView<R> implements RecordView<R> {
                 (s, w) -> ser.writeRec(tx, rec, s, w, TuplePart.KEY_AND_VAL),
                 (s, r) -> ser.readValRec(rec, s, r),
                 null,
-                ClientTupleSerializer.getHashFunction(tx, ser.mapper(), rec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, ser.mapper(), rec));
     }
 
     /** {@inheritDoc} */
@@ -172,7 +172,7 @@ public class ClientRecordView<R> implements RecordView<R> {
                 ClientOp.TUPLE_INSERT,
                 (s, w) -> ser.writeRec(tx, rec, s, w, TuplePart.KEY_AND_VAL),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, ser.mapper(), rec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, ser.mapper(), rec));
     }
 
     /** {@inheritDoc} */
@@ -195,7 +195,7 @@ public class ClientRecordView<R> implements RecordView<R> {
                 (s, w) -> ser.writeRecs(tx, recs, s, w, TuplePart.KEY_AND_VAL),
                 (s, r) -> ser.readRecs(s, r, false, TuplePart.KEY_AND_VAL),
                 Collections.emptyList(),
-                ClientTupleSerializer.getHashFunction(tx, ser.mapper(), recs.iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, ser.mapper(), recs.iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -219,7 +219,7 @@ public class ClientRecordView<R> implements RecordView<R> {
                 ClientOp.TUPLE_REPLACE,
                 (s, w) -> ser.writeRec(tx, rec, s, w, TuplePart.KEY_AND_VAL),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, ser.mapper(), rec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, ser.mapper(), rec));
     }
 
     /** {@inheritDoc} */
@@ -232,7 +232,7 @@ public class ClientRecordView<R> implements RecordView<R> {
                 ClientOp.TUPLE_REPLACE_EXACT,
                 (s, w) -> ser.writeRecs(tx, oldRec, newRec, s, w, TuplePart.KEY_AND_VAL),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, ser.mapper(), oldRec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, ser.mapper(), oldRec));
     }
 
     /** {@inheritDoc} */
@@ -251,7 +251,7 @@ public class ClientRecordView<R> implements RecordView<R> {
                 (s, w) -> ser.writeRec(tx, rec, s, w, TuplePart.KEY_AND_VAL),
                 (s, r) -> ser.readValRec(rec, s, r),
                 null,
-                ClientTupleSerializer.getHashFunction(tx, ser.mapper(), rec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, ser.mapper(), rec));
     }
 
     /** {@inheritDoc} */
@@ -269,7 +269,7 @@ public class ClientRecordView<R> implements RecordView<R> {
                 ClientOp.TUPLE_DELETE,
                 (s, w) -> ser.writeRec(tx, keyRec, s, w, TuplePart.KEY),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, ser.mapper(), keyRec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, ser.mapper(), keyRec));
     }
 
     /** {@inheritDoc} */
@@ -287,7 +287,7 @@ public class ClientRecordView<R> implements RecordView<R> {
                 ClientOp.TUPLE_DELETE_EXACT,
                 (s, w) -> ser.writeRec(tx, rec, s, w, TuplePart.KEY_AND_VAL),
                 ClientMessageUnpacker::unpackBoolean,
-                ClientTupleSerializer.getHashFunction(tx, ser.mapper(), rec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, ser.mapper(), rec));
     }
 
     /** {@inheritDoc} */
@@ -306,7 +306,7 @@ public class ClientRecordView<R> implements RecordView<R> {
                 (s, w) -> ser.writeRec(tx, keyRec, s, w, TuplePart.KEY),
                 (s, r) -> ser.readValRec(keyRec, s, r),
                 null,
-                ClientTupleSerializer.getHashFunction(tx, ser.mapper(), keyRec));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, ser.mapper(), keyRec));
     }
 
     /** {@inheritDoc} */
@@ -329,7 +329,7 @@ public class ClientRecordView<R> implements RecordView<R> {
                 (s, w) -> ser.writeRecs(tx, keyRecs, s, w, TuplePart.KEY),
                 (s, r) -> ser.readRecs(s, r, false, TuplePart.KEY),
                 Collections.emptyList(),
-                ClientTupleSerializer.getHashFunction(tx, ser.mapper(), keyRecs.iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, ser.mapper(), keyRecs.iterator().next()));
     }
 
     /** {@inheritDoc} */
@@ -352,7 +352,7 @@ public class ClientRecordView<R> implements RecordView<R> {
                 (s, w) -> ser.writeRecs(tx, recs, s, w, TuplePart.KEY_AND_VAL),
                 (s, r) -> ser.readRecs(s, r, false, TuplePart.KEY_AND_VAL),
                 Collections.emptyList(),
-                ClientTupleSerializer.getHashFunction(tx, ser.mapper(), recs.iterator().next()));
+                ClientTupleSerializer.getPartitionAwarenessProvider(tx, ser.mapper(), recs.iterator().next()));
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -435,7 +435,7 @@ public class ClientTable implements Table {
             @Nullable PartitionAwarenessProvider provider,
             @Nullable List<String> partitions,
             ClientSchema schema) {
-        if (partitions == null || partitions.isEmpty() || provider == null) {
+        if (provider == null) {
             return null;
         }
 
@@ -444,6 +444,10 @@ public class ClientTable implements Table {
 
         if (ch != null) {
             return ch.protocolContext().clusterNode().id();
+        }
+
+        if (partitions == null || partitions.isEmpty()) {
+            return null;
         }
 
         Integer hash = provider.getObjectHashCode(schema);

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -18,7 +18,7 @@
 package org.apache.ignite.internal.client.table;
 
 import static org.apache.ignite.lang.ErrorGroups.Client.CONNECTION_ERR;
-import static org.apache.ignite.lang.ErrorGroups.Common.UNKNOWN_ERR;
+import static org.apache.ignite.lang.ErrorGroups.Common.UNEXPECTED_ERR;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -160,7 +160,7 @@ public class ClientTable implements Table {
             int schemaCnt = r.in().unpackMapHeader();
 
             if (schemaCnt == 0) {
-                throw new IgniteException(UNKNOWN_ERR, "Schema not found: " + ver);
+                throw new IgniteException(UNEXPECTED_ERR, "Schema not found: " + ver);
             }
 
             ClientSchema last = null;
@@ -239,9 +239,9 @@ public class ClientTable implements Table {
         }
     }
 
-    private static ClientTransaction getClientTx(@NotNull Transaction tx) {
+    static ClientTransaction getClientTx(@NotNull Transaction tx) {
         if (!(tx instanceof ClientTransaction)) {
-            throw new IgniteException(UNKNOWN_ERR, "Unsupported transaction implementation: '"
+            throw new IgniteException(UNEXPECTED_ERR, "Unsupported transaction implementation: '"
                     + tx.getClass()
                     + "'. Use IgniteClient.transactions() to start transactions.");
         }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -228,7 +228,7 @@ public class ClientTable implements Table {
         if (tx == null) {
             out.out().packNil();
         } else {
-            ClientTransaction clientTx = getClientTx(tx);
+            ClientTransaction clientTx = ClientTransaction.get(tx);
 
             if (clientTx.channel() != out.clientChannel()) {
                 // Do not throw IgniteClientConnectionException to avoid retry kicking in.
@@ -237,16 +237,6 @@ public class ClientTable implements Table {
 
             out.out().packLong(clientTx.id());
         }
-    }
-
-    static ClientTransaction getClientTx(@NotNull Transaction tx) {
-        if (!(tx instanceof ClientTransaction)) {
-            throw new IgniteException(UNEXPECTED_ERR, "Unsupported transaction implementation: '"
-                    + tx.getClass()
-                    + "'. Use IgniteClient.transactions() to start transactions.");
-        }
-
-        return (ClientTransaction) tx;
     }
 
     <T> CompletableFuture<T> doSchemaOutInOpAsync(

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
@@ -18,7 +18,6 @@
 package org.apache.ignite.internal.client.table;
 
 import static org.apache.ignite.internal.client.proto.ClientMessageCommon.NO_VALUE;
-import static org.apache.ignite.internal.client.table.ClientTable.getClientTx;
 import static org.apache.ignite.internal.client.table.ClientTable.writeTx;
 import static org.apache.ignite.lang.ErrorGroups.Client.PROTOCOL_ERR;
 
@@ -447,7 +446,7 @@ public class ClientTupleSerializer {
 
     public static PartitionAwarenessProvider getPartitionAwarenessProvider(@Nullable Transaction tx, @NotNull Tuple rec) {
         if (tx != null) {
-            return PartitionAwarenessProvider.of(getClientTx(tx).channel());
+            return PartitionAwarenessProvider.of(ClientTransaction.get(tx).channel());
         }
 
         return PartitionAwarenessProvider.of(schema -> getColocationHash(schema, rec));
@@ -456,7 +455,7 @@ public class ClientTupleSerializer {
     public static PartitionAwarenessProvider getPartitionAwarenessProvider(
             @Nullable Transaction tx, Mapper<?> mapper, @NotNull Object rec) {
         if (tx != null) {
-            return PartitionAwarenessProvider.of(getClientTx(tx).channel());
+            return PartitionAwarenessProvider.of(ClientTransaction.get(tx).channel());
         }
 
         return PartitionAwarenessProvider.of(schema -> getColocationHash(schema, mapper, rec));

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
@@ -444,6 +444,13 @@ public class ClientTupleSerializer {
         }
     }
 
+    /**
+     * Gets partition awareness provider for the specified tuple.
+     *
+     * @param tx Transaction.
+     * @param rec Tuple.
+     * @return Partition awareness provider.
+     */
     public static PartitionAwarenessProvider getPartitionAwarenessProvider(@Nullable Transaction tx, @NotNull Tuple rec) {
         if (tx != null) {
             return PartitionAwarenessProvider.of(ClientTransaction.get(tx).channel());
@@ -452,6 +459,13 @@ public class ClientTupleSerializer {
         return PartitionAwarenessProvider.of(schema -> getColocationHash(schema, rec));
     }
 
+    /**
+     * Gets partition awareness provider for the specified object.
+     *
+     * @param tx Transaction.
+     * @param rec Object.
+     * @return Partition awareness provider.
+     */
     public static PartitionAwarenessProvider getPartitionAwarenessProvider(
             @Nullable Transaction tx, Mapper<?> mapper, @NotNull Object rec) {
         if (tx != null) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.client.table;
 
 import static org.apache.ignite.internal.client.proto.ClientMessageCommon.NO_VALUE;
+import static org.apache.ignite.internal.client.table.ClientTable.getClientTx;
 import static org.apache.ignite.internal.client.table.ClientTable.writeTx;
 import static org.apache.ignite.lang.ErrorGroups.Client.PROTOCOL_ERR;
 
@@ -446,8 +447,7 @@ public class ClientTupleSerializer {
 
     public static PartitionAwarenessProvider getPartitionAwarenessProvider(@Nullable Transaction tx, @NotNull Tuple rec) {
         if (tx != null) {
-            // TODO: Validate tx type?
-            return PartitionAwarenessProvider.of(((ClientTransaction)tx).channel());
+            return PartitionAwarenessProvider.of(getClientTx(tx).channel());
         }
 
         return PartitionAwarenessProvider.of(schema -> getColocationHash(schema, rec));
@@ -456,8 +456,7 @@ public class ClientTupleSerializer {
     public static PartitionAwarenessProvider getPartitionAwarenessProvider(
             @Nullable Transaction tx, Mapper<?> mapper, @NotNull Object rec) {
         if (tx != null) {
-            // TODO: Validate tx type?
-            return PartitionAwarenessProvider.of(((ClientTransaction)tx).channel());
+            return PartitionAwarenessProvider.of(getClientTx(tx).channel());
         }
 
         return PartitionAwarenessProvider.of(schema -> getColocationHash(schema, mapper, rec));

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/PartitionAwarenessProvider.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/PartitionAwarenessProvider.java
@@ -26,12 +26,27 @@ import org.jetbrains.annotations.Nullable;
  * Represents 3 use cases:
  * 1. Partition awareness is enabled. Use hashFunc to determine partition.
  * 2. Transaction is used. Use specific channel.
- * 3. No partition awareness and no transaction. Use any channel.
+ * 3. Null instance = No partition awareness and no transaction. Use any channel.
  */
 class PartitionAwarenessProvider {
     private final @Nullable ClientChannel channel;
 
     private final @Nullable Function<ClientSchema, Integer> hashFunc;
+
+    private PartitionAwarenessProvider(@Nullable ClientChannel channel, @Nullable Function<ClientSchema, Integer> hashFunc) {
+        assert (channel == null) ^ (hashFunc == null) : "One must be null, another not null: channel, hashFunc";
+
+        this.channel = channel;
+        this.hashFunc = hashFunc;
+    }
+
+    public static PartitionAwarenessProvider of(ClientChannel channel) {
+        return new PartitionAwarenessProvider(channel, null);
+    }
+
+    public static PartitionAwarenessProvider of(Function<ClientSchema, Integer> hashFunc) {
+        return new PartitionAwarenessProvider(null, hashFunc);
+    }
 
     @Nullable ClientChannel channel() {
         return channel;
@@ -39,9 +54,9 @@ class PartitionAwarenessProvider {
 
     int getObjectHashCode(ClientSchema schema) {
         if (hashFunc == null) {
-            throw new IllegalStateException("Partition awareness is not enabled.");
+            throw new IllegalStateException("Partition awareness is not enabled. Check channel() first.");
         }
 
-        return hashFunc != null ? hashFunc.apply(schema) : 0;
+        return hashFunc.apply(schema);
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/PartitionAwarenessProvider.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/PartitionAwarenessProvider.java
@@ -52,11 +52,15 @@ class PartitionAwarenessProvider {
         return channel;
     }
 
-    int getObjectHashCode(ClientSchema schema) {
+    Integer getObjectHashCode(ClientSchema schema) {
         if (hashFunc == null) {
             throw new IllegalStateException("Partition awareness is not enabled. Check channel() first.");
         }
 
         return hashFunc.apply(schema);
+    }
+
+    boolean isPartitionAwarenessEnabled() {
+        return hashFunc != null;
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/PartitionAwarenessProvider.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/PartitionAwarenessProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.client.table;
+
+import java.util.function.Function;
+import org.apache.ignite.internal.client.ClientChannel;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Partition awareness provider.
+ * Represents 3 use cases:
+ * 1. Partition awareness is enabled. Use hashFunc to determine partition.
+ * 2. Transaction is used. Use specific channel.
+ * 3. No partition awareness and no transaction. Use any channel.
+ */
+class PartitionAwarenessProvider {
+    private final @Nullable ClientChannel channel;
+
+    private final @Nullable Function<ClientSchema, Integer> hashFunc;
+
+    @Nullable ClientChannel channel() {
+        return channel;
+    }
+
+    int getObjectHashCode(ClientSchema schema) {
+        if (hashFunc == null) {
+            throw new IllegalStateException("Partition awareness is not enabled.");
+        }
+
+        return hashFunc != null ? hashFunc.apply(schema) : 0;
+    }
+}

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/tx/ClientTransaction.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/tx/ClientTransaction.java
@@ -123,9 +123,15 @@ public class ClientTransaction implements Transaction {
     @Override
     public HybridTimestamp readTimestamp() {
         // TODO: IGNITE-17929 Add read-only support to ClientTransactions
-        return null;
+        throw new UnsupportedOperationException("Not implemented yet.");
     }
 
+    /**
+     * Gets the internal transaction from the given public transaction. Throws an exception if the given transaction is
+     * not an instance of {@link ClientTransaction}.
+     * @param tx Public transaction.
+     * @return Internal transaction.
+     */
     public static ClientTransaction get(@NotNull Transaction tx) {
         if (!(tx instanceof ClientTransaction)) {
             throw new IgniteException(UNEXPECTED_ERR, "Unsupported transaction implementation: '"

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/tx/ClientTransaction.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/tx/ClientTransaction.java
@@ -129,6 +129,7 @@ public class ClientTransaction implements Transaction {
     /**
      * Gets the internal transaction from the given public transaction. Throws an exception if the given transaction is
      * not an instance of {@link ClientTransaction}.
+     *
      * @param tx Public transaction.
      * @return Internal transaction.
      */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/tx/ClientTransaction.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/tx/ClientTransaction.java
@@ -18,14 +18,17 @@
 package org.apache.ignite.internal.client.tx;
 
 import static org.apache.ignite.internal.client.ClientUtils.sync;
+import static org.apache.ignite.lang.ErrorGroups.Common.UNEXPECTED_ERR;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.ignite.internal.client.ClientChannel;
 import org.apache.ignite.internal.client.proto.ClientOp;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
+import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.tx.Transaction;
 import org.apache.ignite.tx.TransactionException;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Client transaction.
@@ -121,5 +124,15 @@ public class ClientTransaction implements Transaction {
     public HybridTimestamp readTimestamp() {
         // TODO: IGNITE-17929 Add read-only support to ClientTransactions
         return null;
+    }
+
+    public static ClientTransaction get(@NotNull Transaction tx) {
+        if (!(tx instanceof ClientTransaction)) {
+            throw new IgniteException(UNEXPECTED_ERR, "Unsupported transaction implementation: '"
+                    + tx.getClass()
+                    + "'. Use IgniteClient.transactions() to start transactions.");
+        }
+
+        return (ClientTransaction) tx;
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
@@ -21,10 +21,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.netty.util.ResourceLeakDetector;
+import java.util.Arrays;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.client.fakes.FakeIgnite;
 import org.apache.ignite.client.fakes.FakeIgniteTables;
+import org.apache.ignite.network.ClusterNode;
+import org.apache.ignite.network.NetworkAddress;
 import org.apache.ignite.table.Tuple;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -163,5 +168,21 @@ public abstract class AbstractClientTest {
             assertEquals(x.columnName(i), y.columnName(i));
             assertEquals((Object) x.value(i), y.value(i));
         }
+    }
+
+    public static IgniteClient getClient(TestServer... servers) {
+        String[] addresses = Arrays.stream(servers).map(s -> "127.0.0.1:" + s.port()).toArray(String[]::new);
+
+        return IgniteClient.builder()
+                .addresses(addresses)
+                .reconnectThrottlingPeriod(0)
+                .retryPolicy(new RetryLimitPolicy().retryLimit(3))
+                .build();
+    }
+
+    public static Set<ClusterNode> getClusterNodes(String... names) {
+        return Arrays.stream(names)
+                .map(s -> new ClusterNode("id", s, new NetworkAddress("127.0.0.1", 8080)))
+                .collect(Collectors.toSet());
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
@@ -170,6 +170,12 @@ public abstract class AbstractClientTest {
         }
     }
 
+    /**
+     * Gets a client connected to the specified servers.
+     *
+     * @param servers Servers.
+     * @return Client.
+     */
     public static IgniteClient getClient(TestServer... servers) {
         String[] addresses = Arrays.stream(servers).map(s -> "127.0.0.1:" + s.port()).toArray(String[]::new);
 
@@ -180,6 +186,12 @@ public abstract class AbstractClientTest {
                 .build();
     }
 
+    /**
+     * Gets cluster nodes with the specified names.
+     *
+     * @param names Names.
+     * @return Nodes.
+     */
     public static Set<ClusterNode> getClusterNodes(String... names) {
         return Arrays.stream(names)
                 .map(s -> new ClusterNode("id", s, new NetworkAddress("127.0.0.1", 8080)))

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.ignite.client;
 
+import static org.apache.ignite.client.AbstractClientTest.getClient;
+import static org.apache.ignite.client.AbstractClientTest.getClusterNodes;
 import static org.apache.ignite.lang.ErrorGroups.Table.TABLE_NOT_FOUND_ERR;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -24,19 +26,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Arrays;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.ignite.client.fakes.FakeIgnite;
 import org.apache.ignite.client.fakes.FakeIgniteTables;
 import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.lang.TableNotFoundException;
-import org.apache.ignite.network.ClusterNode;
-import org.apache.ignite.network.NetworkAddress;
 import org.apache.ignite.table.Tuple;
 import org.apache.ignite.table.mapper.Mapper;
 import org.junit.jupiter.api.AfterEach;
@@ -160,16 +157,6 @@ public class ClientComputeTest {
         }
     }
 
-    private IgniteClient getClient(TestServer... servers) {
-        String[] addresses = Arrays.stream(servers).map(s -> "127.0.0.1:" + s.port()).toArray(String[]::new);
-
-        return IgniteClient.builder()
-                .addresses(addresses)
-                .reconnectThrottlingPeriod(0)
-                .retryPolicy(new RetryLimitPolicy().retryLimit(3))
-                .build();
-    }
-
     private void initServers(Function<Integer, Boolean> shouldDropConnection) {
         ignite = new FakeIgnite();
         ((FakeIgniteTables) ignite.tables()).createTable(TABLE_NAME);
@@ -179,11 +166,5 @@ public class ClientComputeTest {
         server1 = new TestServer(10900, 10, 0, ignite, shouldDropConnection, null, "s1", clusterId);
         server2 = new TestServer(10910, 10, 0, ignite, shouldDropConnection, null, "s2", clusterId);
         server3 = new TestServer(10920, 10, 0, ignite, shouldDropConnection, null, "s3", clusterId);
-    }
-
-    private Set<ClusterNode> getClusterNodes(String... names) {
-        return Arrays.stream(names)
-                .map(s -> new ClusterNode("id", s, new NetworkAddress("127.0.0.1", 8080)))
-                .collect(Collectors.toSet());
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -173,7 +173,9 @@ public class PartitionAwarenessTest extends AbstractClientTest {
             // Wait for heartbeat message to receive change notification flag.
             Thread.sleep(500);
         } else {
-            // Perform one request on the default channel to receive change notification flag.
+            // Perform a request on the default channel to receive change notification flag.
+            // Use two requests because of round-robin.
+            client2.tables().tables();
             client2.tables().tables();
         }
 

--- a/modules/client/src/test/java/org/apache/ignite/client/RequestBalancingTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RequestBalancingTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client;
+
+import org.apache.ignite.client.fakes.FakeIgnite;
+import org.apache.ignite.internal.util.IgniteUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests client request balancing.
+ */
+public class RequestBalancingTest {
+    /** Test server 1. */
+    TestServer server1;
+
+    /** Test server 2. */
+    TestServer server2;
+
+    /** Test server 3. */
+    TestServer server3;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        FakeIgnite ignite = new FakeIgnite();
+        server1 = AbstractClientTest.startServer(10900, 10, 0, ignite);
+        server2 = AbstractClientTest.startServer(10900, 10, 0, ignite);
+        server3 = AbstractClientTest.startServer(10900, 10, 0, ignite);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        IgniteUtils.closeAll(server1, server2);
+    }
+
+    @Test
+    public void testRequestsAreRoundRobinBalanced() {
+
+    }
+}

--- a/modules/client/src/test/java/org/apache/ignite/client/RequestBalancingTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RequestBalancingTest.java
@@ -23,13 +23,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.ignite.client.fakes.FakeIgnite;
 import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.internal.util.IgniteUtils;
-import org.apache.ignite.network.ClusterNode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -342,11 +342,11 @@ namespace Apache.Ignite.Internal
         private async ValueTask<ClientSocket> GetNextSocketAsync()
         {
             List<Exception>? errors = null;
-            var startIdx = (int) Interlocked.Increment(ref _endPointIndex);
+            var startIdx = unchecked((int) Interlocked.Increment(ref _endPointIndex));
 
             for (var i = 0; i < _endpoints.Count; i++)
             {
-                var idx = (startIdx + i) % _endpoints.Count;
+                var idx = Math.Abs(startIdx + i) % _endpoints.Count;
                 var endPoint = _endpoints[idx];
 
                 if (endPoint.Socket is { IsDisposed: false })
@@ -375,11 +375,11 @@ namespace Apache.Ignite.Internal
         /// </summary>
         private ClientSocket? GetNextSocketWithoutReconnect()
         {
-            var startIdx = (int) Interlocked.Increment(ref _endPointIndex);
+            var startIdx = unchecked((int) Interlocked.Increment(ref _endPointIndex));
 
             for (var i = 0; i < _endpoints.Count; i++)
             {
-                var idx = (startIdx + i) % _endpoints.Count;
+                var idx = Math.Abs(startIdx + i) % _endpoints.Count;
                 var endPoint = _endpoints[idx];
 
                 if (endPoint.Socket is { IsDisposed: false })

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -118,7 +118,6 @@ namespace Apache.Ignite.Internal
 
             // Because this call is not awaited, execution of the current method continues before the call is completed.
             // Secondary connections are established in the background.
-            // TODO IGNITE-18808 Do this periodically.
             _ = socket.ConnectAllSockets();
 
             return socket;

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSqlTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSqlTest.java
@@ -433,8 +433,9 @@ public class ItThinClientSqlTest extends ItAbstractThinClientTest {
 
             // Do N checks - they will go to different nodes becase of request balancing.
             for (int i = 0; i < nodeCount; i++) {
-                if (client().tables().table(tableName) == null)
+                if (client().tables().table(tableName) == null) {
                     return false;
+                }
             }
 
             return true;

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSqlTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSqlTest.java
@@ -428,6 +428,8 @@ public class ItThinClientSqlTest extends ItAbstractThinClientTest {
     }
 
     private void waitForTableOnAllNodes(String tableName) throws InterruptedException {
+        // TODO IGNITE-18733: remove this workaround when the issue is fixed.
+        // Currently newly created table is not immediately available on all nodes.
         boolean res = IgniteTestUtils.waitForCondition(() -> {
             var nodeCount = client().clusterNodes().size();
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSqlTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSqlTest.java
@@ -428,7 +428,7 @@ public class ItThinClientSqlTest extends ItAbstractThinClientTest {
     }
 
     private void waitForTableOnAllNodes(String tableName) throws InterruptedException {
-        // TODO IGNITE-18733: remove this workaround when the issue is fixed.
+        // TODO IGNITE-18733, IGNITE-18449: remove this workaround when issues are fixed.
         // Currently newly created table is not immediately available on all nodes.
         boolean res = IgniteTestUtils.waitForCondition(() -> {
             var nodeCount = client().clusterNodes().size();

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSqlTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSqlTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionException;
+import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.sql.ColumnMetadata;
 import org.apache.ignite.sql.ColumnType;
@@ -48,6 +49,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Thin client SQL integration test.
  */
+@SuppressWarnings("resource")
 public class ItThinClientSqlTest extends ItAbstractThinClientTest {
     @Test
     void testExecuteAsyncSimpleSelect() {
@@ -96,11 +98,12 @@ public class ItThinClientSqlTest extends ItAbstractThinClientTest {
     }
 
     @Test
-    void testTxCorrectness() {
+    void testTxCorrectness() throws InterruptedException {
         Session ses = client().sql().createSession();
 
         // Create table.
         ses.execute(null, "CREATE TABLE testExecuteDdlDml(ID INT NOT NULL PRIMARY KEY, VAL VARCHAR)");
+        waitForTableOnAllNodes("testExecuteDdlDml");
 
         // Async
         Transaction tx = client().transactions().begin();
@@ -161,7 +164,7 @@ public class ItThinClientSqlTest extends ItAbstractThinClientTest {
     }
 
     @Test
-    void testExecuteAsyncDdlDml() {
+    void testExecuteAsyncDdlDml() throws InterruptedException {
         Session session = client().sql().createSession();
 
         // Create table.
@@ -174,6 +177,8 @@ public class ItThinClientSqlTest extends ItAbstractThinClientTest {
         assertTrue(createRes.wasApplied());
         assertEquals(-1, createRes.affectedRows());
         assertThrows(NoRowSetExpectedException.class, createRes::currentPageSize);
+
+        waitForTableOnAllNodes("testExecuteAsyncDdlDml");
 
         // Insert data.
         for (int i = 0; i < 10; i++) {
@@ -231,13 +236,15 @@ public class ItThinClientSqlTest extends ItAbstractThinClientTest {
 
     @SuppressWarnings("ConstantConditions")
     @Test
-    void testExecuteDdlDml() {
+    void testExecuteDdlDml() throws InterruptedException {
         Session session = client().sql().createSession();
 
         // Create table.
         ResultSet createRes = session.execute(
                 null,
                 "CREATE TABLE testExecuteDdlDml(ID INT NOT NULL PRIMARY KEY, VAL VARCHAR)");
+
+        waitForTableOnAllNodes("testExecuteDdlDml");
 
         assertFalse(createRes.hasRowSet());
         assertNull(createRes.metadata());
@@ -312,10 +319,11 @@ public class ItThinClientSqlTest extends ItAbstractThinClientTest {
     }
 
     @Test
-    void testFetchNextPage() {
+    void testFetchNextPage() throws InterruptedException {
         Session session = client().sql().createSession();
 
         session.executeAsync(null, "CREATE TABLE testFetchNextPage(ID INT PRIMARY KEY, VAL INT)").join();
+        waitForTableOnAllNodes("testFetchNextPage");
 
         for (int i = 0; i < 10; i++) {
             session.executeAsync(null, "INSERT INTO testFetchNextPage VALUES (?, ?)", i, i).join();
@@ -354,10 +362,12 @@ public class ItThinClientSqlTest extends ItAbstractThinClientTest {
     }
 
     @Test
-    void testTransactionRollbackRevertsSqlUpdate() {
+    void testTransactionRollbackRevertsSqlUpdate() throws InterruptedException {
         Session session = client().sql().createSession();
 
         session.executeAsync(null, "CREATE TABLE testTx(ID INT PRIMARY KEY, VAL INT)").join();
+        waitForTableOnAllNodes("testTx");
+
         session.executeAsync(null, "INSERT INTO testTx VALUES (1, 1)").join();
 
         Transaction tx = client().transactions().begin();
@@ -415,6 +425,22 @@ public class ItThinClientSqlTest extends ItAbstractThinClientTest {
 
         assertEquals(0, row.num);
         assertNull(row.str);
+    }
+
+    private void waitForTableOnAllNodes(String tableName) throws InterruptedException {
+        boolean res = IgniteTestUtils.waitForCondition(() -> {
+            var nodeCount = client().clusterNodes().size();
+
+            // Do N checks - they will go to different nodes becase of request balancing.
+            for (int i = 0; i < nodeCount; i++) {
+                if (client().tables().table(tableName) == null)
+                    return false;
+            }
+
+            return true;
+        }, 3000);
+
+        assertTrue(res);
     }
 
     private static class Pojo {


### PR DESCRIPTION
When Java client is connected to more than one server node, send requests to different connections in a round-robin fashion instead of using the same default connection every time. This improves client performance and evens the load among servers.