### PR TITLE
IGNITE-19689 fix ItClusterManagerTest.testClusterConfigurationIsRemovedFromClusterStateAfterUpdating

### DIFF
--- a/modules/cluster-management/src/integrationTest/java/org/apache/ignite/internal/cluster/management/ItClusterManagerTest.java
+++ b/modules/cluster-management/src/integrationTest/java/org/apache/ignite/internal/cluster/management/ItClusterManagerTest.java
@@ -51,6 +51,7 @@ import org.apache.ignite.network.ClusterNode;
 import org.awaitility.Awaitility;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -350,6 +351,7 @@ public class ItClusterManagerTest extends BaseItClusterManagementTest {
         assertThat(node.clusterManager().onJoinReady(), willCompleteSuccessfully());
     }
 
+    @RepeatedTest(100)
     @Test
     void testClusterConfigurationIsRemovedFromClusterStateAfterUpdating(TestInfo testInfo) throws Exception {
         // Start a cluster of 3 nodes so that the CMG leader node could be stopped later.

--- a/modules/cluster-management/src/integrationTest/java/org/apache/ignite/internal/cluster/management/ItClusterManagerTest.java
+++ b/modules/cluster-management/src/integrationTest/java/org/apache/ignite/internal/cluster/management/ItClusterManagerTest.java
@@ -51,7 +51,6 @@ import org.apache.ignite.network.ClusterNode;
 import org.awaitility.Awaitility;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -351,7 +350,6 @@ public class ItClusterManagerTest extends BaseItClusterManagementTest {
         assertThat(node.clusterManager().onJoinReady(), willCompleteSuccessfully());
     }
 
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-19689")
     @Test
     void testClusterConfigurationIsRemovedFromClusterStateAfterUpdating(TestInfo testInfo) throws Exception {
         // Start a cluster of 3 nodes so that the CMG leader node could be stopped later.
@@ -383,6 +381,7 @@ public class ItClusterManagerTest extends BaseItClusterManagementTest {
 
         // Wait for a new leader to be elected.
         MockNode newLeaderNode = Awaitility.await()
+                .timeout(60, TimeUnit.SECONDS)
                 .until(() -> findLeaderNode(cluster), Optional::isPresent)
                 .get();
 

--- a/modules/cluster-management/src/integrationTest/java/org/apache/ignite/internal/cluster/management/ItClusterManagerTest.java
+++ b/modules/cluster-management/src/integrationTest/java/org/apache/ignite/internal/cluster/management/ItClusterManagerTest.java
@@ -51,7 +51,6 @@ import org.apache.ignite.network.ClusterNode;
 import org.awaitility.Awaitility;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -351,7 +350,6 @@ public class ItClusterManagerTest extends BaseItClusterManagementTest {
         assertThat(node.clusterManager().onJoinReady(), willCompleteSuccessfully());
     }
 
-    @RepeatedTest(100)
     @Test
     void testClusterConfigurationIsRemovedFromClusterStateAfterUpdating(TestInfo testInfo) throws Exception {
         // Start a cluster of 3 nodes so that the CMG leader node could be stopped later.


### PR DESCRIPTION
Increase timeout of electing a new leader