### PR TITLE
IGNITE-18962 .NET: Ensure consistent ToString format in public types

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ClientProtocolVersionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ClientProtocolVersionTest.cs
@@ -154,7 +154,7 @@ namespace Apache.Ignite.Tests
         public void TestToString()
         {
             Assert.AreEqual(
-                "ClientProtocolVersion { 16.42.128 }",
+                "ClientProtocolVersion { Version = 16.42.128 }",
                 new ClientProtocolVersion(16, 42, 128).ToString());
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
@@ -52,4 +52,17 @@ public class IgniteToStringBuilderTests
 
         Assert.AreEqual("IgniteToStringBuilderTests { a = 1, b = 2, c = 3 }", builder.Build());
     }
+
+    [Test]
+    public void TestAppendNested()
+    {
+        var builder = new IgniteToStringBuilder(typeof(IgniteToStringBuilderTests));
+        builder.Append("a", 1);
+        builder.Append("b", new Foo(123));
+        builder.Append("c", 3);
+
+        Assert.AreEqual("IgniteToStringBuilderTests { a = 1, b = Foo { X = 123 }, c = 3 }", builder.Build());
+    }
+
+    private record Foo(int X);
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
@@ -64,5 +64,6 @@ public class IgniteToStringBuilderTests
         Assert.AreEqual("IgniteToStringBuilderTests { a = 1, b = Foo { X = 123 }, c = 3 }", builder.Build());
     }
 
