### PR TITLE
IGNITE-19043 ItRaftCommandLeftInLogUntilRestartTest fixed

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItRaftCommandLeftInLogUntilRestartTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItRaftCommandLeftInLogUntilRestartTest.java
@@ -50,7 +50,6 @@ import org.apache.ignite.raft.jraft.entity.NodeId;
 import org.apache.ignite.table.Table;
 import org.apache.ignite.table.Tuple;
 import org.apache.ignite.tx.Transaction;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItRaftCommandLeftInLogUntilRestartTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItRaftCommandLeftInLogUntilRestartTest.java
@@ -56,7 +56,6 @@ import org.junit.jupiter.api.Test;
 /**
  * The class has tests of cluster recovery when no all committed RAFT commands applied to the state machine.
  */
-@Disabled("https://issues.apache.org/jira/browse/IGNITE-19043")
 public class ItRaftCommandLeftInLogUntilRestartTest extends ClusterPerClassIntegrationTest {
 
     private final Object[][] dataSet = {

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/raft/PartitionListener.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/raft/PartitionListener.java
@@ -203,18 +203,6 @@ public class PartitionListener implements RaftGroupListener {
             return;
         }
 
-        TxMeta txMeta = txStateStorage.get(cmd.txId());
-
-        if (txMeta != null && (txMeta.txState() == COMMITED || txMeta.txState() == ABORTED)) {
-            storage.runConsistently(() -> {
-                storage.lastApplied(commandIndex, commandTerm);
-
-                return null;
-            });
-
-            return;
-        }
-
         storageUpdateHandler.handleUpdate(cmd.txId(), cmd.rowUuid(), cmd.tablePartitionId().asTablePartitionId(), cmd.rowBuffer(),
                 rowId -> {
                     txsPendingRowIds.computeIfAbsent(cmd.txId(), entry -> new HashSet<>()).add(rowId);
@@ -235,15 +223,6 @@ public class PartitionListener implements RaftGroupListener {
         // Skips the write command because the storage has already executed it.
         if (commandIndex <= storage.lastAppliedIndex()) {
             return;
-        }
-
-        TxMeta txMeta = txStateStorage.get(cmd.txId());
-        if (txMeta != null && (txMeta.txState() == COMMITED || txMeta.txState() == ABORTED)) {
-            storage.runConsistently(() -> {
-                storage.lastApplied(commandIndex, commandTerm);
-
-                return null;
-            });
         }
 
         storageUpdateHandler.handleUpdateAll(cmd.txId(), cmd.rowsToUpdate(), cmd.tablePartitionId().asTablePartitionId(), rowIds -> {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-19043

After the investigation it's occurred that the reason of the failure is that raft log re-appliance is skipped within PartitionListener#handleUpdateCommand and PartitionListener#handleUpdateAllCommand because of following logic

```
        TxMeta txMeta = txStateStorage.get(cmd.txId());
        if (txMeta != null && (txMeta.txState() == COMMITED || txMeta.txState() == ABORTED)) {
            storage.runConsistently(() -> {
                storage.lastApplied(commandIndex, commandTerm);
                return null;
            });
        } 
```

Full scenario is following:

1. tx1.put populates raft log and mvPartitionStorage with corresponding log record and data.

2. tx1.commit also populates raft log with raft record and finished the transaction within txnStateStorage along wiht cleanup in mvPartitionStorage.

3. RocksDB based txnStateStorage flushes its state to a disk and page memory based doesn't.

4. After node restart raft replays the log, both put and commit commands, however on commit partition we skip put re-application  because of aforementioned
`
if (txMeta != null && (txMeta.txState() == COMMITED || txMeta.txState() == ABORTED))`

Just in case, transaction is considered to be committed because txnStateStorage flushes its state before stop.

So, in order to fix given issue it's enough to just remove the skip logic.