### PR TITLE
IGNITE-19355 .NET: Do not request same schema more than once

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TableGetBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TableGetBenchmarks.cs
@@ -38,7 +38,7 @@ public class TableGetBenchmarks
     [GlobalSetup]
     public async Task GlobalSetup()
     {
-        _server = new FakeServer();
+        _server = new FakeServer(true);
         _client = await IgniteClient.StartAsync(new IgniteClientConfiguration(_server.Endpoint));
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TableGetMultiThreadedBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TableGetMultiThreadedBenchmarks.cs
@@ -51,7 +51,7 @@ public class TableGetMultiThreadedBenchmarks
     {
         // Use a delay on server to imitate some work.
         _servers = Enumerable.Range(0, ServerCount)
-            .Select(_ => new FakeServer { OperationDelay = TimeSpan.FromMilliseconds(5) })
+            .Select(_ => new FakeServer(true) { OperationDelay = TimeSpan.FromMilliseconds(5) })
             .ToList();
 
         _client = await IgniteClient.StartAsync(new IgniteClientConfiguration(_servers.Select(s => s.Endpoint).ToArray()));

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
@@ -82,8 +82,8 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestClientRetriesComputeJobOnPrimaryAndDefaultNodes()
         {
-            using var server1 = new FakeServer(shouldDropConnection: (cnt, _) => cnt % 2 == 0, nodeName: "s1");
-            using var server2 = new FakeServer(shouldDropConnection: (cnt, _) => cnt % 2 == 0, nodeName: "s2");
+            using var server1 = new FakeServer(shouldDropConnection: ctx => ctx.RequestCount % 2 == 0, nodeName: "s1");
+            using var server2 = new FakeServer(shouldDropConnection: ctx => ctx.RequestCount % 2 == 0, nodeName: "s2");
 
             var clientCfg = new IgniteClientConfiguration
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
@@ -82,8 +82,8 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestClientRetriesComputeJobOnPrimaryAndDefaultNodes()
         {
-            using var server1 = new FakeServer(shouldDropConnection: cnt => cnt % 2 == 0, nodeName: "s1");
-            using var server2 = new FakeServer(shouldDropConnection: cnt => cnt % 2 == 0, nodeName: "s2");
+            using var server1 = new FakeServer(shouldDropConnection: (cnt, _) => cnt % 2 == 0, nodeName: "s1");
+            using var server2 = new FakeServer(shouldDropConnection: (cnt, _) => cnt % 2 == 0, nodeName: "s2");
 
             var clientCfg = new IgniteClientConfiguration
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServerTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServerTests.cs
@@ -68,7 +68,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = RetryNonePolicy.Instance
             };
 
-            using var server = new FakeServer((reqId, _) => reqId % 3 == 0);
+            using var server = new FakeServer(ctx => ctx.RequestCount % 3 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             // 2 requests succeed, 3rd fails.

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServerTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServerTests.cs
@@ -68,7 +68,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = RetryNonePolicy.Instance
             };
 
-            using var server = new FakeServer(reqId => reqId % 3 == 0);
+            using var server = new FakeServer((reqId, _) => reqId % 3 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             // 2 requests succeed, 3rd fails.

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -189,7 +189,7 @@ public class MetricsTests
     [Test]
     public async Task TestRequestsRetried()
     {
-        using var server = new FakeServer(shouldDropConnection: idx => idx is > 1 and < 5);
+        using var server = new FakeServer(shouldDropConnection: (idx, _) => idx is > 1 and < 5);
         using var client = await server.ConnectClientAsync();
 
         await client.Tables.GetTablesAsync();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -189,7 +189,7 @@ public class MetricsTests
     [Test]
     public async Task TestRequestsRetried()
     {
-        using var server = new FakeServer(shouldDropConnection: (idx, _) => idx is > 1 and < 5);
+        using var server = new FakeServer(shouldDropConnection: ctx => ctx.RequestCount is > 1 and < 5);
         using var client = await server.ConnectClientAsync();
 
         await client.Tables.GetTablesAsync();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/RetryPolicyTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/RetryPolicyTests.cs
@@ -38,7 +38,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = new RetryLimitPolicy { RetryLimit = 1 }
             };
 
-            using var server = new FakeServer(reqId => reqId % 2 == 0);
+            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             for (int i = 0; i < IterCount; i++)
@@ -52,7 +52,7 @@ namespace Apache.Ignite.Tests
         {
             var cfg = new IgniteClientConfiguration { RetryPolicy = new RetryLimitPolicy() };
 
-            using var server = new FakeServer(reqId => reqId % 2 == 0);
+            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             var ex = Assert.ThrowsAsync<IgniteException>(async () => await client.Tables.GetTableAsync("bad-table"));
@@ -65,7 +65,7 @@ namespace Apache.Ignite.Tests
             var testRetryPolicy = new TestRetryPolicy();
             var cfg = new IgniteClientConfiguration { RetryPolicy = testRetryPolicy };
 
-            using var server = new FakeServer(reqId => reqId % 2 == 0);
+            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             var tx = await client.Transactions.BeginAsync();
@@ -82,7 +82,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = new TestRetryPolicy { RetryLimit = 5 }
             };
 
-            using var server = new FakeServer(reqId => reqId > 1);
+            using var server = new FakeServer((reqId, _) => reqId > 1);
             using var client = await server.ConnectClientAsync(cfg);
 
             await client.Tables.GetTablesAsync();
@@ -94,7 +94,7 @@ namespace Apache.Ignite.Tests
         [Test]
         public async Task TestFailoverWithRetryPolicyThrowsOnDefaultRetryLimitExceeded()
         {
-            using var server = new FakeServer(reqId => reqId > 1);
+            using var server = new FakeServer((reqId, _) => reqId > 1);
             using var client = await server.ConnectClientAsync();
 
             await client.Tables.GetTablesAsync();
@@ -114,7 +114,7 @@ namespace Apache.Ignite.Tests
                 }
             };
 
-            using var server = new FakeServer(reqId => reqId % 30 != 0);
+            using var server = new FakeServer((reqId, _) => reqId % 30 != 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             for (var i = 0; i < IterCount; i++)
@@ -126,7 +126,7 @@ namespace Apache.Ignite.Tests
         [Test]
         public async Task TestRetryPolicyIsDisabledByDefault()
         {
-            using var server = new FakeServer(reqId => reqId > 1);
+            using var server = new FakeServer((reqId, _) => reqId > 1);
             using var client = await server.ConnectClientAsync();
 
             await client.Tables.GetTablesAsync();
@@ -142,7 +142,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = null!
             };
 
-            using var server = new FakeServer(reqId => reqId > 1);
+            using var server = new FakeServer((reqId, _) => reqId > 1);
             using var client = await server.ConnectClientAsync(cfg);
 
             await client.Tables.GetTablesAsync();
@@ -160,7 +160,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = testRetryPolicy
             };
 
-            using var server = new FakeServer(reqId => reqId % 3 == 0);
+            using var server = new FakeServer((reqId, _) => reqId % 3 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             for (var i = 0; i < IterCount; i++)
@@ -188,7 +188,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = testRetryPolicy
             };
 
-            using var server = new FakeServer(reqId => reqId % 2 == 0);
+            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             await client.Tables.GetTablesAsync();
@@ -205,7 +205,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = new TestRetryPolicy { RetryLimit = 1 }
             };
 
-            using var server = new FakeServer(reqId => reqId % 2 == 0);
+            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             for (int i = 0; i < IterCount; i++)
@@ -224,7 +224,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = new TestRetryPolicy()
             };
 
-            using var server = new FakeServer(reqId => reqId % 2 == 0);
+            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
             var tx = await client.Transactions.BeginAsync();
 
@@ -242,7 +242,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = new TestRetryPolicy { RetryLimit = 1 }
             };
 
-            using var server = new FakeServer(reqId => reqId % 2 == 0);
+            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             for (int i = 0; i < IterCount; i++)
@@ -260,7 +260,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = new RetryReadPolicy()
             };
 
