### PR TITLE
IGNITE-19343 Some of DistributionZoneAwaitDataNodesTest are enabled.

### DIFF
--- a/modules/baseline/src/main/java/org/apache/ignite/internal/baseline/BaselineManager.java
+++ b/modules/baseline/src/main/java/org/apache/ignite/internal/baseline/BaselineManager.java
@@ -28,7 +28,7 @@ import org.apache.ignite.network.ClusterService;
  * Baseline manager is responsible for handling baseline related logic.
  */
 // TODO: IGNITE-14586 Remove @SuppressWarnings when implementation provided.
-// TODO: https://issues.apache.org/jira/browse/IGNITE-18624
+// TODO: https://issues.apache.org/jira/browse/IGNITE-19425
 @SuppressWarnings({"FieldCanBeLocal", "unused"})
 public class BaselineManager implements IgniteComponent {
     /** Configuration manager in order to handle and listen baseline specific configuration. */

--- a/modules/distribution-zones/build.gradle
+++ b/modules/distribution-zones/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     testImplementation project(':ignite-network-api')
     testImplementation project(':ignite-metastorage-api')
     testImplementation project(':ignite-metastorage')
+    testImplementation project(':ignite-runner')
     testImplementation(testFixtures(project(':ignite-core')))
     testImplementation(testFixtures(project(':ignite-configuration')))
     testImplementation(testFixtures(project(':ignite-metastorage')))

--- a/modules/distribution-zones/src/test/java/org/apache/ignite/internal/distributionzones/BaseDistributionZoneManagerTest.java
+++ b/modules/distribution-zones/src/test/java/org/apache/ignite/internal/distributionzones/BaseDistributionZoneManagerTest.java
@@ -25,12 +25,17 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.apache.ignite.internal.cluster.management.ClusterManagementGroupManager;
 import org.apache.ignite.internal.cluster.management.raft.ClusterStateStorage;
 import org.apache.ignite.internal.cluster.management.raft.TestClusterStateStorage;
 import org.apache.ignite.internal.cluster.management.topology.LogicalTopology;
 import org.apache.ignite.internal.cluster.management.topology.LogicalTopologyImpl;
 import org.apache.ignite.internal.cluster.management.topology.LogicalTopologyServiceImpl;
+import org.apache.ignite.internal.configuration.ConfigurationManager;
+import org.apache.ignite.internal.configuration.ConfigurationRegistry;
+import org.apache.ignite.internal.configuration.storage.ConfigurationStorage;
+import org.apache.ignite.internal.configuration.storage.DistributedConfigurationStorage;
 import org.apache.ignite.internal.configuration.testframework.ConfigurationExtension;
 import org.apache.ignite.internal.configuration.testframework.InjectConfiguration;
 import org.apache.ignite.internal.distributionzones.configuration.DistributionZonesConfiguration;
@@ -39,6 +44,7 @@ import org.apache.ignite.internal.metastorage.MetaStorageManager;
 import org.apache.ignite.internal.metastorage.impl.StandaloneMetaStorageManager;
 import org.apache.ignite.internal.metastorage.server.SimpleInMemoryKeyValueStorage;
 import org.apache.ignite.internal.schema.configuration.TablesConfiguration;
+import org.apache.ignite.internal.storage.impl.TestPersistStorageConfigurationSchema;
 import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
 import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.vault.VaultManager;
@@ -55,7 +61,6 @@ public class BaseDistributionZoneManagerTest extends BaseIgniteAbstractTest {
     @InjectConfiguration
     private TablesConfiguration tablesConfiguration;
 
-    @InjectConfiguration
     protected DistributionZonesConfiguration zonesConfiguration;
 
     protected DistributionZoneManager distributionZoneManager;
@@ -69,6 +74,10 @@ public class BaseDistributionZoneManagerTest extends BaseIgniteAbstractTest {
     protected MetaStorageManager metaStorageManager;
 
     protected VaultManager vaultMgr;
+
+    private ConfigurationStorage cfgStorage;
+
+    private ConfigurationManager clusterCfgMgr;
 
     private final List<IgniteComponent> components = new ArrayList<>();
 
@@ -84,6 +93,20 @@ public class BaseDistributionZoneManagerTest extends BaseIgniteAbstractTest {
 
         components.add(metaStorageManager);
 
+        cfgStorage = new DistributedConfigurationStorage(metaStorageManager, vaultMgr);
+
+        clusterCfgMgr =  new ConfigurationManager(
+                List.of(DistributionZonesConfiguration.KEY),
+                Set.of(),
+                cfgStorage,
+                List.of(),
+                List.of(TestPersistStorageConfigurationSchema.class)
+        );
+
+        ConfigurationRegistry registry = clusterCfgMgr.configurationRegistry();
+
+        components.add(registry);
+
         clusterStateStorage = new TestClusterStateStorage();
 
         components.add(clusterStateStorage);
@@ -93,6 +116,8 @@ public class BaseDistributionZoneManagerTest extends BaseIgniteAbstractTest {
         ClusterManagementGroupManager cmgManager = mock(ClusterManagementGroupManager.class);
 
         when(cmgManager.logicalTopology()).thenAnswer(invocation -> completedFuture(topology.getLogicalTopology()));
+
+        zonesConfiguration = registry.getConfiguration(DistributionZonesConfiguration.KEY);
 
         distributionZoneManager = new DistributionZoneManager(
                 zonesConfiguration,

--- a/modules/distribution-zones/src/test/java/org/apache/ignite/internal/distributionzones/DistributionZoneManagerScaleUpTest.java
+++ b/modules/distribution-zones/src/test/java/org/apache/ignite/internal/distributionzones/DistributionZoneManagerScaleUpTest.java
@@ -82,6 +82,8 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
     private static final LogicalNode NODE_3 = new LogicalNode("3", "C", new NetworkAddress("localhost", 123));
 
+    private static final long PREREQUISITE_REVISION = 4;
+
     @Test
     @Disabled("https://issues.apache.org/jira/browse/IGNITE-19255")
     void testDataNodesPropagationAfterScaleUpTriggered() throws Exception {
@@ -162,7 +164,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
                 new DistributionZoneConfigurationParameters.Builder(ZONE_NAME).dataNodesAutoAdjustScaleDown(IMMEDIATE_TIMER_VALUE).build()
         ).get();
 
-        assertZoneScaleDownChangeTriggerKey(1, 1, keyValueStorage);
+        assertZoneScaleDownChangeTriggerKey(5, 1, keyValueStorage);
 
         assertDataNodesForZone(1, clusterNodes2.stream().map(ClusterNode::name).collect(Collectors.toSet()), keyValueStorage);
     }
@@ -314,7 +316,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
                 zoneView,
                 Set.of("D"),
                 Set.of(),
-                2,
+                PREREQUISITE_REVISION + 1,
                 (zoneId, revision) -> {
                     try {
                         in1.await();
@@ -331,7 +333,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
         // to the topologyAugmentationMap of the zone.
         assertTrue(
                 waitForCondition(
-                        () -> distributionZoneManager.zonesTimers().get(1).topologyAugmentationMap().containsKey(2L),
+                        () -> distributionZoneManager.zonesTimers().get(1).topologyAugmentationMap().containsKey(PREREQUISITE_REVISION + 1),
                         1000
                 )
         );
@@ -340,7 +342,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
                 zoneView,
                 Set.of("E"),
                 Set.of(),
-                3,
+                PREREQUISITE_REVISION + 2,
                 (zoneId, revision) -> {
                     try {
                         in2.await();
@@ -363,7 +365,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
         // to the topologyAugmentationMap of the zone.
         assertTrue(
                 waitForCondition(
-                        () -> distributionZoneManager.zonesTimers().get(1).topologyAugmentationMap().containsKey(3L),
+                        () -> distributionZoneManager.zonesTimers().get(1).topologyAugmentationMap().containsKey(PREREQUISITE_REVISION + 2),
                         1000
                 )
         );
@@ -372,7 +374,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
         //Second task is propagating data nodes first.
         in2.countDown();
 
-        assertZoneScaleUpChangeTriggerKey(3, 1, keyValueStorage);
+        assertZoneScaleUpChangeTriggerKey(PREREQUISITE_REVISION + 2, 1, keyValueStorage);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C", "D", "E"), keyValueStorage);
 
@@ -384,7 +386,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
         out1.countDown();
 
         // Assert that nothing has been changed.
-        assertZoneScaleUpChangeTriggerKey(3, 1, keyValueStorage);
+        assertZoneScaleUpChangeTriggerKey(PREREQUISITE_REVISION + 2, 1, keyValueStorage);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C", "D", "E"), keyValueStorage);
     }
@@ -407,7 +409,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
                 zoneView,
                 Set.of(),
                 Set.of("B"),
-                2,
+                PREREQUISITE_REVISION + 1,
                 (t1, t2) -> null,
                 (zoneId, revision) -> {
                     try {
@@ -424,7 +426,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
         // to the topologyAugmentationMap of the zone.
         assertTrue(
                 waitForCondition(
-                        () -> distributionZoneManager.zonesTimers().get(1).topologyAugmentationMap().containsKey(2L),
+                        () -> distributionZoneManager.zonesTimers().get(1).topologyAugmentationMap().containsKey(PREREQUISITE_REVISION + 1),
                         1000
                 )
         );
@@ -433,7 +435,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
                 zoneView,
                 Set.of(),
                 Set.of("C"),
-                3,
+                PREREQUISITE_REVISION + 2,
                 (t1, t2) -> null,
                 (zoneId, revision) -> {
                     try {
@@ -456,7 +458,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
         // to the topologyAugmentationMap of the zone.
         assertTrue(
                 waitForCondition(
-                        () -> distributionZoneManager.zonesTimers().get(1).topologyAugmentationMap().containsKey(3L),
+                        () -> distributionZoneManager.zonesTimers().get(1).topologyAugmentationMap().containsKey(PREREQUISITE_REVISION + 2),
                         1000
                 )
         );
@@ -465,7 +467,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
         //Second task is propagating data nodes first.
         in2.countDown();
 
-        assertZoneScaleDownChangeTriggerKey(3, 1, keyValueStorage);
+        assertZoneScaleDownChangeTriggerKey(PREREQUISITE_REVISION + 2, 1, keyValueStorage);
 
         assertDataNodesForZone(1, Set.of("A"), keyValueStorage);
 
@@ -477,7 +479,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
         out1.countDown();
 
         // Assert that nothing has been changed.
-        assertZoneScaleDownChangeTriggerKey(3, 1, keyValueStorage);
+        assertZoneScaleDownChangeTriggerKey(PREREQUISITE_REVISION + 2, 1, keyValueStorage);
 
         assertDataNodesForZone(1, Set.of("A"), keyValueStorage);
     }
@@ -499,7 +501,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
                 zoneView,
                 Set.of("D"),
                 Set.of(),
-                2,
+                PREREQUISITE_REVISION + 1,
                 (zoneId, revision) -> {
                     in1.countDown();
 
@@ -522,7 +524,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
                 zoneView,
                 Set.of("E"),
                 Set.of(),
-                3,
+                PREREQUISITE_REVISION + 2,
                 (zoneId, revision) -> {
                     try {
                         in2.await();
@@ -539,19 +541,19 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
         // to the topologyAugmentationMap of the zone.
         assertTrue(
                 waitForCondition(
-                        () -> distributionZoneManager.zonesTimers().get(1).topologyAugmentationMap().containsKey(3L),
+                        () -> distributionZoneManager.zonesTimers().get(1).topologyAugmentationMap().containsKey(PREREQUISITE_REVISION + 2),
                         1000
                 )
         );
 
-        assertZoneScaleUpChangeTriggerKey(2, 1, keyValueStorage);
+        assertZoneScaleUpChangeTriggerKey(PREREQUISITE_REVISION + 1, 1, keyValueStorage);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C", "D"), keyValueStorage);
 
         // Second task is run and we await that data nodes will be changed from ["A", "B", "C", "D"] to ["A", "B", "C", "D", "E"]
         in2.countDown();
 
-        assertZoneScaleUpChangeTriggerKey(3, 1, keyValueStorage);
+        assertZoneScaleUpChangeTriggerKey(PREREQUISITE_REVISION + 2, 1, keyValueStorage);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C", "D", "E"), keyValueStorage);
 
@@ -575,7 +577,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
                 zoneView,
                 Set.of(),
                 Set.of("B"),
-                2,
+                PREREQUISITE_REVISION + 1,
                 (t1, t2) -> null,
                 (zoneId, revision) -> {
                     in1.countDown();
@@ -598,7 +600,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
                 zoneView,
                 Set.of(),
                 Set.of("C"),
-                3,
+                PREREQUISITE_REVISION + 2,
                 (t1, t2) -> null,
                 (zoneId, revision) -> {
                     try {
@@ -615,19 +617,19 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
         // to the topologyAugmentationMap of the zone.
         assertTrue(
                 waitForCondition(
-                        () -> distributionZoneManager.zonesTimers().get(1).topologyAugmentationMap().containsKey(3L),
+                        () -> distributionZoneManager.zonesTimers().get(1).topologyAugmentationMap().containsKey(PREREQUISITE_REVISION + 2),
                         1000
                 )
         );
 
-        assertZoneScaleDownChangeTriggerKey(2, 1, keyValueStorage);
+        assertZoneScaleDownChangeTriggerKey(PREREQUISITE_REVISION + 1, 1, keyValueStorage);
 
         assertDataNodesForZone(1, Set.of("A", "C"), keyValueStorage);
 
         // Second task is run and we await that data nodes will be changed from ["A", "C"] to ["A"]
         in2.countDown();
 
-        assertZoneScaleDownChangeTriggerKey(3, 1, keyValueStorage);
+        assertZoneScaleDownChangeTriggerKey(PREREQUISITE_REVISION + 2, 1, keyValueStorage);
 
         assertDataNodesForZone(1, Set.of("A"), keyValueStorage);
 
@@ -646,7 +648,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         assertDataNodesForZone(1, Set.of(), keyValueStorage);
 
-        assertZoneScaleDownChangeTriggerKey(1, 1, keyValueStorage);
+        assertZoneScaleDownChangeTriggerKey(3, 1, keyValueStorage);
 
         topology.putNode(NODE_1);
 
@@ -721,29 +723,29 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 3);
-        zoneState.nodesToAddToDataNodes(Set.of("E"), 4);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 7);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToAddToDataNodes(Set.of("E"), PREREQUISITE_REVISION + 3);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 6);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 3);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 2);
 
-        assertTrue(zoneState.topologyAugmentationMap().containsKey(3L));
-        assertTrue(zoneState.topologyAugmentationMap().containsKey(4L));
-        assertTrue(zoneState.topologyAugmentationMap().containsKey(7L));
+        assertTrue(zoneState.topologyAugmentationMap().containsKey(PREREQUISITE_REVISION + 2));
+        assertTrue(zoneState.topologyAugmentationMap().containsKey(PREREQUISITE_REVISION + 3));
+        assertTrue(zoneState.topologyAugmentationMap().containsKey(PREREQUISITE_REVISION + 6));
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 4);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 3);
 
-        assertTrue(zoneState.topologyAugmentationMap().containsKey(3L));
-        assertTrue(zoneState.topologyAugmentationMap().containsKey(4L));
-        assertTrue(zoneState.topologyAugmentationMap().containsKey(7L));
+        assertTrue(zoneState.topologyAugmentationMap().containsKey(PREREQUISITE_REVISION + 2));
+        assertTrue(zoneState.topologyAugmentationMap().containsKey(PREREQUISITE_REVISION + 3));
+        assertTrue(zoneState.topologyAugmentationMap().containsKey(PREREQUISITE_REVISION + 6));
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 7);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 6);
 
-        assertFalse(zoneState.topologyAugmentationMap().containsKey(3L));
-        assertFalse(zoneState.topologyAugmentationMap().containsKey(4L));
-        assertTrue(zoneState.topologyAugmentationMap().containsKey(7L));
+        assertFalse(zoneState.topologyAugmentationMap().containsKey(PREREQUISITE_REVISION + 2));
+        assertFalse(zoneState.topologyAugmentationMap().containsKey(PREREQUISITE_REVISION + 3));
+        assertTrue(zoneState.topologyAugmentationMap().containsKey(PREREQUISITE_REVISION + 6));
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 15);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 14);
 
         assertTrue(zoneState.topologyAugmentationMap().isEmpty());
         assertDataNodesForZone(1, Set.of("A", "B", "D", "E"), keyValueStorage);
@@ -761,7 +763,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         assertDataNodesForZone(1, Set.of(), keyValueStorage);
 
-        assertZoneScaleDownChangeTriggerKey(1, 1, keyValueStorage);
+        assertZoneScaleDownChangeTriggerKey(3, 1, keyValueStorage);
 
         topology.putNode(NODE_1);
 
@@ -797,7 +799,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         assertDataNodesForZone(1, Set.of(NODE_1.name()), keyValueStorage);
 
-        assertZoneScaleDownChangeTriggerKey(1, 1, keyValueStorage);
+        assertZoneScaleDownChangeTriggerKey(4, 1, keyValueStorage);
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
@@ -827,7 +829,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         assertDataNodesForZone(1, Set.of(), keyValueStorage);
 
-        assertZoneScaleDownChangeTriggerKey(1, 1, keyValueStorage);
+        assertZoneScaleDownChangeTriggerKey(3, 1, keyValueStorage);
 
         doAnswer(invocation -> {
             If iif = invocation.getArgument(0);
@@ -868,7 +870,7 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         assertDataNodesForZone(1, Set.of(NODE_1.name()), keyValueStorage);
 
-        assertZoneScaleDownChangeTriggerKey(1, 1, keyValueStorage);
+        assertZoneScaleDownChangeTriggerKey(4, 1, keyValueStorage);
 
         doAnswer(invocation -> {
             If iif = invocation.getArgument(0);
@@ -897,11 +899,11 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 3);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 7);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 6);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 3);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 7);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 2);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 6);
 
         assertDataNodesForZone(1, Set.of("A", "B", "D"), keyValueStorage);
     }
@@ -912,11 +914,11 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 3);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 7);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 6);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 7);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 3);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 6);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 2);
 
         assertDataNodesForZone(1, Set.of("A", "B", "D"), keyValueStorage);
     }
