### PR TITLE
IGNITE-19316 Fix ItIgnitePicocliCommandsTest

### DIFF
--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/core/repl/executor/ItIgnitePicocliCommandsTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/core/repl/executor/ItIgnitePicocliCommandsTest.java
@@ -52,7 +52,6 @@ import org.jline.reader.ParsedLine;
 import org.jline.reader.impl.DefaultParser;
 import org.jline.reader.impl.completer.SystemCompleter;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
@@ -63,7 +62,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 /** Integration test for all completions in interactive mode. */
-@Disabled("IGNITE-19351")
 public class ItIgnitePicocliCommandsTest extends CliCommandTestInitializedIntegrationBase {
 
     private static final String DEFAULT_REST_URL = "http://localhost:10300";

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/ClusterConfigRegistryImpl.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/ClusterConfigRegistryImpl.java
@@ -53,16 +53,12 @@ public class ClusterConfigRegistryImpl implements ClusterConfigRegistry, AsyncSe
 
     @Override
     public void onDisconnect() {
-
+        configRef = null;
     }
 
     /** {@inheritDoc} */
     @Override
     public Config config() {
-        if (configRef == null) {
-            return null;
-        }
-
-        return configRef.get();
+        return configRef == null ? null : configRef.get();
     }
 }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/ClusterConfigRegistryImpl.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/ClusterConfigRegistryImpl.java
@@ -20,8 +20,6 @@ package org.apache.ignite.internal.cli.core.repl.registry.impl;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import jakarta.inject.Singleton;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.ignite.internal.cli.call.configuration.ClusterConfigShowCall;
 import org.apache.ignite.internal.cli.call.configuration.ClusterConfigShowCallInput;
 import org.apache.ignite.internal.cli.core.repl.AsyncSessionEventListener;
@@ -34,7 +32,7 @@ public class ClusterConfigRegistryImpl implements ClusterConfigRegistry, AsyncSe
 
     private final ClusterConfigShowCall clusterConfigShowCall;
 
-    private final AtomicReference<Config> config = new AtomicReference<>(null);
+    private LazyObjectRef<Config> configRef;
 
     public ClusterConfigRegistryImpl(ClusterConfigShowCall clusterConfigShowCall) {
         this.clusterConfigShowCall = clusterConfigShowCall;
@@ -42,17 +40,13 @@ public class ClusterConfigRegistryImpl implements ClusterConfigRegistry, AsyncSe
 
     @Override
     public void onConnect(SessionInfo sessionInfo) {
-        CompletableFuture.runAsync(() -> {
-            try {
-                config.set(ConfigFactory.parseString(
+        configRef = new LazyObjectRef<>(
+                () -> ConfigFactory.parseString(
                         clusterConfigShowCall.execute(
                                 ClusterConfigShowCallInput.builder().clusterUrl(sessionInfo.nodeUrl()).build()
                         ).body().getValue()
-                ));
-            } catch (Exception ignored) {
-                // no-op
-            }
-        });
+                )
+        );
     }
 
     @Override
@@ -63,6 +57,10 @@ public class ClusterConfigRegistryImpl implements ClusterConfigRegistry, AsyncSe
     /** {@inheritDoc} */
     @Override
     public Config config() {
-        return config.get();
+        if (configRef == null) {
+            return null;
+        }
+
+        return configRef.get();
     }
 }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/ClusterConfigRegistryImpl.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/ClusterConfigRegistryImpl.java
@@ -40,12 +40,14 @@ public class ClusterConfigRegistryImpl implements ClusterConfigRegistry, AsyncSe
 
     @Override
     public void onConnect(SessionInfo sessionInfo) {
-        configRef = new LazyObjectRef<>(
-                () -> ConfigFactory.parseString(
-                        clusterConfigShowCall.execute(
-                                ClusterConfigShowCallInput.builder().clusterUrl(sessionInfo.nodeUrl()).build()
-                        ).body().getValue()
-                )
+        configRef = new LazyObjectRef<>(() -> fetchConfig(sessionInfo));
+    }
+
+    private Config fetchConfig(SessionInfo sessionInfo) {
+        return ConfigFactory.parseString(
+                clusterConfigShowCall.execute(
+                        ClusterConfigShowCallInput.builder().clusterUrl(sessionInfo.nodeUrl()).build()
+                ).body().getValue()
         );
     }
 

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/JdbcUrlRegistryImpl.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/JdbcUrlRegistryImpl.java
@@ -91,7 +91,7 @@ public class JdbcUrlRegistryImpl implements JdbcUrlRegistry, AsyncSessionEventLi
     }
 
     @Override
