### PR TITLE
IGNITE-18551 Create general task executor for all registries

### DIFF
--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/core/repl/executor/ItIgnitePicocliCommandsTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/core/repl/executor/ItIgnitePicocliCommandsTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.when;
 
 import jakarta.inject.Inject;
 import java.io.File;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -396,7 +395,7 @@ public class ItIgnitePicocliCommandsTest extends CliCommandTestInitializedIntegr
         await().until(() -> nodeNameRegistry.urls(), not(empty()));
 
         // Then
-        String[] expectedUrls = nodeNameRegistry.urls().stream().map(URL::toString).toArray(String[]::new);
+        String[] expectedUrls = nodeNameRegistry.urls().toArray(String[]::new);
         assertThat("For given parsed words: " + parsedLine.words(),
                 complete(parsedLine),
                 containsInAnyOrder(expectedUrls));

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/node/NodeUrlMixin.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/node/NodeUrlMixin.java
@@ -71,7 +71,6 @@ public class NodeUrlMixin {
             }
             if (options.nodeName != null) {
                 return nodeNameRegistry.nodeUrlByName(options.nodeName)
-                        .map(URL::toString)
                         .orElseThrow(() -> new IgniteCliException("Node " + options.nodeName
                                 + " not found. Provide a valid name or use a URL"));
             }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/converters/NodeNameOrUrlConverter.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/converters/NodeNameOrUrlConverter.java
@@ -50,11 +50,11 @@ public class NodeNameOrUrlConverter implements CommandLine.ITypeConverter<NodeNa
         if (isUrl) {
             return new NodeNameOrUrl(stringToUrl(input));
         } else {
-            return new NodeNameOrUrl(findNodeUrlByNodeName(input));
+            return new NodeNameOrUrl(stringToUrl(findNodeUrlByNodeName(input)));
         }
     }
 
-    private URL findNodeUrlByNodeName(String name) {
+    private String findNodeUrlByNodeName(String name) {
         return nodeNameRegistry.nodeUrlByName(name)
                 .orElseThrow(() -> new TypeConversionException("Node " + name + " not found. Provide valid name or use URL"));
     }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/PeriodicSessionTask.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/PeriodicSessionTask.java
@@ -15,21 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.internal.cli.core.repl.registry;
+package org.apache.ignite.internal.cli.core.repl;
 
-import java.util.Optional;
-import java.util.Set;
+/** Task which will be executed periodically while {@link Session} is connected. */
+public interface PeriodicSessionTask {
 
-/** Node name registry. */
-public interface NodeNameRegistry {
+    /** This method is called periodically. */
+    void update(SessionInfo sessionInfo);
 
-    /** Returns a node url by a provided node name. */
-    Optional<String> nodeUrlByName(String nodeName);
-
-    /** Returns set of node names. */
-    Set<String> names();
-
-    /** Returns set of node urls. */
-    Set<String> urls();
-
+    /** This method is called when the session is disconnected. */
+    void onDisconnect();
 }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/PeriodicSessionTaskExecutor.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/PeriodicSessionTaskExecutor.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.cli.core.repl;
+
+import static org.apache.ignite.internal.util.IgniteUtils.shutdownAndAwaitTermination;
+
+import jakarta.inject.Singleton;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.ignite.internal.cli.logger.CliLoggers;
+import org.apache.ignite.internal.logger.IgniteLogger;
+import org.apache.ignite.internal.thread.NamedThreadFactory;
+import org.jetbrains.annotations.Nullable;
+
+/** Executes tasks periodically while the session is connected. */
+@Singleton
+public class PeriodicSessionTaskExecutor implements AsyncSessionEventListener {
+    private static final IgniteLogger LOG = CliLoggers.forClass(PeriodicSessionTaskExecutor.class);
+
+    @Nullable
+    private ScheduledExecutorService executor;
+
+    private final List<? extends PeriodicSessionTask> tasks;
+
+    public PeriodicSessionTaskExecutor(List<? extends PeriodicSessionTask> tasks) {
+        this.tasks = tasks;
+    }
+
+    @Override
+    public synchronized void onConnect(SessionInfo sessionInfo) {
+        if (executor == null) {
+            executor = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("SessionTaskExecutor", LOG));
+            executor.scheduleWithFixedDelay(() -> runTasks(sessionInfo), 0, 5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Override
+    public synchronized void onDisconnect() {
+        if (executor != null) {
+            shutdownAndAwaitTermination(executor, 3, TimeUnit.SECONDS);
+            tasks.forEach(PeriodicSessionTask::onDisconnect);
+            executor = null;
+        }
+    }
+
+    private void runTasks(SessionInfo sessionInfo) {
+        tasks.forEach(periodicSessionTask -> periodicSessionTask.update(sessionInfo));
+    }
+}

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/completer/cluster/ClusterUrlDynamicCompleterFactory.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/completer/cluster/ClusterUrlDynamicCompleterFactory.java
@@ -18,9 +18,8 @@
 package org.apache.ignite.internal.cli.core.repl.completer.cluster;
 
 import jakarta.inject.Singleton;
-import java.net.URL;
+import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.ignite.internal.cli.core.repl.completer.DynamicCompleter;
 import org.apache.ignite.internal.cli.core.repl.completer.DynamicCompleterFactory;
 import org.apache.ignite.internal.cli.core.repl.completer.StringDynamicCompleter;
@@ -38,10 +37,7 @@ public class ClusterUrlDynamicCompleterFactory implements DynamicCompleterFactor
 
     @Override
     public DynamicCompleter getDynamicCompleter(String[] words) {
-        Set<String> urls = nodeNameRegistry.urls()
-                .stream()
-                .map(URL::toString)
-                .collect(Collectors.toSet());
+        Set<String> urls = new HashSet<>(nodeNameRegistry.urls());
         return new StringDynamicCompleter(urls);
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-18551

This also simplifies `NodeNameRegistry` to use `String` instead of `URL`.