### PR TITLE
IGNITE-19045 .NET: Refactor SslStreamFactory to use SslClientAuthenticationOptions

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/SslTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/SslTests.cs
@@ -207,12 +207,12 @@ public class SslTests : IgniteTestsBase
 
     private class NullSslStreamFactory : ISslStreamFactory
     {
-        public SslStream? Create(Stream stream, string targetHost) => null;
+        public Task<SslStream?> CreateAsync(Stream stream, string targetHost) => Task.FromResult<SslStream?>(null);
     }
 
     private class CustomSslStreamFactory : ISslStreamFactory
     {
-        public SslStream Create(Stream stream, string targetHost)
+        public async Task<SslStream?> CreateAsync(Stream stream, string targetHost)
         {
             var sslStream = new SslStream(
                 innerStream: stream,
@@ -220,7 +220,7 @@ public class SslTests : IgniteTestsBase
                 userCertificateValidationCallback: (_, certificate, _, _) => certificate!.Issuer.Contains("ignite"),
                 userCertificateSelectionCallback: null);
 
-            sslStream.AuthenticateAsClient(targetHost, null, SslProtocols.None, false);
+            await sslStream.AuthenticateAsClientAsync(targetHost, null, SslProtocols.None, false);
 
             return sslStream;
         }

--- a/modules/platforms/dotnet/Apache.Ignite/ISslStreamFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/ISslStreamFactory.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite;
 
 using System.IO;
 using System.Net.Security;
+using System.Threading.Tasks;
 
 /// <summary>
 /// SSL Stream Factory defines how SSL connection is established.
@@ -35,5 +36,5 @@ public interface ISslStreamFactory
     /// <returns>
     /// SSL stream, or null if SSL is not enabled.
     /// </returns>
-    SslStream? Create(Stream stream, string targetHost);
+    Task<SslStream?> CreateAsync(Stream stream, string targetHost);
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -181,7 +181,7 @@ namespace Apache.Ignite.Internal
                 Stream stream = new NetworkStream(socket, ownsSocket: true);
 
                 if (configuration.SslStreamFactory is { } sslStreamFactory &&
-                    sslStreamFactory.Create(stream, endPoint.Host) is { } sslStream)
+                    await sslStreamFactory.CreateAsync(stream, endPoint.Host).ConfigureAwait(false) is { } sslStream)
                 {
                     stream = sslStream;
 

--- a/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite;
 
 using System.IO;
 using System.Net.Security;
+using System.Threading.Tasks;
 using Internal.Common;
 
 /// <summary>
@@ -32,7 +33,7 @@ public sealed class SslStreamFactory : ISslStreamFactory
     public SslClientAuthenticationOptions? SslClientAuthenticationOptions { get; set; }
 
     /// <inheritdoc />
-    public SslStream Create(Stream stream, string targetHost)
+    public async Task<SslStream?> CreateAsync(Stream stream, string targetHost)
     {
         IgniteArgumentCheck.NotNull(stream, "stream");
 
@@ -41,8 +42,7 @@ public sealed class SslStreamFactory : ISslStreamFactory
         var options = SslClientAuthenticationOptions ?? new SslClientAuthenticationOptions();
         options.TargetHost ??= targetHost;
 
-        // TODO: Make async?
-        sslStream.AuthenticateAsClient(options);
+        await sslStream.AuthenticateAsClientAsync(options).ConfigureAwait(false);
 
         return sslStream;
     }

--- a/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
@@ -41,6 +41,7 @@ public sealed class SslStreamFactory : ISslStreamFactory
         var options = SslClientAuthenticationOptions ?? new SslClientAuthenticationOptions();
         options.TargetHost ??= targetHost;
 
+        // TODO: Make async?
         sslStream.AuthenticateAsClient(options);
 
         return sslStream;

--- a/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
@@ -17,11 +17,8 @@
 
 namespace Apache.Ignite;
 
-using System.ComponentModel;
 using System.IO;
 using System.Net.Security;
-using System.Security.Authentication;
-using System.Security.Cryptography.X509Certificates;
 using Internal.Common;
 
 /// <summary>
@@ -30,76 +27,19 @@ using Internal.Common;
 public sealed class SslStreamFactory : ISslStreamFactory
 {
     /// <summary>
-    /// Default SSL protocols.
+    /// Gets or sets client authentication options.
     /// </summary>
-    public const SslProtocols DefaultSslProtocols = SslProtocols.None;
-
-    /// <summary>
-    /// Gets or sets the certificate file path (see <see cref="X509Certificate2"/>).
-    /// </summary>
-    public string? CertificatePath { get; set; }
-
-    /// <summary>
-    /// Gets or sets the certificate file password (see <see cref="X509Certificate2"/>).
-    /// </summary>
-    public string? CertificatePassword { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether to ignore invalid remote (server) certificates.
-    /// This may be useful for testing with self-signed certificates.
-    /// </summary>
-    public bool SkipServerCertificateValidation { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the certificate revocation list is checked during authentication.
-    /// </summary>
-    public bool CheckCertificateRevocation { get; set; }
-
-    /// <summary>
-    /// Gets or sets the SSL protocols.
-    /// </summary>
-    [DefaultValue(DefaultSslProtocols)]
-    public SslProtocols SslProtocols { get; set; } = DefaultSslProtocols;
+    public SslClientAuthenticationOptions? SslClientAuthenticationOptions { get; set; }
 
     /// <inheritdoc />
     public SslStream Create(Stream stream, string targetHost)
     {
         IgniteArgumentCheck.NotNull(stream, "stream");
 
-        var sslStream = new SslStream(stream, false, ValidateServerCertificate, null);
+        var sslStream = new SslStream(stream, false, null, null);
 
-        var cert = string.IsNullOrEmpty(CertificatePath)
-            ? null
-            : new X509Certificate2(CertificatePath, CertificatePassword);
-
-        var certs = cert == null
-            ? null
-            : new X509CertificateCollection(new X509Certificate[] { cert });
-
-        sslStream.AuthenticateAsClient(targetHost, certs, SslProtocols, CheckCertificateRevocation);
+        sslStream.AuthenticateAsClient(SslClientAuthenticationOptions ?? new SslClientAuthenticationOptions());
 
         return sslStream;
-    }
-
-    /// <summary>
-    /// Validates the server certificate.
-    /// </summary>
-    private bool ValidateServerCertificate(
-        object sender,
-        X509Certificate? certificate,
-        X509Chain? chain,
-        SslPolicyErrors sslPolicyErrors)
-    {
-        if (SkipServerCertificateValidation)
-        {
-            return true;
-        }
-
-        if (sslPolicyErrors == SslPolicyErrors.None)
-        {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
@@ -38,7 +38,10 @@ public sealed class SslStreamFactory : ISslStreamFactory
 
         var sslStream = new SslStream(stream, false, null, null);
 
-        sslStream.AuthenticateAsClient(SslClientAuthenticationOptions ?? new SslClientAuthenticationOptions());
+        var options = SslClientAuthenticationOptions ?? new SslClientAuthenticationOptions();
+        options.TargetHost ??= targetHost;
+
+        sslStream.AuthenticateAsClient(options);
 
         return sslStream;
     }


### PR DESCRIPTION
* Replace a custom and potentially incomplete (e.g. ciphers could not be set before) set of options in `SslStreamFactory` with `SslClientAuthenticationOptions`. This way our API is simpler, and full set of options is available to the users.
* Make `ISslStreamFactory` asynchronous.

[SslClientAuthenticationOptions](https://learn.microsoft.com/en-us/dotnet/api/system.net.security.sslclientauthenticationoptions?view=net-7.0) is a property bag that can be passed to `SslStream.AuthenticateAsClientAsync`. This API is not available in "classic" .NET or .NET standard, so we could not use it in Ignite 2.x.