### PR TITLE
IGNITE-19298 .NET: Fix MetricsTests.TestRequestsActive flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -39,8 +39,6 @@ public class MetricsTests
     public void TearDown()
     {
         // ReSharper disable AccessToDisposedClosure
-        // TODO: This fails with "-1 active requests", and it is an ObservableCounter,
-        // so it is not about decrement coming later, but about incorrect counting somewhere in ClientSocket (on Dispose?).
         TestUtils.WaitForCondition(
             () => _listener.GetMetric("requests-active") == 0,
             3000,

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -188,7 +188,8 @@ public class MetricsTests
         new()
         {
             HeartbeatInterval = TimeSpan.FromMilliseconds(50),
-            SocketTimeout = TimeSpan.FromMilliseconds(50)
+            SocketTimeout = TimeSpan.FromMilliseconds(50),
+            RetryPolicy = new RetryNonePolicy()
         };
 
     private sealed class Listener : IDisposable

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -36,7 +36,16 @@ public class MetricsTests
     public void SetUp() => _listener = new Listener();
 
     [TearDown]
-    public void TearDown() => _listener.Dispose();
+    public void TearDown()
+    {
+        // ReSharper disable once AccessToDisposedClosure
+        TestUtils.WaitForCondition(() => _listener.GetMetric("requests-active") == 0);
+
+        // ReSharper disable once AccessToDisposedClosure
+        TestUtils.WaitForCondition(() => _listener.GetMetric("connections-active") == 0);
+
+        _listener.Dispose();
+    }
 
     [Test]
     public async Task TestConnectionsMetrics()

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -39,6 +39,8 @@ public class MetricsTests
     public void TearDown()
     {
         // ReSharper disable AccessToDisposedClosure
+        // TODO: This fails with "-1 active requests", and it is an ObservableCounter,
+        // so it is not about decrement coming later, but about incorrect counting somewhere in ClientSocket (on Dispose?).
         TestUtils.WaitForCondition(
             () => _listener.GetMetric("requests-active") == 0,
             3000,

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -289,8 +289,11 @@ namespace Apache.Ignite.Internal
                             completionSource.TrySetException(task.Exception);
                         }
 
-                        Metrics.RequestsFailed.Add(1);
-                        Metrics.RequestsActiveDecrement();
+                        if (_requests.TryRemove(requestId, out _))
+                        {
+                            Metrics.RequestsFailed.Add(1);
+                            Metrics.RequestsActiveDecrement();
+                        }
                     },
                     taskCompletionSource,
                     CancellationToken.None,


### PR DESCRIPTION
* Fix potentially duplicate `RequestsActiveDecrement` call in `ClientSocket`.
* Disable retry policy to avoid extra requests.
* Wait for active requests and connections to go to zero.