### PR TITLE
IGNITE-19171 Fix flaky ItClusterInitTest.testDoubleInit

### DIFF
--- a/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/ClusterInitializer.java
+++ b/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/ClusterInitializer.java
@@ -48,6 +48,8 @@ import org.apache.ignite.security.AuthenticationConfig;
 public class ClusterInitializer {
     private static final IgniteLogger LOG = Loggers.forClass(ClusterInitializer.class);
 
+    private static final int INIT_MESSAGE_SEND_TIMEOUT_MILLIS = 10_000;
+
     private final ClusterService clusterService;
 
     private final CmgMessagesFactory msgFactory = new CmgMessagesFactory();
@@ -192,7 +194,7 @@ public class ClusterInitializer {
     private CompletableFuture<Void> invokeMessage(Collection<ClusterNode> nodes, NetworkMessage message) {
         return allOf(nodes, node ->
                 clusterService.messagingService()
-                        .invoke(node, message, 10000)
+                        .invoke(node, message, INIT_MESSAGE_SEND_TIMEOUT_MILLIS)
                         .thenAccept(response -> {
                             if (response instanceof InitErrorMessage) {
                                 var errorResponse = (InitErrorMessage) response;

--- a/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/raft/CmgRaftService.java
+++ b/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/raft/CmgRaftService.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.cluster.management.raft;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.toSet;
 
 import java.util.List;
@@ -81,7 +82,7 @@ public class CmgRaftService implements ManuallyCloseable {
         } else {
             String nodeName = clusterService.topologyService().localMember().name();
 
-            return CompletableFuture.completedFuture(leader.consistentId().equals(nodeName));
+            return completedFuture(leader.consistentId().equals(nodeName));
         }
     }
 
@@ -243,6 +244,16 @@ public class CmgRaftService implements ManuallyCloseable {
      * @return Future that completes when the request is processed.
      */
     public CompletableFuture<Void> updateLearners(long term) {
+        List<Peer> currentLearners = raftService.learners();
+
+        if (currentLearners == null) {
+            return raftService.refreshMembers(true).thenCompose(v -> updateLearners(term));
+        }
+
+        Set<String> currentLearnerNames = currentLearners.stream()
+                .map(Peer::consistentId)
+                .collect(toSet());
+
         Set<String> currentPeers = nodeNames();
 
         Set<String> newLearners = logicalTopology.getLogicalTopology().nodes().stream()
@@ -250,9 +261,18 @@ public class CmgRaftService implements ManuallyCloseable {
                 .filter(name -> !currentPeers.contains(name))
                 .collect(toSet());
 
+        if (currentLearnerNames.equals(newLearners)) {
+            return completedFuture(null);
+        }
+
         PeersAndLearners newConfiguration = PeersAndLearners.fromConsistentIds(currentPeers, newLearners);
 
-        return raftService.changePeersAsync(newConfiguration, term);
+        if (newLearners.isEmpty()) {
+            // Methods for working with learners do not support empty peer lists for some reason.
+            return raftService.changePeersAsync(newConfiguration, term);
+        } else {
+            return raftService.resetLearners(newConfiguration.learners());
+        }
     }
 
     @Override


### PR DESCRIPTION
* Also reduce the number of changePeersAsync calls in CMG manager.

https://issues.apache.org/jira/browse/IGNITE-19171