### PR TITLE
IGNITE-19653 Fix NPEs in client test logs

### DIFF
--- a/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.apache.ignite.client.IgniteClient.Builder;
 import org.apache.ignite.client.fakes.FakeIgnite;
+import org.apache.ignite.client.fakes.FakeSession;
 import org.apache.ignite.internal.client.ClientMetricSource;
 import org.apache.ignite.internal.client.TcpIgniteClient;
 import org.apache.ignite.internal.testframework.IgniteTestUtils;
@@ -169,7 +170,7 @@ public class ClientMetricsTest {
         assertEquals(1, metrics().requestsSent());
         assertEquals(0, metrics().requestsRetried());
 
-        assertThrows(IgniteException.class, () -> client.sql().createSession().execute(null, "foo bar"));
+        assertThrows(IgniteException.class, () -> client.sql().createSession().execute(null, FakeSession.FAILED_SQL));
 
         assertEquals(0, metrics().requestsActive());
         assertEquals(1, metrics().requestsFailed());

--- a/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
@@ -195,7 +195,7 @@ public class TestClientHandlerModule implements IgniteComponent {
                                         configuration,
                                         compute,
                                         clusterService,
-                                        mock(IgniteSql.class),
+                                        ignite.sql(),
                                         clusterId,
                                         metrics,
                                         authenticationManager(authenticationConfiguration)));

--- a/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
@@ -48,7 +48,6 @@ import org.apache.ignite.internal.table.IgniteTablesInternal;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.network.ClusterService;
 import org.apache.ignite.network.NettyBootstrapFactory;
-import org.apache.ignite.sql.IgniteSql;
 import org.jetbrains.annotations.Nullable;
 
 /**

--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeAsyncResultSet.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeAsyncResultSet.java
@@ -196,7 +196,7 @@ public class FakeAsyncResultSet implements AsyncResultSet {
     /** {@inheritDoc} */
     @Override
     public CompletableFuture<? extends AsyncResultSet> fetchNextPage() {
-        return null;
+        return CompletableFuture.completedFuture(new FakeAsyncResultSet(session, transaction, statement, arguments));
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeSession.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeSession.java
@@ -38,6 +38,8 @@ import org.jetbrains.annotations.Nullable;
  * Client SQL session.
  */
 public class FakeSession implements Session {
+    public static final String FAILED_SQL = "SELECT FAIL";
+
     @Nullable
     private final Integer defaultPageSize;
 
@@ -91,6 +93,10 @@ public class FakeSession implements Session {
             Statement statement,
             @Nullable Object... arguments) {
         Objects.requireNonNull(statement);
+
+        if (FAILED_SQL.equals(statement.query())) {
+            return CompletableFuture.failedFuture(new RuntimeException("Query failed"));
+        }
 
         return CompletableFuture.completedFuture(new FakeAsyncResultSet(this, transaction, statement, arguments));
     }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -157,7 +157,7 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
 
         var cause = (IgniteException) ex.getCause();
 
-        assertThat(cause.getMessage(), containsString("NullPointerException: null ref"));
+        assertThat(cause.getMessage(), containsString("ArithmeticException: math err"));
         assertEquals(INTERNAL_ERR, cause.code());
         assertNull(cause.getCause()); // No stack trace by default.
     }
@@ -171,7 +171,7 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
 
         var cause = (IgniteException) ex.getCause();
 
-        assertThat(cause.getMessage(), containsString("NullPointerException: null ref"));
+        assertThat(cause.getMessage(), containsString("ArithmeticException: math err"));
         assertEquals(INTERNAL_ERR, cause.code());
 
         assertNotNull(cause.getCause());
@@ -263,7 +263,7 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
     private static class ExceptionJob implements ComputeJob<String> {
         @Override
         public String execute(JobExecutionContext context, Object... args) {
-            throw new NullPointerException("null ref");
+            throw new ArithmeticException("math err");
         }
     }
 


### PR DESCRIPTION
TeamCity now triggers a failure condition on **NullReferenceException** in the log - it usually indicates a bug. Fix client tests to avoid NPEs.