@@ -927,11 +929,11 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 3);
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 7);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 6);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 3);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 7);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 2);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 6);
 
         assertDataNodesForZone(1, Set.of("A", "B", "D"), keyValueStorage);
     }
@@ -942,11 +944,11 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 3);
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 7);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 6);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 7);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 3);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 6);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 2);
 
         assertDataNodesForZone(1, Set.of("A", "B", "D"), keyValueStorage);
     }
@@ -957,12 +959,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 3);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), 7);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), PREREQUISITE_REVISION + 6);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 3);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 2);
         assertDataNodesForZone(1, Set.of("A", "B", "C", "D"), keyValueStorage);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 7);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 6);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C"), keyValueStorage);
     }
@@ -973,11 +975,11 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 3);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), 7);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), PREREQUISITE_REVISION + 6);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 7);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 3);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 6);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 2);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C"), keyValueStorage);
     }
@@ -988,11 +990,11 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 3);
-        zoneState.nodesToAddToDataNodes(Set.of("C"), 7);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToAddToDataNodes(Set.of("C"), PREREQUISITE_REVISION + 6);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 3);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 7);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 2);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 6);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C"), keyValueStorage);
     }
@@ -1003,11 +1005,11 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 3);
-        zoneState.nodesToAddToDataNodes(Set.of("C"), 7);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToAddToDataNodes(Set.of("C"), PREREQUISITE_REVISION + 6);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 7);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 3);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 6);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 2);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C"), keyValueStorage);
     }
