### PR TITLE
IGNITE-19391 .NET: Add commit hash to assembly version

### DIFF
--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTableCommon.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTableCommon.java
@@ -255,7 +255,6 @@ public class ClientTableCommon {
      * @return Tuple.
      */
     public static Tuple readTuple(ClientMessageUnpacker unpacker, TableImpl table, boolean keyOnly) {
-        // TODO IGNITE-18925: Read BinaryTuple as Row, avoid unnecessary back and forth conversion.
         SchemaDescriptor schema = readSchema(unpacker, table);
 
         return readTuple(unpacker, keyOnly, schema);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Tests;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using Internal;
 using Log;
 using NUnit.Framework;
 
@@ -48,6 +49,10 @@ public class LoggingTests
         }
 
         var log = logger.GetLogString();
+
+        StringAssert.Contains(
+            $"ClientFailoverSocket [Info] Ignite.NET client version {VersionUtils.GetInformationalVersion()} is starting",
+            log);
 
         StringAssert.Contains("Connection established", log);
         StringAssert.Contains("Handshake succeeded", log);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/VersionTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/VersionTests.cs
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests;
+
+using System.Reflection;
+using NUnit.Framework;
+
+public class VersionTests
+{
+    [Test]
+    public void TestAssemblyInformationalVersionHasGitCommitHash()
+    {
+        var asm = typeof(IIgnite).Assembly;
+        var informationalVersion = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion!;
+        var version = asm.GetName().Version!;
+        var parts = informationalVersion.Split('+');
+
+        StringAssert.StartsWith($"{version.Major}.{version.Minor}.{version.Build}", informationalVersion);
+        Assert.AreEqual(2, parts.Length, informationalVersion);
+        StringAssert.IsMatch("[0-9a-f]{7}", parts[1], informationalVersion);
+    }
+
+    [Test]
+    public void TestAssemblyVersionMatchesJavaServerVersion()
+    {
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/VersionTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/VersionTests.cs
@@ -18,8 +18,8 @@
 namespace Apache.Ignite.Tests;
 
 using System.IO;
-using System.Reflection;
 using System.Text.RegularExpressions;
+using Internal;
 using NUnit.Framework;
 
 public class VersionTests
@@ -27,13 +27,10 @@ public class VersionTests
     [Test]
     public void TestAssemblyInformationalVersionHasGitCommitHash()
     {
-        var asm = typeof(IIgnite).Assembly;
-        var version = asm.GetName().Version!;
+        var informationalVersion = VersionUtils.GetInformationalVersion();
+        StringAssert.StartsWith(GetAssemblyVersion(), informationalVersion);
 
-        var informationalVersion = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion!;
         var parts = informationalVersion.Split('+');
-
-        StringAssert.StartsWith($"{version.Major}.{version.Minor}.{version.Build}", informationalVersion);
         Assert.AreEqual(2, parts.Length, informationalVersion);
         StringAssert.IsMatch("[0-9a-f]{7}", parts[1], informationalVersion);
     }
@@ -48,9 +45,15 @@ public class VersionTests
         Assert.IsTrue(versionMatch.Success);
 
         var gradleVersion = versionMatch.Groups[1].Value.Replace("-SNAPSHOT", string.Empty);
+
+        Assert.AreEqual(gradleVersion, GetAssemblyVersion());
+    }
+
+    private static string GetAssemblyVersion()
+    {
         var asm = typeof(IIgnite).Assembly;
         var asmVersion = asm.GetName().Version!;
 
-        Assert.AreEqual(gradleVersion, $"{asmVersion.Major}.{asmVersion.Minor}.{asmVersion.Build}");
+        return $"{asmVersion.Major}.{asmVersion.Minor}.{asmVersion.Build}";
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.sln
+++ b/modules/platforms/dotnet/Apache.Ignite.sln
@@ -17,6 +17,7 @@ ProjectSection(SolutionItems) = preProject
 	.editorconfig = .editorconfig
 	global.json = global.json
 	.config\dotnet-tools.json = .config\dotnet-tools.json
+	version.json = version.json
 EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apache.Ignite.Benchmarks", "Apache.Ignite.Benchmarks\Apache.Ignite.Benchmarks.csproj", "{9E63F965-535F-4AF2-A380-0780EAC6390E}"

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -116,6 +116,9 @@ namespace Apache.Ignite.Internal
         {
             var socket = new ClientFailoverSocket(configuration);
 
+            var logger = configuration.Logger.GetLogger(typeof(ClientFailoverSocket));
+            logger?.Info("Ignite.NET client version " + VersionUtils.GetInformationalVersion() + " is starting");
+
             await socket.GetNextSocketAsync().ConfigureAwait(false);
 
             // Because this call is not awaited, execution of the current method continues before the call is completed.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -228,7 +228,6 @@ namespace Apache.Ignite.Internal.Compute
             {
                 var reader = buf.GetReader();
 
-                // TODO IGNITE-19242: Retrieve new schema when necessary.
                 _ = reader.ReadInt32();
 
                 return (T)reader.ReadObjectFromBinaryTuple()!;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -402,7 +402,6 @@ namespace Apache.Ignite.Internal.Table
         {
             var reader = buf.GetReader();
 
-            // TODO IGNITE-19242: Retrieve new schema when necessary.
             _ = reader.ReadInt32();
 
             return reader.ReadBoolean();

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/VersionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/VersionUtils.cs
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Internal;
+
+using System.Reflection;
+
+/// <summary>
+/// Version utils.
+/// </summary>
+internal static class VersionUtils
+{
+    /// <summary>
+    /// Gets the informational version.
+    /// </summary>
+    /// <returns>Version string.</returns>
+    public static string GetInformationalVersion() =>
+        typeof(VersionUtils).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion!;
+}

--- a/modules/platforms/dotnet/DEVNOTES.md
+++ b/modules/platforms/dotnet/DEVNOTES.md
@@ -37,6 +37,10 @@ Static code analysis (Roslyn-based) runs as part of the build and includes code 
 
 ## Release Procedure
 
+### Update Version
+
+Update version number in `version.json`.
+
 ### Build Binaries
 `dotnet publish Apache.Ignite --configuration Release --output release/bin`
 

--- a/modules/platforms/dotnet/Directory.Build.props
+++ b/modules/platforms/dotnet/Directory.Build.props
@@ -51,4 +51,11 @@
         <None Include="$(MSBuildThisFileDirectory)\Apache_Ignite_logo_128x128.png" Pack="true" PackagePath=""/>
     </ItemGroup>
 
+    <ItemGroup>
+        <PackageReference Include="Nerdbank.GitVersioning">
+            <PrivateAssets>all</PrivateAssets>
+            <Version>3.6.128</Version>
+        </PackageReference>
+    </ItemGroup>
+
 </Project>

--- a/modules/platforms/dotnet/Directory.Build.props
+++ b/modules/platforms/dotnet/Directory.Build.props
@@ -23,8 +23,6 @@
         <Nullable>enable</Nullable>
         <AnalysisMode>All</AnalysisMode>
 
-        <Version>3.0.0-SNAPSHOT</Version>
-
         <Company>Apache Software Foundation</Company>
         <Authors>Apache Ignite</Authors>
         <Copyright>© Apache Software Foundation</Copyright>

--- a/modules/platforms/dotnet/version.json
+++ b/modules/platforms/dotnet/version.json
@@ -7,7 +7,7 @@
   ],
   "cloudBuild": {
     "buildNumber": {
-      "enabled": true
+      "enabled": false
     }
   }
 }

--- a/modules/platforms/dotnet/version.json
+++ b/modules/platforms/dotnet/version.json
@@ -1,4 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.0.0-beta2"
+  "version": "3.0.0-beta2",
+  "publicReleaseRefSpec": [
+    "^refs/heads/main",
+    "^refs/heads/\\d+.*$"
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
 }

--- a/modules/platforms/dotnet/version.json
+++ b/modules/platforms/dotnet/version.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "3.0.0-beta"
+}

--- a/modules/platforms/dotnet/version.json
+++ b/modules/platforms/dotnet/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.0.0-beta"
+  "version": "3.0.0-beta2"
 }


### PR DESCRIPTION
* Add [GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) library to manage assembly and package versions in one place (`version.json`).
  * Build-time only dependency, does not affect users.
* `AssemblyInformationalVersion` includes git revision hash.
* Log version with hash with `Info` level on client start.
* Add test to check that versions in .NET and Java projects are the same.

Extra:
* Remove TODO leftovers for closed tickets.