### PR TITLE
IGNITE-19142 IncomingSnapshotCopier.cancel() blocks forever if called from multiple threads

### DIFF
--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/raft/snapshot/incoming/IncomingSnapshotCopier.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/raft/snapshot/incoming/IncomingSnapshotCopier.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.apache.ignite.internal.logger.IgniteLogger;
@@ -71,6 +72,9 @@ public class IncomingSnapshotCopier extends SnapshotCopier {
     private final PartitionSnapshotStorage partitionSnapshotStorage;
 
     private final SnapshotUri snapshotUri;
+
+    /** Used to make sure that we execute cancellation at most once. */
+    private final AtomicBoolean cancellationGuard = new AtomicBoolean();
 
     /** Busy lock for synchronous rebalance cancellation. */
     private final IgniteSpinBusyLock busyLock = new IgniteSpinBusyLock();
@@ -151,6 +155,11 @@ public class IncomingSnapshotCopier extends SnapshotCopier {
 
     @Override
     public void cancel() {
+        // Cancellation from one thread must not block cancellations from other threads. hence this check.
+        if (!cancellationGuard.compareAndSet(false, true)) {
+            return;
+        }
+
         busyLock.block();
 
         LOG.info("Copier is canceled for partition [{}]", createPartitionInfo());

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/raft/snapshot/incoming/IncomingSnapshotCopier.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/raft/snapshot/incoming/IncomingSnapshotCopier.java
@@ -155,7 +155,7 @@ public class IncomingSnapshotCopier extends SnapshotCopier {
 
     @Override
     public void cancel() {
-        // Cancellation from one thread must not block cancellations from other threads. hence this check.
+        // Cancellation from one thread must not block cancellations from other threads, hence this check.
         if (!cancellationGuard.compareAndSet(false, true)) {
             return;
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-19142