### PR TITLE
IGNITE-19238 ItDataTypesTest and ItCreateTableDdlTest are flaky

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItIgniteNodeRestartTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItIgniteNodeRestartTest.java
@@ -782,8 +782,7 @@ public class ItIgniteNodeRestartTest extends IgniteAbstractTest {
             res2.close();
         }
 
-        // TODO: Uncomment after IGNITE-18203
-        /*stopNode(0);
+        stopNode(0);
 
         ignite1 = startNode(0);
 
@@ -791,7 +790,7 @@ public class ItIgniteNodeRestartTest extends IgniteAbstractTest {
             ResultSet<SqlRow> res3 = session1.execute(null, sql);
 
             assertEquals(intRes, res3.next().intValue(0));
-        }*/
+        }
     }
 
     /**

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
@@ -382,12 +382,6 @@ public class TableManager extends Producer<TableEvent, TableEventParameters> imp
 
         tablesByIdVv = new IncrementalVersionedValue<>(registry, HashMap::new);
 
-        registry.accept(token -> {
-            tablesToStopInCaseOfError.clear();
-
-            return completedFuture(null);
-        });
-
         txStateStorageScheduledPool = Executors.newSingleThreadScheduledExecutor(
                 NamedThreadFactory.create(nodeName, "tx-state-storage-scheduled-pool", LOG));
 

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
@@ -989,8 +989,8 @@ public class TableManager extends Producer<TableEvent, TableEventParameters> imp
         metaStorageMgr.unregisterWatch(stableAssignmentsRebalanceListener);
         metaStorageMgr.unregisterWatch(assignmentsSwitchRebalanceListener);
 
-        Map<UUID, TableImpl> tablesToStop = Stream.concat(tablesByIdVv.latest().entrySet().stream(), pendingTables.entrySet().stream()).
-                collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (v1, v2) -> v1));
+        Map<UUID, TableImpl> tablesToStop = Stream.concat(tablesByIdVv.latest().entrySet().stream(), pendingTables.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (v1, v2) -> v1));
 
         cleanUpTablesResources(tablesToStop);
 
@@ -1149,7 +1149,7 @@ public class TableManager extends Producer<TableEvent, TableEventParameters> imp
 
         pendingTables.put(tblId, table);
 
-        tablesByIdVv.get(causalityToken).thenAccept(ignored -> inBusyLock(busyLock,  ()-> {
+        tablesByIdVv.get(causalityToken).thenAccept(ignored -> inBusyLock(busyLock, () -> {
             pendingTables.remove(tblId);
         }));
 

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
@@ -1152,6 +1152,10 @@ public class TableManager extends Producer<TableEvent, TableEventParameters> imp
 
         tablesToStopInCaseOfError.put(tblId, table);
 
+        tablesByIdVv.get(causalityToken).thenAccept(ignored -> inBusyLock(busyLock,  ()-> {
+            tablesToStopInCaseOfError.remove(tblId);
+        }));
+
         tablesByIdVv.get(causalityToken)
                 .thenRun(() -> inBusyLock(busyLock, () -> completeApiCreateFuture(table)));
 

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
@@ -249,7 +249,7 @@ public class TableManager extends Producer<TableEvent, TableEventParameters> imp
 
     /**
      * {@link TableImpl} is created during update of tablesByIdVv, we store reference to it in case of updating of tablesByIdVv fails, so we
-     * can stop resources associated with the table.
+     * can stop resources associated with the table or to clean up table resources on {@code TableManager#stop()}.
      */
     private final Map<UUID, TableImpl> pendingTables = new ConcurrentHashMap<>();
 
@@ -527,7 +527,6 @@ public class TableManager extends Producer<TableEvent, TableEventParameters> imp
 
             return failedFuture(new NodeStoppingException());
         }
-
 
         try {
             return createTableLocally(
@@ -990,7 +989,8 @@ public class TableManager extends Producer<TableEvent, TableEventParameters> imp
         metaStorageMgr.unregisterWatch(assignmentsSwitchRebalanceListener);
 
         Stream<TableImpl> tablesToStop =
-                Stream.concat(tablesByIdVv.latest().values().stream(), pendingTables.values().stream());
+                Stream.concat(tablesByIdVv.latest().entrySet().stream(), pendingTables.entrySet().stream()).
+                        map(Map.Entry::getValue);
 
         cleanUpTablesResources(tablesToStop);
 

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
@@ -989,7 +989,7 @@ public class TableManager extends Producer<TableEvent, TableEventParameters> imp
         metaStorageMgr.unregisterWatch(assignmentsSwitchRebalanceListener);
 
         Stream<TableImpl> tablesToStop =
-                Stream.concat(tablesByIdVv.latest().entrySet().stream(), pendingTables.entrySet().stream()).
+                Stream.concat(tablesByIdVv.latest().entrySet().stream(), pendingTables.entrySet().stream()).distinct().
                         map(Map.Entry::getValue);
 
         cleanUpTablesResources(tablesToStop);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-19238

1. First of all I've renamed tablesToStopInCaseOfError to pending tables, because they aren't only ...InCaseOfError.
2. I've also reworked tablesToStopInCaseOfError cleanup by substituting tablesToStopInCaseOfError.clear on revision change with
```
tablesByIdVv.get(causalityToken).thenAccept(ignored -> inBusyLock(busyLock,  ()-> {      
  pendingTables.remove(tblId);
})); 
```
meaning that we
2.1. remove specific table by id instead of ready.
2.2. do that removal on corresponding table publishing wihtin tablesByIdVv.
3. That means that at some point right after the publishing but before removal it's possible to have same table both within tablesByIdVv and pendingTables thus in order not to stop same table twice (which is safe by the way because of idempotentce) I've substituted
```
cleanUpTablesResources(tables);
cleanUpTablesResources(tablesToStopInCaseOfError); 
```
with
```
        Map<UUID, TableImpl> tablesToStop = Stream.concat(tablesByIdVv.latest().entrySet().stream(), pendingTables.entrySet().stream()).
                collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (v1, v2) -> v1));

cleanUpTablesResources(tablesToStop); 
```