### PR TITLE
IGNITE-17765 Sql. Avoid parsing queries that already have cached plans.

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
@@ -105,7 +105,7 @@ public class ItDmlTest extends ClusterPerClassIntegrationTest {
     public void failMergeOpOnChangePrimaryKey() {
         clearAndPopulateMergeTable1();
 
-        clearAndPopulateMergeTable2();
+        clearAndPopulateMergeTable2(true);
 
         String sql = "MERGE INTO test2 dst USING test1 src ON dst.a = src.a "
                 + "WHEN MATCHED THEN UPDATE SET b = src.b, k1 = src.k1 "
@@ -191,80 +191,90 @@ public class ItDmlTest extends ClusterPerClassIntegrationTest {
     public void testMerge() {
         clearAndPopulateMergeTable1();
 
-        clearAndPopulateMergeTable2();
+        clearAndPopulateMergeTable2(true);
 
-        String sql = "MERGE INTO test2 dst USING test1 src ON dst.a = src.a "
-                + "WHEN MATCHED THEN UPDATE SET b = 100 * src.b "
-                + "WHEN NOT MATCHED THEN INSERT (k1, k2, a, b) VALUES (src.k1, src.k2, 10 * src.a, src.b)";
+        for (int i = 0; i < 10; i++) {
+            System.out.println(">xxx> itr " + i);
 
-        sql(sql);
+            String sql = "MERGE INTO test2 dst USING test1 src ON dst.a = src.a "
+                    + "WHEN MATCHED THEN UPDATE SET b = 100 * src.b "
+                    + "WHEN NOT MATCHED THEN INSERT (k1, k2, a, b) VALUES (src.k1, src.k2, 10 * src.a, src.b)";
 
-        assertQuery("SELECT * FROM test2 ORDER BY k1")
-                .returns(222, 222, 10, 300, null)
-                .returns(333, 333, 0, 10000, "")
-                .returns(444, 444, 2, 200, null)
-                .check();
+            sql(sql);
 
-        // ---- the same but ON fld _a = src.a_ append to MATCHED too
-        clearAndPopulateMergeTable2();
+            assertQuery("SELECT * FROM test2 ORDER BY k1")
+                    .returns(222, 222, 10, 300, null)
+                    .returns(333, 333, 0, 10000, "")
+                    .returns(444, 444, 2, 200, null)
+                    .check();
 
-        sql = "MERGE INTO test2 dst USING test1 src ON dst.a = src.a "
-                + "WHEN MATCHED THEN UPDATE SET b = src.b, a = src.a "
-                + "WHEN NOT MATCHED THEN INSERT (k1, k2, a, b) VALUES (src.k1, src.k2, src.a, src.b)";
+            // ---- the same but ON fld _a = src.a_ append to MATCHED too
+            clearAndPopulateMergeTable2(false);
 
-        sql(sql);
+            sql = "MERGE INTO test2 dst USING test1 src ON dst.a = src.a "
+                    + "WHEN MATCHED THEN UPDATE SET b = src.b, a = src.a "
+                    + "WHEN NOT MATCHED THEN INSERT (k1, k2, a, b) VALUES (src.k1, src.k2, src.a, src.b)";
 
-        assertQuery("SELECT * FROM test2 ORDER BY k1")
-                .returns(222, 222, 1, 300, null)
-                .returns(333, 333, 0, 100, "")
-                .returns(444, 444, 2, 200, null)
-                .check();
+            sql(sql);
 
-        // ---- all flds covered on NOT MATCHED
-        clearAndPopulateMergeTable2();
+            assertQuery("SELECT * FROM test2 ORDER BY k1")
+                    .returns(222, 222, 1, 300, null)
+                    .returns(333, 333, 0, 100, "")
+                    .returns(444, 444, 2, 200, null)
+                    .check();
 
-        sql = "MERGE INTO test2 dst USING test1 src ON dst.a = src.a "
-                + "WHEN MATCHED THEN UPDATE SET b = src.b, a = src.a "
-                + "WHEN NOT MATCHED THEN INSERT (k1, k2, a, b, c) VALUES (src.k1, src.k2, src.a, src.b, src.c)";
+            // ---- all flds covered on NOT MATCHED
+            clearAndPopulateMergeTable2(false);
 
-        sql(sql);
+            sql = "MERGE INTO test2 dst USING test1 src ON dst.a = src.a "
+                    + "WHEN MATCHED THEN UPDATE SET b = src.b, a = src.a "
+                    + "WHEN NOT MATCHED THEN INSERT (k1, k2, a, b, c) VALUES (src.k1, src.k2, src.a, src.b, src.c)";
 
-        assertQuery("SELECT * FROM test2 ORDER BY k1")
-                .returns(222, 222, 1, 300, "1")
-                .returns(333, 333, 0, 100, "")
-                .returns(444, 444, 2, 200, null)
-                .check();
+            sql(sql);
 
-        // --- only WHEN MATCHED section.
-        clearAndPopulateMergeTable2();
+            assertQuery("SELECT * FROM test2 ORDER BY k1")
+                    .returns(222, 222, 1, 300, "1")
+                    .returns(333, 333, 0, 100, "")
+                    .returns(444, 444, 2, 200, null)
+                    .check();
 
-        sql = "MERGE INTO test2 dst USING test1 src ON dst.a = src.a "
-                + "WHEN MATCHED THEN UPDATE SET b = src.b, a = src.a";
-        sql(sql);
+            // --- only WHEN MATCHED section.
+            clearAndPopulateMergeTable2(false);
 
-        assertQuery("SELECT * FROM test2 ORDER BY k1")
-                .returns(333, 333, 0, 100, "")
-                .returns(444, 444, 2, 200, null)
-                .check();
+            sql = "MERGE INTO test2 dst USING test1 src ON dst.a = src.a "
+                    + "WHEN MATCHED THEN UPDATE SET b = src.b, a = src.a";
+            sql(sql);
 
-        // ---- only WHEN NOT MATCHED section.
-        clearAndPopulateMergeTable2();
+            assertQuery("SELECT * FROM test2 ORDER BY k1")
+                    .returns(333, 333, 0, 100, "")
+                    .returns(444, 444, 2, 200, null)
+                    .check();
 
-        sql = "MERGE INTO test2 dst USING test1 src ON dst.a = src.a "
-                + "WHEN NOT MATCHED THEN INSERT (k1, k2, a, b, c) VALUES (src.k1, src.k2, src.a, src.b, src.c)";
+            // ---- only WHEN NOT MATCHED section.
+            clearAndPopulateMergeTable2(false);
 
-        sql(sql);
+            sql = "MERGE INTO test2 dst USING test1 src ON dst.a = src.a "
+                    + "WHEN NOT MATCHED THEN INSERT (k1, k2, a, b, c) VALUES (src.k1, src.k2, src.a, src.b, src.c)";
 
-        assertQuery("SELECT * FROM test2 ORDER BY k1")
-                .returns(222, 222, 1, 300, "1")
-                .returns(333, 333, 0, 100, "")
-                .returns(444, 444, 2, 200, null)
-                .check();
+            sql(sql);
+
+            assertQuery("SELECT * FROM test2 ORDER BY k1")
+                    .returns(222, 222, 1, 300, "1")
+                    .returns(333, 333, 0, 100, "")
+                    .returns(444, 444, 2, 200, null)
+                    .check();
+
+            clearAndPopulateMergeTable2(false);
+        }
     }
 
-    private void clearAndPopulateMergeTable2() {
-        sql("DROP TABLE IF EXISTS test2 ");
-        sql("CREATE TABLE test2 (k1 int, k2 int, a int, b int, c varchar, CONSTRAINT PK PRIMARY KEY (k1, k2))");
+    private void clearAndPopulateMergeTable2(boolean recreate) {
+        if (recreate) {
+            sql("DROP TABLE IF EXISTS test2 ");
+            sql("CREATE TABLE test2 (k1 int, k2 int, a int, b int, c varchar, CONSTRAINT PK PRIMARY KEY (k1, k2))");
+        } else {
+            sql("DELETE FROM test2");
+        }
         sql("INSERT INTO test2 VALUES (333, 333, 0, 100, '')");
         sql("INSERT INTO test2 VALUES (444, 444, 2, 200, null)");
     }
@@ -385,9 +395,9 @@ public class ItDmlTest extends ClusterPerClassIntegrationTest {
         sql("CREATE TABLE test2 (k int PRIMARY KEY, a int, b int)");
 
         IgniteException ex = assertThrows(IgniteException.class, () -> sql(
-                        "MERGE INTO test2 USING test1 ON test1.a = test2.a "
-                                + "WHEN MATCHED THEN UPDATE SET b = test1.b + 1 "
-                                + "WHEN NOT MATCHED THEN INSERT (k, a, b) VALUES (0, a, b)"));
+                "MERGE INTO test2 USING test1 ON test1.a = test2.a "
+                        + "WHEN MATCHED THEN UPDATE SET b = test1.b + 1 "
+                        + "WHEN NOT MATCHED THEN INSERT (k, a, b) VALUES (0, a, b)"));
 
         assertEquals(Sql.DUPLICATE_KEYS_ERR, ex.code());
     }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
@@ -646,7 +646,7 @@ public class ItDmlTest extends ClusterPerClassIntegrationTest {
         CyclicBarrier barrier = new CyclicBarrier(threads);
 
         SqlQueryProcessor queryProc = (SqlQueryProcessor) ((IgniteImpl) CLUSTER_NODES.get(0)).queryEngine();
-        Map<?, ?> cache = IgniteTestUtils.getFieldValue(queryProc, "planCache");
+        Map<?, ?> cache = IgniteTestUtils.getFieldValue(queryProc, "queryCache");
 
         assertEquals(0, cache.size());
 

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/SqlQueryProcessor.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/SqlQueryProcessor.java
@@ -410,15 +410,12 @@ public class SqlQueryProcessor implements QueryProcessor {
         AtomicReference<InternalTransaction> tx = new AtomicReference<>();
 
         CompletableFuture<AsyncSqlCursor<List<Object>>> stage = start
-                .thenApply(v -> {
+                .thenCompose(v -> {
                     StatementParseResult parseResult = IgniteSqlParser.parse(sql, StatementParseResult.MODE);
                     SqlNode sqlNode = parseResult.statement();
 
                     validateParsedStatement(context, outerTx, parseResult, sqlNode, params);
 
-                    return sqlNode;
-                })
-                .thenCompose(sqlNode -> {
                     boolean rwOp = dataModificationOp(sqlNode);
 
                     boolean implicitTxRequired = outerTx == null;

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/CacheKey.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/CacheKey.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
  * context could be schema name, dynamic parameters, and so on...
  */
 public class CacheKey {
-    public static final Class[] EMPTY_CLASS_ARRAY = {};
+    private static final Class[] EMPTY_CLASS_ARRAY = {};
 
     private final String schemaName;
 
@@ -38,12 +38,14 @@ public class CacheKey {
      *
      * @param schemaName Schema name.
      * @param query      Query string.
-     * @param paramTypes Types of all dynamic parameters, no any type can be {@code null}.
+     * @param params     Dynamic parameters.
      */
-    public CacheKey(String schemaName, String query, Class[] paramTypes) {
+    public CacheKey(String schemaName, String query, Object[] params) {
         this.schemaName = schemaName;
         this.query = query;
-        this.paramTypes = paramTypes;
+        this.paramTypes = params.length == 0
+                ? EMPTY_CLASS_ARRAY
+                : Arrays.stream(params).map(p -> (p != null) ? p.getClass() : Void.class).toArray(Class[]::new);
     }
 
     /** {@inheritDoc} */

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/CacheKey.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/CacheKey.java
@@ -18,7 +18,6 @@
 package org.apache.ignite.internal.sql.engine.prepare;
 
 import java.util.Arrays;
-import java.util.Objects;
 
 /**
  * CacheKey.
@@ -36,7 +35,8 @@ public class CacheKey {
 
     /**
      * Constructor.
-     *  @param schemaName Schema name.
+     *
+     * @param schemaName Schema name.
      * @param query      Query string.
      * @param paramTypes Types of all dynamic parameters, no any type can be {@code null}.
      */

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/CacheKey.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/CacheKey.java
@@ -32,34 +32,18 @@ public class CacheKey {
 
     private final String query;
 
-    private final Object contextKey;
-
     private final Class[] paramTypes;
 
     /**
      * Constructor.
-     *
-     * @param schemaName Schema name.
+     *  @param schemaName Schema name.
      * @param query      Query string.
-     * @param contextKey Optional context key to differ queries with and without/different flags, having an impact on result plan (like
-     *                   LOCAL flag)
      * @param paramTypes Types of all dynamic parameters, no any type can be {@code null}.
      */
-    public CacheKey(String schemaName, String query, Object contextKey, Class[] paramTypes) {
+    public CacheKey(String schemaName, String query, Class[] paramTypes) {
         this.schemaName = schemaName;
         this.query = query;
-        this.contextKey = contextKey;
         this.paramTypes = paramTypes;
-    }
-
-    /**
-     * Constructor.
-     *
-     * @param schemaName Schema name.
-     * @param query      Query string.
-     */
-    public CacheKey(String schemaName, String query) {
-        this(schemaName, query, null, EMPTY_CLASS_ARRAY);
     }
 
     /** {@inheritDoc} */
@@ -80,9 +64,6 @@ public class CacheKey {
         if (!query.equals(cacheKey.query)) {
             return false;
         }
-        if (!Objects.equals(contextKey, cacheKey.contextKey)) {
-            return false;
-        }
 
         return Arrays.deepEquals(paramTypes, cacheKey.paramTypes);
     }
@@ -91,7 +72,6 @@ public class CacheKey {
     public int hashCode() {
         int result = schemaName.hashCode();
         result = 31 * result + query.hashCode();
-        result = 31 * result + (contextKey != null ? contextKey.hashCode() : 0);
         result = 31 * result + Arrays.deepHashCode(paramTypes);
         return result;
     }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PrepareServiceImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PrepareServiceImpl.java
@@ -19,7 +19,6 @@ package org.apache.ignite.internal.sql.engine.prepare;
 
 import static org.apache.ignite.internal.sql.engine.prepare.CacheKey.EMPTY_CLASS_ARRAY;
 import static org.apache.ignite.internal.sql.engine.prepare.PlannerHelper.optimize;
-import static org.apache.ignite.internal.sql.engine.trait.TraitUtils.distributionPresent;
 import static org.apache.ignite.lang.ErrorGroups.Sql.QUERY_VALIDATION_ERR;
 import static org.apache.ignite.lang.ErrorGroups.Sql.UNSUPPORTED_SQL_OPERATION_KIND_ERR;
 
@@ -213,13 +212,11 @@ public class PrepareServiceImpl implements PrepareService, SchemaUpdateListener 
     }
 
     private CompletableFuture<QueryPlan> prepareQuery(SqlNode sqlNode, PlanningContext ctx) {
-        boolean distributed = distributionPresent(ctx.config().getTraitDefs());
-
         Class[] paramTypes = ctx.parameters().length == 0
                 ? EMPTY_CLASS_ARRAY :
                 Arrays.stream(ctx.parameters()).map(p -> (p != null) ? p.getClass() : Void.class).toArray(Class[]::new);
 
-        var key = new CacheKey(ctx.schemaName(), sqlNode.toString(), distributed, paramTypes);
+        var key = new CacheKey(ctx.schemaName(), sqlNode.toString(), null, paramTypes);
 
         CompletableFuture<QueryPlan> planFut = cache.computeIfAbsent(key, k -> CompletableFuture.supplyAsync(() -> {
             IgnitePlanner planner = ctx.planner();

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PrepareServiceImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PrepareServiceImpl.java
@@ -194,7 +194,7 @@ public class PrepareServiceImpl implements PrepareService {
     }
 
     private CompletableFuture<QueryPlan> prepareQuery(SqlNode sqlNode, PlanningContext ctx) {
-        CompletableFuture<MultiStepQueryPlan> planFut = CompletableFuture.supplyAsync(() -> {
+        return CompletableFuture.supplyAsync(() -> {
             IgnitePlanner planner = ctx.planner();
 
             // Validate
@@ -211,12 +211,10 @@ public class PrepareServiceImpl implements PrepareService {
 
             return new MultiStepQueryPlan(template, resultSetMetadata(validated.dataType(), validated.origins()));
         }, planningPool);
-
-        return planFut.thenApply(QueryPlan::copy);
     }
 
     private CompletableFuture<QueryPlan> prepareDml(SqlNode sqlNode, PlanningContext ctx) {
-        CompletableFuture<MultiStepDmlPlan> planFut = CompletableFuture.supplyAsync(() -> {
+        return CompletableFuture.supplyAsync(() -> {
             IgnitePlanner planner = ctx.planner();
 
             // Validate
@@ -232,8 +230,6 @@ public class PrepareServiceImpl implements PrepareService {
 
             return new MultiStepDmlPlan(template);
         }, planningPool);
-
-        return planFut.thenApply(QueryPlan::copy);
     }
 
     private ResultSetMetadata resultSetMetadata(

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PrepareServiceImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PrepareServiceImpl.java
@@ -218,7 +218,25 @@ public class PrepareServiceImpl implements PrepareService, SchemaUpdateListener 
 
         var key = new CacheKey(ctx.schemaName(), sqlNode.toString(), null, paramTypes);
 
-        CompletableFuture<QueryPlan> planFut = cache.computeIfAbsent(key, k -> CompletableFuture.supplyAsync(() -> {
+//        CompletableFuture<QueryPlan> planFut = cache.computeIfAbsent(key, k -> CompletableFuture.supplyAsync(() -> {
+//            IgnitePlanner planner = ctx.planner();
+//
+//            // Validate
+//            ValidationResult validated = planner.validateAndGetTypeMetadata(sqlNode);
+//
+//            SqlNode validatedNode = validated.sqlNode();
+//
+//            IgniteRel igniteRel = optimize(validatedNode, planner);
+//
+//            // Split query plan to query fragments.
+//            List<Fragment> fragments = new Splitter().go(igniteRel);
+//
+//            QueryTemplate template = new QueryTemplate(fragments);
+//
+//            return new MultiStepQueryPlan(template, resultSetMetadata(validated.dataType(), validated.origins()));
+//        }, planningPool));
+
+        CompletableFuture<MultiStepQueryPlan> planFut = CompletableFuture.supplyAsync(() -> {
             IgnitePlanner planner = ctx.planner();
 
             // Validate
@@ -234,7 +252,7 @@ public class PrepareServiceImpl implements PrepareService, SchemaUpdateListener 
             QueryTemplate template = new QueryTemplate(fragments);
 
             return new MultiStepQueryPlan(template, resultSetMetadata(validated.dataType(), validated.origins()));
-        }, planningPool));
+        }, planningPool);
 
         return planFut.thenApply(QueryPlan::copy);
     }
@@ -242,7 +260,24 @@ public class PrepareServiceImpl implements PrepareService, SchemaUpdateListener 
     private CompletableFuture<QueryPlan> prepareDml(SqlNode sqlNode, PlanningContext ctx) {
         var key = new CacheKey(ctx.schemaName(), sqlNode.toString());
 
-        CompletableFuture<QueryPlan> planFut = cache.computeIfAbsent(key, k -> CompletableFuture.supplyAsync(() -> {
+//        CompletableFuture<QueryPlan> planFut = cache.computeIfAbsent(key, k -> CompletableFuture.supplyAsync(() -> {
+//            IgnitePlanner planner = ctx.planner();
+//
+//            // Validate
+//            SqlNode validatedNode = planner.validate(sqlNode);
+//
+//            // Convert to Relational operators graph
+//            IgniteRel igniteRel = optimize(validatedNode, planner);
+//
+//            // Split query plan to query fragments.
+//            List<Fragment> fragments = new Splitter().go(igniteRel);
+//
+//            QueryTemplate template = new QueryTemplate(fragments);
+//
+//            return new MultiStepDmlPlan(template);
+//        }, planningPool));
+
+        CompletableFuture<MultiStepDmlPlan> planFut = CompletableFuture.supplyAsync(() -> {
             IgnitePlanner planner = ctx.planner();
 
             // Validate
@@ -257,7 +292,7 @@ public class PrepareServiceImpl implements PrepareService, SchemaUpdateListener 
             QueryTemplate template = new QueryTemplate(fragments);
 
             return new MultiStepDmlPlan(template);
-        }, planningPool));
+        }, planningPool);
 
         return planFut.thenApply(QueryPlan::copy);
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-17765

InsertBenchmark on local machine shows the following results:

|cache type| disabled | query plan optimization |query parse + plan optimization|
| --- | ----------- |-|-|
| ms/op | 2.441 | 0.924 |    0.659 |