### PR TITLE
IGNITE-19605 ItDeploymentUnitTest is flaky

### DIFF
--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/commands/CliCommandTestNotInitializedIntegrationBase.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/commands/CliCommandTestNotInitializedIntegrationBase.java
@@ -94,7 +94,7 @@ public class CliCommandTestNotInitializedIntegrationBase extends CliIntegrationT
     }
 
     @AfterEach
-    void tearDown() {
+    public void tearDown() {
         session.disconnect();
     }
 

--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/commands/sql/CliSqlCommandTestBase.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/commands/sql/CliSqlCommandTestBase.java
@@ -31,8 +31,10 @@ public class CliSqlCommandTestBase extends CliCommandTestInitializedIntegrationB
         createAndPopulateTable();
     }
 
+    @Override
     @AfterEach
-    void tearDown() {
+    public void tearDown() {
+        super.tearDown();
         dropAllTables();
     }
 }

--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/ssl/ItJdbcSslTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/ssl/ItJdbcSslTest.java
@@ -36,8 +36,10 @@ public class ItJdbcSslTest extends CliSslClientConnectorIntegrationTestBase {
         createAndPopulateTable();
     }
 
+    @Override
     @AfterEach
-    void tearDown() {
+    public void tearDown() {
+        super.tearDown();
         dropAllTables();
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-19605

This test fail happens when previous test used `connect` command without paired `disconnect`, which leaves the periodic session task running.
When starting the nodes in the next test, it so happens that the request for the node configuration from the `JdbcUrlRegistryImpl` or any other periodic task is received while the Micronaut's context is starting in the `RestController` for the second node. In this case the `io.micronaut.core.convert.ConversionService#SHARED` is cleared and is not yet populated.
It's not entirely clear what happens next, but most probably the HTTP server caches the state where there's no corresponding type converter and this leaves the node in the broken state.

It doesn't seem possible to properly fix this outside of Micronaut, so there's just a workaround which adds missing `disconnect` calls.