@@ -1018,12 +1020,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 3);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), 7);
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 9);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), PREREQUISITE_REVISION + 6);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 8);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 9);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 7);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 8);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 6);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C", "D"), keyValueStorage);
     }
@@ -1034,12 +1036,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 3);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), 7);
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 9);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), PREREQUISITE_REVISION + 6);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 8);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 7);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 9);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 6);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 8);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C", "D"), keyValueStorage);
     }
@@ -1050,14 +1052,14 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 3);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), 7);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), PREREQUISITE_REVISION + 6);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 7);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 6);
 
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 9);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 8);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 9);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 8);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C", "D"), keyValueStorage);
     }
@@ -1068,12 +1070,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 3);
-        zoneState.nodesToAddToDataNodes(Set.of("C"), 7);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 9);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToAddToDataNodes(Set.of("C"), PREREQUISITE_REVISION + 6);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 8);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 9);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 7);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 8);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 6);
 
         assertDataNodesForZone(1, Set.of("A", "B"), keyValueStorage);
     }
@@ -1084,12 +1086,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 3);
-        zoneState.nodesToAddToDataNodes(Set.of("C"), 7);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 9);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToAddToDataNodes(Set.of("C"), PREREQUISITE_REVISION + 6);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 8);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 7);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 9);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 6);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 8);
 
         assertDataNodesForZone(1, Set.of("A", "B"), keyValueStorage);
     }
