### PR TITLE
IGNITE-19139 Fix flaky ItDeployUndeployCallsTest

### DIFF
--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/commands/unit/ItDeploymentUnitTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/commands/unit/ItDeploymentUnitTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.cli.commands.unit;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.io.IOException;
@@ -24,12 +25,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.apache.ignite.internal.cli.commands.CliCommandTestInitializedIntegrationBase;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /** Integration test for deployment commands. */
-@Disabled("https://issues.apache.org/jira/browse/IGNITE-19139")
 public class ItDeploymentUnitTest extends CliCommandTestInitializedIntegrationBase {
 
     private String testFile;
@@ -114,14 +113,17 @@ public class ItDeploymentUnitTest extends CliCommandTestInitializedIntegrationBa
                 () -> assertOutputContains("Done")
         );
 
-        execute("unit", "status", "test.unit.id.5");
+        await().untilAsserted(() -> {
+            resetOutput();
+            execute("unit", "status", "test.unit.id.5");
 
-        assertAll(
-                this::assertExitCodeIsZero,
-                this::assertErrOutputIsEmpty,
-                () -> assertOutputContains("1.0.0"),
-                () -> assertOutputContains("DEPLOYED")
-        );
+            assertAll(
+                    this::assertExitCodeIsZero,
+                    this::assertErrOutputIsEmpty,
+                    () -> assertOutputContains("1.0.0"),
+                    () -> assertOutputContains("DEPLOYED")
+            );
+        });
     }
 
     @Test

--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/rest/ItGeneratedRestClientTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/rest/ItGeneratedRestClientTest.java
@@ -20,6 +20,7 @@ package org.apache.ignite.internal.rest;
 import static java.util.stream.Collectors.toList;
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.testNodeName;
 import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willCompleteSuccessfully;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -400,7 +401,7 @@ public class ItGeneratedRestClientTest {
         assertThat(deploymentApi.versions("test.unit.id"), contains("1.0.0"));
 
         deploymentApi.undeployUnit("test.unit.id", "1.0.0");
-        assertThat(deploymentApi.units(), empty());
+        await().untilAsserted(() -> assertThat(deploymentApi.units(), empty()));
     }
 
     @Test

--- a/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/api/deployment/DeploymentCodeApi.java
+++ b/modules/rest-api/src/main/java/org/apache/ignite/internal/rest/api/deployment/DeploymentCodeApi.java
@@ -29,6 +29,8 @@ import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.multipart.CompletedFileUpload;
+import io.micronaut.security.annotation.Secured;
+import io.micronaut.security.rules.SecurityRule;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -45,6 +47,7 @@ import org.reactivestreams.Publisher;
  * REST endpoint allows to deployment code service.
  */
 @Controller("/management/v1/deployment/")
+@Secured(SecurityRule.IS_AUTHENTICATED)
 @Tag(name = "deployment")
 public interface DeploymentCodeApi {
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-19139

The underlying issue is a static converters registry in the Mirconaut framework: `io.micronaut.core.convert.ConversionService#SHARED`
1. First node is started, this registry is populated with `io.micronaut.security.config.InterceptUrlMapConverter`
2. Second node begins starting, clearing the registry in `io.micronaut.context.DefaultBeanContext#start`
3. First node receives any HTTP request, instantiating `io.micronaut.security.rules.ConfigurationInterceptUrlMapRule` which retrieves the `micronaut.security.intercept-url-map[1].pattern` configuration value, tries to convert it to the `InterceptUrlMapPattern` and fails since the registry is cleared. So the `ConfigurationInterceptUrlMapRule` in the first node is broken and every subsequent request to the unsecured endpoint will fail with authorization exception.

This issue manifested itself because the deployment API was mistakenly left out as an unsecured endpoint. Securing it changes the logic of `SecurityFilter` as it first checks the `SecuredAnnotationRule` and doesn't check the `ConfigurationInterceptUrlMapRule`.

Another issue which seems to be much rarer is caused by the similar problem but the converter in question seems to be the `io.micronaut.http.converters.HttpConverterRegistrar`, specifically conversion from `String` to `MediaType` which is invoked when first node receives deploy request `org.apache.ignite.internal.rest.deployment.DeploymentManagementController#deploy` and it doesn't get processed as a form.

The shared converters registry is [deprecated](https://github.com/micronaut-projects/micronaut-core/issues/8620) in Micronaut 3.9.0 and hopefully this will be working in the next major version.
These issues are present only in case where there are multiple nodes running inside a single JVM.

Other flakiness is caused by not waiting properly for the deployment state.