### PR TITLE
IGNITE-19826 .NET: Fix partition awareness node ids

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Common/CollectionExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Common/CollectionExtensions.cs
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests.Common;
+
+using System;
+using System.Collections.Generic;
+
+public static class CollectionExtensions
+{
+    public static void ForEach<T>(this IEnumerable<T> source, Action<T> action)
+    {
+        foreach (var item in source)
+        {
+            action(item);
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -286,9 +286,10 @@ namespace Apache.Ignite.Tests.Compute
             Assert.AreEqual(expectedNodeName, resNodeName2);
             Assert.AreEqual(expectedNodeName, resNodeName3);
 
-            // Assert.AreEqual(expectedNodeName, requestTargetNodeName);
-            // Assert.AreEqual(expectedNodeName, requestTargetNodeName2);
-            // Assert.AreEqual(expectedNodeName, requestTargetNodeName3);
+            // TODO: Why requests go to a wrong node?
+            Assert.AreEqual(expectedNodeName, requestTargetNodeName);
+            Assert.AreEqual(expectedNodeName, requestTargetNodeName2);
+            Assert.AreEqual(expectedNodeName, requestTargetNodeName3);
             void ClearOps() => proxies.Values.ForEach(p => p.ClearOps());
 
             string GetRequestTargetNodeName() =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -286,10 +286,11 @@ namespace Apache.Ignite.Tests.Compute
             Assert.AreEqual(expectedNodeName, resNodeName2);
             Assert.AreEqual(expectedNodeName, resNodeName3);
 
-            // TODO: Why requests go to a wrong node?
+            // TODO: Why requests go to a wrong node? Because we don't have direct connection to all of them!
             Assert.AreEqual(expectedNodeName, requestTargetNodeName);
             Assert.AreEqual(expectedNodeName, requestTargetNodeName2);
             Assert.AreEqual(expectedNodeName, requestTargetNodeName3);
+
             void ClearOps() => proxies.Values.ForEach(p => p.ClearOps());
 
             string GetRequestTargetNodeName() =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -287,6 +287,7 @@ namespace Apache.Ignite.Tests.Compute
             Assert.AreEqual(expectedNodeName, resNodeName3);
 
             // TODO: Why requests go to a wrong node? Because we don't have direct connection to all of them!
+            // And we can't connect to all because of different auth settings.
             Assert.AreEqual(expectedNodeName, requestTargetNodeName);
             Assert.AreEqual(expectedNodeName, requestTargetNodeName2);
             Assert.AreEqual(expectedNodeName, requestTargetNodeName3);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -244,10 +244,14 @@ namespace Apache.Ignite.Tests.Compute
 
         [Test]
         [TestCase(1, "_4")]
+        [TestCase(2, "_4")]
+        [TestCase(4, "_2")]
         [TestCase(5, "_2")]
+        [TestCase(6, "")]
+        [TestCase(7, "_4")]
+        [TestCase(8, "_2")]
         [TestCase(9, "_3")]
         [TestCase(10, "")]
-        [TestCase(11, "_2")]
         public async Task TestExecuteColocated(long key, string nodeName)
         {
             var proxies = Client.GetConnections().ToDictionary(c => c.Node.Name, c => new IgniteProxy(c.Node.Address));
@@ -277,14 +281,14 @@ namespace Apache.Ignite.Tests.Compute
             var requestTargetNodeName3 = GetRequestTargetNodeName();
 
             var expectedNodeName = PlatformTestNodeRunner + nodeName;
+
             Assert.AreEqual(expectedNodeName, resNodeName);
             Assert.AreEqual(expectedNodeName, resNodeName2);
             Assert.AreEqual(expectedNodeName, resNodeName3);
 
-            Assert.AreEqual(expectedNodeName, requestTargetNodeName);
-            Assert.AreEqual(expectedNodeName, requestTargetNodeName2);
-            Assert.AreEqual(expectedNodeName, requestTargetNodeName3);
-
+            // Assert.AreEqual(expectedNodeName, requestTargetNodeName);
+            // Assert.AreEqual(expectedNodeName, requestTargetNodeName2);
+            // Assert.AreEqual(expectedNodeName, requestTargetNodeName3);
             void ClearOps() => proxies.Values.ForEach(p => p.ClearOps());
 
             string GetRequestTargetNodeName() =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -252,6 +252,7 @@ namespace Apache.Ignite.Tests.Compute
         [TestCase(8, 2)]
         [TestCase(9, 3)]
         [TestCase(10, 1)]
+        [TestCase(11, 2)]
         public async Task TestExecuteColocated(long key, int nodeIdx)
         {
             var proxies = Client.GetConnections().ToDictionary(c => c.Node.Name, c => new IgniteProxy(c.Node.Address));
@@ -287,8 +288,7 @@ namespace Apache.Ignite.Tests.Compute
             Assert.AreEqual(expectedNodeName, resNodeName2);
             Assert.AreEqual(expectedNodeName, resNodeName3);
 
-            // TODO: Why requests go to a wrong node? Because we don't have direct connection to all of them!
-            // And we can't connect to all because of different auth settings.
+            // We only connect to 2 of 4 nodes because of different auth settings.
             if (nodeIdx < 3)
             {
                 Assert.AreEqual(expectedNodeName, requestTargetNodeName);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -251,20 +251,17 @@ namespace Apache.Ignite.Tests.Compute
             // ReSharper disable once AccessToDisposedClosure
             TestUtils.WaitForCondition(() => client.GetConnections().Count == proxies.Count);
 
-            ClearOps();
             var keyTuple = new IgniteTuple { [KeyCol] = key };
             var resNodeName = await client.Compute.ExecuteColocatedAsync<string>(TableName, keyTuple, Units, NodeNameJob);
-            var requestTargetNodeName = GetRequestTargetNodeName();
+            var requestTargetNodeName = GetRequestTargetNodeName(proxies, ClientOp.ComputeExecuteColocated);
 
-            ClearOps();
             var keyPoco = new Poco { Key = key };
             var resNodeName2 = await client.Compute.ExecuteColocatedAsync<string, Poco>(TableName, keyPoco, Units.Reverse(), NodeNameJob);
-            var requestTargetNodeName2 = GetRequestTargetNodeName();
+            var requestTargetNodeName2 = GetRequestTargetNodeName(proxies, ClientOp.ComputeExecuteColocated);
 
-            ClearOps();
             var keyPocoStruct = new PocoStruct(key, null);
             var resNodeName3 = await client.Compute.ExecuteColocatedAsync<string, PocoStruct>(TableName, keyPocoStruct, Units, NodeNameJob);
-            var requestTargetNodeName3 = GetRequestTargetNodeName();
+            var requestTargetNodeName3 = GetRequestTargetNodeName(proxies, ClientOp.ComputeExecuteColocated);
 
             var nodeName = nodeIdx == 1 ? string.Empty : "_" + nodeIdx;
             var expectedNodeName = PlatformTestNodeRunner + nodeName;
@@ -280,14 +277,6 @@ namespace Apache.Ignite.Tests.Compute
                 Assert.AreEqual(expectedNodeName, requestTargetNodeName2);
                 Assert.AreEqual(expectedNodeName, requestTargetNodeName3);
             }
-
-            void ClearOps() => proxies.ForEach(p => p.ClearOps());
-
-            string GetRequestTargetNodeName() =>
-                proxies
-                    .Where(x => x.ClientOps.Contains(ClientOp.ComputeExecuteColocated))
-                    .Select(x => x.NodeName)
-                    .Single();
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -285,15 +285,13 @@ namespace Apache.Ignite.Tests.Compute
             Assert.AreEqual(expectedNodeName, requestTargetNodeName2);
             Assert.AreEqual(expectedNodeName, requestTargetNodeName3);
 
-            void ClearOps() => proxies.Values.ForEach(p => p.ClientOps.Clear());
+            void ClearOps() => proxies.Values.ForEach(p => p.ClearOps());
 
-            string GetRequestTargetNodeName()
-            {
-                return proxies
+            string GetRequestTargetNodeName() =>
+                proxies
                     .Where(x => x.Value.ClientOps.Contains(ClientOp.ComputeExecuteColocated))
                     .Select(x => x.Key)
                     .Single();
-            }
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -27,6 +27,7 @@ namespace Apache.Ignite.Tests.Compute
     using Ignite.Compute;
     using Ignite.Table;
     using Internal.Network;
+    using Internal.Proto;
     using Network;
     using NodaTime;
     using NUnit.Framework;
@@ -255,6 +256,11 @@ namespace Apache.Ignite.Tests.Compute
             var keyTuple = new IgniteTuple { [KeyCol] = key };
             var resNodeName = await client.Compute.ExecuteColocatedAsync<string>(TableName, keyTuple, Units, NodeNameJob);
 
+            var requestNodeName = proxies
+                .Where(x => x.Value.ClientOps.Contains(ClientOp.ComputeExecuteColocated))
+                .Select(x => x.Key)
+                .Single();
+
             var keyPoco = new Poco { Key = key };
             var resNodeName2 = await client.Compute.ExecuteColocatedAsync<string, Poco>(TableName, keyPoco, Units.Reverse(), NodeNameJob);
 
@@ -266,6 +272,7 @@ namespace Apache.Ignite.Tests.Compute
             Assert.AreEqual(expectedNodeName, resNodeName);
             Assert.AreEqual(expectedNodeName, resNodeName2);
             Assert.AreEqual(expectedNodeName, resNodeName3);
+            Assert.AreEqual(expectedNodeName, requestNodeName);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -38,11 +38,11 @@ namespace Apache.Ignite.Tests.Compute
     /// </summary>
     public class ComputeTests : IgniteTestsBase
     {
+        public const string NodeNameJob = ItThinClientComputeTest + "$NodeNameJob";
+
         private const string ItThinClientComputeTest = "org.apache.ignite.internal.runner.app.client.ItThinClientComputeTest";
 
         private const string ConcatJob = ItThinClientComputeTest + "$ConcatJob";
-
-        private const string NodeNameJob = ItThinClientComputeTest + "$NodeNameJob";
 
         private const string ErrorJob = ItThinClientComputeTest + "$IgniteExceptionJob";
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -118,6 +118,8 @@ namespace Apache.Ignite.Tests
 
         public bool SendInvalidMagic { get; set; }
 
+        public int RequestCount { get; set; }
+
         internal IList<ClientOp> ClientOps => _ops?.ToList() ?? throw new Exception("Ops tracking is disabled");
 
         public async Task<IIgniteClient> ConnectClientAsync(IgniteClientConfiguration? cfg = null)
@@ -164,8 +166,6 @@ namespace Apache.Ignite.Tests
 
             handler.Send(handshakeMem.Span);
 
-            int requestCount = 0;
-
             while (!cancellationToken.IsCancellationRequested)
             {
                 msgSize = ReceiveMessageSize(handler);
@@ -180,7 +180,7 @@ namespace Apache.Ignite.Tests
                 var opCode = (ClientOp)reader.ReadInt32();
                 var requestId = reader.ReadInt64();
 
-                if (_shouldDropConnection(new RequestContext(++requestCount, opCode, requestId)))
+                if (_shouldDropConnection(new RequestContext(++RequestCount, opCode, requestId)))
                 {
                     DroppedConnectionCount++;
                     break;

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -176,7 +176,7 @@ namespace Apache.Ignite.Tests
                     Thread.Sleep(OperationDelay);
                 }
 
-                var reader = new MsgPackReader(msg.AsMemory().Span);
+                var reader = msg.GetReader();
                 var opCode = (ClientOp)reader.ReadInt32();
                 var requestId = reader.ReadInt64();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
@@ -24,11 +24,11 @@ using System.Net;
 /// </summary>
 public sealed class IgniteProxy : IgniteServerBase
 {
-    private readonly IPEndPoint _endPoint;
-
     public IgniteProxy(IPEndPoint endPoint)
     {
         // TODO: Connect.
-        _endPoint = endPoint;
+        EndPoint = endPoint;
     }
+
+    public IPEndPoint EndPoint { get; private init; }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
@@ -1,0 +1,45 @@
+namespace Apache.Ignite.Tests;
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+
+/// <summary>
+/// Proxy for Ignite server with request logging and interception.
+/// </summary>
+public sealed class IgniteProxy : IDisposable
+{
+    private readonly IPEndPoint _endPoint;
+    private readonly Socket _listener;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly object _disposeSyncRoot = new();
+    private volatile Socket? _handler;
+    private bool _disposed;
+
+    public IgniteProxy(IPEndPoint endPoint)
+    {
+        _endPoint = endPoint;
+    }
+
+    public void Dispose()
+    {
+        // TODO: Extract IgniteServerBase class.
+        lock (_disposeSyncRoot)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _cts.Cancel();
+            _handler?.Dispose();
+            _listener.Disconnect(false);
+            _listener.Dispose();
+            _cts.Dispose();
+
+            _disposed = true;
+        }
+    }
+
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
@@ -48,6 +48,8 @@ public sealed class IgniteProxy : IgniteServerBase
 
     internal IList<ClientOp> ClientOps => _ops.ToList();
 
+    public void ClearOps() => _ops.Clear();
+
     protected override void Handle(Socket handler, CancellationToken cancellationToken)
     {
         int messageCount = 0;

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
@@ -28,6 +28,7 @@ using Internal.Proto;
 
 /// <summary>
 /// Proxy for Ignite server with request logging and interception.
+/// Provides a way to test request routing while using real Ignite cluster.
 /// </summary>
 public sealed class IgniteProxy : IgniteServerBase
 {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
@@ -29,15 +29,15 @@ public sealed class IgniteProxy : IgniteServerBase
 {
     private readonly Socket _socket;
 
-    public IgniteProxy(IPEndPoint endPoint)
+    public IgniteProxy(IPEndPoint targetEndpoint)
     {
-        EndPoint = endPoint;
+        TargetEndpoint = targetEndpoint;
 
         _socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-        _socket.Connect(endPoint);
+        _socket.Connect(targetEndpoint);
     }
 
-    public IPEndPoint EndPoint { get; private init; }
+    public IPEndPoint TargetEndpoint { get; private init; }
 
     protected override void Handle(Socket handler, CancellationToken cancellationToken)
     {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
@@ -18,17 +18,34 @@
 namespace Apache.Ignite.Tests;
 
 using System.Net;
+using System.Net.Sockets;
+using Internal.Proto;
 
 /// <summary>
 /// Proxy for Ignite server with request logging and interception.
 /// </summary>
 public sealed class IgniteProxy : IgniteServerBase
 {
+    private readonly Socket _socket;
+
     public IgniteProxy(IPEndPoint endPoint)
     {
-        // TODO: Connect.
         EndPoint = endPoint;
+
+        _socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        _socket.Connect(endPoint);
+        _socket.Send(ProtoCommon.MagicBytes);
     }
 
     public IPEndPoint EndPoint { get; private init; }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (disposing)
+        {
+            _socket.Dispose();
+        }
+    }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
@@ -36,13 +36,16 @@ public sealed class IgniteProxy : IgniteServerBase
 
     private readonly ConcurrentQueue<ClientOp> _ops = new();
 
-    public IgniteProxy(IPEndPoint targetEndpoint)
+    public IgniteProxy(IPEndPoint targetEndpoint, string nodeName)
     {
         TargetEndpoint = targetEndpoint;
+        NodeName = nodeName;
 
         _socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
         _socket.Connect(targetEndpoint);
     }
+
+    public string NodeName { get; private init; }
 
     public IPEndPoint TargetEndpoint { get; private init; }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxyTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxyTests.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Tests;
 
 using System.Linq;
 using System.Threading.Tasks;
+using Internal.Proto;
 using NUnit.Framework;
 
 /// <summary>
@@ -34,6 +35,10 @@ public class IgniteProxyTests : IgniteTestsBase
         using var client = await IgniteClient.StartAsync(new IgniteClientConfiguration(proxy.Endpoint));
 
         var tables = await client.Tables.GetTablesAsync();
+        var table = await client.Tables.GetTableAsync(TableName);
+
         Assert.Greater(tables.Count, 1);
+        Assert.IsNotNull(table);
+        Assert.AreEqual(new[] { ClientOp.TablesGet, ClientOp.TableGet }, proxy.ClientOps);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxyTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxyTests.cs
@@ -31,7 +31,7 @@ public class IgniteProxyTests : IgniteTestsBase
     public async Task TestBasicProxying()
     {
         var addr = Client.GetConnections().First().Node.Address;
-        using var proxy = new IgniteProxy(addr);
+        using var proxy = new IgniteProxy(addr, "test");
         using var client = await IgniteClient.StartAsync(new IgniteClientConfiguration(proxy.Endpoint));
 
         var tables = await client.Tables.GetTablesAsync();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxyTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxyTests.cs
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests;
+
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests for <see cref="IgniteProxy"/>.
+/// </summary>
+public class IgniteProxyTests : IgniteTestsBase
+{
+    [Test]
+    public async Task TestBasicProxying()
+    {
+        var addr = Client.GetConnections().First().Node.Address;
+        using var proxy = new IgniteProxy(addr);
+        using var client = await IgniteClient.StartAsync(new IgniteClientConfiguration(proxy.Endpoint));
+
+        var tables = await client.Tables.GetTablesAsync();
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxyTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxyTests.cs
@@ -34,5 +34,6 @@ public class IgniteProxyTests : IgniteTestsBase
         using var client = await IgniteClient.StartAsync(new IgniteClientConfiguration(proxy.Endpoint));
 
         var tables = await client.Tables.GetTablesAsync();
+        Assert.Greater(tables.Count, 1);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteServerBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteServerBase.cs
@@ -44,6 +44,14 @@ public abstract class IgniteServerBase : IDisposable
         Task.Run(ListenLoop);
     }
 
+    public int Port => ((IPEndPoint)Listener.LocalEndPoint!).Port;
+
+    public string Endpoint => "127.0.0.1:" + Port;
+
+    protected Socket Listener => _listener;
+
+    public void DropExistingConnection() => _handler?.Dispose();
+
     public void Dispose()
     {
         lock (_disposeSyncRoot)
@@ -74,13 +82,13 @@ public abstract class IgniteServerBase : IDisposable
         }
     }
 
-    private static int ReceiveMessageSize(Socket handler)
+    protected static int ReceiveMessageSize(Socket handler)
     {
         using var buf = ReceiveBytes(handler, 4);
         return IPAddress.NetworkToHostOrder(BitConverter.ToInt32(buf.AsMemory().Span));
     }
 
-    private static PooledBuffer ReceiveBytes(Socket socket, int size)
+    protected internal static PooledBuffer ReceiveBytes(Socket socket, int size)
     {
         int received = 0;
         var buf = ByteArrayPool.Rent(size);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteServerBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteServerBase.cs
@@ -1,0 +1,44 @@
+namespace Apache.Ignite.Tests;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Sockets;
+using Internal.Buffers;
+
+[SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Tests.")]
+public abstract class IgniteServerBase
+{
+    private static int ReceiveMessageSize(Socket handler)
+    {
+        using var buf = ReceiveBytes(handler, 4);
+        return IPAddress.NetworkToHostOrder(BitConverter.ToInt32(buf.AsMemory().Span));
+    }
+
+    private static PooledBuffer ReceiveBytes(Socket socket, int size)
+    {
+        int received = 0;
+        var buf = ByteArrayPool.Rent(size);
+
+        while (received < size)
+        {
+            var res = socket.Receive(buf, received, size - received, SocketFlags.None);
+
+            if (res == 0)
+            {
+                throw new ConnectionLostException();
+            }
+
+            received += res;
+        }
+
+        return new PooledBuffer(buf, 0, size);
+    }
+
+
+    [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "Tests.")]
+    [SuppressMessage("Design", "CA1064:Exceptions should be public", Justification = "Tests.")]
+    public class ConnectionLostException : Exception
+    {
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -22,6 +22,7 @@ namespace Apache.Ignite.Tests
     using System.Linq;
     using System.Threading.Tasks;
     using Ignite.Table;
+    using Internal.Proto;
     using Log;
     using NUnit.Framework;
     using Table;
@@ -129,6 +130,22 @@ namespace Apache.Ignite.Tests
 
             _disposables.ForEach(x => x.Dispose());
             _disposables.Clear();
+        }
+
+        internal static string GetRequestTargetNodeName(IEnumerable<IgniteProxy> proxies, ClientOp op)
+        {
+            foreach (var proxy in proxies)
+            {
+                var ops = proxy.ClientOps;
+                proxy.ClearOps();
+
+                if (ops.Contains(op))
+                {
+                    return proxy.NodeName;
+                }
+            }
+
+            return string.Empty;
         }
 
         protected static IIgniteTuple GetTuple(long id) => new IgniteTuple { [KeyCol] = id };

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessRealClusterTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessRealClusterTests.cs
@@ -30,13 +30,19 @@ using NUnit.Framework;
 /// </summary>
 public class PartitionAwarenessRealClusterTests : IgniteTestsBase
 {
+    /// <summary>
+    /// Uses <see cref="ComputeTests.NodeNameJob"/> to get the name of the node that should be the primary for the given key,
+    /// and compares to the actual node that received the request (using IgniteProxy).
+    /// </summary>
+    /// <param name="key">Key.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [TestCase(4, 2)]
-    [TestCase(5, 2)]
-    [TestCase(6, 1)]
-    [TestCase(10, 1)]
-    [TestCase(11, 2)]
-    public async Task TestPutRoutesRequestToPrimaryNode(long key, int nodeIdx)
+    [TestCase(4)]
+    [TestCase(5)]
+    [TestCase(6)]
+    [TestCase(10)]
+    [TestCase(11)]
+    public async Task TestPutRoutesRequestToPrimaryNode(long key)
     {
         var proxies = GetProxies();
         using var client = await IgniteClient.StartAsync(GetConfig(proxies));

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessRealClusterTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessRealClusterTests.cs
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests;
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests partition awareness in real cluster.
+/// </summary>
+public class PartitionAwarenessRealClusterTests : IgniteTestsBase
+{
+    // TODO:
+    // 1. Use Proxy to check actual routing.
+    // 2. Use Compute to get the primary node for the given key.
+    [Test]
+    public async Task TestPutRoutesRequestToPrimaryNode()
+    {
+        var proxies = GetProxies();
+        using var client = await IgniteClient.StartAsync(GetConfig(proxies));
+        var recordView = (await client.Tables.GetTableAsync(FakeServer.ExistingTableName))!.GetRecordView<int>();
+
+        // Warm up.
+        await recordView.UpsertAsync(null, 1);
+
+        // Check.
+        // await AssertOpOnNode(async () => await recordView.UpsertAsync(null, 1), ClientOp.TupleUpsert, _server2, _server1);
+        // await AssertOpOnNode(async () => await recordView.UpsertAsync(null, 3), ClientOp.TupleUpsert, _server1, _server2);
+        // await AssertOpOnNode(async () => await recordView.UpsertAsync(null, 4), ClientOp.TupleUpsert, _server2, _server1);
+        // await AssertOpOnNode(async () => await recordView.UpsertAsync(null, 5), ClientOp.TupleUpsert, _server1, _server2);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessTests.cs
@@ -53,7 +53,7 @@ public class PartitionAwarenessTests
         _server1 = new FakeServer(nodeName: "srv1");
         _server2 = new FakeServer(nodeName: "srv2");
 
-        var assignment = new[] { _server1.Node.Id, _server2.Node.Id };
+        var assignment = new[] { _server1.Node.Name, _server2.Node.Name };
         _server1.PartitionAssignment = assignment;
         _server2.PartitionAssignment = assignment;
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/PreferredNode.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/PreferredNode.cs
@@ -23,26 +23,14 @@ namespace Apache.Ignite.Internal.Proto;
 internal record struct PreferredNode
 {
     /// <summary>
-    /// Gets the id.
+    /// Gets the name (same as Consistent ID).
     /// </summary>
-    public string? Id { get; private init; }
-
-    /// <summary>
-    /// Gets the name.
-    /// </summary>
-    public string? Name { get; private init; }
+    public string Name { get; private init; }
 
     /// <summary>
     /// Creates an instance from name.
     /// </summary>
     /// <param name="name">Name.</param>
     /// <returns>Preferred node.</returns>
-    public static PreferredNode FromName(string name) => new() { Id = null, Name = name };
-
-    /// <summary>
-    /// Creates an instance from id.
-    /// </summary>
-    /// <param name="id">Id.</param>
-    /// <returns>Preferred node.</returns>
-    public static PreferredNode FromId(string id) => new() { Id = id, Name = null };
+    public static PreferredNode FromName(string name) => new() { Name = name };
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -337,7 +337,7 @@ namespace Apache.Ignite.Internal.Table
                             ClientOp.TupleUpsertAll,
                             tx: null,
                             batch,
-                            PreferredNode.FromId(preferredNode),
+                            PreferredNode.FromName(preferredNode),
                             retryPolicy)
                         .ConfigureAwait(false);
                 },

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -200,9 +200,9 @@ namespace Apache.Ignite.Internal.Table
             }
 
             var partition = Math.Abs(colocationHash % assignment.Length);
-            var nodeId = assignment[partition];
+            var nodeConsistentId = assignment[partition];
 
-            return PreferredNode.FromId(nodeId);
+            return PreferredNode.FromName(nodeConsistentId);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Network/IClusterNode.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Network/IClusterNode.cs
@@ -30,7 +30,7 @@ namespace Apache.Ignite.Network
         string Id { get; }
 
         /// <summary>
-        /// Gets the unique name of the cluster member. Does not change after node restart.
+        /// Gets the unique name (consistent id) of the cluster member. Does not change after node restart.
         /// </summary>
         string Name { get; }
 


### PR DESCRIPTION
There was a confusion between *Local Node ID* (`ConnectionContext.ClusterNode.Id`) and *Consistent Node ID* (which is the same as Node Name, comes from `ConnectionContext.ClusterNode.Name`). Partition assignment (returned by `ClientTablePartitionAssignmentGetRequest` on the server) must be based on *Consistent Node ID*.

All partition awareness tests use `FakeServer`, so we never tested that it actually works.

* Remove `ClientFailoverSocket._endpointsById` and related logic, identify nodes only by Name (consistent id)
* Add `IgniteProxy` to track request routing on real cluster, and compare results to the primary node calculated on the Java side