@@ -1100,12 +1102,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 3);
-        zoneState.nodesToAddToDataNodes(Set.of("C"), 7);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 7);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToAddToDataNodes(Set.of("C"), PREREQUISITE_REVISION + 6);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 6);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 9);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 9);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 8);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 8);
 
         assertDataNodesForZone(1, Set.of("A", "B"), keyValueStorage);
     }
@@ -1116,13 +1118,13 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 3);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), 7);
-        zoneState.nodesToAddToDataNodes(Set.of("E"), 9);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), PREREQUISITE_REVISION + 6);
+        zoneState.nodesToAddToDataNodes(Set.of("E"), PREREQUISITE_REVISION + 8);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 9);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 8);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 7);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 6);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C", "E"), keyValueStorage);
     }
@@ -1133,12 +1135,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 3);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), 7);
-        zoneState.nodesToAddToDataNodes(Set.of("E"), 9);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), PREREQUISITE_REVISION + 6);
+        zoneState.nodesToAddToDataNodes(Set.of("E"), PREREQUISITE_REVISION + 8);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 7);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 9);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 6);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 8);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C", "E"), keyValueStorage);
     }
@@ -1149,12 +1151,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 3);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), 7);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 7);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), PREREQUISITE_REVISION + 6);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 6);
 