+    // ReSharper disable once NotAccessedPositionalProperty.Local
     private record Foo(int X);
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests.Common;
+
+using Internal.Common;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests <see cref="IgniteToStringBuilder"/>.
+/// </summary>
+public class IgniteToStringBuilderTests
+{
+    [Test]
+    public void TestEmpty()
+    {
+        var builder = new IgniteToStringBuilder(typeof(IgniteToStringBuilderTests));
+
+        Assert.AreEqual("IgniteToStringBuilderTests {  }", builder.Build());
+    }
+
+    [Test]
+    public void TestAppendOne()
+    {
+        var builder = new IgniteToStringBuilder(typeof(IgniteClient));
+        builder.Append("a", 1);
+
+        Assert.AreEqual("IgniteClient { a = 1 }", builder.Build());
+    }
+
+    [Test]
+    public void TestAppendMultiple()
+    {
+        var builder = new IgniteToStringBuilder(typeof(IgniteToStringBuilderTests));
+        builder.Append("a", 1);
+        builder.Append("b", 2);
+        builder.Append("c", 3);
+
+        Assert.AreEqual("IgniteToStringBuilderTests { a = 1, b = 2, c = 3 }", builder.Build());
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
@@ -68,11 +68,12 @@ public class IgniteToStringBuilderTests
     [Test]
     public void TestGetNested()
     {
+        // TODO: Test double build, double close, etc
         var res = new IgniteToStringBuilder("Foo").Append("a", 1)
-            .GetNested("Bar")
+            .BeginNested("Bar")
             .Append("b", 2)
             .Append("c", 3)
-            .CloseNested()
+            .EndNested()
             .Append("d", 4)
             .Build();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
@@ -45,23 +45,38 @@ public class IgniteToStringBuilderTests
     [Test]
     public void TestAppendMultiple()
     {
-        var builder = new IgniteToStringBuilder(typeof(IgniteToStringBuilderTests));
-        builder.Append("a", 1);
-        builder.Append("b", 2);
-        builder.Append("c", 3);
+        var res = new IgniteToStringBuilder(typeof(IgniteToStringBuilderTests))
+            .Append("a", 1)
+            .Append("b", 2)
+            .Append("c", 3)
+            .Build();
 
-        Assert.AreEqual("IgniteToStringBuilderTests { a = 1, b = 2, c = 3 }", builder.Build());
+        Assert.AreEqual("IgniteToStringBuilderTests { a = 1, b = 2, c = 3 }", res);
     }
 
     [Test]
-    public void TestAppendNested()
+    public void TestAppendNestedRecord()
     {
-        var builder = new IgniteToStringBuilder(typeof(IgniteToStringBuilderTests));
-        builder.Append("a", 1);
-        builder.Append("b", new Foo(123));
-        builder.Append("c", 3);
+        var res = new IgniteToStringBuilder(typeof(IgniteToStringBuilderTests)).Append("a", 1)
+            .Append("b", new Foo(123))
+            .Append("c", 3)
+            .Build();
 
-        Assert.AreEqual("IgniteToStringBuilderTests { a = 1, b = Foo { X = 123 }, c = 3 }", builder.Build());
+        Assert.AreEqual("IgniteToStringBuilderTests { a = 1, b = Foo { X = 123 }, c = 3 }", res);
+    }
+
+    [Test]
+    public void TestGetNested()
+    {
+        var res = new IgniteToStringBuilder("Foo").Append("a", 1)
+            .GetNested("Bar")
+            .Append("b", 2)
+            .Append("c", 3)
+            .CloseNested()
+            .Append("d", 4)
+            .Build();
+
+        Assert.AreEqual("IgniteToStringBuilderTests { a = 1, b = Foo { X = 123 }, c = 3 }", res);
     }
 
     // ReSharper disable once NotAccessedPositionalProperty.Local

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
@@ -30,7 +30,7 @@ public class IgniteToStringBuilderTests
     {
         var builder = new IgniteToStringBuilder(typeof(IgniteToStringBuilderTests));
 
-        Assert.AreEqual("IgniteToStringBuilderTests {  }", builder.Build());
+        Assert.AreEqual("IgniteToStringBuilderTests { }", builder.Build());
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
@@ -76,7 +76,7 @@ public class IgniteToStringBuilderTests
             .Append("d", 4)
             .Build();
 
-        Assert.AreEqual("IgniteToStringBuilderTests { a = 1, b = Foo { X = 123 }, c = 3 }", res);
+        Assert.AreEqual("Foo { a = 1, Bar { b = 2, c = 3 }, d = 4 }", res);
     }
 
     // ReSharper disable once NotAccessedPositionalProperty.Local

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
@@ -37,7 +37,7 @@ public class IgniteToStringBuilderTests
     public void TestAppendOne()
     {
         var builder = new IgniteToStringBuilder(typeof(IgniteClient));
-        builder.Append("a", 1);
+        builder.Append(1, "a");
 
         Assert.AreEqual("IgniteClient { a = 1 }", builder.Build());
     }
@@ -46,9 +46,9 @@ public class IgniteToStringBuilderTests
     public void TestAppendMultiple()
     {
         var res = new IgniteToStringBuilder(typeof(IgniteToStringBuilderTests))
-            .Append("a", 1)
-            .Append("b", 2)
-            .Append("c", 3)
+            .Append(1, "a")
+            .Append(2, "b")
+            .Append(3, "c")
             .Build();
 
         Assert.AreEqual("IgniteToStringBuilderTests { a = 1, b = 2, c = 3 }", res);
@@ -57,9 +57,10 @@ public class IgniteToStringBuilderTests
     [Test]
     public void TestAppendNestedRecord()
     {
-        var res = new IgniteToStringBuilder(typeof(IgniteToStringBuilderTests)).Append("a", 1)
-            .Append("b", new Foo(123))
-            .Append("c", 3)
+        var res = new IgniteToStringBuilder(typeof(IgniteToStringBuilderTests))
+            .Append(1, "a")
+            .Append(new Foo(123), "b")
+            .Append(3, "c")
             .Build();
 
         Assert.AreEqual("IgniteToStringBuilderTests { a = 1, b = Foo { X = 123 }, c = 3 }", res);
@@ -69,12 +70,13 @@ public class IgniteToStringBuilderTests
     public void TestGetNested()
     {
         // TODO: Test double build, double close, etc
-        var res = new IgniteToStringBuilder("Foo").Append("a", 1)
+        var res = new IgniteToStringBuilder("Foo")
+            .Append(1, "a")
             .BeginNested("Bar")
-            .Append("b", 2)
-            .Append("c", 3)
+            .Append(2, "b")
+            .Append(3, "c")
             .EndNested()
-            .Append("d", 4)
+            .Append(4, "d")
             .Build();
 
         Assert.AreEqual("Foo { a = 1, Bar { b = 2, c = 3 }, d = 4 }", res);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
@@ -17,6 +17,8 @@
 
 namespace Apache.Ignite.Tests.Common;
 
+using System;
+using System.Collections.Generic;
 using Internal.Common;
 using NUnit.Framework;
 
@@ -67,9 +69,14 @@ public class IgniteToStringBuilderTests
     }
 
     [Test]
+    public void TestGenericType()
+    {
+        Assert.AreEqual("KeyValuePair`2[Int32, String] { }", IgniteToStringBuilder.Build(typeof(KeyValuePair<int, string>)));
+    }
+
+    [Test]
     public void TestGetNested()
     {
-        // TODO: Test double build, double close, etc
         var res = new IgniteToStringBuilder(typeof(Foo))
             .Append(1, "a")
             .BeginNested("Bar")
@@ -80,6 +87,34 @@ public class IgniteToStringBuilderTests
             .Build();
 
         Assert.AreEqual("Foo { a = 1, Bar { b = 2, c = 3 }, d = 4 }", res);
+    }
+
+    [Test]
+    public void TestMultipleBuildReturnsSameString()
+    {
+        var builder = new IgniteToStringBuilder(typeof(IgniteToStringBuilderTests));
+        builder.Append(1, "a");
+
+        Assert.AreEqual("IgniteToStringBuilderTests { a = 1 }", builder.Build());
+        Assert.AreEqual("IgniteToStringBuilderTests { a = 1 }", builder.Build());
+        Assert.AreEqual("IgniteToStringBuilderTests { a = 1 }", builder.ToString());
+    }
+
+    [Test]
+    public void TestAppendAfterBuildThrows()
+    {
+        var builder = new IgniteToStringBuilder(typeof(IgniteToStringBuilderTests));
+        builder.Build();
+
+        Assert.Throws<InvalidOperationException>(() => builder.Append(1, "a"));
+    }
+
+    [Test]
+    public void TestBuildBeforeCloseNestedThrows()
+    {
+        var builder = new IgniteToStringBuilder(typeof(Foo));
+
+        Assert.Throws<InvalidOperationException>(() => builder.BeginNested("abc").Build());
     }
 
     // ReSharper disable once NotAccessedPositionalProperty.Local

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Common/IgniteToStringBuilderTests.cs
@@ -70,7 +70,7 @@ public class IgniteToStringBuilderTests
     public void TestGetNested()
     {
         // TODO: Test double build, double close, etc
-        var res = new IgniteToStringBuilder("Foo")
+        var res = new IgniteToStringBuilder(typeof(Foo))
             .Append(1, "a")
             .BeginNested("Bar")
             .Append(2, "b")

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Common/StringBuilderExtensionsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Common/StringBuilderExtensionsTests.cs
@@ -37,4 +37,16 @@ public class StringBuilderExtensionsTests
 
         Assert.AreEqual(expected, sb.ToString());
     }
+
+    [Test]
+    [TestCase("abc", "abc def")]
+    [TestCase("abc ", "abc def")]
+    [TestCase("abc  ", "abc  def")]
+    public void TestAppendWithSpace(string input, string expected)
+    {
+        var sb = new StringBuilder(input);
+        sb.AppendWithSpace("def");
+
+        Assert.AreEqual(expected, sb.ToString());
+    }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Common/StringBuilderExtensionsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Common/StringBuilderExtensionsTests.cs
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests.Common;
+
+using System.Text;
+using Internal.Common;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests for <see cref="StringBuilderExtensions"/>.
+/// </summary>
+public class StringBuilderExtensionsTests
+{
+    [Test]
+    [TestCase("abc", "abc")]
+    [TestCase(" abc ", " abc")]
+    [TestCase("  abc  ", "  abc")]
+    public void TestTrimEnd(string input, string expected)
+    {
+        var sb = new StringBuilder(input);
+        sb.TrimEnd();
+
+        Assert.AreEqual(expected, sb.ToString());
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteClientTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteClientTests.cs
@@ -45,5 +45,20 @@ namespace Apache.Ignite.Tests
 
             Assert.Greater(tables.Count, 0);
         }
+
+        [Test]
+        public async Task TestToString()
+        {
+            using var client = await IgniteClient.StartAsync(GetConfig());
+
+            // IgniteClientInternal { Connections = [ ClusterNode {
+            // Id = 703cc4d7-41ef-4321-b960-70ad9df2617b,
+            // Name = org.apache.ignite.internal.runner.app.PlatformTestNodeRunner,
+            // Address = 127.0.0.1:10942 } ] }
+            StringAssert.StartsWith("IgniteClientInternal { Connections = [ ClusterNode { Id = ", client.ToString());
+            StringAssert.Contains(
+                "Name = org.apache.ignite.internal.runner.app.PlatformTestNodeRunner, Address = 127.0.0.1:109",
+                client.ToString());
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -360,7 +360,7 @@ public partial class LinqSqlGenerationTests
         const string expectedToString =
             "IgniteQueryable`1 { Query = " +
             expectedQueryText +
-            ", Parameters = 3, v-2 }";
+            ", Parameters = [ 3, v-2 ] }";
 
         Assert.AreEqual(expectedQueryText, query.ToQueryString());
         Assert.AreEqual(expectedToString, query.ToString());

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -358,9 +358,9 @@ public partial class LinqSqlGenerationTests
             "where ((_T0.KEY IS NOT DISTINCT FROM ?) and (_T0.VAL IS DISTINCT FROM ?))";
 
         const string expectedToString =
-            "Apache.Ignite.Internal.Linq.IgniteQueryable`1[<>f__AnonymousType4`2[System.String,System.Int64]] [Query=" +
+            "IgniteQueryable`1 { Query = " +
             expectedQueryText +
-            ", Parameters=3, v-2]";
+            ", Parameters = 3, v-2 }";
 
         Assert.AreEqual(expectedQueryText, query.ToQueryString());
         Assert.AreEqual(expectedToString, query.ToString());

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -358,7 +358,7 @@ public partial class LinqSqlGenerationTests
             "where ((_T0.KEY IS NOT DISTINCT FROM ?) and (_T0.VAL IS DISTINCT FROM ?))";
 
         const string expectedToString =
-            "IgniteQueryable`1 { Query = " +
+            "IgniteQueryable`1[<>f__AnonymousType4`2[String, Int64]] { Query = " +
             expectedQueryText +
             ", Parameters = [ 3, v-2 ] }";
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Functions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Functions.cs
@@ -273,7 +273,7 @@ public partial class LinqTests
         TestOpString(
             x => Regex.Replace(x.Val!, @"V-(\d+)", "V$1", RegexOptions.IgnoreCase | RegexOptions.Multiline),
             "V9",
-            @"select regexp_replace(_T0.VAL, ?, ?, 1, 1, ?) from PUBLIC.TBL1 as _T0, Parameters=V-(\d+), V$1, im");
+            @"select regexp_replace(_T0.VAL, ?, ?, 1, 1, ?) from PUBLIC.TBL1 as _T0, Parameters = V-(\d+), V$1, im");
     }
 
     private static void TestOp<T, TRes>(IRecordView<T> view, Expression<Func<T, TRes>> expr, TRes expectedRes, string expectedQuery)

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Functions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Functions.cs
@@ -273,7 +273,7 @@ public partial class LinqTests
         TestOpString(
             x => Regex.Replace(x.Val!, @"V-(\d+)", "V$1", RegexOptions.IgnoreCase | RegexOptions.Multiline),
             "V9",
-            @"select regexp_replace(_T0.VAL, ?, ?, 1, 1, ?) from PUBLIC.TBL1 as _T0, Parameters = V-(\d+), V$1, im");
+            @"select regexp_replace(_T0.VAL, ?, ?, 1, 1, ?) from PUBLIC.TBL1 as _T0, Parameters = [ V-(\d+), V$1, im ]");
     }
 
     private static void TestOp<T, TRes>(IRecordView<T> view, Expression<Func<T, TRes>> expr, TRes expectedRes, string expectedQuery)

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -409,7 +409,7 @@ public partial class LinqTests : IgniteTestsBase
         CollectionAssert.AreEquivalent(new[] { "v-2", "v-4" }, res);
 
         StringAssert.Contains(
-            "select _T0.VAL from PUBLIC.TBL1 as _T0 where (_T0.KEY IN (?, ?)), Parameters=4, 2",
+            "select _T0.VAL from PUBLIC.TBL1 as _T0 where (_T0.KEY IN (?, ?)), Parameters = 4, 2",
             query.ToString());
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -669,7 +669,7 @@ public partial class LinqTests : IgniteTestsBase
             .Select(x => new { x.Key, Res = x.Val });
 
         StringAssert.Contains(
-            "select _T0.KEY, _T0.VAL from PUBLIC.TBL_INT32 as _T0 where (cast(_T0.VAL as int) IS NOT DISTINCT FROM ?), Parameters=3",
+            "select _T0.KEY, _T0.VAL from PUBLIC.TBL_INT32 as _T0 where (cast(_T0.VAL as int) IS NOT DISTINCT FROM ?), Parameters = 3",
             query.ToString());
 
         var res = query.ToList();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -409,7 +409,7 @@ public partial class LinqTests : IgniteTestsBase
         CollectionAssert.AreEquivalent(new[] { "v-2", "v-4" }, res);
 
         StringAssert.Contains(
-            "select _T0.VAL from PUBLIC.TBL1 as _T0 where (_T0.KEY IN (?, ?)), Parameters = 4, 2",
+            "select _T0.VAL from PUBLIC.TBL1 as _T0 where (_T0.KEY IN (?, ?)), Parameters = [ 4, 2 ]",
             query.ToString());
     }
 
@@ -669,7 +669,7 @@ public partial class LinqTests : IgniteTestsBase
             .Select(x => new { x.Key, Res = x.Val });
 
         StringAssert.Contains(
-            "select _T0.KEY, _T0.VAL from PUBLIC.TBL_INT32 as _T0 where (cast(_T0.VAL as int) IS NOT DISTINCT FROM ?), Parameters = 3",
+            "select _T0.KEY, _T0.VAL from PUBLIC.TBL_INT32 as _T0 where (cast(_T0.VAL as int) IS NOT DISTINCT FROM ?), Parameters = [ 300 ]",
             query.ToString());
 
         var res = query.ToList();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/RetryPolicyTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/RetryPolicyTests.cs
@@ -267,6 +267,15 @@ namespace Apache.Ignite.Tests
             Assert.ThrowsAsync<IgniteClientConnectionException>(async () => await table!.RecordBinaryView.UpsertAsync(null, new IgniteTuple()));
         }
 
+        [Test]
+        public void TestToString()
+        {
+            Assert.AreEqual("RetryReadPolicy { RetryLimit = 3 }", new RetryReadPolicy { RetryLimit = 3 }.ToString());
+            Assert.AreEqual("RetryLimitPolicy { RetryLimit = 4 }", new RetryLimitPolicy { RetryLimit = 4 }.ToString());
+            Assert.AreEqual("TestRetryPolicy { RetryLimit = 5 }", new TestRetryPolicy { RetryLimit = 5 }.ToString());
+            Assert.AreEqual("RetryNonePolicy { }", new RetryNonePolicy().ToString());
+        }
+
         private class TestRetryPolicy : RetryLimitPolicy
         {
             private readonly List<IRetryPolicyContext> _invocations = new();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/IgniteDbDataReaderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/IgniteDbDataReaderTests.cs
@@ -101,6 +101,11 @@ public class IgniteDbDataReaderTests : IgniteTestsBase
         Assert.AreEqual("KEY", reader.Metadata.Columns[0].Name);
         Assert.AreEqual("INT8", reader.Metadata.Columns[1].Name);
 
+        StringAssert.StartsWith(
+            "IgniteDbDataReader { FieldCount = 2, RecordsAffected = -1, HasRows = True, IsClosed = False, " +
+            "Metadata = ResultSetMetadata { Columns = [",
+            reader.ToString());
+
         Assert.Throws<InvalidOperationException>(() => reader.GetByte(1));
 
         await reader.ReadAsync();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
@@ -70,6 +70,12 @@ namespace Apache.Ignite.Tests.Sql
             Assert.AreEqual(0, resultSet.Metadata!.IndexOf("NUM"));
             Assert.AreEqual(1, resultSet.Metadata!.IndexOf("STR"));
 
+            Assert.AreEqual(
+                "ResultSetMetadata { Columns = [ " +
+                "ColumnMetadata { Name = NUM, Type = Int32, Precision = 10, Scale = 0, Nullable = False, Origin =  }, " +
+                "ColumnMetadata { Name = STR, Type = String, Precision = 5, Scale = -2147483648, Nullable = False, Origin =  } ] }",
+                resultSet.Metadata.ToString());
+
             Assert.AreEqual(1, rows.Count);
             Assert.AreEqual("IgniteTuple { NUM = 1, STR = hello }", rows[0].ToString());
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
@@ -404,5 +404,18 @@ namespace Apache.Ignite.Tests.Sql
             Assert.AreEqual("10", props["prop1"]);
             Assert.AreEqual("xyz", props["prop-2"]);
         }
+
+        [Test]
+        public async Task TestResultSetToString()
+        {
+            await using IResultSet<IIgniteTuple> resultSet = await Client.Sql.ExecuteAsync(null, "select 1 as num, 'hello' as str");
+
+            Assert.AreEqual(
+                "ResultSet`1[IIgniteTuple] { HasRowSet = True, AffectedRows = -1, WasApplied = False, " +
+                "Metadata = ResultSetMetadata { Columns = [ " +
+                "ColumnMetadata { Name = NUM, Type = Int32, Precision = 10, Scale = 0, Nullable = False, Origin =  }, " +
+                "ColumnMetadata { Name = STR, Type = String, Precision = 5, Scale = -2147483648, Nullable = False, Origin =  } ] } }",
+                resultSet.ToString());
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/KeyValueViewBinaryTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/KeyValueViewBinaryTests.cs
@@ -290,4 +290,10 @@ public class KeyValueViewBinaryTests : IgniteTestsBase
         Assert.IsTrue(res4.HasValue);
         Assert.AreEqual("11", res4.Value[0]);
     }
+
+    [Test]
+    public void TestToString()
+    {
+        StringAssert.StartsWith("KeyValueView`2[IIgniteTuple, IIgniteTuple] { Table = Table { Name = TBL1, Id =", KvView.ToString());
+    }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/KeyValueViewPocoTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/KeyValueViewPocoTests.cs
@@ -291,4 +291,10 @@ public class KeyValueViewPocoTests : IgniteTestsBase
         Assert.IsTrue(res4.HasValue);
         Assert.AreEqual("11", res4.Value.Val);
     }
