### PR TITLE
IGNITE-19069 .NET: Fix TestReconnectAfterFullClusterRestart flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -135,7 +135,7 @@ public class ReconnectTests
         var cfg = new IgniteClientConfiguration
         {
             ReconnectInterval = TimeSpan.FromMilliseconds(100),
-            SocketTimeout = TimeSpan.FromMilliseconds(200),
+            SocketTimeout = TimeSpan.FromSeconds(3),
             Logger = logger
         };
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -130,9 +130,6 @@ public class ReconnectTests
     [Test]
     public async Task TestReconnectAfterFullClusterRestart()
     {
-        // TODO: Two connections go out to the same node, which is not supported by the FakeServer.
-        // One is from background reconnect, another from regular operation.
-        // We should prevent this in the client.
         var logger = new ConsoleLogger { MinLevel = LogLevel.Trace };
 
         var cfg = new IgniteClientConfiguration

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -130,6 +130,19 @@ public class ReconnectTests
     [Test]
     public async Task TestReconnectAfterFullClusterRestart()
     {
+        // TODO:
+        // Expected: <Apache.Ignite.IgniteClientConnectionException>
+        //  But was:  <System.AggregateException: One or more errors occurred. (Cannot access a disposed object.)
+        // ---> System.ObjectDisposedException: Cannot access a disposed object.
+        //   at System.Threading.TimerQueueTimer.Change(UInt32 dueTime, UInt32 period)
+        //   at System.Threading.Timer.Change(Int64 dueTime, Int64 period)
+        //   at System.Threading.Timer.Change(TimeSpan dueTime, TimeSpan period)
+        //   at Apache.Ignite.Internal.ClientSocket.SendRequestAsync(PooledArrayBuffer request, ClientOp op, Int64 requestId) in /home/pavel/w/ignite-3/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs:line 526
+        //   --- End of inner exception stack trace ---
+        //   at Apache.Ignite.Internal.ClientFailoverSocket.DoOutInOpAndGetSocketAsync(ClientOp clientOp, Transaction tx, PooledArrayBuffer request, PreferredNode preferredNode) in /home/pavel/w/ignite-3/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs:line 185
+        //   at Apache.Ignite.Internal.ClientFailoverSocket.DoOutInOpAsync(ClientOp clientOp, PooledArrayBuffer request, PreferredNode preferredNode) in /home/pavel/w/ignite-3/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs:line 145
+        //   at Apache.Ignite.Internal.Table.Tables.GetTablesAsync() in /home/pavel/w/ignite-3/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Tables.cs:line 64
+        //   at Apache.Ignite.Tests.ReconnectTests.<>c__DisplayClass6_0.<<TestReconnectAfterFullClusterRestart>b__1>d.MoveNext() in /home/pavel/w/ignite-3/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs:line 154
         var logger = new ConsoleLogger { MinLevel = LogLevel.Trace };
 
         var cfg = new IgniteClientConfiguration

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -135,7 +135,7 @@ public class ReconnectTests
         var cfg = new IgniteClientConfiguration
         {
             ReconnectInterval = TimeSpan.FromMilliseconds(100),
-            SocketTimeout = TimeSpan.FromSeconds(3),
+            SocketTimeout = TimeSpan.FromSeconds(2),
             Logger = logger
         };
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -130,19 +130,6 @@ public class ReconnectTests
     [Test]
     public async Task TestReconnectAfterFullClusterRestart()
     {
-        // TODO:
-        // Expected: <Apache.Ignite.IgniteClientConnectionException>
-        //  But was:  <System.AggregateException: One or more errors occurred. (Cannot access a disposed object.)
-        // ---> System.ObjectDisposedException: Cannot access a disposed object.
-        //   at System.Threading.TimerQueueTimer.Change(UInt32 dueTime, UInt32 period)
-        //   at System.Threading.Timer.Change(Int64 dueTime, Int64 period)
-        //   at System.Threading.Timer.Change(TimeSpan dueTime, TimeSpan period)
-        //   at Apache.Ignite.Internal.ClientSocket.SendRequestAsync(PooledArrayBuffer request, ClientOp op, Int64 requestId) in /home/pavel/w/ignite-3/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs:line 526
-        //   --- End of inner exception stack trace ---
-        //   at Apache.Ignite.Internal.ClientFailoverSocket.DoOutInOpAndGetSocketAsync(ClientOp clientOp, Transaction tx, PooledArrayBuffer request, PreferredNode preferredNode) in /home/pavel/w/ignite-3/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs:line 185
-        //   at Apache.Ignite.Internal.ClientFailoverSocket.DoOutInOpAsync(ClientOp clientOp, PooledArrayBuffer request, PreferredNode preferredNode) in /home/pavel/w/ignite-3/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs:line 145
-        //   at Apache.Ignite.Internal.Table.Tables.GetTablesAsync() in /home/pavel/w/ignite-3/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Tables.cs:line 64
-        //   at Apache.Ignite.Tests.ReconnectTests.<>c__DisplayClass6_0.<<TestReconnectAfterFullClusterRestart>b__1>d.MoveNext() in /home/pavel/w/ignite-3/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs:line 154
         var logger = new ConsoleLogger { MinLevel = LogLevel.Trace };
 
         var cfg = new IgniteClientConfiguration

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -130,6 +130,9 @@ public class ReconnectTests
     [Test]
     public async Task TestReconnectAfterFullClusterRestart()
     {
+        // TODO: Two connections go out to the same node, which is not supported by the FakeServer.
+        // One is from background reconnect, another from regular operation.
+        // We should prevent this in the client.
         var logger = new ConsoleLogger { MinLevel = LogLevel.Trace };
 
         var cfg = new IgniteClientConfiguration

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -409,6 +409,11 @@ namespace Apache.Ignite.Internal
 
             await _socketLock.WaitAsync().ConfigureAwait(false);
 
+            if (endpoint.Socket?.IsDisposed == false)
+            {
+                return endpoint.Socket;
+            }
+
             try
             {
                 var socket = await ClientSocket.ConnectAsync(endpoint, Configuration, OnAssignmentChanged).ConfigureAwait(false);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -523,6 +523,7 @@ namespace Apache.Ignite.Internal
         private async ValueTask SendRequestAsync(PooledArrayBuffer? request, ClientOp op, long requestId)
         {
             // Reset heartbeat timer - don't sent heartbeats when connection is active anyway.
+            // TODO: ObjectDisposedException is possible here when Dispose is called concurrently.
             _heartbeatTimer.Change(dueTime: _heartbeatInterval, period: TimeSpan.FromMilliseconds(-1));
 
             if (_logger?.IsEnabled(LogLevel.Trace) == true)

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -256,7 +256,7 @@ namespace Apache.Ignite.Internal
                     {
                         var completionSource = (TaskCompletionSource<PooledBuffer>)state!;
 
-                        if (task.IsCanceled || task.Exception?.GetBaseException() is TaskCanceledException)
+                        if (task.IsCanceled || task.Exception?.GetBaseException() is TaskCanceledException or ObjectDisposedException)
                         {
                             // Canceled task means Dispose was called.
                             completionSource.TrySetException(
@@ -523,7 +523,6 @@ namespace Apache.Ignite.Internal
         private async ValueTask SendRequestAsync(PooledArrayBuffer? request, ClientOp op, long requestId)
         {
             // Reset heartbeat timer - don't sent heartbeats when connection is active anyway.
-            // TODO: ObjectDisposedException is possible here when Dispose is called concurrently.
             _heartbeatTimer.Change(dueTime: _heartbeatInterval, period: TimeSpan.FromMilliseconds(-1));
 
             if (_logger?.IsEnabled(LogLevel.Trace) == true)

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/SocketEndpoint.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/SocketEndpoint.cs
@@ -48,7 +48,12 @@ namespace Apache.Ignite.Internal
             set
             {
                 Debug.Assert(value != null, "value != null");
+
+                var oldValue = _socket;
+
                 _socket = value;
+
+                oldValue?.Dispose();
             }
         }
 


### PR DESCRIPTION
* Use double check locking in `ClientFailoverSocket.ConnectAsync` to avoid connecting the same endpoint twice (this was the root cause of flakiness: `FakeServer` does not support multiple connections. But this is also a bug - two connections to the same server should not happen).
* Handle `ObjectDisposedException` when sending requests (may happen connection is closed concurrently).
* Increase `SocketTimeout` - 200ms is too short.
