### PR TITLE
IGNITE-18513 .NET: Ignore commit/rollback on completed tx

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
@@ -119,7 +119,7 @@ namespace Apache.Ignite.Tests.Transactions
         }
 
         [Test]
-        public async Task TestCommitRollbackSameTxThrows()
+        public async Task TestCommitAfterRollbackIsIgnored()
         {
             await using var tx = await Client.Transactions.BeginAsync();
             await tx.CommitAsync();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
@@ -124,19 +124,19 @@ namespace Apache.Ignite.Tests.Transactions
         {
             await using var tx = await Client.Transactions.BeginAsync();
             await tx.CommitAsync();
+            await tx.RollbackAsync();
 
-            var ex = Assert.ThrowsAsync<TransactionException>(async () => await tx.RollbackAsync());
-            Assert.AreEqual("Transaction is already committed.", ex?.Message);
+            StringAssert.Contains("State = Committed", tx.ToString());
         }
 
         [Test]
-        public async Task TestRollbackCommitSameTxThrows()
+        public async Task TestRollbackAfterCommitIsIgnored()
         {
             await using var tx = await Client.Transactions.BeginAsync();
             await tx.RollbackAsync();
+            await tx.CommitAsync();
 
-            var ex = Assert.ThrowsAsync<TransactionException>(async () => await tx.CommitAsync());
-            Assert.AreEqual("Transaction is already rolled back.", ex?.Message);
+            StringAssert.Contains("State = RolledBack", tx.ToString());
         }
 
         [Test]
@@ -146,9 +146,9 @@ namespace Apache.Ignite.Tests.Transactions
 
             await tx.DisposeAsync();
             await tx.DisposeAsync();
+            await tx.CommitAsync();
 
-            var ex = Assert.ThrowsAsync<TransactionException>(async () => await tx.CommitAsync());
-            Assert.AreEqual("Transaction is already rolled back.", ex?.Message);
+            StringAssert.Contains("State = RolledBack", tx.ToString());
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transaction.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transaction.cs
@@ -17,7 +17,6 @@
 
 namespace Apache.Ignite.Internal.Transactions
 {
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Ignite.Transactions;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transaction.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transaction.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Internal.Transactions
 {
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Ignite.Transactions;
@@ -90,6 +91,19 @@ namespace Apache.Ignite.Internal.Transactions
 
         /// <inheritdoc/>
         public async ValueTask DisposeAsync() => await RollbackAsyncInternal().ConfigureAwait(false);
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            var state = _state switch
+            {
+                StateOpen => "Open",
+                StateCommitted => "Committed",
+                _ => "RolledBack"
+            };
+
+            return $"Transaction {{ Id = {Id}, State = {state}, IsReadOnly = {IsReadOnly} }}";
+        }
 
         /// <summary>
         /// Rolls back the transaction without state check.


### PR DESCRIPTION
* Do not throw exception on `Commit` & `Rollback` when transaction is already completed (committed or rolled back).
* Add `TroString` override.