-    public void onConnect(SessionInfo sessionInfo) {
+    public synchronized void onConnect(SessionInfo sessionInfo) {
         if (executor == null) {
             executor = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("JdbcUrlRegistry", log));
             executor.scheduleWithFixedDelay(this::fetchJdbcUrls, 0, 5, TimeUnit.SECONDS);
@@ -99,7 +99,7 @@ public class JdbcUrlRegistryImpl implements JdbcUrlRegistry, AsyncSessionEventLi
     }
 
     @Override
-    public void onDisconnect() {
+    public synchronized void onDisconnect() {
         if (executor != null) {
             shutdownAndAwaitTermination(executor, 3, TimeUnit.SECONDS);
             executor = null;

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/LazyObjectRef.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/LazyObjectRef.java
@@ -53,7 +53,7 @@ public final class LazyObjectRef<R> {
                 });
     }
 
-    /** Returns null if the fetching in progress or the value from the source. */
+    /** Returns {@code null} if the fetching is in progress or the value returned from the source is {@code null}. */
     @Nullable
     public R get() {
         if (ref.get() == null && execInProgress.get()) {

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/LazyObjectRef.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/LazyObjectRef.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.cli.core.repl.registry.impl;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.apache.ignite.internal.cli.logger.CliLoggers;
+import org.apache.ignite.internal.logger.IgniteLogger;
+import org.jetbrains.annotations.Nullable;
+
+/** Lazy async reference that will fetch the value from the source until the value is not null. */
+public final class LazyObjectRef<R> {
+
+    private static final IgniteLogger LOG = CliLoggers.forClass(LazyObjectRef.class);
+
+    private final Supplier<R> source;
+
+    private final AtomicReference<R> ref = new AtomicReference<>(null);
+
+    private final AtomicReference<Boolean> execItProgress = new AtomicReference<>(false);
+
+    public LazyObjectRef(Supplier<R> source) {
+        this.source = source;
+        fetchFrom(source);
+    }
+
+    private void fetchFrom(Supplier<R> source) {
+        execItProgress.set(true);
+
+        CompletableFuture.supplyAsync(source)
+                .thenAccept(ref::set)
+                .whenComplete((v, t) -> {
+                    if (t != null) {
+                      LOG.warn("Got exception when fetch from source", t);
+                    }
+                    execItProgress.set(false);
+                });
+    }
+
+    @Nullable
+    public R get() {
+      if (ref.get() == null && execItProgress.get()) {
+          return null;
+      }
+
+      if (ref.get() == null && !execItProgress.get()) {
+          fetchFrom(source);
+      }
+
+      return ref.get();
+    }
+}

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/MetricRegistryImpl.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/MetricRegistryImpl.java
@@ -55,7 +55,6 @@ public class MetricRegistryImpl implements MetricRegistry, AsyncSessionEventList
         metricSourcesRef = new LazyObjectRef<>(() -> fetchMetricSources(sessionInfo));
     }
 
-    @NotNull
     private Set<String> fetchMetricSources(SessionInfo sessionInfo) {
         return metricSourceListCall.execute(new UrlCallInput(sessionInfo.nodeUrl()))
                 .body().stream()

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/MetricRegistryImpl.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/MetricRegistryImpl.java
@@ -27,7 +27,6 @@ import org.apache.ignite.internal.cli.core.repl.AsyncSessionEventListener;
 import org.apache.ignite.internal.cli.core.repl.SessionInfo;
 import org.apache.ignite.internal.cli.core.repl.registry.MetricRegistry;
 import org.apache.ignite.rest.client.model.MetricSource;
-import org.jetbrains.annotations.NotNull;
 
 /** Implementation of {@link MetricRegistry}. */
 @Singleton

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/NodeConfigRegistryImpl.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/NodeConfigRegistryImpl.java
@@ -53,7 +53,7 @@ public class NodeConfigRegistryImpl implements NodeConfigRegistry, AsyncSessionE
 
     @Override
     public void onDisconnect() {
-
+        configRef = null;
     }
 
     /** {@inheritDoc} */

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/NodeNameRegistryImpl.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/NodeNameRegistryImpl.java
@@ -108,7 +108,7 @@ public class NodeNameRegistryImpl implements NodeNameRegistry, AsyncSessionEvent
      */
 
     @Override
-    public void onConnect(SessionInfo sessionInfo) {
+    public synchronized void onConnect(SessionInfo sessionInfo) {
         if (executor == null) {
             executor = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("NodeNameRegistry", log));
             executor.scheduleWithFixedDelay(() ->
@@ -120,7 +120,7 @@ public class NodeNameRegistryImpl implements NodeNameRegistry, AsyncSessionEvent
      * Stops pulling updates.
      */
     @Override
-    public void onDisconnect() {
+    public synchronized void onDisconnect() {
         if (executor != null) {
             shutdownAndAwaitTermination(executor, 3, TimeUnit.SECONDS);
             executor = null;

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/UnitsRegistryImpl.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/UnitsRegistryImpl.java
@@ -19,11 +19,10 @@ package org.apache.ignite.internal.cli.core.repl.registry.impl;
 
 import jakarta.inject.Singleton;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import org.apache.ignite.internal.cli.call.unit.ListUnitCall;
 import org.apache.ignite.internal.cli.call.unit.UnitStatusRecord;
 import org.apache.ignite.internal.cli.core.call.CallOutput;
@@ -40,7 +39,7 @@ public class UnitsRegistryImpl implements UnitsRegistry, AsyncSessionEventListen
 
     private final ListUnitCall call;
 
-    private final ConcurrentMap<String, Set<String>> idToVersions = new ConcurrentHashMap<>();
+    private LazyObjectRef<Map<String, Set<String>>> idToVersionsRef;
 
     public UnitsRegistryImpl(ListUnitCall call) {
         this.call = call;
@@ -48,34 +47,44 @@ public class UnitsRegistryImpl implements UnitsRegistry, AsyncSessionEventListen
 
     @Override
     public void onConnect(SessionInfo sessionInfo) {
-        CompletableFuture.runAsync(() -> updateState(sessionInfo.nodeUrl()));
+        updateState(sessionInfo.nodeUrl());
     }
 
     private void updateState(String url) {
-        try {
-            lastKnownUrl.set(url);
+        lastKnownUrl.set(url);
+
+        idToVersionsRef = new LazyObjectRef<>(() -> {
             CallOutput<List<UnitStatusRecord>> output = call.execute(new UrlCallInput(url));
             if (!output.hasError() && !output.isEmpty()) {
-                output.body().forEach(record -> idToVersions.put(record.id(), record.versionToDeploymentInfo().keySet()));
+
+                return output.body().stream()
+                        .collect(Collectors.toMap(
+                                UnitStatusRecord::id,
+                                record -> record.versionToDeploymentInfo().keySet())
+                        );
+            } else {
+                return null;
             }
-        } catch (Exception ignored) {
-            // no-op
-        }
+        });
     }
 
     @Override
     public void onDisconnect() {
-        idToVersions.clear();
+        idToVersionsRef = null;
     }
 
     @Override
     public Set<String> versions(String unitId) {
-        return idToVersions.get(unitId);
+        return (idToVersionsRef == null || idToVersionsRef.get() == null)
+                ? Set.of()
+                : idToVersionsRef.get().get(unitId);
     }
 
     @Override
     public Set<String> ids() {
-        return idToVersions.keySet();
+        return (idToVersionsRef == null || idToVersionsRef.get() == null)
+                ? Set.of()
+                : idToVersionsRef.get().keySet();
     }
 
     @Override

--- a/modules/cli/src/test/java/org/apache/ignite/internal/cli/core/repl/registry/impl/LazyObjectRefTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/internal/cli/core/repl/registry/impl/LazyObjectRefTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.cli.core.repl.registry.impl;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.util.concurrent.CountDownLatch;
+import org.junit.jupiter.api.Test;
+
+class LazyObjectRefTest {
+
+    @Test
+    void returnsOk() {
+        // Given not throwing supplier
+        LazyObjectRef<String> ref = new LazyObjectRef<>(() -> "Hi");
+
+        // Expect returns value from supplier
+        await().untilAsserted(
+                () -> assertThat(ref.get(), equalTo("Hi"))
+        );
+    }
+
+    @Test
+    void returnsOkLazy() {
+        // Given supplier that returns a value only on a second call
+        CountDownLatch latch = new CountDownLatch(1);
+        LazyObjectRef<String> ref = new LazyObjectRef<>(() -> {
+            if (latch.getCount() == 1L) {
+                latch.countDown();
+                throw new RuntimeException();
+            } else {
+                return "Hi from the second attempt";
+            }
+        });
+
+        // When
+        await().untilAsserted(
+                () -> assertThat(ref.get(), equalTo("Hi from the second attempt"))
+        );
+        // And the latch is counted down
+        assertThat(latch.getCount(), is(0L));
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-19316

I've added logging to the process of background fetching of configurations and other stuff that is needed for the  CLI completions. Also `LazyObjectRef` is introduced. This reference will try to fetch the value from the source till this is not null.