### PR TITLE
IGNITE-19659 NPE in ClusterConfigRegistryImpl.fetchConfig

### DIFF
--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/ssl/ItSslTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/ssl/ItSslTest.java
@@ -19,18 +19,34 @@ package org.apache.ignite.internal.cli.ssl;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import jakarta.inject.Inject;
 import org.apache.ignite.internal.NodeConfig;
+import org.apache.ignite.internal.cli.call.connect.ConnectCall;
+import org.apache.ignite.internal.cli.core.call.UrlCallInput;
+import org.apache.ignite.internal.cli.core.flow.builder.Flows;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /** Tests for SSL. */
 public class ItSslTest extends CliSslNotInitializedIntegrationTestBase {
+    @Inject
+    ConnectCall connectCall;
+
+    /** Mimics non-REPL "connect" command without starting REPL mode. Overriding getCommandClass and returning TopLevelCliReplCommand
+     * wouldn't help because it will start to ask questions.
+     */
+    private void connect(String url) {
+        Flows.from(new UrlCallInput(url))
+                .then(Flows.fromCall(connectCall))
+                .print()
+                .start();
+    }
 
     @Test
     @DisplayName("Should get SSL error, when connect to secured node without SSL settings")
     void connectToSecuredNodeWithoutSslSettings() {
         // When connect via HTTPS without SSL
-        execute("connect", "https://localhost:10401");
+        connect("https://localhost:10401");
 
         // Then
         assertAll(
@@ -50,7 +66,7 @@ public class ItSslTest extends CliSslNotInitializedIntegrationTestBase {
         resetOutput();
 
         // And connect via HTTPS
-        execute("connect", "https://localhost:10401");
+        connect("https://localhost:10401");
 
         // Then
         assertAll(
@@ -70,7 +86,7 @@ public class ItSslTest extends CliSslNotInitializedIntegrationTestBase {
         resetOutput();
 
         // And connect via HTTPS
-        execute("connect", "https://localhost:10401");
+        connect("https://localhost:10401");
 
         // Then
         assertAll(
@@ -90,7 +106,7 @@ public class ItSslTest extends CliSslNotInitializedIntegrationTestBase {
         resetOutput();
 
         // And connect via HTTPS
-        execute("connect", "https://localhost:10401");
+        connect("https://localhost:10401");
 
         // Then
         assertAll(
@@ -110,7 +126,7 @@ public class ItSslTest extends CliSslNotInitializedIntegrationTestBase {
         resetOutput();
 
         // And connect via HTTPS
-        execute("connect", "https://localhost:10401");
+        connect("https://localhost:10401");
 
         // Then
         assertAll(
@@ -130,7 +146,7 @@ public class ItSslTest extends CliSslNotInitializedIntegrationTestBase {
         resetOutput();
 
         // And connect via HTTPS
-        execute("connect", "https://localhost:10401");
+        connect("https://localhost:10401");
 
         // Then
         assertAll(

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/MetricRegistryImpl.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/MetricRegistryImpl.java
@@ -19,14 +19,17 @@ package org.apache.ignite.internal.cli.core.repl.registry.impl;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.ignite.internal.cli.call.node.metric.NodeMetricSourceListCall;
+import org.apache.ignite.internal.cli.core.call.CallOutput;
 import org.apache.ignite.internal.cli.core.call.UrlCallInput;
 import org.apache.ignite.internal.cli.core.repl.AsyncSessionEventListener;
 import org.apache.ignite.internal.cli.core.repl.SessionInfo;
 import org.apache.ignite.internal.cli.core.repl.registry.MetricRegistry;
 import org.apache.ignite.rest.client.model.MetricSource;
+import org.jetbrains.annotations.Nullable;
 
 /** Implementation of {@link MetricRegistry}. */
 @Singleton
@@ -54,9 +57,13 @@ public class MetricRegistryImpl implements MetricRegistry, AsyncSessionEventList
         metricSourcesRef = new LazyObjectRef<>(() -> fetchMetricSources(sessionInfo));
     }
 
+    @Nullable
     private Set<String> fetchMetricSources(SessionInfo sessionInfo) {
-        return metricSourceListCall.execute(new UrlCallInput(sessionInfo.nodeUrl()))
-                .body().stream()
+        CallOutput<List<MetricSource>> output = metricSourceListCall.execute(new UrlCallInput(sessionInfo.nodeUrl()));
+        if (output.hasError()) {
+            return null;
+        }
+        return output.body().stream()
                 .map(MetricSource::getName)
                 .collect(Collectors.toSet());
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-19659

First NPE is shown in the logs when we connect to uninitialized cluster.
Second NPE is shown when we run non-REPL `connect` command without proper environment.