### PR TITLE
IGNITE-19393 Java thin 3.0: testAccessLockedKeyTimesOut is flaky

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientTransactionsTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientTransactionsTest.java
@@ -188,10 +188,15 @@ public class ItThinClientTransactionsTest extends ItAbstractThinClientTest {
     }
 
     @Test
-    void testAccessLockedKeyTimesOut() {
+    void testAccessLockedKeyTimesOut() throws Exception {
         KeyValueView<Integer, String> kvView = kvView();
 
         Transaction tx1 = client().transactions().begin();
+
+        // Here we guarantee that tx2 will strictly after tx2 even if the transactions start in different server nodes.
+        // TODO:IGNITE-19849 Generate transaction id in client side
+        Thread.sleep(50);
+
         Transaction tx2 = client().transactions().begin();
 
         kvView.put(tx2, -100, "1");

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientTransactionsTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientTransactionsTest.java
@@ -194,7 +194,7 @@ public class ItThinClientTransactionsTest extends ItAbstractThinClientTest {
         Transaction tx1 = client().transactions().begin();
 
         // Here we guarantee that tx2 will strictly after tx2 even if the transactions start in different server nodes.
-        // TODO:IGNITE-19849 Generate transaction id in client side
+        // TODO: https://issues.apache.org/jira/browse/IGNITE-19900 Client should participate in RW TX clock adjustment
         Thread.sleep(50);
 
         Transaction tx2 = client().transactions().begin();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-19393