### PR TITLE
IGNITE-18674 Introduce async logic to CLI

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,6 +72,7 @@ testkit = "1.8.2"
 openapi = "3.2.0"
 autoService = "1.0.1"
 awaitility = "4.2.0"
+progressBar = "0.9.4"
 
 #Tools
 pmdTool = "6.28.0"
@@ -229,3 +230,5 @@ auto-service = { module = "com.google.auto.service:auto-service", version.ref = 
 auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }
 
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
+
+progressBar = { module = "me.tongfei:progressbar", version.ref = "progressBar" }

--- a/modules/cli/build.gradle
+++ b/modules/cli/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation libs.okhttp.logging
     implementation libs.threetenbp
     implementation libs.swagger.legacy.annotations
-    implementation 'me.tongfei:progressbar:0.9.4'
+    implementation libs.progressBar
 
     testAnnotationProcessor libs.picocli.annotation.processor
     testAnnotationProcessor libs.micronaut.inject.annotation.processor

--- a/modules/cli/build.gradle
+++ b/modules/cli/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation libs.okhttp.logging
     implementation libs.threetenbp
     implementation libs.swagger.legacy.annotations
+    implementation 'me.tongfei:progressbar:0.9.4'
 
     testAnnotationProcessor libs.picocli.annotation.processor
     testAnnotationProcessor libs.micronaut.inject.annotation.processor

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/sql/SqlCompleter.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/sql/SqlCompleter.java
@@ -18,7 +18,6 @@
 package org.apache.ignite.internal.cli.commands.sql;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.internal.cli.sql.SchemaProvider;
 import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
@@ -72,10 +71,5 @@ class SqlCompleter implements Completer {
     private static void addCandidate(String string, List<Candidate> candidates) {
         candidates.add(new Candidate(string));
         candidates.add(new Candidate(string.toLowerCase()));
-    }
-
-    public void initStateAsync() {
-        // trigger schema loading in background
-        CompletableFuture.supplyAsync(schemaProvider::getSchema);
     }
 }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/sql/SqlCompleter.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/sql/SqlCompleter.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.cli.commands.sql;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.internal.cli.sql.SchemaProvider;
 import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
@@ -71,5 +72,10 @@ class SqlCompleter implements Completer {
     private static void addCandidate(String string, List<Candidate> candidates) {
         candidates.add(new Candidate(string));
         candidates.add(new Candidate(string.toLowerCase()));
+    }
+
+    public void initStateAsync() {
+        // trigger schema loading in background
+        CompletableFuture.supplyAsync(schemaProvider::getSchema);
     }
 }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/sql/SqlReplCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/sql/SqlReplCommand.java