+
+    [Test]
+    public void TestToString()
+    {
+        StringAssert.StartsWith("KeyValueView`2[Poco, Poco] { Table = Table { Name = TBL1, Id =", KvView.ToString());
+    }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/KeyValueViewPrimitiveTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/KeyValueViewPrimitiveTests.cs
@@ -300,6 +300,12 @@ public class KeyValueViewPrimitiveTests : IgniteTestsBase
         await TestKey(new BitArray(new[] { byte.MaxValue }), TableBitmaskName);
     }
 
+    [Test]
+    public void TestToString()
+    {
+        StringAssert.StartsWith("KeyValueView`2[Int64, String] { Table = Table { Name = TBL1, Id =", KvView.ToString());
+    }
+
     private static async Task TestKey<T>(T val, IKeyValueView<T, T> kvView)
         where T : notnull
     {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
@@ -597,5 +597,11 @@ namespace Apache.Ignite.Tests.Table
             Assert.IsTrue(await TupleView.ContainsKeyAsync(null, tuple));
             Assert.IsFalse(await TupleView.ContainsKeyAsync(null, GetTuple(-128)));
         }
+
+        [Test]
+        public void TestToString()
+        {
+            StringAssert.StartsWith("RecordView`1[IIgniteTuple] { Table = Table { Name = TBL1, Id =", TupleView.ToString());
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewPocoTests.cs
@@ -795,6 +795,12 @@ namespace Apache.Ignite.Tests.Table
             Assert.IsFalse(await PocoView.ContainsKeyAsync(null, GetPoco(-128)));
         }
 
+        [Test]
+        public void TestToString()
+        {
+            StringAssert.StartsWith("RecordView`1[Poco] { Table = Table { Name = TBL1, Id =", PocoView.ToString());
+        }
+
         // ReSharper disable once NotAccessedPositionalProperty.Local
         private record UnsupportedByteType(byte Int8);
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TablesTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/TablesTests.cs
@@ -66,5 +66,14 @@ namespace Apache.Ignite.Tests.Table
 
             Assert.IsNull(table);
         }
