### PR TITLE
IGNITE-18851 .NET: Fix TestReconnectAfterFullClusterRestart flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ClientSocketTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ClientSocketTests.cs
@@ -66,8 +66,10 @@ namespace Apache.Ignite.Tests
             using var requestWriter = new PooledArrayBuffer();
             requestWriter.MessageWriter.Write(123);
 
-            Assert.ThrowsAsync<ObjectDisposedException>(
+            var ex = Assert.ThrowsAsync<IgniteClientConnectionException>(
                 async () => await socket.DoOutInOpAsync(ClientOp.SchemasGet, requestWriter));
+
+            Assert.IsInstanceOf<ObjectDisposedException>(ex!.InnerException);
 
             // Multiple dispose is allowed.
             socket.Dispose();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -441,6 +441,9 @@ namespace Apache.Ignite.Tests
 
                 if (DropNewConnections)
                 {
+                    handler.Disconnect(true);
+                    _handler = null;
+
                     continue;
                 }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -66,7 +66,9 @@ namespace Apache.Ignite.Tests
 
         private bool _disposed;
 
-        private Socket? _handler;
+        private volatile Socket? _handler;
+
+        private volatile bool _dropNewConnections;
 
         public FakeServer(
             Func<int, bool>? shouldDropConnection = null,
@@ -117,7 +119,11 @@ namespace Apache.Ignite.Tests
 
         public long? LastSqlTxId { get; set; }
 
-        public bool DropNewConnections { get; set; }
+        public bool DropNewConnections
+        {
+            get => _dropNewConnections;
+            set => _dropNewConnections = value;
+        }
 
         public bool SendInvalidMagic { get; set; }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/HeartbeatTests.cs
@@ -48,7 +48,7 @@ namespace Apache.Ignite.Tests
             var log = await ConnectAndGetLog(IgniteClientConfiguration.DefaultHeartbeatInterval);
 
             StringAssert.Contains(
-                "ClientSocket [Warn] Server-side IdleTimeout is 00:00:03, " +
+                "[Warn] Server-side IdleTimeout is 00:00:03, " +
                 "configured IgniteClientConfiguration.HeartbeatInterval is 00:00:30, which is longer than recommended IdleTimeout / 3. " +
                 "Overriding heartbeat interval with max(IdleTimeout / 3, 500ms): 00:00:01",
                 log);
@@ -60,7 +60,7 @@ namespace Apache.Ignite.Tests
             var log = await ConnectAndGetLog(TimeSpan.FromMilliseconds(50));
 
             StringAssert.Contains(
-                "ClientSocket [Info] Server-side IdleTimeout is 00:00:03, " +
+                "[Info] Server-side IdleTimeout is 00:00:03, " +
                 "using configured IgniteClientConfiguration.HeartbeatInterval: 00:00:00.0500000",
                 log);
         }
@@ -71,7 +71,7 @@ namespace Apache.Ignite.Tests
             var log = await ConnectAndGetLog(TimeSpan.FromSeconds(4));
 
             StringAssert.Contains(
-                "ClientSocket [Warn] Server-side IdleTimeout is 00:00:03, " +
+                "[Warn] Server-side IdleTimeout is 00:00:03, " +
                 "configured IgniteClientConfiguration.HeartbeatInterval is 00:00:04, which is longer than recommended IdleTimeout / 3. " +
                 "Overriding heartbeat interval with max(IdleTimeout / 3, 500ms): 00:00:01",
                 log);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -153,6 +153,9 @@ public class ReconnectTests
         Assert.DoesNotThrowAsync(async () => await client.Tables.GetTablesAsync());
 
         // All connections are restored.
-        TestUtils.WaitForCondition(() => client.GetConnections().Count == 10, 3000);
+        TestUtils.WaitForCondition(
+            () => client.GetConnections().Count == 10,
+            5000,
+            () => "Actual connection count: " + client.GetConnections().Count);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -111,8 +111,7 @@ public class ReconnectTests
     {
         var cfg = new IgniteClientConfiguration
         {
-            ReconnectInterval = TimeSpan.FromMilliseconds(100),
-            SocketTimeout = TimeSpan.FromMilliseconds(200)
+            ReconnectInterval = TimeSpan.FromMilliseconds(100)
         };
 
         using var servers = FakeServerGroup.Create(5, idx => new FakeServer { DropNewConnections = idx > 0 });
@@ -136,6 +135,7 @@ public class ReconnectTests
         var cfg = new IgniteClientConfiguration
         {
             ReconnectInterval = TimeSpan.FromMilliseconds(100),
+            SocketTimeout = TimeSpan.FromMilliseconds(200),
             Logger = logger
         };
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -111,7 +111,8 @@ public class ReconnectTests
     {
         var cfg = new IgniteClientConfiguration
         {
-            ReconnectInterval = TimeSpan.FromMilliseconds(100)
+            ReconnectInterval = TimeSpan.FromMilliseconds(100),
+            SocketTimeout = TimeSpan.FromMilliseconds(200)
         };
 
         using var servers = FakeServerGroup.Create(5, idx => new FakeServer { DropNewConnections = idx > 0 });

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -21,6 +21,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Internal;
+using Log;
 using NUnit.Framework;
 
 /// <summary>
@@ -131,7 +132,8 @@ public class ReconnectTests
     {
         var cfg = new IgniteClientConfiguration
         {
-            ReconnectInterval = TimeSpan.FromMilliseconds(100)
+            ReconnectInterval = TimeSpan.FromMilliseconds(100),
+            Logger = new ConsoleLogger { MinLevel = LogLevel.Trace }
         };
 
         using var servers = FakeServerGroup.Create(10, _ => new FakeServer());

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -296,6 +296,7 @@ namespace Apache.Ignite.Internal
                 try
                 {
                     tasks.Clear();
+                    _logger?.Debug("Trying to establish secondary connections...");
 
                     foreach (var endpoint in _endpoints)
                     {
@@ -307,7 +308,11 @@ namespace Apache.Ignite.Internal
                         tasks.Add(ConnectAsync(endpoint).AsTask());
                     }
 
+                    _logger?.Debug("Trying to establish secondary connections - awaiting {0} tasks...", tasks.Count);
+
                     await Task.WhenAll(tasks).ConfigureAwait(false);
+
+                    _logger?.Debug("All secondary connections established.");
                 }
                 catch (Exception e)
                 {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -296,7 +296,6 @@ namespace Apache.Ignite.Internal
                 try
                 {
                     tasks.Clear();
-                    _logger?.Debug("Trying to establish secondary connections...");
 
                     foreach (var endpoint in _endpoints)
                     {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -164,10 +164,10 @@ namespace Apache.Ignite.Internal
                 NoDelay = true
             };
 
+            var logger = configuration.Logger.GetLogger(nameof(ClientSocket) + "-" + Interlocked.Increment(ref _socketId));
+
             try
             {
-                var logger = configuration.Logger.GetLogger(nameof(ClientSocket) + "-" + Interlocked.Increment(ref _socketId));
-
                 await socket.ConnectAsync(endPoint).ConfigureAwait(false);
                 logger?.Debug($"Socket connection established: {socket.LocalEndPoint} -> {socket.RemoteEndPoint}, starting handshake...");
 
@@ -183,6 +183,8 @@ namespace Apache.Ignite.Internal
             }
             catch (Exception e)
             {
+                logger?.Warn($"Connection failed before or during handshake: {e.Message}.", e);
+
                 // ReSharper disable once MethodHasAsyncOverload
                 socket.Dispose();
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -205,7 +205,10 @@ namespace Apache.Ignite.Internal
 
             if (_disposeTokenSource.IsCancellationRequested)
             {
-                throw new ObjectDisposedException(nameof(ClientSocket));
+                throw new IgniteClientConnectionException(
+                    ErrorGroups.Client.Connection,
+                    "Socket is disposed.",
+                    new ObjectDisposedException(nameof(ClientSocket)));
             }
 
             var requestId = Interlocked.Increment(ref _requestId);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -51,6 +51,9 @@ namespace Apache.Ignite.Internal
         /** Minimum supported heartbeat interval. */
         private static readonly TimeSpan MinRecommendedHeartbeatInterval = TimeSpan.FromMilliseconds(500);
 
+        /** Socket id for debug logging. */
+        private static long _socketId;
+
         /** Underlying stream. */
         private readonly NetworkStream _stream;
 
@@ -111,7 +114,7 @@ namespace Apache.Ignite.Internal
             _stream = stream;
             ConnectionContext = connectionContext;
             _assignmentChangeCallback = assignmentChangeCallback;
-            _logger = configuration.Logger.GetLogger(GetType());
+            _logger = configuration.Logger.GetLogger(nameof(ClientSocket) + "-" + Interlocked.Increment(ref _socketId));
             _socketTimeout = configuration.SocketTimeout;
 
             _heartbeatInterval = GetHeartbeatInterval(configuration.HeartbeatInterval, connectionContext.IdleTimeout, _logger);
@@ -164,7 +167,7 @@ namespace Apache.Ignite.Internal
                 var logger = configuration.Logger.GetLogger(typeof(ClientSocket));
 
                 await socket.ConnectAsync(endPoint).ConfigureAwait(false);
-                logger?.Debug($"Socket connection established: {socket.LocalEndPoint} -> {socket.RemoteEndPoint}");
+                logger?.Debug($"Socket connection established: {socket.LocalEndPoint} -> {socket.RemoteEndPoint}, starting handshake...");
 
                 var stream = new NetworkStream(socket, ownsSocket: true);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Log/LoggerExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Log/LoggerExtensions.cs
@@ -312,7 +312,7 @@ namespace Apache.Ignite.Log
         /// <returns>Logger that uses specified category when no other category is provided.</returns>
         public static IIgniteLogger? GetLogger(this IIgniteLogger? logger, string category)
         {
-            IgniteArgumentCheck.NotNull(logger, "logger");
+            IgniteArgumentCheck.NotNull(category, "category");
 
             return logger == null ? null : new CategoryLogger(logger, category);
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Log/LoggerExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Log/LoggerExtensions.cs
@@ -310,11 +310,11 @@ namespace Apache.Ignite.Log
         /// <param name="logger">The logger.</param>
         /// <param name="category">The category.</param>
         /// <returns>Logger that uses specified category when no other category is provided.</returns>
-        public static IIgniteLogger GetLogger(this IIgniteLogger logger, string category)
+        public static IIgniteLogger? GetLogger(this IIgniteLogger? logger, string category)
         {
             IgniteArgumentCheck.NotNull(logger, "logger");
 
-            return new CategoryLogger(logger, category);
+            return logger == null ? null : new CategoryLogger(logger, category);
         }
 
         /// <summary>


### PR DESCRIPTION
Root cause: `TaskCancelledException` and `ObjectDisposedException` are sometimes thrown on disconnect from `ClientSocket`, and those exceptions are not retried.

* Fix exceptions.
* Improve logging: include socket id to correlate messages.
* Enable logging in the test.
* Improve assertion message.