-            using var server = new FakeServer(reqId => reqId % 2 == 0);
+            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             var table = await client.Tables.GetTableAsync(FakeServer.ExistingTableName);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/RetryPolicyTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/RetryPolicyTests.cs
@@ -38,7 +38,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = new RetryLimitPolicy { RetryLimit = 1 }
             };
 
-            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
+            using var server = new FakeServer(ctx => ctx.RequestCount % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             for (int i = 0; i < IterCount; i++)
@@ -52,7 +52,7 @@ namespace Apache.Ignite.Tests
         {
             var cfg = new IgniteClientConfiguration { RetryPolicy = new RetryLimitPolicy() };
 
-            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
+            using var server = new FakeServer(ctx => ctx.RequestCount % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             var ex = Assert.ThrowsAsync<IgniteException>(async () => await client.Tables.GetTableAsync("bad-table"));
@@ -65,7 +65,7 @@ namespace Apache.Ignite.Tests
             var testRetryPolicy = new TestRetryPolicy();
             var cfg = new IgniteClientConfiguration { RetryPolicy = testRetryPolicy };
 
-            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
+            using var server = new FakeServer(ctx => ctx.RequestCount % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             var tx = await client.Transactions.BeginAsync();
@@ -82,7 +82,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = new TestRetryPolicy { RetryLimit = 5 }
             };
 
-            using var server = new FakeServer((reqId, _) => reqId > 1);
+            using var server = new FakeServer(ctx => ctx.RequestCount > 1);
             using var client = await server.ConnectClientAsync(cfg);
 
             await client.Tables.GetTablesAsync();
@@ -94,7 +94,7 @@ namespace Apache.Ignite.Tests
         [Test]
         public async Task TestFailoverWithRetryPolicyThrowsOnDefaultRetryLimitExceeded()
         {
-            using var server = new FakeServer((reqId, _) => reqId > 1);
+            using var server = new FakeServer(ctx => ctx.RequestCount > 1);
             using var client = await server.ConnectClientAsync();
 
             await client.Tables.GetTablesAsync();
@@ -114,7 +114,7 @@ namespace Apache.Ignite.Tests
                 }
             };
 
-            using var server = new FakeServer((reqId, _) => reqId % 30 != 0);
+            using var server = new FakeServer(ctx => ctx.RequestCount % 30 != 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             for (var i = 0; i < IterCount; i++)
@@ -126,7 +126,7 @@ namespace Apache.Ignite.Tests
         [Test]
         public async Task TestRetryPolicyIsDisabledByDefault()
         {
-            using var server = new FakeServer((reqId, _) => reqId > 1);
+            using var server = new FakeServer(ctx => ctx.RequestCount > 1);
             using var client = await server.ConnectClientAsync();
 
             await client.Tables.GetTablesAsync();
@@ -142,7 +142,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = null!
             };
 
-            using var server = new FakeServer((reqId, _) => reqId > 1);
+            using var server = new FakeServer(ctx => ctx.RequestCount > 1);
             using var client = await server.ConnectClientAsync(cfg);
 
             await client.Tables.GetTablesAsync();
@@ -160,7 +160,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = testRetryPolicy
             };
 
-            using var server = new FakeServer((reqId, _) => reqId % 3 == 0);
+            using var server = new FakeServer(ctx => ctx.RequestCount % 3 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             for (var i = 0; i < IterCount; i++)
@@ -188,7 +188,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = testRetryPolicy
             };
 
-            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
+            using var server = new FakeServer(ctx => ctx.RequestCount % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             await client.Tables.GetTablesAsync();
@@ -205,7 +205,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = new TestRetryPolicy { RetryLimit = 1 }
             };
 
-            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
+            using var server = new FakeServer(ctx => ctx.RequestCount % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             for (int i = 0; i < IterCount; i++)
@@ -224,7 +224,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = new TestRetryPolicy()
             };
 
-            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
+            using var server = new FakeServer(ctx => ctx.RequestCount % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
             var tx = await client.Transactions.BeginAsync();
 
@@ -242,7 +242,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = new TestRetryPolicy { RetryLimit = 1 }
             };
 
-            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
+            using var server = new FakeServer(ctx => ctx.RequestCount % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             for (int i = 0; i < IterCount; i++)
@@ -260,7 +260,7 @@ namespace Apache.Ignite.Tests
                 RetryPolicy = new RetryReadPolicy()
             };
 
-            using var server = new FakeServer((reqId, _) => reqId % 2 == 0);
+            using var server = new FakeServer(ctx => ctx.RequestCount % 2 == 0);
             using var client = await server.ConnectClientAsync(cfg);
 
             var table = await client.Tables.GetTableAsync(FakeServer.ExistingTableName);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaUpdateTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaUpdateTest.cs
@@ -62,7 +62,7 @@ public class SchemaUpdateTest
     [Test]
     public async Task TestFailedSchemaLoadTaskIsRetried()
     {
-        using var server = new FakeServer(shouldDropConnection: (idx, op) => op == ClientOp.SchemasGet && idx < 5)
+        using var server = new FakeServer(shouldDropConnection: ctx => ctx is { OpCode: ClientOp.SchemasGet, RequestCount: < 5 })
         {
             OperationDelay = TimeSpan.FromMilliseconds(100)
         };

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaUpdateTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaUpdateTest.cs
@@ -52,6 +52,8 @@ public class SchemaUpdateTest
             {
                 ClientOp.TableGet,
                 ClientOp.SchemasGet,
+                ClientOp.PartitionAssignmentGet,
+                ClientOp.TupleUpsert,
                 ClientOp.TupleUpsert
             },
             server.ClientOps);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaUpdateTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaUpdateTest.cs
@@ -58,4 +58,11 @@ public class SchemaUpdateTest
             },
             server.ClientOps);
     }