+
+        [Test]
+        public async Task TestToString()
+        {
+            _ = await Client.Tables.GetTablesAsync();
+
+            StringAssert.StartsWith("Tables { CachedTables = [ Table { Name = ", Client.Tables.ToString());
+            StringAssert.Contains("{ Name = TBL_STRING, Id = ", Client.Tables.ToString());
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests;
+
+using NUnit.Framework;
+
+/// <summary>
+/// Tests for <see cref="object.ToString"/> methods.
+/// </summary>
+public class ToStringTests
+{
+    [Test]
+    public void TestAllPublicFacingTypesHaveConsistentToString()
+    {
+        // TODO:
+        // 1. Get all public types.
+        // For interfaces, get internal types implementing them.
+        // For abstract classes, get internal types deriving from them.
+        // 2. Check that all types have ToString() method, which uses 'TypeName { Property = Value }' format.
+        // We can introduce IgniteToStringBuilder for that.
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
@@ -18,7 +18,6 @@
 namespace Apache.Ignite.Tests;
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
@@ -53,7 +53,7 @@ public class ToStringTests
                 continue;
             }
 
-            if (type.IsPublic || type.GetInterfaces().Any(x => x.IsPublic))
+            if (type.IsPublic || type.GetInterfaces().Any(x => x.IsPublic && x.Assembly == asm))
             {
                 yield return type;
             }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
@@ -47,7 +47,13 @@ public class ToStringTests
 
         foreach (var type in types)
         {
-            if (type.IsInterface || type.IsAbstract)
+            if (typeof(Exception).IsAssignableFrom(type))
+            {
+                // Exceptions use built-in string conversion.
+                continue;
+            }
+
+            if (type.IsInterface || type.IsAbstract || type.IsEnum)
             {
                 continue;
             }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Ignite.Table;
 using NUnit.Framework;
 
 /// <summary>
@@ -28,6 +29,8 @@ using NUnit.Framework;
 /// </summary>
 public class ToStringTests
 {
+    private static readonly List<Type> PublicFacingTypes = GetPublicFacingTypes().ToList();
+
     [Test]
     public void TestAllPublicFacingTypesHaveConsistentToString()
     {
@@ -37,6 +40,7 @@ public class ToStringTests
         // For abstract classes, get internal types deriving from them.
         // 2. Check that all types have ToString() method, which uses 'TypeName { Property = Value }' format.
         // We can introduce IgniteToStringBuilder for that.
+        // 3. Check that GetPublicFacingTypes returns something.
         foreach (var type in GetPublicFacingTypes())
         {
             var path = GetSourcePath(type);
@@ -44,6 +48,15 @@ public class ToStringTests
             Console.WriteLine(path);
             Assert.IsTrue(File.Exists(path), path);
         }
+    }
+
+    [Test]
+    public void TestPublicFacingTypes()
+    {
+        CollectionAssert.Contains(PublicFacingTypes, typeof(IgniteTuple));
+        CollectionAssert.Contains(PublicFacingTypes, typeof(SslStreamFactory));
+        CollectionAssert.Contains(PublicFacingTypes, typeof(Internal.Table.Table));
+        CollectionAssert.Contains(PublicFacingTypes, typeof(Internal.Compute.Compute));
     }
 
     private static string GetSourcePath(Type type)
@@ -60,12 +73,11 @@ public class ToStringTests
             .TrimStart('.')
             .Replace('.', Path.DirectorySeparatorChar);
 
-        var path = Path.Combine(
+        return Path.Combine(
             TestUtils.SolutionDir,
             "Apache.Ignite",
             subNamespace,
             typeName + ".cs");
-        return path;
     }
 
     private static IEnumerable<Type> GetPublicFacingTypes()

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
@@ -31,6 +31,11 @@ public class ToStringTests
 {
     private static readonly List<Type> PublicFacingTypes = GetPublicFacingTypes().ToList();
 
+    private static readonly HashSet<Type> ExcludedTypes = new()
+    {
+        typeof(RetryReadPolicy), // Inherits from RetryReadPolicy
+    };
+
     [Test]
     public void TestAllPublicFacingTypesHaveConsistentToString()
     {
@@ -38,6 +43,11 @@ public class ToStringTests
         {
             foreach (var type in GetPublicFacingTypes())
             {
+                if (ExcludedTypes.Contains(type))
+                {
+                    continue;
+                }
+
                 var path = GetSourcePath(type);
                 var code = File.ReadAllText(path);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
@@ -17,6 +17,10 @@
 
 namespace Apache.Ignite.Tests;
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 
 /// <summary>
@@ -33,5 +37,26 @@ public class ToStringTests
         // For abstract classes, get internal types deriving from them.
         // 2. Check that all types have ToString() method, which uses 'TypeName { Property = Value }' format.
         // We can introduce IgniteToStringBuilder for that.
+        var typeNames = string.Join(Environment.NewLine, GetPublicFacingTypes().Select(x => x.Name).OrderBy(x => x));
+        Console.WriteLine(typeNames);
+    }
+
+    private static IEnumerable<Type> GetPublicFacingTypes()
+    {
+        var asm = typeof(IIgnite).Assembly;
+        var types = asm.GetTypes();
+
+        foreach (var type in types)
+        {
+            if (type.IsInterface || type.IsAbstract)
+            {
+                continue;
+            }
+
+            if (type.IsPublic || type.GetInterfaces().Any(x => x.IsPublic))
+            {
+                yield return type;
+            }
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
@@ -49,6 +49,7 @@ public class ToStringTests
                 if (code.Contains("record " + GetCleanTypeName(type)) ||
                     code.Contains("record struct " + GetCleanTypeName(type)))
                 {
+                    // records provide property-based ToString() in the same format we use.
                     continue;
                 }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
@@ -51,7 +51,8 @@ public class ToStringTests
                 var path = GetSourcePath(type);
                 var code = File.ReadAllText(path);
 
-                if (code.Contains("new IgniteToStringBuilder("))
+                if (code.Contains("new IgniteToStringBuilder(", StringComparison.Ordinal) ||
+                    code.Contains("IgniteToStringBuilder.Build(", StringComparison.Ordinal))
                 {
                     continue;
                 }

--- a/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.csproj
@@ -56,7 +56,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientProtocolVersion.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientProtocolVersion.cs
@@ -185,7 +185,7 @@ namespace Apache.Ignite.Internal
         /** <inheritdoc /> */
         public override string ToString() =>
             new IgniteToStringBuilder(nameof(ClientProtocolVersion))
-                .Append("Version", $"{Major}.{Minor}.{Patch}")
+                .Append($"{Major}.{Minor}.{Patch}", "Version")
                 .Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientProtocolVersion.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientProtocolVersion.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Internal
 {
     using System;
+    using Common;
 
     /// <summary>
     /// Client protocol version.
@@ -182,9 +183,9 @@ namespace Apache.Ignite.Internal
         }
 
         /** <inheritdoc /> */
-        public override string ToString()
-        {
-            return $"{nameof(ClientProtocolVersion)} {{ {Major}.{Minor}.{Patch} }}";
-        }
+        public override string ToString() =>
+            new IgniteToStringBuilder(nameof(ClientProtocolVersion))
+                .Append("Version", $"{Major}.{Minor}.{Patch}")
+                .Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientProtocolVersion.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientProtocolVersion.cs
@@ -184,7 +184,7 @@ namespace Apache.Ignite.Internal
 
         /** <inheritdoc /> */
         public override string ToString() =>
-            new IgniteToStringBuilder(nameof(ClientProtocolVersion))
+            new IgniteToStringBuilder(GetType())
                 .Append($"{Major}.{Minor}.{Patch}", "Version")
                 .Build();
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteArgumentCheck.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteArgumentCheck.cs
@@ -19,6 +19,7 @@
 namespace Apache.Ignite.Internal.Common
 {
     using System;
+    using System.Runtime.CompilerServices;
     using JetBrains.Annotations;
 
     /// <summary>
@@ -33,7 +34,7 @@ namespace Apache.Ignite.Internal.Common
         /// <param name="argName">Name of the argument.</param>
         /// <typeparam name="T">Arg type.</typeparam>
         /// <returns>Argument.</returns>
-        public static T NotNull<T>([NoEnumeration] T arg, string argName) =>
+        public static T NotNull<T>([NoEnumeration] T arg, [CallerArgumentExpression("arg")] string? argName = null) =>
             arg == null ? throw new ArgumentNullException(argName) : arg;
 
         /// <summary>
@@ -42,7 +43,7 @@ namespace Apache.Ignite.Internal.Common
         /// <param name="arg">The argument.</param>
         /// <param name="argName">Name of the argument.</param>
         /// <returns>Argument.</returns>
-        public static string NotNullOrEmpty(string arg, string argName)
+        public static string NotNullOrEmpty(string arg, [CallerArgumentExpression("arg")] string? argName = null)
         {
             if (string.IsNullOrEmpty(arg))
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -88,7 +88,19 @@ internal record IgniteToStringBuilder
     /// </summary>
     /// <param name="name">Property name.</param>
     /// <returns>Builder.</returns>
-    public IgniteToStringBuilder GetNested(string name) => new(_builder, name, this);
+    public IgniteToStringBuilder GetNested(string name)
+    {
+        if (_first)
+        {
+            _first = false;
+        }
+        else
+        {
+            _builder.Append(", ");
+        }
+
+        return new(_builder, name, this);
+    }
 
     /// <summary>
     /// Closes the builder.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Internal.Common;
+
+using System;
+using System.Text;
+
+/// <summary>
+/// ToString helper.
+/// </summary>
+internal ref struct IgniteToStringBuilder
+{
+    private readonly StringBuilder _builder = new();
+
+    private bool _first = true;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IgniteToStringBuilder"/> struct.
+    /// </summary>
+    /// <param name="type">Type.</param>
+    public IgniteToStringBuilder(Type type)
+    {
+        _builder.Append(type.Name);
+        _builder.Append(" { ");
+    }
+
+    /// <summary>
+    /// Appends a property.
+    /// </summary>
+    /// <param name="name">Property name.</param>
+    /// <param name="value">Property value.</param>
+    public void Append(string name, object value)
+    {
+        if (_first)
+        {
+            _first = false;
+        }
+        else
+        {
+            _builder.Append(", ");
+        }
+
+        _builder.Append(name);
+        _builder.Append(" = ");
+        _builder.Append(value);
+    }
+
+    /// <summary>
+    /// Builds the resulting string.
+    /// </summary>
+    /// <returns>String representation.</returns>
+    public string Build()
+    {
+        _builder.Append(" }");
+
+        return _builder.ToString();
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -66,7 +66,7 @@ internal ref struct IgniteToStringBuilder
     /// <returns>String representation.</returns>
     public string Build()
     {
-        _builder.Append(" }");
+        _builder.AppendWithSpace("}");
 
         return _builder.ToString();
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -88,7 +88,7 @@ internal record IgniteToStringBuilder
     /// </summary>
     /// <param name="name">Property name.</param>
     /// <returns>Builder.</returns>
-    public IgniteToStringBuilder GetNested(string name)
+    public IgniteToStringBuilder BeginNested(string name)
     {
         if (_first)
         {
@@ -106,7 +106,7 @@ internal record IgniteToStringBuilder
     /// Closes the builder.
     /// </summary>
     /// <returns>Parent builder.</returns>
-    public IgniteToStringBuilder CloseNested()
+    public IgniteToStringBuilder EndNested()
     {
         if (_parent == null)
         {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -64,27 +64,10 @@ internal record IgniteToStringBuilder
     /// <summary>
     /// Appends a property.
     /// </summary>
-    /// <param name="name">Property name.</param>
-    /// <param name="value">Property value.</param>
-    /// <returns>This instance.</returns>
-    public IgniteToStringBuilder Append(string name, object? value)
-    {
-        AppendComma();
-
-        _builder.Append(name);
-        _builder.Append(" = ");
-        _builder.Append(value);
-
-        return this;
-    }
-
-    /// <summary>
-    /// Appends a property.
-    /// </summary>
     /// <param name="value">Property value.</param>
     /// <param name="name">Property name.</param>
     /// <returns>This instance.</returns>
-    public IgniteToStringBuilder Append2(object? value, [CallerArgumentExpression("value")] string? name = null)
+    public IgniteToStringBuilder Append(object? value, [CallerArgumentExpression("value")] string? name = null)
     {
         IgniteArgumentCheck.NotNull(name, nameof(name));
 
@@ -141,7 +124,7 @@ internal record IgniteToStringBuilder
     {
         foreach (var pair in pairs)
         {
-            Append(pair.Key, pair.Value);
+            Append(pair.Value, pair.Key);
         }
 
         return this;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -68,18 +68,45 @@ internal record IgniteToStringBuilder
     /// <returns>This instance.</returns>
     public IgniteToStringBuilder Append(string name, object? value)
     {
-        if (_first)
-        {
-            _first = false;
-        }
-        else
-        {
-            _builder.Append(", ");
-        }
+        AppendComma();
 
         _builder.Append(name);
         _builder.Append(" = ");
         _builder.Append(value);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a property.
+    /// </summary>
+    /// <param name="name">Property name.</param>
+    /// <param name="value">Property value.</param>
+    /// <typeparam name="T">Value type.</typeparam>
+    /// <returns>This instance.</returns>
+    public IgniteToStringBuilder AppendList<T>(string name, IEnumerable<T> value)
+    {
+        AppendComma();
+
+        _builder.Append(name);
+        _builder.Append(" = [ ");
+        bool first = true;
+
+        foreach (var item in value)
+        {
+            if (first)
+            {
+                first = false;
+            }
+            else
+            {
+                _builder.Append(", ");
+            }
+
+            _builder.Append(item);
+        }
+
+        _builder.Append(" ]");
 
         return this;
     }
@@ -107,14 +134,7 @@ internal record IgniteToStringBuilder
     /// <returns>Builder.</returns>
     public IgniteToStringBuilder BeginNested(string name)
     {
-        if (_first)
-        {
-            _first = false;
-        }
-        else
-        {
-            _builder.Append(", ");
-        }
+        AppendComma();
 
         return new(_builder, name, this);
     }
@@ -149,6 +169,18 @@ internal record IgniteToStringBuilder
         Close();
 
         return _builder.ToString();
+    }
+
+    private void AppendComma()
+    {
+        if (_first)
+        {
+            _first = false;
+        }
+        else
+        {
+            _builder.Append(", ");
+        }
     }
 
     private void Close()

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Internal.Common;
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 
 /// <summary>
@@ -65,7 +66,7 @@ internal record IgniteToStringBuilder
     /// <param name="name">Property name.</param>
     /// <param name="value">Property value.</param>
     /// <returns>This instance.</returns>
-    public IgniteToStringBuilder Append(string name, object value)
+    public IgniteToStringBuilder Append(string name, object? value)
     {
         if (_first)
         {
@@ -79,6 +80,22 @@ internal record IgniteToStringBuilder
         _builder.Append(name);
         _builder.Append(" = ");
         _builder.Append(value);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Appends multiple properties.
+    /// </summary>
+    /// <param name="pairs">Key value pairs.</param>
+    /// <typeparam name="T">Value type.</typeparam>
+    /// <returns>This instance.</returns>
+    public IgniteToStringBuilder AppendAll<T>(IEnumerable<KeyValuePair<string, T>> pairs)
+    {
+        foreach (var pair in pairs)
+        {
+            Append(pair.Key, pair.Value);
+        }
 
         return this;
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -83,12 +83,14 @@ internal record IgniteToStringBuilder
     /// <summary>
     /// Appends a property.
     /// </summary>
-    /// <param name="name">Property name.</param>
     /// <param name="value">Property value.</param>
+    /// <param name="name">Property name.</param>
     /// <typeparam name="T">Value type.</typeparam>
     /// <returns>This instance.</returns>
-    public IgniteToStringBuilder AppendList<T>(string name, IEnumerable<T> value)
+    public IgniteToStringBuilder AppendList<T>(IEnumerable<T> value, [CallerArgumentExpression("value")] string? name = null)
     {
+        IgniteArgumentCheck.NotNull(name, nameof(name));
+
         AppendComma();
 
         _builder.Append(name);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Internal.Common;
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 /// <summary>
@@ -68,6 +69,25 @@ internal record IgniteToStringBuilder
     /// <returns>This instance.</returns>
     public IgniteToStringBuilder Append(string name, object? value)
     {
+        AppendComma();
+
+        _builder.Append(name);
+        _builder.Append(" = ");
+        _builder.Append(value);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Appends a property.
+    /// </summary>
+    /// <param name="value">Property value.</param>
+    /// <param name="name">Property name.</param>
+    /// <returns>This instance.</returns>
+    public IgniteToStringBuilder Append2(object? value, [CallerArgumentExpression("value")] string? name = null)
+    {
+        IgniteArgumentCheck.NotNull(name, nameof(name));
+
         AppendComma();
 
         _builder.Append(name);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -69,6 +69,7 @@ internal record IgniteToStringBuilder
     {
         IgniteArgumentCheck.NotNull(name, nameof(name));
 
+        CheckClosed();
         AppendComma();
 
         _builder.Append(name);
@@ -89,6 +90,7 @@ internal record IgniteToStringBuilder
     {
         IgniteArgumentCheck.NotNull(name, nameof(name));
 
+        CheckClosed();
         AppendComma();
 
         _builder.Append(name);
@@ -174,6 +176,9 @@ internal record IgniteToStringBuilder
         return _builder.ToString();
     }
 
+    /// <inheritdoc/>
+    public override string ToString() => Build();
+
     private static string GetTypeName(Type type)
     {
         if (!type.IsGenericType)
@@ -213,12 +218,18 @@ internal record IgniteToStringBuilder
 
     private void Close()
     {
+        if (!_closed)
+        {
+            _builder.AppendWithSpace("}");
+            _closed = true;
+        }
+    }
+
+    private void CheckClosed()
+    {
         if (_closed)
         {
             throw new InvalidOperationException("Builder is already closed.");
         }
-
-        _builder.AppendWithSpace("}");
-        _closed = true;
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -29,11 +29,11 @@ internal record IgniteToStringBuilder
 {
     private readonly StringBuilder _builder;
 
+    private readonly IgniteToStringBuilder? _parent;
+
     private bool _first = true;
 
     private bool _closed;
-
-    private IgniteToStringBuilder? _parent;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="IgniteToStringBuilder"/> class.
@@ -60,6 +60,13 @@ internal record IgniteToStringBuilder
         _builder.Append(typeName);
         _builder.Append(" { ");
     }
+
+    /// <summary>
+    /// Builds the string representation.
+    /// </summary>
+    /// <param name="typeName">Type name.</param>
+    /// <returns>String.</returns>
+    public static string Build(string typeName) => typeName + " { }";
 
     /// <summary>
     /// Appends a property.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -38,18 +38,9 @@ internal record IgniteToStringBuilder
     /// <summary>
     /// Initializes a new instance of the <see cref="IgniteToStringBuilder"/> class.
     /// </summary>
-    /// <param name="typeName">Type name.</param>
-    public IgniteToStringBuilder(string typeName)
-        : this(new(), typeName, null)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="IgniteToStringBuilder"/> class.
-    /// </summary>
     /// <param name="type">Type.</param>
     public IgniteToStringBuilder(Type type)
-        : this(new(), type.Name, null)
+        : this(new(), GetTypeName(type), null)
     {
     }
 
@@ -64,9 +55,9 @@ internal record IgniteToStringBuilder
     /// <summary>
     /// Builds the string representation.
     /// </summary>
-    /// <param name="typeName">Type name.</param>
+    /// <param name="type">Type.</param>
     /// <returns>String.</returns>
-    public static string Build(string typeName) => typeName + " { }";
+    public static string Build(Type type) => GetTypeName(type) + " { }";
 
     /// <summary>
     /// Appends a property.
@@ -181,6 +172,12 @@ internal record IgniteToStringBuilder
         Close();
 
         return _builder.ToString();
+    }
+
+    private static string GetTypeName(Type type)
+    {
+        // TODO: Generics
+        return type.Name;
     }
 
     private void AppendComma()

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -176,8 +176,31 @@ internal record IgniteToStringBuilder
 
     private static string GetTypeName(Type type)
     {
-        // TODO: Generics
-        return type.Name;
+        if (!type.IsGenericType)
+        {
+            return type.Name;
+        }
+
+        var sb = new StringBuilder(type.Name);
+        var args = type.GetGenericArguments();
+
+        sb.Append('`')
+            .Append(args.Length)
+            .Append('[');
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(", ");
+            }
+
+            sb.Append(GetTypeName(args[i]));
+        }
+
+        sb.Append(']');
+
+        return sb.ToString();
     }
 
     private void AppendComma()

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -181,12 +181,8 @@ internal record IgniteToStringBuilder
             return type.Name;
         }
 
-        var sb = new StringBuilder(type.Name);
+        var sb = new StringBuilder(type.Name).Append('[');
         var args = type.GetGenericArguments();
-
-        sb.Append('`')
-            .Append(args.Length)
-            .Append('[');
 
         for (var i = 0; i < args.Length; i++)
         {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -105,6 +105,9 @@ namespace Apache.Ignite.Internal.Compute
             return res;
         }
 
+        /// <inheritdoc/>
+        public override string ToString() => IgniteToStringBuilder.Build(GetType());
+
         [SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Secure random is not required here.")]
         private static IClusterNode GetRandomNode(IEnumerable<IClusterNode> nodes)
         {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Endpoint.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Endpoint.cs
@@ -38,7 +38,7 @@ namespace Apache.Ignite.Internal
         /// </summary>
         private Endpoint(string host, int port = IgniteClientConfiguration.DefaultPort, int portRange = 0)
         {
-            Host = IgniteArgumentCheck.NotNullOrEmpty(host, "host");
+            Host = IgniteArgumentCheck.NotNullOrEmpty(host);
             Port = port;
             PortRange = portRange;
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
@@ -19,8 +19,10 @@ namespace Apache.Ignite.Internal
 {
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
+    using Common;
     using Ignite.Compute;
     using Ignite.Network;
     using Ignite.Sql;
@@ -107,5 +109,11 @@ namespace Apache.Ignite.Internal
         {
             _socket.Dispose();
         }
+
+        /// <inheritdoc/>
+        public override string ToString() =>
+            new IgniteToStringBuilder(nameof(IgniteClientInternal))
+                .AppendList(GetConnections().Select(c => c.Node), "Connections")
+                .Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
@@ -112,7 +112,7 @@ namespace Apache.Ignite.Internal
 
         /// <inheritdoc/>
         public override string ToString() =>
-            new IgniteToStringBuilder(nameof(IgniteClientInternal))
+            new IgniteToStringBuilder(GetType())
                 .AppendList(GetConnections().Select(c => c.Node), "Connections")
                 .Build();
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryable.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryable.cs
@@ -87,7 +87,7 @@ internal sealed class IgniteQueryable<T>
 
         return new IgniteToStringBuilder(GetType())
             .Append(queryData.QueryText, "Query")
-            .AppendList("Parameters", queryData.Parameters)
+            .AppendList(queryData.Parameters, "Parameters")
             .Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryable.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryable.cs
@@ -19,7 +19,7 @@ namespace Apache.Ignite.Internal.Linq;
 
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
+using Common;
 using Remotion.Linq;
 
 /// <summary>
@@ -84,28 +84,10 @@ internal sealed class IgniteQueryable<T>
     public override string ToString()
     {
         var queryData = GetQueryData();
-        var sb = new StringBuilder();
 
-        sb.Append(GetType());
-        sb.Append(" [Query=").Append(queryData.QueryText);
-
-        sb.Append(", Parameters=");
-        var count = 0;
-
-        foreach (var parameter in queryData.Parameters)
-        {
-            if (count > 0)
-            {
-                sb.Append(", ");
-            }
-
-            sb.Append(parameter);
-
-            count++;
-        }
-
-        sb.Append(']');
-
-        return sb.ToString();
+        return new IgniteToStringBuilder(GetType())
+            .Append("Query", queryData.QueryText)
+            .Append("Parameters", string.Join(", ", queryData.Parameters))
+            .Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryable.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryable.cs
@@ -87,7 +87,7 @@ internal sealed class IgniteQueryable<T>
 
         return new IgniteToStringBuilder(GetType())
             .Append("Query", queryData.QueryText)
-            .Append("Parameters", string.Join(", ", queryData.Parameters))
+            .AppendList("Parameters", queryData.Parameters)
             .Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryable.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryable.cs
@@ -86,7 +86,7 @@ internal sealed class IgniteQueryable<T>
         var queryData = GetQueryData();
 
         return new IgniteToStringBuilder(GetType())
-            .Append("Query", queryData.QueryText)
+            .Append(queryData.QueryText, "Query")
             .AppendList("Parameters", queryData.Parameters)
             .Build();
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/RetryPolicyContext.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/RetryPolicyContext.cs
@@ -15,44 +15,19 @@
  * limitations under the License.
  */
 
-namespace Apache.Ignite.Internal
-{
-    using System;
+namespace Apache.Ignite.Internal;
 
-    /// <summary>
-    /// Retry policy context.
-    /// </summary>
-    internal class RetryPolicyContext : IRetryPolicyContext
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RetryPolicyContext"/> class.
-        /// </summary>
-        /// <param name="configuration">Configuration.</param>
-        /// <param name="operation">Operation.</param>
-        /// <param name="iteration">Iteration.</param>
-        /// <param name="exception">Exception.</param>
-        public RetryPolicyContext(
-            IgniteClientConfiguration configuration,
-            ClientOperationType operation,
-            int iteration,
-            Exception exception)
-        {
-            Configuration = configuration;
-            Operation = operation;
-            Iteration = iteration;
-            Exception = exception;
-        }
+using System;
 
-        /// <inheritdoc/>
-        public IgniteClientConfiguration Configuration { get; }
-
-        /// <inheritdoc/>
-        public ClientOperationType Operation { get; }
-
-        /// <inheritdoc/>
-        public int Iteration { get; }
-
-        /// <inheritdoc/>
-        public Exception Exception { get; }
-    }
-}
+/// <summary>
+/// Retry policy context.
+/// </summary>
+/// <param name="Configuration">Client configuration.</param>
+/// <param name="Operation">Operation.</param>
+/// <param name="Iteration">Current iteration.</param>
+/// <param name="Exception">Exception that caused current retry iteration.</param>
+internal sealed record RetryPolicyContext(
+    IgniteClientConfiguration Configuration,
+    ClientOperationType Operation,
+    int Iteration,
+    Exception Exception) : IRetryPolicyContext;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSet.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSet.cs
@@ -230,6 +230,15 @@ namespace Apache.Ignite.Internal.Sql
             return EnumerateRows().GetAsyncEnumerator(cancellationToken);
         }
 
+        /// <inheritdoc/>
+        public override string ToString() =>
+            new IgniteToStringBuilder(GetType())
+                .Append(HasRowSet)
+                .Append(AffectedRows)
+                .Append(WasApplied)
+                .Append(Metadata)
+                .Build();
+
         /// <summary>
         /// Enumerates ResultSet pages.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSetMetadata.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSetMetadata.cs
@@ -49,7 +49,7 @@ namespace Apache.Ignite.Internal.Sql
         /// <inheritdoc/>
         public override string ToString() =>
             new IgniteToStringBuilder(nameof(ResultSetMetadata))
-                .AppendList("Columns", Columns)
+                .AppendList(Columns)
                 .Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSetMetadata.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSetMetadata.cs
@@ -18,7 +18,7 @@
 namespace Apache.Ignite.Internal.Sql
 {
     using System.Collections.Generic;
-    using System.Text;
+    using Common;
     using Ignite.Sql;
 
     internal sealed record ResultSetMetadata(IReadOnlyList<IColumnMetadata> Columns) : IResultSetMetadata
@@ -47,17 +47,9 @@ namespace Apache.Ignite.Internal.Sql
         }
 
         /// <inheritdoc/>
-        public override string ToString()
-        {
-            var builder = new StringBuilder();
-
-            builder
-                .Append("ResultSetMetadata { ")
-                .Append("Columns = { ")
-                .Append(string.Join(", ", Columns))
-                .Append(" } }");
-
-            return builder.ToString();
-        }
+        public override string ToString() =>
+            new IgniteToStringBuilder(nameof(ResultSetMetadata))
+                .AppendList("Columns", Columns)
+                .Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSetMetadata.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSetMetadata.cs
@@ -48,7 +48,7 @@ namespace Apache.Ignite.Internal.Sql
 
         /// <inheritdoc/>
         public override string ToString() =>
-            new IgniteToStringBuilder(nameof(ResultSetMetadata))
+            new IgniteToStringBuilder(GetType())
                 .AppendList(Columns)
                 .Build();
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/Sql.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/Sql.cs
@@ -74,6 +74,9 @@ namespace Apache.Ignite.Internal.Sql
             return new IgniteDbDataReader(resultSet);
         }
 
+        /// <inheritdoc/>
+        public override string ToString() => IgniteToStringBuilder.Build(GetType());
+
         /// <summary>
         /// Reads column value.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
@@ -156,6 +156,12 @@ internal sealed class KeyValueView<TK, TV> : IKeyValueView<TK, TV>
         return new IgniteQueryable<KeyValuePair<TK, TV>>(provider);
     }
 
+    /// <inheritdoc/>
+    public override string ToString() =>
+        new IgniteToStringBuilder(GetType())
+            .Append(_recordView.Table, "Table")
+            .Build();
+
     private static KvPair<TK, TV> ToKv(KeyValuePair<TK, TV> x)
     {
         IgniteArgumentCheck.NotNull(x.Key, "key");

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -323,6 +323,12 @@ namespace Apache.Ignite.Internal.Table
         public async Task<IList<T>> DeleteAllExactAsync(ITransaction? transaction, IEnumerable<T> records) =>
             await DeleteAllAsync(transaction, records, exact: true).ConfigureAwait(false);
 
+        /// <inheritdoc/>
+        public override string ToString() =>
+            new IgniteToStringBuilder(GetType())
+                .Append(Table)
+                .Build();
+
         /// <summary>
         /// Deletes multiple records. If one or more keys do not exist, other records are still deleted.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -23,6 +23,7 @@ namespace Apache.Ignite.Internal.Table
     using System.Threading;
     using System.Threading.Tasks;
     using Buffers;
+    using Common;
     using Ignite.Table;
     using Ignite.Transactions;
     using Log;
@@ -126,6 +127,13 @@ namespace Apache.Ignite.Internal.Table
             where TK : notnull
             where TV : notnull =>
             new KeyValueView<TK, TV>(GetRecordViewInternal<KvPair<TK, TV>>());
+
+        /// <inheritdoc/>
+        public override string ToString() =>
+            new IgniteToStringBuilder(GetType())
+                .Append(Name)
+                .Append(Id)
+                .ToString();
 
         /// <summary>
         /// Gets the record view for the specified type.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -133,7 +133,7 @@ namespace Apache.Ignite.Internal.Table
             new IgniteToStringBuilder(GetType())
                 .Append(Name)
                 .Append(Id)
-                .ToString();
+                .Build();
 
         /// <summary>
         /// Gets the record view for the specified type.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transaction.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transaction.cs
@@ -103,9 +103,9 @@ namespace Apache.Ignite.Internal.Transactions
             };
 
             var builder = new IgniteToStringBuilder(typeof(Transaction));
-            builder.Append(Id, nameof(Id));
+            builder.Append(Id);
             builder.Append(state, "State");
-            builder.Append(IsReadOnly, nameof(IsReadOnly));
+            builder.Append(IsReadOnly);
 
             return builder.Build();
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transaction.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transaction.cs
@@ -103,9 +103,9 @@ namespace Apache.Ignite.Internal.Transactions
             };
 
             var builder = new IgniteToStringBuilder(typeof(Transaction));
-            builder.Append(nameof(Id), Id);
-            builder.Append("State", state);
-            builder.Append(nameof(IsReadOnly), IsReadOnly);
+            builder.Append(Id, nameof(Id));
+            builder.Append(state, "State");
+            builder.Append(IsReadOnly, nameof(IsReadOnly));
 
             return builder.Build();
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transaction.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transaction.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Internal.Transactions
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Common;
     using Ignite.Transactions;
     using Proto;
     using Proto.MsgPack;
@@ -101,7 +102,12 @@ namespace Apache.Ignite.Internal.Transactions
                 _ => "RolledBack"
             };
 
-            return $"Transaction {{ Id = {Id}, State = {state}, IsReadOnly = {IsReadOnly} }}";
+            var builder = new IgniteToStringBuilder(typeof(Transaction));
+            builder.Append(nameof(Id), Id);
+            builder.Append("State", state);
+            builder.Append(nameof(IsReadOnly), IsReadOnly);
+
+            return builder.Build();
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transactions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transactions.cs
@@ -57,6 +57,6 @@ namespace Apache.Ignite.Internal.Transactions
         }
 
         /// <inheritdoc />
-        public override string ToString() => IgniteToStringBuilder.Build(nameof(Transactions));
+        public override string ToString() => IgniteToStringBuilder.Build(GetType());
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transactions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transactions.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Internal.Transactions
 {
     using System.Threading.Tasks;
+    using Common;
     using Ignite.Transactions;
     using Proto;
 
@@ -54,5 +55,8 @@ namespace Apache.Ignite.Internal.Transactions
                 return new Transaction(txId, socket, _socket, options.ReadOnly);
             }
         }
+
+        /// <inheritdoc />
+        public override string ToString() => IgniteToStringBuilder.Build(nameof(Transactions));
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Log/CategoryLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Log/CategoryLogger.cs
@@ -31,9 +31,6 @@ namespace Apache.Ignite.Log
         /** Wrapped logger. */
         private readonly IIgniteLogger _logger;
 
-        /** Category to use. */
-        private readonly string _category;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="CategoryLogger"/> class.
         /// </summary>
@@ -46,8 +43,13 @@ namespace Apache.Ignite.Log
             // If logger is already a CategoryLogger, get underlying logger instead to avoid unnecessary nesting.
             _logger = logger is CategoryLogger catLogger ? catLogger._logger : logger;
 
-            _category = category;
+            Category = category;
         }
+
+        /// <summary>
+        /// Gets the category name.
+        /// </summary>
+        public string Category { get; }
 
         /// <summary>
         /// Logs the specified message.
@@ -69,7 +71,7 @@ namespace Apache.Ignite.Log
             string? nativeErrorInfo,
             Exception? ex)
         {
-            _logger.Log(level, message, args, formatProvider, category ?? _category, nativeErrorInfo, ex);
+            _logger.Log(level, message, args, formatProvider, category ?? Category, nativeErrorInfo, ex);
         }
 
         /// <summary>
@@ -83,5 +85,11 @@ namespace Apache.Ignite.Log
         {
             return _logger.IsEnabled(level);
         }
+
+        /// <inheritdoc />
+        public override string ToString() =>
+            new IgniteToStringBuilder(nameof(CategoryLogger))
+                .Append(Category)
+                .Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Log/CategoryLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Log/CategoryLogger.cs
@@ -88,7 +88,7 @@ namespace Apache.Ignite.Log
 
         /// <inheritdoc />
         public override string ToString() =>
-            new IgniteToStringBuilder(nameof(CategoryLogger))
+            new IgniteToStringBuilder(GetType())
                 .Append(Category)
                 .Build();
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Log/ConsoleLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Log/ConsoleLogger.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Log
     using System;
     using System.Globalization;
     using System.Text;
+    using Internal.Common;
 
     /// <summary>
     /// Logs to Console.
@@ -109,5 +110,11 @@ namespace Apache.Ignite.Log
         {
             return level >= MinLevel;
         }
+
+        /// <inheritdoc />
+        public override string ToString() =>
+            new IgniteToStringBuilder(nameof(ConsoleLogger))
+                .Append(MinLevel)
+                .Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Log/ConsoleLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Log/ConsoleLogger.cs
@@ -113,7 +113,7 @@ namespace Apache.Ignite.Log
 
         /// <inheritdoc />
         public override string ToString() =>
-            new IgniteToStringBuilder(nameof(ConsoleLogger))
+            new IgniteToStringBuilder(GetType())
                 .Append(MinLevel)
                 .Build();
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Log/LocalDateTimeProvider.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Log/LocalDateTimeProvider.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Log
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
+    using Internal.Common;
 
     /// <summary>
     /// Returns <see cref="DateTime.Now"/>.
@@ -32,12 +33,15 @@ namespace Apache.Ignite.Log
             "Microsoft.Security",
             "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes",
             Justification = "Type is immutable.")]
-        public static readonly LocalDateTimeProvider Instance = new LocalDateTimeProvider();
+        public static readonly LocalDateTimeProvider Instance = new();
 
         /// <inheritdoc />
         public DateTime Now()
         {
             return DateTime.Now;
         }
+
+        /// <inheritdoc />
+        public override string ToString() => new IgniteToStringBuilder(nameof(LocalDateTimeProvider)).Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Log/LocalDateTimeProvider.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Log/LocalDateTimeProvider.cs
@@ -42,6 +42,6 @@ namespace Apache.Ignite.Log
         }
 
         /// <inheritdoc />
-        public override string ToString() => IgniteToStringBuilder.Build(nameof(LocalDateTimeProvider));
+        public override string ToString() => IgniteToStringBuilder.Build(GetType());
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Log/LocalDateTimeProvider.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Log/LocalDateTimeProvider.cs
@@ -42,6 +42,6 @@ namespace Apache.Ignite.Log
         }
 
         /// <inheritdoc />
-        public override string ToString() => new IgniteToStringBuilder(nameof(LocalDateTimeProvider)).Build();
+        public override string ToString() => IgniteToStringBuilder.Build(nameof(LocalDateTimeProvider));
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Log/LoggerExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Log/LoggerExtensions.cs
@@ -256,7 +256,7 @@ namespace Apache.Ignite.Log
         /// <param name="message">The message.</param>
         public static void Log(this IIgniteLogger logger, LogLevel level, string message)
         {
-            IgniteArgumentCheck.NotNull(logger, "logger");
+            IgniteArgumentCheck.NotNull(logger);
 
             logger.Log(level, message, null, null, null, null, null);
         }
@@ -270,7 +270,7 @@ namespace Apache.Ignite.Log
         /// <param name="args">The arguments.</param>
         public static void Log(this IIgniteLogger logger, LogLevel level, string message, params object?[]? args)
         {
-            IgniteArgumentCheck.NotNull(logger, "logger");
+            IgniteArgumentCheck.NotNull(logger);
 
             logger.Log(level, message, args, CultureInfo.InvariantCulture, null, null, null);
         }
@@ -284,7 +284,7 @@ namespace Apache.Ignite.Log
         /// <param name="message">The message.</param>
         public static void Log(this IIgniteLogger logger, LogLevel level, Exception? ex, string message)
         {
-            IgniteArgumentCheck.NotNull(logger, "logger");
+            IgniteArgumentCheck.NotNull(logger);
 
             logger.Log(level, message, null, null, null, null, ex);
         }
@@ -299,7 +299,7 @@ namespace Apache.Ignite.Log
         /// <param name="args">The arguments.</param>
         public static void Log(this IIgniteLogger logger, LogLevel level, Exception? ex, string message, params object?[]? args)
         {
-            IgniteArgumentCheck.NotNull(logger, "logger");
+            IgniteArgumentCheck.NotNull(logger);
 
             logger.Log(level, message, args, CultureInfo.InvariantCulture, null, null, ex);
         }
@@ -312,7 +312,7 @@ namespace Apache.Ignite.Log
         /// <returns>Logger that uses specified category when no other category is provided.</returns>
         public static IIgniteLogger? GetLogger(this IIgniteLogger? logger, string category)
         {
-            IgniteArgumentCheck.NotNull(category, "category");
+            IgniteArgumentCheck.NotNull(category);
 
             return logger == null ? null : new CategoryLogger(logger, category);
         }
@@ -325,7 +325,7 @@ namespace Apache.Ignite.Log
         /// <returns>Logger that uses specified category when no other category is provided.</returns>
         public static IIgniteLogger? GetLogger(this IIgniteLogger? logger, Type category)
         {
-            IgniteArgumentCheck.NotNull(category, "category");
+            IgniteArgumentCheck.NotNull(category);
 
             return logger == null ? null : new CategoryLogger(logger, category.Name);
         }

--- a/modules/platforms/dotnet/Apache.Ignite/RetryLimitPolicy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/RetryLimitPolicy.cs
@@ -51,7 +51,7 @@ namespace Apache.Ignite
         /// <inheritdoc />
         public override string ToString() =>
             new IgniteToStringBuilder(GetType())
-                .Append(nameof(RetryLimit), RetryLimit)
+                .Append(RetryLimit, nameof(RetryLimit))
                 .Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/RetryLimitPolicy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/RetryLimitPolicy.cs
@@ -51,7 +51,7 @@ namespace Apache.Ignite
         /// <inheritdoc />
         public override string ToString() =>
             new IgniteToStringBuilder(GetType())
-                .Append(RetryLimit, nameof(RetryLimit))
+                .Append(RetryLimit)
                 .Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/RetryLimitPolicy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/RetryLimitPolicy.cs
@@ -47,5 +47,11 @@ namespace Apache.Ignite
 
             return context.Iteration < RetryLimit;
         }
+
+        /// <inheritdoc />
+        public override string ToString() =>
+            new IgniteToStringBuilder(GetType())
+                .Append(nameof(RetryLimit), RetryLimit)
+                .Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/RetryNonePolicy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/RetryNonePolicy.cs
@@ -17,6 +17,8 @@
 
 namespace Apache.Ignite
 {
+    using Internal.Common;
+
     /// <summary>
     /// Retry policy that always returns false.
     /// </summary>
@@ -32,5 +34,8 @@ namespace Apache.Ignite
         {
             return false;
         }
+
+        /// <inheritdoc />
+        public override string ToString() => new IgniteToStringBuilder(nameof(RetryNonePolicy)).Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/RetryNonePolicy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/RetryNonePolicy.cs
@@ -36,6 +36,6 @@ namespace Apache.Ignite
         }
 
         /// <inheritdoc />
-        public override string ToString() => IgniteToStringBuilder.Build(nameof(RetryNonePolicy));
+        public override string ToString() => IgniteToStringBuilder.Build(GetType());
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/RetryNonePolicy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/RetryNonePolicy.cs
@@ -36,6 +36,6 @@ namespace Apache.Ignite
         }
 
         /// <inheritdoc />
-        public override string ToString() => new IgniteToStringBuilder(nameof(RetryNonePolicy)).Build();
+        public override string ToString() => IgniteToStringBuilder.Build(nameof(RetryNonePolicy));
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbColumn.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbColumn.cs
@@ -52,12 +52,12 @@ public sealed class IgniteDbColumn : DbColumn
     /// <inheritdoc />
     public override string ToString() =>
         new IgniteToStringBuilder(nameof(IgniteDbColumn))
-            .Append(ColumnName, nameof(ColumnName))
-            .Append(ColumnOrdinal, nameof(ColumnOrdinal))
-            .Append(DataTypeName, nameof(DataTypeName))
-            .Append(AllowDBNull, nameof(AllowDBNull))
-            .Append(NumericPrecision, nameof(NumericPrecision))
-            .Append(NumericScale, nameof(NumericScale))
-            .Append(ColumnMetadata, nameof(ColumnMetadata))
+            .Append(ColumnName)
+            .Append(ColumnOrdinal)
+            .Append(DataTypeName)
+            .Append(AllowDBNull)
+            .Append(NumericPrecision)
+            .Append(NumericScale)
+            .Append(ColumnMetadata)
             .Build();
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbColumn.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbColumn.cs
@@ -52,12 +52,12 @@ public sealed class IgniteDbColumn : DbColumn
     /// <inheritdoc />
     public override string ToString() =>
         new IgniteToStringBuilder(nameof(IgniteDbColumn))
-            .Append(nameof(ColumnName), ColumnName)
-            .Append(nameof(ColumnOrdinal), ColumnOrdinal)
-            .Append(nameof(DataTypeName), DataTypeName)
-            .Append(nameof(AllowDBNull), AllowDBNull)
-            .Append(nameof(NumericPrecision), NumericPrecision)
-            .Append(nameof(NumericScale), NumericScale)
-            .Append(nameof(ColumnMetadata), ColumnMetadata)
+            .Append(ColumnName, nameof(ColumnName))
+            .Append(ColumnOrdinal, nameof(ColumnOrdinal))
+            .Append(DataTypeName, nameof(DataTypeName))
+            .Append(AllowDBNull, nameof(AllowDBNull))
+            .Append(NumericPrecision, nameof(NumericPrecision))
+            .Append(NumericScale, nameof(NumericScale))
+            .Append(ColumnMetadata, nameof(ColumnMetadata))
             .Build();
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbColumn.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbColumn.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Sql;
 
 using System.Data.Common;
+using Internal.Common;
 using Internal.Sql;
 
 /// <summary>
@@ -38,6 +39,7 @@ public sealed class IgniteDbColumn : DbColumn
         DataTypeName = column.Type.ToSqlTypeName();
         DataType = column.Type.ToClrType();
         AllowDBNull = column.Nullable;
+        AllowDBNull = column.Nullable;
         NumericPrecision = column.Precision < 0 ? null : column.Precision;
         NumericScale = column.Scale < 0 ? null : column.Scale;
     }
@@ -46,4 +48,16 @@ public sealed class IgniteDbColumn : DbColumn
     /// Gets Ignite-specific column metadata.
     /// </summary>
     public IColumnMetadata ColumnMetadata { get; }
+
+    /// <inheritdoc />
+    public override string ToString() =>
+        new IgniteToStringBuilder(nameof(IgniteDbColumn))
+            .Append(nameof(ColumnName), ColumnName)
+            .Append(nameof(ColumnOrdinal), ColumnOrdinal)
+            .Append(nameof(DataTypeName), DataTypeName)
+            .Append(nameof(AllowDBNull), AllowDBNull)
+            .Append(nameof(NumericPrecision), NumericPrecision)
+            .Append(nameof(NumericScale), NumericScale)
+            .Append(nameof(ColumnMetadata), ColumnMetadata)
+            .Build();
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbColumn.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbColumn.cs
@@ -39,7 +39,6 @@ public sealed class IgniteDbColumn : DbColumn
         DataTypeName = column.Type.ToSqlTypeName();
         DataType = column.Type.ToClrType();
         AllowDBNull = column.Nullable;
-        AllowDBNull = column.Nullable;
         NumericPrecision = column.Precision < 0 ? null : column.Precision;
         NumericScale = column.Scale < 0 ? null : column.Scale;
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbColumn.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbColumn.cs
@@ -51,7 +51,7 @@ public sealed class IgniteDbColumn : DbColumn
 
     /// <inheritdoc />
     public override string ToString() =>
-        new IgniteToStringBuilder(nameof(IgniteDbColumn))
+        new IgniteToStringBuilder(GetType())
             .Append(ColumnName)
             .Append(ColumnOrdinal)
             .Append(DataTypeName)

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbDataReader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbDataReader.cs
@@ -463,11 +463,11 @@ public sealed class IgniteDbDataReader : DbDataReader, IDbColumnSchemaGenerator
     /// <inheritdoc/>
     public override string ToString() =>
         new IgniteToStringBuilder(nameof(IgniteDbDataReader))
-            .Append2(FieldCount)
-            .Append2(RecordsAffected)
-            .Append2(HasRows)
-            .Append2(IsClosed)
-            .Append2(Metadata)
+            .Append(FieldCount)
+            .Append(RecordsAffected)
+            .Append(HasRows)
+            .Append(IsClosed)
+            .Append(Metadata)
             .Build();
 
     /// <inheritdoc/>

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbDataReader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbDataReader.cs
@@ -461,6 +461,16 @@ public sealed class IgniteDbDataReader : DbDataReader, IDbColumnSchemaGenerator
     public override Type GetFieldType(int ordinal) => Metadata.Columns[ordinal].Type.ToClrType();
 
     /// <inheritdoc/>
+    public override string ToString() =>
+        new IgniteToStringBuilder(nameof(IgniteDbDataReader))
+            .Append2(FieldCount)
+            .Append2(RecordsAffected)
+            .Append2(HasRows)
+            .Append2(IsClosed)
+            .Append2(Metadata)
+            .Build();
+
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing) => DisposeAsync().AsTask().GetAwaiter().GetResult();
 
     private static void ValidateColumnType(Type type, IColumnMetadata column)

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbDataReader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbDataReader.cs
@@ -462,7 +462,7 @@ public sealed class IgniteDbDataReader : DbDataReader, IDbColumnSchemaGenerator
 
     /// <inheritdoc/>
     public override string ToString() =>
-        new IgniteToStringBuilder(nameof(IgniteDbDataReader))
+        new IgniteToStringBuilder(GetType())
             .Append(FieldCount)
             .Append(RecordsAffected)
             .Append(HasRows)

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/SqlStatement.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/SqlStatement.cs
@@ -114,10 +114,10 @@ namespace Apache.Ignite.Sql
         /// <inheritdoc />
         public override string ToString() =>
             new IgniteToStringBuilder(nameof(SqlStatement))
-                .Append(nameof(Query), Query)
-                .Append(nameof(Timeout), Timeout)
-                .Append(nameof(Schema), Schema)
-                .Append(nameof(PageSize), PageSize)
+                .Append(Query, nameof(Query))
+                .Append(Timeout, nameof(Timeout))
+                .Append(Schema, nameof(Schema))
+                .Append(PageSize, nameof(PageSize))
                 .BeginNested(nameof(Properties) + " =")
                 .AppendAll(Properties)
                 .EndNested()

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/SqlStatement.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/SqlStatement.cs
@@ -118,7 +118,7 @@ namespace Apache.Ignite.Sql
                 .Append(nameof(Timeout), Timeout)
                 .Append(nameof(Schema), Schema)
                 .Append(nameof(PageSize), PageSize)
-                .BeginNested(nameof(Properties))
+                .BeginNested(nameof(Properties) + " =")
                 .AppendAll(Properties)
                 .EndNested()
                 .Build();

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/SqlStatement.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/SqlStatement.cs
@@ -114,10 +114,10 @@ namespace Apache.Ignite.Sql
         /// <inheritdoc />
         public override string ToString() =>
             new IgniteToStringBuilder(nameof(SqlStatement))
-                .Append(Query, nameof(Query))
-                .Append(Timeout, nameof(Timeout))
-                .Append(Schema, nameof(Schema))
-                .Append(PageSize, nameof(PageSize))
+                .Append(Query)
+                .Append(Timeout)
+                .Append(Schema)
+                .Append(PageSize)
                 .BeginNested(nameof(Properties) + " =")
                 .AppendAll(Properties)
                 .EndNested()

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/SqlStatement.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/SqlStatement.cs
@@ -20,8 +20,6 @@ namespace Apache.Ignite.Sql
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
-    using System.Text;
     using Internal.Common;
 
     /// <summary>
@@ -114,31 +112,15 @@ namespace Apache.Ignite.Sql
         public static SqlStatement ToSqlStatement(string query) => new(query);
 
         /// <inheritdoc />
-        public override string ToString()
-        {
-            var builder = new StringBuilder();
-
-            builder
-                .Append("SqlStatement { ")
-                .Append(CultureInfo.InvariantCulture, $"Query = {Query}, Timeout = {Timeout}, Schema = {Schema}, PageSize = {PageSize}, ")
-                .Append("Properties = {");
-
-            var first = true;
-
-            foreach (var (key, val) in Properties)
-            {
-                builder
-                    .Append(first ? " " : ", ")
-                    .Append(key)
-                    .Append(" = ")
-                    .Append(val);
-
-                first = false;
-            }
-
-            builder.Append(" } }");
-
-            return builder.ToString();
-        }
+        public override string ToString() =>
+            new IgniteToStringBuilder(nameof(SqlStatement))
+                .Append(nameof(Query), Query)
+                .Append(nameof(Timeout), Timeout)
+                .Append(nameof(Schema), Schema)
+                .Append(nameof(PageSize), PageSize)
+                .BeginNested(nameof(Properties))
+                .AppendAll(Properties)
+                .EndNested()
+                .Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/SqlStatement.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/SqlStatement.cs
@@ -113,7 +113,7 @@ namespace Apache.Ignite.Sql
 
         /// <inheritdoc />
         public override string ToString() =>
-            new IgniteToStringBuilder(nameof(SqlStatement))
+            new IgniteToStringBuilder(GetType())
                 .Append(Query)
                 .Append(Timeout)
                 .Append(Schema)

--- a/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
@@ -35,7 +35,7 @@ public sealed class SslStreamFactory : ISslStreamFactory
     /// <inheritdoc />
     public async Task<SslStream?> CreateAsync(Stream stream, string targetHost)
     {
-        IgniteArgumentCheck.NotNull(stream, "stream");
+        IgniteArgumentCheck.NotNull(stream);
 
         var sslStream = new SslStream(stream, false, null, null);
 

--- a/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
@@ -50,6 +50,6 @@ public sealed class SslStreamFactory : ISslStreamFactory
     /// <inheritdoc />
     public override string ToString() =>
         new IgniteToStringBuilder(nameof(SslStreamFactory))
-            .Append(nameof(SslClientAuthenticationOptions), SslClientAuthenticationOptions)
+            .Append(SslClientAuthenticationOptions, nameof(SslClientAuthenticationOptions))
             .Build();
 }

--- a/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
@@ -50,6 +50,6 @@ public sealed class SslStreamFactory : ISslStreamFactory
     /// <inheritdoc />
     public override string ToString() =>
         new IgniteToStringBuilder(nameof(SslStreamFactory))
-            .Append(SslClientAuthenticationOptions, nameof(SslClientAuthenticationOptions))
+            .Append(SslClientAuthenticationOptions)
             .Build();
 }

--- a/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
@@ -46,4 +46,10 @@ public sealed class SslStreamFactory : ISslStreamFactory
 
         return sslStream;
     }
+
+    /// <inheritdoc />
+    public override string ToString() =>
+        new IgniteToStringBuilder(nameof(SslStreamFactory))
+            .Append(nameof(SslClientAuthenticationOptions), SslClientAuthenticationOptions)
+            .Build();
 }

--- a/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
@@ -49,7 +49,7 @@ public sealed class SslStreamFactory : ISslStreamFactory
 
     /// <inheritdoc />
     public override string ToString() =>
-        new IgniteToStringBuilder(nameof(SslStreamFactory))
+        new IgniteToStringBuilder(GetType())
             .Append(SslClientAuthenticationOptions)
             .Build();
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
@@ -20,7 +20,6 @@ namespace Apache.Ignite.Table
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using System.Text;
     using Internal.Common;
 
     /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
@@ -21,6 +21,7 @@ namespace Apache.Ignite.Table
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Text;
+    using Internal.Common;
 
     /// <summary>
     /// Ignite tuple.
@@ -86,28 +87,14 @@ namespace Apache.Ignite.Table
         /// <inheritdoc />
         public override string ToString()
         {
-            if (FieldCount == 0)
-            {
-                return nameof(IgniteTuple) + " { }";
-            }
-
-            var sb = new StringBuilder();
-
-            sb.Append(nameof(IgniteTuple)).Append(" { ");
+            var builder = new IgniteToStringBuilder(nameof(IgniteTuple));
 
             for (var i = 0; i < FieldCount; i++)
             {
-                if (i > 0)
-                {
-                    sb.Append(", ");
-                }
-
-                sb.Append(GetName(i)).Append(" = ").Append(this[i]);
+                builder.Append(GetName(i), this[i]);
             }
 
-            sb.Append(" }");
-
-            return sb.ToString();
+            return builder.Build();
         }
 
         /// <inheritdoc />

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
@@ -90,7 +90,7 @@ namespace Apache.Ignite.Table
 
             for (var i = 0; i < FieldCount; i++)
             {
-                builder.Append(GetName(i), this[i]);
+                builder.Append(this[i], GetName(i));
             }
 
             return builder.Build();

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
@@ -86,7 +86,7 @@ namespace Apache.Ignite.Table
         /// <inheritdoc />
         public override string ToString()
         {
-            var builder = new IgniteToStringBuilder(nameof(IgniteTuple));
+            var builder = new IgniteToStringBuilder(GetType());
 
             for (var i = 0; i < FieldCount; i++)
             {


### PR DESCRIPTION
* Implement `IgniteToStringBuilder` to encapsulate `ToString` logic. Use the same format `TypeName { Prop = Val }` that C# record types use.
* Add `TestAllPublicFacingTypesHaveConsistentToString` that checks all public types and all non-public types that implement public interfaces (= will be handled by user code) for a correct `ToString` override.
* Update all matching types.

Expected usages of `ToString` are:
* Development, prototyping (`Console.WriteLine`) and debugging (debugger shows string representation of variables, fields, etc).
* Logging and exceptions (objects may end up converted to string there).

Therefore, some implementations include internal details (like Table ID), which may help with troubleshooting.