### PR TITLE
IGNITE-18485 ItTableRaftSnapshotsTest.entriesKeepAppendedAfterSnapshotInstallation() sometimes hangs

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/raftsnapshot/ItTableRaftSnapshotsTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/raftsnapshot/ItTableRaftSnapshotsTest.java
@@ -587,7 +587,6 @@ class ItTableRaftSnapshotsTest extends IgniteIntegrationTest {
      * Tests that entries can still be added to a follower using AppendEntries after it gets fed with a RAFT snapshot.
      */
     @Test
-    @Disabled("Enable when IGNITE-18485 is fixed")
     void entriesKeepAppendedAfterSnapshotInstallation() throws Exception {
         feedNode2WithSnapshotOfOneRow();
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-18485