### PR TITLE
IGNITE-19044 ItIgniteInMemoryNodeRestartTest#inMemoryNodeRestartNotLeader and inMemoryNodeFullPartitionRestart enabled

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItIgniteInMemoryNodeRestartTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItIgniteInMemoryNodeRestartTest.java
@@ -186,7 +186,6 @@ public class ItIgniteInMemoryNodeRestartTest extends IgniteAbstractTest {
     /**
      * Restarts an in-memory node that is not a leader of the table's partition.
      */
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-19044")
     @Test
     public void inMemoryNodeRestartNotLeader(TestInfo testInfo) throws Exception {
         // Start three nodes, the first one is going to be CMG and MetaStorage leader.
@@ -294,7 +293,6 @@ public class ItIgniteInMemoryNodeRestartTest extends IgniteAbstractTest {
     /**
      * Restarts all the nodes with the partition.
      */
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-18822")
     @Test
     public void inMemoryNodeFullPartitionRestart(TestInfo testInfo) throws Exception {
         // Start three nodes, the first one is going to be CMG and MetaStorage leader.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-19044

- ItIgniteInMemoryNodeRestartTest#inMemoryNodeRestartNotLeader was fixed within https://issues.apache.org/jira/browse/IGNITE-19043
- And I've also enabled inMemoryNodeFullPartitionRestart because the problem was probably fixed within https://issues.apache.org/jira/browse/IGNITE-19059 and https://issues.apache.org/jira/browse/IGNITE-19022