### PR TITLE
IGNITE-18949 .NET: Enable NuGet package validation

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.csproj
@@ -17,6 +17,8 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
+
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.csproj
@@ -27,6 +27,8 @@
     <IsPackable>true</IsPackable>
     <EmitCompilerGeneratedFiles>false</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+
+    <PackageValidationBaselineVersion>3.0.0-beta1</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.csproj
@@ -28,7 +28,8 @@
     <EmitCompilerGeneratedFiles>false</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
 
-    <PackageValidationBaselineVersion>3.0.0-beta1</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion />
+    <GenerateCompatibilitySuppressionFile>false</GenerateCompatibilitySuppressionFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Enable package validation in main project.
* Add `dotnet pack` step on CI to validate on every build (https://ci.ignite.apache.org/admin/editBuild.html?id=buildType:ApacheIgnite3xGradle_Test_RunNetTests).