@@ -101,6 +101,7 @@ public class SqlReplCommand extends BaseCommand implements Runnable {
             // When passing white space to this command, picocli will treat it as a positional argument
             if (execOptions == null || (execOptions.command != null && execOptions.command.isBlank())) {
                 SqlCompleter sqlCompleter = new SqlCompleter(new SqlSchemaProvider(sqlManager::getMetadata));
+                sqlCompleter.initStateAsync();
                 IgniteSqlCommandCompleter sqlCommandCompleter = new IgniteSqlCommandCompleter();
                 replExecutorProvider.get().execute(Repl.builder()
                         .withPromptProvider(() -> ansi(fg(Color.GREEN).mark("sql-cli> ")))

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/sql/SqlReplCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/sql/SqlReplCommand.java
@@ -100,8 +100,10 @@ public class SqlReplCommand extends BaseCommand implements Runnable {
         try (SqlManager sqlManager = new SqlManager(jdbc)) {
             // When passing white space to this command, picocli will treat it as a positional argument
             if (execOptions == null || (execOptions.command != null && execOptions.command.isBlank())) {
-                SqlCompleter sqlCompleter = new SqlCompleter(new SqlSchemaProvider(sqlManager::getMetadata));
-                sqlCompleter.initStateAsync();
+                SqlSchemaProvider schemaProvider = new SqlSchemaProvider(sqlManager::getMetadata);
+                schemaProvider.initStateAsync();
+
+                SqlCompleter sqlCompleter = new SqlCompleter(schemaProvider);
                 IgniteSqlCommandCompleter sqlCommandCompleter = new IgniteSqlCommandCompleter();
                 replExecutorProvider.get().execute(Repl.builder()
                         .withPromptProvider(() -> ansi(fg(Color.GREEN).mark("sql-cli> ")))

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AbstractCallExecutionPipeline.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AbstractCallExecutionPipeline.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.cli.core.call;
+
+import java.io.PrintWriter;
+import java.util.function.Supplier;
+import org.apache.ignite.internal.cli.core.decorator.Decorator;
+import org.apache.ignite.internal.cli.core.decorator.TerminalOutput;
+import org.apache.ignite.internal.cli.core.exception.ExceptionHandlers;
+import org.apache.ignite.internal.cli.core.exception.ExceptionWriter;
+import org.apache.ignite.internal.cli.logger.CliLoggers;
+
+/**
+ * Abstract implementation of {@link CallExecutionPipeline}.
+ * Implements common error handling logic and verbose output redirection.
+ */
+public abstract class AbstractCallExecutionPipeline<I extends CallInput, T> implements CallExecutionPipeline<I, T> {
+
+    /** Writer for execution output. */
+    protected final PrintWriter output;
+
+    /** Writer for error execution output. */
+    protected final PrintWriter errOutput;
+
+    /** Decorator that decorates call's output. */
+    protected final Decorator<T, TerminalOutput> decorator;
+
+    /** Handlers for any exceptions. */
+    protected final ExceptionHandlers exceptionHandlers;
+
+    /** Provider for call's input. */
+    protected final Supplier<I> inputProvider;
+
+    /** If {@code true}, debug output will be printed to console. */
+    protected final boolean verbose;
+
+    AbstractCallExecutionPipeline(
+            PrintWriter output,
+            PrintWriter errOutput,
+            ExceptionHandlers exceptionHandlers,
+            Decorator<T, TerminalOutput> decorator,
+            Supplier<I> inputProvider,
+            boolean verbose
+    ) {
+        this.output = output;
+        this.exceptionHandlers = exceptionHandlers;
+        this.errOutput = errOutput;
+        this.decorator = decorator;
+        this.inputProvider = inputProvider;
+        this.verbose = verbose;
+    }
+
+    /**
+     * Runs the pipeline.
+     *
+     * @return exit code.
+     */
+    @Override
+    public int runPipeline() {
+        try {
+            if (verbose) {
+                CliLoggers.startOutputRedirect(errOutput);
+            }
+            return runPipelineInternal();
+        } finally {
+            if (verbose) {
+                CliLoggers.stopOutputRedirect();
+            }
+        }
+    }
+
+    int handleResult(CallOutput<T> callOutput) {
+        if (callOutput.hasError()) {
+            return handleException(callOutput.errorCause());
+        }
+
+        if (!callOutput.isEmpty()) {
+            TerminalOutput decoratedOutput = decorator.decorate(callOutput.body());
+            output.println(decoratedOutput.toTerminalString());
+        }
+
+        return 0;
+    }
+
+    /**
+     * Runs the pipeline and blocks the thread until the result is ready.
+     */
+    protected abstract int runPipelineInternal();
+
+    int handleException(Throwable error) {
+        return exceptionHandlers.handleException(ExceptionWriter.fromPrintWriter(errOutput), error);
+    }
+}

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AsyncCall.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AsyncCall.java
@@ -17,14 +17,13 @@
 
 package org.apache.ignite.internal.cli.core.call;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
- * Call that represents an action that can be performed given an input.
- * It can be rest call, dictionary lookup or whatever.
- *
- * @param <IT> Input for the call.
- * @param <OT> Output of the call.
+ * Call that represents an asynchronous action that can be performed given an input.
+ * It can be REST call, dictionary lookup or whatever.
  */
 @FunctionalInterface
-public interface Call<IT extends CallInput, OT> {
-    CallOutput<OT> execute(IT input);
+public interface AsyncCall<IT extends CallInput, OT> {
+    CompletableFuture<CallOutput<OT>> execute(IT input);
 }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AsyncCallExecutionPipeline.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AsyncCallExecutionPipeline.java
@@ -76,7 +76,7 @@ public class AsyncCallExecutionPipeline<I extends CallInput, T> extends Abstract
     }
 
     private void print(String s) {
-        output.print("\r" + s);
+        output.print("\r" + s); // carriage return to the beginning of the line to overwrite the previous progress bar
         output.flush();
     }
 }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AsyncCallExecutionPipeline.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AsyncCallExecutionPipeline.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.cli.core.call;
+
+import java.io.PrintWriter;
+import java.util.concurrent.CompletionException;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import me.tongfei.progressbar.DelegatingProgressBarConsumer;
+import me.tongfei.progressbar.ProgressBar;
+import me.tongfei.progressbar.ProgressBarBuilder;
+import org.apache.ignite.internal.cli.core.decorator.Decorator;
+import org.apache.ignite.internal.cli.core.decorator.TerminalOutput;
+import org.apache.ignite.internal.cli.core.exception.ExceptionHandlers;
+
+/** Call execution pipeline that executes an async call and displays progress bar. */
+public class AsyncCallExecutionPipeline<I extends CallInput, T> extends AbstractCallExecutionPipeline<I, T> {
+    /** Async call factory. */
+    private final Function<ProgressTracker, AsyncCall<I, T>> callFactory;
+
+    /** Builder for progress bar rendering. */
+    private final ProgressBarBuilder progressBarBuilder;
+
+    AsyncCallExecutionPipeline(
+            Function<ProgressTracker, AsyncCall<I, T>> callFactory,
+            ProgressBarBuilder progressBarBuilder,
+            PrintWriter output,
+            PrintWriter errOutput,
+            ExceptionHandlers exceptionHandlers,
+            Decorator<T, TerminalOutput> decorator,
+            Supplier<I> inputProvider,
+            boolean verbose
+    ) {
+        super(output, errOutput, exceptionHandlers, decorator, inputProvider, verbose);
+        this.callFactory = callFactory;
+        this.progressBarBuilder = progressBarBuilder;
+    }
+
+    @Override
+    public int runPipelineInternal() {
+        I callInput = inputProvider.get();
+
+        progressBarBuilder.setConsumer(new DelegatingProgressBarConsumer(this::print));
+        ProgressBar progressBar = progressBarBuilder.build();
+
+        try {
+            CallOutput<T> result = callFactory.apply(progressBar::step)
+                    .execute(callInput)
+                    .whenComplete((el, err) -> progressBar.close())
+                    .join();
+
+            // move carriage to the next line
+            output.println();
+
+            return handleResult(result);
+        } catch (CompletionException e) {
+            return handleException(e.getCause());
+        } catch (Exception e) {
+            return handleException(e);
+        }
+    }
+
+    private void print(String s) {
+        output.print("\r" + s);
+        output.flush();
+    }
+}

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AsyncCallExecutionPipeline.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AsyncCallExecutionPipeline.java
@@ -59,7 +59,7 @@ public class AsyncCallExecutionPipeline<I extends CallInput, T> extends Abstract
         ProgressBar progressBar = progressBarBuilder.build();
 
         try {
-            CallOutput<T> result = callFactory.apply(progressBar::step)
+            CallOutput<T> result = callFactory.apply(new ProgressBarTracker(progressBar))
                     .execute(callInput)
                     .whenComplete((el, err) -> progressBar.close())
                     .join();

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AsyncCallExecutionPipelineBuilder.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AsyncCallExecutionPipelineBuilder.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.cli.core.call;
+
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
+import java.time.temporal.ChronoUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import me.tongfei.progressbar.ProgressBarBuilder;
+import me.tongfei.progressbar.ProgressBarStyle;
+import org.apache.ignite.internal.cli.core.decorator.Decorator;
+import org.apache.ignite.internal.cli.core.decorator.TerminalOutput;
+import org.apache.ignite.internal.cli.core.exception.ExceptionHandler;
+import org.apache.ignite.internal.cli.core.exception.ExceptionHandlers;
+import org.apache.ignite.internal.cli.core.exception.handler.DefaultExceptionHandlers;
+import org.apache.ignite.internal.cli.decorators.DefaultDecorator;
+
+/** Builder for {@link AsyncCallExecutionPipeline}. */
+public class AsyncCallExecutionPipelineBuilder<I extends CallInput, T> {
+
+    private final Function<ProgressTracker, AsyncCall<I, T>> callFactory;
+
+    private final ProgressBarBuilder progressBarBuilder = new ProgressBarBuilder()
+            .setStyle(ProgressBarStyle.UNICODE_BLOCK)
+            .continuousUpdate()
+            .setSpeedUnit(ChronoUnit.SECONDS)
+            .setInitialMax(100)
+            .hideETA()
+            .setTaskName("")
+            .showSpeed();
+
+    private final ExceptionHandlers exceptionHandlers = new DefaultExceptionHandlers();
+
+    private Supplier<I> inputProvider;
+
+    private PrintWriter output = wrapOutputStream(System.out);
+
+    private PrintWriter errOutput = wrapOutputStream(System.err);
+
+    private Decorator<T, TerminalOutput> decorator = new DefaultDecorator<>();
+
+    private boolean verbose;
+
+    AsyncCallExecutionPipelineBuilder(Function<ProgressTracker, AsyncCall<I, T>> callFactory) {
+        this.callFactory = callFactory;
+    }
+
+    private static PrintWriter wrapOutputStream(OutputStream output) {
+        return new PrintWriter(output, true, getStdoutEncoding());
+    }
+
+    private static Charset getStdoutEncoding() {
+        String encoding = System.getProperty("sun.stdout.encoding");
+        return encoding != null ? Charset.forName(encoding) : Charset.defaultCharset();
+    }
+
+    public AsyncCallExecutionPipelineBuilder<I, T> inputProvider(Supplier<I> inputProvider) {
+        this.inputProvider = inputProvider;
+        return this;
+    }
+
+    public AsyncCallExecutionPipelineBuilder<I, T> output(PrintWriter output) {
+        this.output = output;
+        return this;
+    }
+
+    public AsyncCallExecutionPipelineBuilder<I, T> output(OutputStream output) {
+        return output(wrapOutputStream(output));
+    }
+
+    public AsyncCallExecutionPipelineBuilder<I, T> errOutput(PrintWriter errOutput) {
+        this.errOutput = errOutput;
+        return this;
+    }
+
+    public AsyncCallExecutionPipelineBuilder<I, T> errOutput(OutputStream output) {
+        return errOutput(wrapOutputStream(output));
+    }
+
+    public AsyncCallExecutionPipelineBuilder<I, T> exceptionHandler(ExceptionHandler<?> exceptionHandler) {
+        exceptionHandlers.addExceptionHandler(exceptionHandler);
+        return this;
+    }
+
+    public AsyncCallExecutionPipelineBuilder<I, T> exceptionHandlers(ExceptionHandlers exceptionHandlers) {
+        this.exceptionHandlers.addExceptionHandlers(exceptionHandlers);
+        return this;
+    }
+
+    public AsyncCallExecutionPipelineBuilder<I, T> decorator(Decorator<T, TerminalOutput> decorator) {
+        this.decorator = decorator;
+        return this;
+    }
+
+    public AsyncCallExecutionPipelineBuilder<I, T> verbose(boolean verbose) {
+        this.verbose = verbose;
+        return this;
+    }
+
+    public AsyncCallExecutionPipelineBuilder<I, T> name(String name) {
+        this.progressBarBuilder.setTaskName(name);
+        return this;
+    }
+
+    /** Builds {@link AsyncCallExecutionPipeline}. */
+    public CallExecutionPipeline<I, T> build() {
+        return new AsyncCallExecutionPipeline<>(
+                callFactory, progressBarBuilder, output, errOutput, exceptionHandlers, decorator, inputProvider, verbose
+        );
+    }
+}

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/CallExecutionPipelineBuilder.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/CallExecutionPipelineBuilder.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.cli.core.call;
+
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
+import java.util.function.Supplier;
+import org.apache.ignite.internal.cli.core.decorator.Decorator;
+import org.apache.ignite.internal.cli.core.decorator.TerminalOutput;
+import org.apache.ignite.internal.cli.core.exception.ExceptionHandler;
+import org.apache.ignite.internal.cli.core.exception.ExceptionHandlers;
+import org.apache.ignite.internal.cli.core.exception.handler.DefaultExceptionHandlers;
+import org.apache.ignite.internal.cli.decorators.DefaultDecorator;
+
+/** Builder for {@link CallExecutionPipeline}. */
+public class CallExecutionPipelineBuilder<I extends CallInput, T> {
+
+    private final Call<I, T> call;
+
+    private final ExceptionHandlers exceptionHandlers = new DefaultExceptionHandlers();
+
+    private Supplier<I> inputProvider;
+
+    private PrintWriter output = wrapOutputStream(System.out);
+
+    private PrintWriter errOutput = wrapOutputStream(System.err);
+
+    private Decorator<T, TerminalOutput> decorator = new DefaultDecorator<>();
+
+    private boolean verbose;
+
+    CallExecutionPipelineBuilder(Call<I, T> call) {
+        this.call = call;
+    }
+
+    private static PrintWriter wrapOutputStream(OutputStream output) {
+        return new PrintWriter(output, true, getStdoutEncoding());
+    }
+
+    private static Charset getStdoutEncoding() {
+        String encoding = System.getProperty("sun.stdout.encoding");
+        return encoding != null ? Charset.forName(encoding) : Charset.defaultCharset();
+    }
+
+    public CallExecutionPipelineBuilder<I, T> inputProvider(Supplier<I> inputProvider) {
+        this.inputProvider = inputProvider;
+        return this;
+    }
+
+    public CallExecutionPipelineBuilder<I, T> output(PrintWriter output) {
+        this.output = output;
+        return this;
+    }
+
+    public CallExecutionPipelineBuilder<I, T> output(OutputStream output) {
+        return output(wrapOutputStream(output));
+    }
+
+    public CallExecutionPipelineBuilder<I, T> errOutput(PrintWriter errOutput) {
+        this.errOutput = errOutput;
+        return this;
+    }
+
+    public CallExecutionPipelineBuilder<I, T> errOutput(OutputStream output) {
+        return errOutput(wrapOutputStream(output));
+    }
+
+    public CallExecutionPipelineBuilder<I, T> exceptionHandler(ExceptionHandler<?> exceptionHandler) {
+        exceptionHandlers.addExceptionHandler(exceptionHandler);
+        return this;
+    }
+
+    public CallExecutionPipelineBuilder<I, T> exceptionHandlers(ExceptionHandlers exceptionHandlers) {
+        this.exceptionHandlers.addExceptionHandlers(exceptionHandlers);
+        return this;
+    }
+
+    public CallExecutionPipelineBuilder<I, T> decorator(Decorator<T, TerminalOutput> decorator) {
+        this.decorator = decorator;
+        return this;
+    }
+
+    public CallExecutionPipelineBuilder<I, T> verbose(boolean verbose) {
+        this.verbose = verbose;
+        return this;
+    }
+
+    public CallExecutionPipeline<I, T> build() {
+        return new SingleCallExecutionPipeline<>(call, output, errOutput, exceptionHandlers, decorator, inputProvider, verbose);
+    }
+}

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/ProgressBarTracker.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/ProgressBarTracker.java
@@ -17,14 +17,19 @@
 
 package org.apache.ignite.internal.cli.core.call;
 
-/**
- * Call that represents an action that can be performed given an input.
- * It can be rest call, dictionary lookup or whatever.
- *
- * @param <IT> Input for the call.
- * @param <OT> Output of the call.
- */
-@FunctionalInterface
-public interface Call<IT extends CallInput, OT> {
-    CallOutput<OT> execute(IT input);
+import me.tongfei.progressbar.ProgressBar;
+
+/** {@link ProgressBar} based tracker. */
+public class ProgressBarTracker implements ProgressTracker {
+    private final ProgressBar progressBar;
+
+    public ProgressBarTracker(ProgressBar progressBar) {
+        this.progressBar = progressBar;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void track() {
+        progressBar.step();
+    }
 }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/ProgressTracker.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/ProgressTracker.java
@@ -17,14 +17,8 @@
 
 package org.apache.ignite.internal.cli.core.call;
 
-/**
- * Call that represents an action that can be performed given an input.
- * It can be rest call, dictionary lookup or whatever.
- *
- * @param <IT> Input for the call.
- * @param <OT> Output of the call.
- */
-@FunctionalInterface
-public interface Call<IT extends CallInput, OT> {
-    CallOutput<OT> execute(IT input);
+/** Progress tracker that will be called periodically during the call execution. */
+public interface ProgressTracker {
+    /** Tracks that the step is performed. */
+    void track(); // todo: add the increment parameter in https://issues.apache.org/jira/browse/IGNITE-18731
 }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/SingleCallExecutionPipeline.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/SingleCallExecutionPipeline.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.cli.core.call;
+
+import java.io.PrintWriter;
+import java.util.function.Supplier;
+import org.apache.ignite.internal.cli.core.decorator.Decorator;
+import org.apache.ignite.internal.cli.core.decorator.TerminalOutput;
+import org.apache.ignite.internal.cli.core.exception.ExceptionHandlers;
+
+/**
+ * Call execution pipeline that executes a single call.
+ *
+ * @param <I> Call input type.
+ * @param <T> Call output's body type.
+ */
+public class SingleCallExecutionPipeline<I extends CallInput, T> extends AbstractCallExecutionPipeline<I, T> {
+    /** Call to execute. */
+    private final Call<I, T> call;
+
+    SingleCallExecutionPipeline(
+            Call<I, T> call,
+            PrintWriter output,
+            PrintWriter errOutput,
+            ExceptionHandlers exceptionHandlers,
+            Decorator<T, TerminalOutput> decorator,
+            Supplier<I> inputProvider,
+            boolean verbose
+    ) {
+        super(output, errOutput, exceptionHandlers, decorator, inputProvider, verbose);
+        this.call = call;
+    }
+
+
+    @Override
+    public int runPipelineInternal() {
+        I callInput = inputProvider.get();
+
+        CallOutput<T> callOutput = call.execute(callInput);
+
+        return handleResult(callOutput);
+    }
+}

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/sql/SqlSchemaProvider.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/sql/SqlSchemaProvider.java
@@ -34,7 +34,7 @@ public class SqlSchemaProvider implements SchemaProvider {
 
     private final AtomicReference<SqlSchema> schema = new AtomicReference<>(null);
 
-    private final AtomicReference<Instant> lastUpdate = new AtomicReference<>(null);
+    private final AtomicReference<Instant> lastUpdate = new AtomicReference<>(Instant.now());
 
     public SqlSchemaProvider(MetadataSupplier metadataSupplier) {
         this(metadataSupplier, SCHEMA_UPDATE_TIMEOUT);

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/sql/SqlSchemaProvider.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/sql/SqlSchemaProvider.java
@@ -61,4 +61,8 @@ public class SqlSchemaProvider implements SchemaProvider {
         return schema.get();
     }
 
+    public void initStateAsync() {
+        // trigger schema loading in background
+        CompletableFuture.supplyAsync(this::getSchema);
+    }
 }

--- a/modules/cli/src/test/java/org/apache/ignite/internal/cli/sql/SqlSchemaProviderTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/internal/cli/sql/SqlSchemaProviderTest.java
@@ -44,16 +44,26 @@ class SqlSchemaProviderTest {
     }
 
     @Test
-    public void testProviderWithoutTimeout() {
+    public void testProviderWithoutTimeout() throws InterruptedException {
         SqlSchemaProvider provider = new SqlSchemaProvider(supplier, 0);
-        Assertions.assertNotEquals(provider.getSchema(), provider.getSchema());
+
+        SqlSchema firstSchema = provider.getSchema();
+        provider.getSchema(); // trigger update
+        Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+
+        Assertions.assertNotEquals(firstSchema, provider.getSchema());
     }
 
     @Test
     public void testProviderWith1secTimeout() throws InterruptedException {
         SqlSchemaProvider provider = new SqlSchemaProvider(supplier, 1);
+
+        provider.initStateAsync();
+        Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+
         SqlSchema schema = provider.getSchema();
         Thread.sleep(TimeUnit.SECONDS.toMillis(2));
+
         Assertions.assertNotEquals(schema, provider.getSchema());
     }
 }


### PR DESCRIPTION
I've introduced the core functionality for background async calls with a progress bar. The SQL completion hanging is fixed with background async initialization. 

I don't see any reason to use a UI thread with a special API.

https://issues.apache.org/jira/browse/IGNITE-18674 