### PR TITLE
IGNITE-18809 Java client: Reconnect secondary endpoints in background

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
@@ -217,7 +217,7 @@ public interface IgniteClient extends Ignite {
 
         /**
          * Sets the reconnect interval, in milliseconds. Set to {@code 0} to disable background reconnect.
-
+         *
          * <p>Ignite balances requests across all healthy connections (when multiple endpoints are configured).
          * Ignite also repairs connections on demand (when a request is made).
          * However, "secondary" connections can be lost (due to network issues, or node restarts). This property controls how ofter Ignite

--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
@@ -215,8 +215,24 @@ public interface IgniteClient extends Ignite {
             return this;
         }
 
-        // TODO
+        /**
+         * Sets the reconnect interval, in milliseconds. Set to {@code 0} to disable background reconnect.
+
+         * <p>Ignite balances requests across all healthy connections (when multiple endpoints are configured).
+         * Ignite also repairs connections on demand (when a request is made).
+         * However, "secondary" connections can be lost (due to network issues, or node restarts). This property controls how ofter Ignite
+         * client will check all configured endpoints and try to reconnect them in case of failure.
+         *
+         * @param reconnectInterval Reconnect interval, in milliseconds.
+         * @return This instance.
+         * @throws IllegalArgumentException When value is less than zero.
+         */
         public Builder reconnectInterval(long reconnectInterval) {
+            if (reconnectInterval < 0) {
+                throw new IllegalArgumentException("reconnectInterval ["
+                        + reconnectInterval + "] must be a non-negative integer value.");
+            }
+
             this.reconnectInterval = reconnectInterval;
 
             return this;

--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
@@ -20,6 +20,7 @@ package org.apache.ignite.client;
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_CONNECT_TIMEOUT;
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_HEARTBEAT_INTERVAL;
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_HEARTBEAT_TIMEOUT;
+import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_RECONNECT_INTERVAL;
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_RECONNECT_THROTTLING_PERIOD;
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_RECONNECT_THROTTLING_RETRIES;
 import static org.apache.ignite.internal.client.ClientUtils.sync;
@@ -81,6 +82,9 @@ public interface IgniteClient extends Ignite {
 
         /** Reconnect throttling retries. */
         private int reconnectThrottlingRetries = DFLT_RECONNECT_THROTTLING_RETRIES;
+
+        /** Reconnect interval, in milliseconds. */
+        private long reconnectInterval = DFLT_RECONNECT_INTERVAL;
 
         /** Async continuation executor. */
         private Executor asyncContinuationExecutor;
@@ -211,6 +215,13 @@ public interface IgniteClient extends Ignite {
             return this;
         }
 
+        // TODO
+        public Builder reconnectInterval(long reconnectInterval) {
+            this.reconnectInterval = reconnectInterval;
+
+            return this;
+        }
+
         /**
          * Sets the async continuation executor.
          *
@@ -296,6 +307,7 @@ public interface IgniteClient extends Ignite {
                     connectTimeout,
                     reconnectThrottlingPeriod,
                     reconnectThrottlingRetries,
+                    reconnectInterval,
                     asyncContinuationExecutor,
                     heartbeatInterval,
                     heartbeatTimeout,

--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConfiguration.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConfiguration.java
@@ -101,6 +101,7 @@ public interface IgniteClientConfiguration {
 
     /**
      * Gets the background reconnect interval, in milliseconds. Set to {@code 0} to disable background reconnect.
+     * Default is {@link #DFLT_RECONNECT_INTERVAL}.
      *
      * <p>Ignite balances requests across all healthy connections (when multiple endpoints are configured).
      * Ignite also repairs connections on demand (when a request is made).

--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConfiguration.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConfiguration.java
@@ -42,11 +42,14 @@ public interface IgniteClientConfiguration {
     /** Default heartbeat interval, in milliseconds. */
     int DFLT_HEARTBEAT_INTERVAL = 30_000;
 
-    /** Default reconnect throttling period. */
+    /** Default reconnect throttling period, in milliseconds. */
     long DFLT_RECONNECT_THROTTLING_PERIOD = 30_000L;
 
     /** Default reconnect throttling retries. */
     int DFLT_RECONNECT_THROTTLING_RETRIES = 3;
+
+    /** Default reconnect interval, in milliseconds. */
+    long DFLT_RECONNECT_INTERVAL = 30_000L;
 
     /**
      * Gets the address finder.
@@ -59,6 +62,9 @@ public interface IgniteClientConfiguration {
      * Gets the addresses of Ignite server nodes within a cluster. An address can be an IP address or a hostname, with or without port. If
      * port is not set then Ignite will generate multiple addresses for default port range. See {@link IgniteClientConfiguration#DFLT_PORT},
      * {@link IgniteClientConfiguration#DFLT_PORT_RANGE}.
+     *
+     * <p>Providing addresses of multiple nodes in the cluster will improve performance: Ignite will balance requests across all
+     * connections, and use partition awareness to send key-based requests directly to the primary node.
      *
      * @return Addresses.
      */
@@ -94,9 +100,21 @@ public interface IgniteClientConfiguration {
     int reconnectThrottlingRetries();
 
     /**
+     * Gets the background reconnect interval, in milliseconds. Set to {@code 0} to disable background reconnect.
+     *
+     * <p>Ignite balances requests across all healthy connections (when multiple endpoints are configured).
+     * Ignite also repairs connections on demand (when a request is made).
+     * However, "secondary" connections can be lost (due to network issues, or node restarts). This property controls how ofter Ignite
+     * client will check all configured endpoints and try to reconnect them in case of failure.
+     *
+     * @return Background reconnect interval, in milliseconds.
+     */
+    long reconnectInterval();
+
+    /**
      * Gets the async continuation executor.
      *
-     * <p>When <code>null</code> (default), {@link ForkJoinPool#commonPool()} is used.
+     * <p>When {@code null} (default), {@link ForkJoinPool#commonPool()} is used.
      *
      * <p>When async client operation completes, corresponding {@link java.util.concurrent.CompletableFuture} continuations
      * (such as {@link java.util.concurrent.CompletableFuture#thenApply(Function)}) will be invoked using this executor.

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/IgniteClientConfigurationImpl.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/IgniteClientConfigurationImpl.java
@@ -142,7 +142,7 @@ public final class IgniteClientConfigurationImpl implements IgniteClientConfigur
     /** {@inheritDoc} */
     @Override
     public long reconnectInterval() {
-        return 0;
+        return reconnectInterval;
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/IgniteClientConfigurationImpl.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/IgniteClientConfigurationImpl.java
@@ -44,6 +44,9 @@ public final class IgniteClientConfigurationImpl implements IgniteClientConfigur
     /** Reconnect throttling retries. */
     private final int reconnectThrottlingRetries;
 
+    /** Reconnect interval, in milliseconds. */
+    private final long reconnectInterval;
+
     /** Async continuation executor. */
     private final Executor asyncContinuationExecutor;
 
@@ -68,6 +71,7 @@ public final class IgniteClientConfigurationImpl implements IgniteClientConfigur
      * @param connectTimeout Socket connect timeout.
      * @param reconnectThrottlingPeriod Reconnect throttling period, in milliseconds.
      * @param reconnectThrottlingRetries Reconnect throttling retries.
+     * @param reconnectInterval Reconnect throttling retries.
      * @param asyncContinuationExecutor Async continuation executor.
      * @param heartbeatInterval Heartbeat message interval.
      * @param heartbeatTimeout Heartbeat message timeout.
@@ -80,6 +84,7 @@ public final class IgniteClientConfigurationImpl implements IgniteClientConfigur
             long connectTimeout,
             long reconnectThrottlingPeriod,
             int reconnectThrottlingRetries,
+            long reconnectInterval,
             Executor asyncContinuationExecutor,
             long heartbeatInterval,
             long heartbeatTimeout,
@@ -95,6 +100,7 @@ public final class IgniteClientConfigurationImpl implements IgniteClientConfigur
         this.connectTimeout = connectTimeout;
         this.reconnectThrottlingPeriod = reconnectThrottlingPeriod;
         this.reconnectThrottlingRetries = reconnectThrottlingRetries;
+        this.reconnectInterval = reconnectInterval;
         this.asyncContinuationExecutor = asyncContinuationExecutor;
         this.heartbeatInterval = heartbeatInterval;
         this.heartbeatTimeout = heartbeatTimeout;
@@ -131,6 +137,12 @@ public final class IgniteClientConfigurationImpl implements IgniteClientConfigur
     @Override
     public int reconnectThrottlingRetries() {
         return reconnectThrottlingRetries;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long reconnectInterval() {
+        return 0;
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -609,6 +609,9 @@ public final class ReliableChannel implements AutoCloseable {
      * Asynchronously try to establish a connection to all configured servers.
      */
     private void initAllChannelsAsync() {
+        // TODO: IGNITE-18809: Repeat reconnect periodically.
+        // 1. Use a separate executor for that instead of ForkJoinPool.commonPool()? Or a timer?
+        // 2. Make sure this process is initiated only once.
         ForkJoinPool.commonPool().submit(
                 () -> {
                     List<ClientChannelHolder> holders = channels;

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -630,7 +630,9 @@ public final class ReliableChannel implements AutoCloseable {
         if (interval > 0 && !closed) {
             // After current round of connection attempts is finished, schedule the next one with a configured delay.
             CompletableFuture.allOf(futs.toArray(CompletableFuture[]::new))
-                    .thenRunAsync(this::initAllChannelsAsync, CompletableFuture.delayedExecutor(interval, TimeUnit.MILLISECONDS));
+                    .whenCompleteAsync(
+                            (res, err) -> initAllChannelsAsync(),
+                            CompletableFuture.delayedExecutor(interval, TimeUnit.MILLISECONDS));
         }
     }
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -36,6 +36,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -612,6 +613,8 @@ public final class ReliableChannel implements AutoCloseable {
         // TODO: IGNITE-18809: Repeat reconnect periodically.
         // 1. Use a separate executor for that instead of ForkJoinPool.commonPool()? Or a timer?
         // 2. Make sure this process is initiated only once.
+        // CompletableFuture.delayedExecutor(1, TimeUnit.SECONDS).execute();
+
         ForkJoinPool.commonPool().submit(
                 () -> {
                     List<ClientChannelHolder> holders = channels;

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -627,6 +627,7 @@ public final class ReliableChannel implements AutoCloseable {
         long interval = clientCfg.reconnectInterval();
 
         if (interval > 0 && !closed) {
+            // TODO: Initiate only after all futures from above are completed.
             CompletableFuture.delayedExecutor(interval, TimeUnit.MILLISECONDS).execute(this::initAllChannelsAsync);
         }
     }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -157,7 +157,7 @@ public final class ReliableChannel implements AutoCloseable {
             if (chFut != null) {
                 var ch = ClientFutureUtils.getNowSafe(chFut);
 
-                if (ch != null) {
+                if (ch != null && !ch.closed()) {
                     res.add(ch.protocolContext().clusterNode());
                 }
             }

--- a/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
@@ -19,6 +19,7 @@ package org.apache.ignite.client;
 
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.assertThrowsWithCause;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.UUID;
 import java.util.function.Function;
@@ -43,9 +44,10 @@ public class HeartbeatTest {
                     .loggerFactory(loggerFactory);
 
             try (var ignored = builder.build()) {
-                IgniteTestUtils.waitForCondition(
-                        () -> loggerFactory.logger.entries().stream().anyMatch(x -> x.contains("Disconnected from server")),
-                        1000);
+                assertTrue(
+                        IgniteTestUtils.waitForCondition(
+                                () -> loggerFactory.logger.entries().stream().anyMatch(x -> x.contains("Disconnected from server")),
+                                1000));
             }
         }
     }
@@ -98,9 +100,11 @@ public class HeartbeatTest {
                     .loggerFactory(loggerFactory);
 
             try (var ignored = builder.build()) {
-                IgniteTestUtils.waitForCondition(
-                        () -> loggerFactory.logger.entries().stream().anyMatch(x -> x.contains("Heartbeat timeout, closing the channel")),
-                        3000);
+                assertTrue(
+                        IgniteTestUtils.waitForCondition(
+                                () -> loggerFactory.logger.entries().stream()
+                                        .anyMatch(x -> x.contains("Heartbeat timeout, closing the channel")),
+                                3000));
             }
         }
     }

--- a/modules/client/src/test/java/org/apache/ignite/client/ReconnectTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ReconnectTest.java
@@ -18,14 +18,18 @@
 package org.apache.ignite.client;
 
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.assertThrowsWithCause;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.ignite.client.IgniteClient.Builder;
 import org.apache.ignite.client.fakes.FakeIgnite;
 import org.apache.ignite.client.fakes.FakeIgniteTables;
 import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.internal.util.IgniteUtils;
+import org.apache.ignite.network.ClusterNode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -145,6 +149,9 @@ public class ReconnectTest {
                 assertTrue(IgniteTestUtils.waitForCondition(
                                 () -> client.connections().size() == 2, 5000),
                         () -> "Client should have 2 connections: " + client.connections().size());
+
+                String[] nodeNames = client.connections().stream().map(ClusterNode::name).sorted().toArray(String[]::new);
+                assertArrayEquals(new String[]{"node1", "node3"}, nodeNames);
             } else {
                 Thread.sleep(100);
                 assertEquals(1, client.connections().size());

--- a/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
@@ -228,7 +228,7 @@ public class RetryPolicyTest {
     @Test
     public void testRetryReadPolicyAllOperationsSupported() {
         var plc = new RetryReadPolicy();
-        var cfg = new IgniteClientConfigurationImpl(null, null, 0, 0, 0, null, 0, 0, null, null, null);
+        var cfg = new IgniteClientConfigurationImpl(null, null, 0, 0, 0, 0, null, 0, 0, null, null, null);
 
         for (var op : ClientOperationType.values()) {
             var ctx = new RetryPolicyContextImpl(cfg, op, 0, null);


### PR DESCRIPTION
Add `reconnectInterval` property to client configuration, which controls periodic background connect/repair of all known endpoints.