+
+    [Test]
+    public async Task TestFailedSchemaLoadTaskIsRetried()
+    {
+        await Task.Delay(1);
+        Assert.Fail("TODO");
+    }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaUpdateTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaUpdateTest.cs
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests.Table;
+
+using System;
+using System.Threading.Tasks;
+using Ignite.Table;
+using Internal.Proto;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests schema update logic.
+/// </summary>
+public class SchemaUpdateTest
+{
+    [Test]
+    public async Task TestMultipleParallelOperationsRequestSchemaOnce()
+    {
+        using var server = new FakeServer
+        {
+            OperationDelay = TimeSpan.FromMilliseconds(100)
+        };
+
+        using var client = await server.ConnectClientAsync();
+        var table = await client.Tables.GetTableAsync(FakeServer.ExistingTableName);
+        var view = table!.RecordBinaryView;
+
+        // Schema is not known initially, so both operations will request it.
+        // However, we cache the request task, so only one request will be sent.
+        var task1 = view.UpsertAsync(null, new IgniteTuple { ["id"] = 1 });
+        var task2 = view.UpsertAsync(null, new IgniteTuple { ["id"] = 2 });
+
+        await Task.WhenAll(task1, task2);
+
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                ClientOp.TableGet,
+                ClientOp.SchemasGet,
+                ClientOp.TupleUpsert
+            },
+            server.ClientOps);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaUpdateTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaUpdateTest.cs
@@ -62,10 +62,7 @@ public class SchemaUpdateTest
     [Test]
     public async Task TestFailedSchemaLoadTaskIsRetried()
     {
-        using var server = new FakeServer(shouldDropConnection: ctx => ctx is { OpCode: ClientOp.SchemasGet, RequestCount: < 3 })
-        {
-            OperationDelay = TimeSpan.FromMilliseconds(100)
-        };
+        using var server = new FakeServer(shouldDropConnection: ctx => ctx is { OpCode: ClientOp.SchemasGet, RequestCount: < 3 });
 
         var cfg = new IgniteClientConfiguration
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaUpdateTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaUpdateTest.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Tests.Table;
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Ignite.Table;
 using Internal.Proto;
@@ -47,16 +48,7 @@ public class SchemaUpdateTest
 
         await Task.WhenAll(task1, task2);
 
-        CollectionAssert.AreEqual(
-            new[]
-            {
-                ClientOp.TableGet,
-                ClientOp.SchemasGet,
-                ClientOp.PartitionAssignmentGet,
-                ClientOp.TupleUpsert,
-                ClientOp.TupleUpsert
-            },
-            server.ClientOps);
+        Assert.AreEqual(1, server.ClientOps.Count(x => x == ClientOp.SchemasGet), string.Join(", ", server.ClientOps));
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/TestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/TestUtils.cs
@@ -62,6 +62,14 @@ namespace Apache.Ignite.Tests
             Assert.Fail(message);
         }
 