-        zoneState.nodesToAddToDataNodes(Set.of("E"), 9);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 9);
+        zoneState.nodesToAddToDataNodes(Set.of("E"), PREREQUISITE_REVISION + 8);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 8);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C", "E"), keyValueStorage);
     }
@@ -1165,12 +1167,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 3);
-        zoneState.nodesToAddToDataNodes(Set.of("C"), 7);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("B"), 9);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToAddToDataNodes(Set.of("C"), PREREQUISITE_REVISION + 6);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("B"), PREREQUISITE_REVISION + 8);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 9);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 7);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 8);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 6);
 
         assertDataNodesForZone(1, Set.of("A", "C"), keyValueStorage);
     }
@@ -1181,12 +1183,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 3);
-        zoneState.nodesToAddToDataNodes(Set.of("C"), 7);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("B"), 9);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToAddToDataNodes(Set.of("C"), PREREQUISITE_REVISION + 6);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("B"), PREREQUISITE_REVISION + 8);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 7);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 9);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 6);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 8);
 
         assertDataNodesForZone(1, Set.of("A", "C"), keyValueStorage);
     }
@@ -1197,12 +1199,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 3);
-        zoneState.nodesToAddToDataNodes(Set.of("C"), 7);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 7);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToAddToDataNodes(Set.of("C"), PREREQUISITE_REVISION + 6);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 6);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("B"), 9);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 9);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("B"), PREREQUISITE_REVISION + 8);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 8);
 
         assertDataNodesForZone(1, Set.of("A", "C"), keyValueStorage);
     }