+        public static T GetFieldValue<T>(this object obj, string fieldName)
+        {
+            var field = obj.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(field, $"Field '{fieldName}' not found in '{obj.GetType()}'");
+
+            return (T) field!.GetValue(obj)!;
+        }
+
         private static string GetSolutionDir()
         {
             var dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -20,7 +20,6 @@ namespace Apache.Ignite.Internal.Table
     using System;
     using System.Collections.Concurrent;
     using System.Diagnostics;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Buffers;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -175,7 +175,7 @@ namespace Apache.Ignite.Internal.Table
                 return _schemas[latestSchemaVersion];
             }
 
-            return LoadSchemaAsync(null);
+            return LoadSchemaAsync(version: null);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -207,7 +207,7 @@ namespace Apache.Ignite.Internal.Table
 
         private Task<Schema> GetCachedSchemaAsync(int version)
         {
-            var task = _schemas.GetOrAdd(version, static (ver, tbl) => tbl.LoadSchemaAsync(ver), this);
+            var task = GetOrAdd();
 
             if (!task.IsFaulted)
             {
@@ -217,7 +217,9 @@ namespace Apache.Ignite.Internal.Table
             // Do not return failed task. Remove it from the cache and try again.
             _schemas.TryRemove(new KeyValuePair<int, Task<Schema>>(version, task));
 
-            return _schemas.GetOrAdd(version, static (ver, tbl) => tbl.LoadSchemaAsync(ver), this);
+            return GetOrAdd();
+
+            Task<Schema> GetOrAdd() => _schemas.GetOrAdd(version, static (ver, tbl) => tbl.LoadSchemaAsync(ver), this);
         }
 
         private async ValueTask<string[]?> GetPartitionAssignmentAsync()

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -39,6 +39,9 @@ namespace Apache.Ignite.Internal.Table
     /// </summary>
     internal sealed class Table : ITable
     {
+        /** Unknown schema version. */
+        private const int UnknownSchemaVersion = -1;
+
         /** Socket. */
         private readonly ClientFailoverSocket _socket;
 
@@ -178,10 +181,8 @@ namespace Apache.Ignite.Internal.Table
                 return _schemas[latestSchemaVersion];
             }
 
-            // TODO: There is a race here - we can still load schema twice?
-            // We haven't loaded any schema yet, but if there is any pending task - return it.
-            return _schemas.Values.FirstOrDefault() ??
-                   LoadSchemaAsync(version: null);
+            // TODO: Check if task is failed.
+            return _schemas.GetOrAdd(UnknownSchemaVersion, static (v, tbl) => tbl.LoadSchemaAsync(v), this);
         }
 
         /// <summary>


### PR DESCRIPTION
Cache schema tasks instead of schemas (task results). If a given schema is already requested, await existing task instead of sending another request.