@@ -1213,12 +1215,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 3);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 7);
-        zoneState.nodesToAddToDataNodes(Set.of("C"), 9);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 6);
+        zoneState.nodesToAddToDataNodes(Set.of("C"), PREREQUISITE_REVISION + 8);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 9);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 7);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 8);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 6);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C", "D"), keyValueStorage);
     }
@@ -1229,12 +1231,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 3);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 7);
-        zoneState.nodesToAddToDataNodes(Set.of("C"), 9);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 6);
+        zoneState.nodesToAddToDataNodes(Set.of("C"), PREREQUISITE_REVISION + 8);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 7);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 9);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 6);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 8);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C", "D"), keyValueStorage);
     }
@@ -1245,12 +1247,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 3);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 7);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 7);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 6);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 6);
 
-        zoneState.nodesToAddToDataNodes(Set.of("C"), 9);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 9);
+        zoneState.nodesToAddToDataNodes(Set.of("C"), PREREQUISITE_REVISION + 8);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 8);
 
         assertDataNodesForZone(1, Set.of("A", "B", "C", "D"), keyValueStorage);
     }
@@ -1261,12 +1263,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 3);
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 7);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), 9);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 6);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), PREREQUISITE_REVISION + 8);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 9);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 7);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 8);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 6);
 
         assertDataNodesForZone(1, Set.of("A", "B"), keyValueStorage);
     }
@@ -1277,12 +1279,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 3);
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 7);
-        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), 9);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 6);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), PREREQUISITE_REVISION + 8);
 
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 7);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 9);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 6);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 8);
 
         assertDataNodesForZone(1, Set.of("A", "B"), keyValueStorage);
     }
@@ -1293,12 +1295,12 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         ZoneState zoneState = distributionZoneManager.zonesTimers().get(1);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), 3);
-        zoneState.nodesToAddToDataNodes(Set.of("D"), 7);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, 7);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("C"), PREREQUISITE_REVISION + 2);
+        zoneState.nodesToAddToDataNodes(Set.of("D"), PREREQUISITE_REVISION + 6);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleUp(1, PREREQUISITE_REVISION + 6);
 
-        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), 9);
-        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, 9);
+        zoneState.nodesToRemoveFromDataNodes(Set.of("D"), PREREQUISITE_REVISION + 8);
+        distributionZoneManager.saveDataNodesToMetaStorageOnScaleDown(1, PREREQUISITE_REVISION + 8);
 
         assertDataNodesForZone(1, Set.of("A", "B"), keyValueStorage);
     }
@@ -1351,8 +1353,8 @@ public class DistributionZoneManagerScaleUpTest extends BaseDistributionZoneMana
 
         assertDataNodesForZone(1, clusterNodesNames, keyValueStorage);
 
-        assertZoneScaleUpChangeTriggerKey(1, 1, keyValueStorage);
-        assertZoneScaleDownChangeTriggerKey(1, 1, keyValueStorage);
+        assertZoneScaleUpChangeTriggerKey(PREREQUISITE_REVISION, 1, keyValueStorage);
+        assertZoneScaleDownChangeTriggerKey(PREREQUISITE_REVISION, 1, keyValueStorage);
     }
 
     private CompletableFuture<Void> testSaveDataNodesOnScaleUp(int zoneId, long revision) {


### PR DESCRIPTION
* DistributedConfigurationStorage is used in BaseDistributionZoneManagerTest to fix an issue when metaStorageManager and zonesConfiguration use different storage and have different storage revisions.