### PR TITLE
IGNITE-19827 Java client: fix partition awareness node ids

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -172,7 +172,7 @@ public class ClientCompute implements IgniteCompute {
             }
 
             packJob(w.out(), units, jobClassName, args);
-        }, r -> (R) r.in().unpackObjectFromBinaryTuple(), node.name(), null, null);
+        }, r -> (R) r.in().unpackObjectFromBinaryTuple(), node.name(), null);
     }
 
     private static ClusterNode randomNode(Set<ClusterNode> nodes) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueBinaryView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueBinaryView.java
@@ -451,11 +451,11 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
 
         // Partition-aware (best effort) sender with retries.
         // The batch may go to a different node when a direct connection is not available.
-        StreamerBatchSender<Entry<Tuple, Tuple>, String> batchSender = (nodeId, items) -> tbl.doSchemaOutOpAsync(
+        StreamerBatchSender<Entry<Tuple, Tuple>, String> batchSender = (nodeName, items) -> tbl.doSchemaOutOpAsync(
                 ClientOp.TUPLE_UPSERT_ALL,
                 (s, w) -> ser.writeKvTuples(null, items, s, w),
                 r -> null,
-                PartitionAwarenessProvider.of(nodeId),
+                PartitionAwarenessProvider.of(nodeName),
                 new RetryLimitPolicy().retryLimit(opts.retryLimit()));
 
         return ClientDataStreamer.streamData(publisher, opts, batchSender, provider, tbl);

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -278,13 +278,12 @@ public class ClientTable implements Table {
         return CompletableFuture.allOf(schemaFut, partitionsFut)
                 .thenCompose(v -> {
                     ClientSchema schema = schemaFut.getNow(null);
-                    String preferredNodeId = getPreferredNodeId(provider, partitionsFut.getNow(null), schema);
+                    String preferredNodeName = getPreferredNodeName(provider, partitionsFut.getNow(null), schema);
 
                     return ch.serviceAsync(opCode,
                             w -> writer.accept(schema, w),
                             r -> readSchemaAndReadData(schema, r.in(), reader, defaultValue),
-                            null,
-                            preferredNodeId,
+                            preferredNodeName,
                             null);
                 })
                 .thenCompose(t -> loadSchemaAndReadData(t, reader));
@@ -333,7 +332,7 @@ public class ClientTable implements Table {
         return CompletableFuture.allOf(schemaFut, partitionsFut)
                 .thenCompose(v -> {
                     ClientSchema schema = schemaFut.getNow(null);
-                    String preferredNodeId = getPreferredNodeId(provider, partitionsFut.getNow(null), schema);
+                    String preferredNodeName = getPreferredNodeName(provider, partitionsFut.getNow(null), schema);
 
                     return ch.serviceAsync(opCode,
                             w -> writer.accept(schema, w),
@@ -342,8 +341,7 @@ public class ClientTable implements Table {
 
                                 return reader.apply(r.in());
                             },
-                            null,
-                            preferredNodeId,
+                            preferredNodeName,
                             retryPolicyOverride);
                 });
     }
@@ -445,7 +443,7 @@ public class ClientTable implements Table {
     }
 
     @Nullable
-    private static String getPreferredNodeId(
+    private static String getPreferredNodeName(
             @Nullable PartitionAwarenessProvider provider,
             @Nullable List<String> partitions,
             ClientSchema schema) {
@@ -453,10 +451,10 @@ public class ClientTable implements Table {
             return null;
         }
 
-        String nodeId = provider.nodeId();
+        String nodeName = provider.nodeName();
 
-        if (nodeId != null) {
-            return nodeId;
+        if (nodeName != null) {
+            return nodeName;
         }
 
         if (partitions == null || partitions.isEmpty()) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -30,10 +30,8 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.apache.ignite.client.RetryPolicy;
-import org.apache.ignite.internal.client.ClientChannel;
 import org.apache.ignite.internal.client.ClientUtils;
 import org.apache.ignite.internal.client.PayloadOutputChannel;
-import org.apache.ignite.internal.client.PayloadReader;
 import org.apache.ignite.internal.client.ReliableChannel;
 import org.apache.ignite.internal.client.proto.ClientMessageUnpacker;
 import org.apache.ignite.internal.client.proto.ClientOp;
@@ -273,24 +271,13 @@ public class ClientTable implements Table {
             @Nullable PartitionAwarenessProvider provider
     ) {
         CompletableFuture<ClientSchema> schemaFut = getLatestSchema();
-
-        @SuppressWarnings("resource")
-        ClientChannel ch0 = provider != null ? provider.channel() : null;
-
-        CompletableFuture<List<String>> partitionsFut = provider == null || !provider.isPartitionAwarenessEnabled() || ch0 != null
+        CompletableFuture<List<String>> partitionsFut = provider == null || !provider.isPartitionAwarenessEnabled()
                 ? CompletableFuture.completedFuture(null)
                 : getPartitionAssignment();
 
         return CompletableFuture.allOf(schemaFut, partitionsFut)
                 .thenCompose(v -> {
                     ClientSchema schema = schemaFut.getNow(null);
-
-                    if (ch0 != null) {
-                        return ch0.serviceAsync(opCode,
-                                w -> writer.accept(schema, w),
-                                r -> readSchemaAndReadData(schema, r.in(), reader, defaultValue));
-                    }
-
                     String preferredNodeName = getPreferredNodeName(provider, partitionsFut.getNow(null), schema);
 
                     return ch.serviceAsync(opCode,
@@ -336,36 +323,24 @@ public class ClientTable implements Table {
             Function<ClientMessageUnpacker, T> reader,
             @Nullable PartitionAwarenessProvider provider,
             @Nullable RetryPolicy retryPolicyOverride) {
+
         CompletableFuture<ClientSchema> schemaFut = getLatestSchema();
-
-        @SuppressWarnings("resource")
-        ClientChannel ch0 = provider != null ? provider.channel() : null;
-
-        CompletableFuture<List<String>> partitionsFut = provider == null || !provider.isPartitionAwarenessEnabled() || ch0 != null
+        CompletableFuture<List<String>> partitionsFut = provider == null || !provider.isPartitionAwarenessEnabled()
                 ? CompletableFuture.completedFuture(null)
                 : getPartitionAssignment();
 
         return CompletableFuture.allOf(schemaFut, partitionsFut)
                 .thenCompose(v -> {
                     ClientSchema schema = schemaFut.getNow(null);
-
-                    PayloadReader<T> payloadReader = r -> {
-                        ensureSchemaLoadedAsync(r.in().unpackInt());
-
-                        return reader.apply(r.in());
-                    };
-
-                    if (ch0 != null) {
-                        return ch0.serviceAsync(opCode,
-                                w -> writer.accept(schema, w),
-                                payloadReader);
-                    }
-
                     String preferredNodeName = getPreferredNodeName(provider, partitionsFut.getNow(null), schema);
 
                     return ch.serviceAsync(opCode,
                             w -> writer.accept(schema, w),
-                            payloadReader,
+                            r -> {
+                                ensureSchemaLoadedAsync(r.in().unpackInt());
+
+                                return reader.apply(r.in());
+                            },
                             preferredNodeName,
                             retryPolicyOverride);
                 });
@@ -476,8 +451,10 @@ public class ClientTable implements Table {
             return null;
         }
 
-        if (provider.nodeName() != null) {
-            return provider.nodeName();
+        String nodeName = provider.nodeName();
+
+        if (nodeName != null) {
+            return nodeName;
         }
 
         if (partitions == null || partitions.isEmpty()) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
@@ -411,7 +411,7 @@ public class ClientTupleSerializer {
     public static PartitionAwarenessProvider getPartitionAwarenessProvider(@Nullable Transaction tx, @NotNull Tuple rec) {
         if (tx != null) {
             //noinspection resource
-            return PartitionAwarenessProvider.of(ClientTransaction.get(tx).channel().protocolContext().clusterNode().id());
+            return PartitionAwarenessProvider.of(ClientTransaction.get(tx).channel());
         }
 
         return PartitionAwarenessProvider.of(schema -> getColocationHash(schema, rec));

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
@@ -411,7 +411,7 @@ public class ClientTupleSerializer {
     public static PartitionAwarenessProvider getPartitionAwarenessProvider(@Nullable Transaction tx, @NotNull Tuple rec) {
         if (tx != null) {
             //noinspection resource
-            return PartitionAwarenessProvider.of(ClientTransaction.get(tx).channel().protocolContext().clusterNode().id());
+            return PartitionAwarenessProvider.of(ClientTransaction.get(tx).channel().protocolContext().clusterNode().name());
         }
 
         return PartitionAwarenessProvider.of(schema -> getColocationHash(schema, rec));
@@ -428,7 +428,7 @@ public class ClientTupleSerializer {
             @Nullable Transaction tx, Mapper<?> mapper, @NotNull Object rec) {
         if (tx != null) {
             //noinspection resource
-            return PartitionAwarenessProvider.of(ClientTransaction.get(tx).channel().protocolContext().clusterNode().id());
+            return PartitionAwarenessProvider.of(ClientTransaction.get(tx).channel().protocolContext().clusterNode().name());
         }
 
         return PartitionAwarenessProvider.of(schema -> getColocationHash(schema, mapper, rec));

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTupleSerializer.java
@@ -411,7 +411,7 @@ public class ClientTupleSerializer {
     public static PartitionAwarenessProvider getPartitionAwarenessProvider(@Nullable Transaction tx, @NotNull Tuple rec) {
         if (tx != null) {
             //noinspection resource
-            return PartitionAwarenessProvider.of(ClientTransaction.get(tx).channel());
+            return PartitionAwarenessProvider.of(ClientTransaction.get(tx).channel().protocolContext().clusterNode().id());
         }
 
         return PartitionAwarenessProvider.of(schema -> getColocationHash(schema, rec));

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/PartitionAwarenessProvider.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/PartitionAwarenessProvider.java
@@ -28,27 +28,27 @@ import org.jetbrains.annotations.Nullable;
  * 3. Null instance = No partition awareness and no transaction. Use any channel.
  */
 class PartitionAwarenessProvider {
-    private final @Nullable String nodeId;
+    private final @Nullable String nodeName;
 
     private final @Nullable Function<ClientSchema, Integer> hashFunc;
 
-    private PartitionAwarenessProvider(@Nullable String nodeId, @Nullable Function<ClientSchema, Integer> hashFunc) {
-        assert (nodeId == null) ^ (hashFunc == null) : "One must be null, another not null: nodeId, hashFunc";
+    private PartitionAwarenessProvider(@Nullable String nodeName, @Nullable Function<ClientSchema, Integer> hashFunc) {
+        assert (nodeName == null) ^ (hashFunc == null) : "One must be null, another not null: nodeId, hashFunc";
 
-        this.nodeId = nodeId;
+        this.nodeName = nodeName;
         this.hashFunc = hashFunc;
     }
 
-    public static PartitionAwarenessProvider of(String nodeId) {
-        return new PartitionAwarenessProvider(nodeId, null);
+    public static PartitionAwarenessProvider of(String nodeName) {
+        return new PartitionAwarenessProvider(nodeName, null);
     }
 
     public static PartitionAwarenessProvider of(Function<ClientSchema, Integer> hashFunc) {
         return new PartitionAwarenessProvider(null, hashFunc);
     }
 
-    @Nullable String nodeId() {
-        return nodeId;
+    @Nullable String nodeName() {
+        return nodeName;
     }
 
     Integer getObjectHashCode(ClientSchema schema) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/PartitionAwarenessProvider.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/PartitionAwarenessProvider.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.client.table;
 
 import java.util.function.Function;
+import org.apache.ignite.internal.client.ClientChannel;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -32,23 +33,37 @@ class PartitionAwarenessProvider {
 
     private final @Nullable Function<ClientSchema, Integer> hashFunc;
 
-    private PartitionAwarenessProvider(@Nullable String nodeName, @Nullable Function<ClientSchema, Integer> hashFunc) {
-        assert (nodeName == null) ^ (hashFunc == null) : "One must be null, another not null: nodeId, hashFunc";
+    private final @Nullable ClientChannel channel;
+
+    private PartitionAwarenessProvider(
+            @Nullable String nodeName,
+            @Nullable Function<ClientSchema, Integer> hashFunc,
+            @Nullable ClientChannel channel) {
+        assert (nodeName != null) ^ (hashFunc != null) ^ (channel != null) : "Exactly one of nodeName, hashFunc or channel must be set";
 
         this.nodeName = nodeName;
         this.hashFunc = hashFunc;
+        this.channel = channel;
     }
 
     public static PartitionAwarenessProvider of(String nodeName) {
-        return new PartitionAwarenessProvider(nodeName, null);
+        return new PartitionAwarenessProvider(nodeName, null, null);
     }
 
     public static PartitionAwarenessProvider of(Function<ClientSchema, Integer> hashFunc) {
-        return new PartitionAwarenessProvider(null, hashFunc);
+        return new PartitionAwarenessProvider(null, hashFunc, null);
+    }
+
+    public static PartitionAwarenessProvider of(ClientChannel channel) {
+        return new PartitionAwarenessProvider(null, null, channel);
     }
 
     @Nullable String nodeName() {
         return nodeName;
+    }
+
+    @Nullable ClientChannel channel() {
+        return channel;
     }
 
     Integer getObjectHashCode(ClientSchema schema) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/PartitionAwarenessProvider.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/PartitionAwarenessProvider.java
@@ -18,7 +18,6 @@
 package org.apache.ignite.internal.client.table;
 
 import java.util.function.Function;
-import org.apache.ignite.internal.client.ClientChannel;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -33,37 +32,23 @@ class PartitionAwarenessProvider {
 
     private final @Nullable Function<ClientSchema, Integer> hashFunc;
 
-    private final @Nullable ClientChannel channel;
-
-    private PartitionAwarenessProvider(
-            @Nullable String nodeName,
-            @Nullable Function<ClientSchema, Integer> hashFunc,
-            @Nullable ClientChannel channel) {
-        assert (nodeName != null) ^ (hashFunc != null) ^ (channel != null) : "Exactly one of nodeName, hashFunc or channel must be set";
+    private PartitionAwarenessProvider(@Nullable String nodeName, @Nullable Function<ClientSchema, Integer> hashFunc) {
+        assert (nodeName == null) ^ (hashFunc == null) : "One must be null, another not null: nodeId, hashFunc";
 
         this.nodeName = nodeName;
         this.hashFunc = hashFunc;
-        this.channel = channel;
     }
 
     public static PartitionAwarenessProvider of(String nodeName) {
-        return new PartitionAwarenessProvider(nodeName, null, null);
+        return new PartitionAwarenessProvider(nodeName, null);
     }
 
     public static PartitionAwarenessProvider of(Function<ClientSchema, Integer> hashFunc) {
-        return new PartitionAwarenessProvider(null, hashFunc, null);
-    }
-
-    public static PartitionAwarenessProvider of(ClientChannel channel) {
-        return new PartitionAwarenessProvider(null, null, channel);
+        return new PartitionAwarenessProvider(null, hashFunc);
     }
 
     @Nullable String nodeName() {
         return nodeName;
-    }
-
-    @Nullable ClientChannel channel() {
-        return channel;
     }
 
     Integer getObjectHashCode(ClientSchema schema) {

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -170,8 +170,8 @@ public class PartitionAwarenessTest extends AbstractClientTest {
         // Update partition assignment.
         var assignments = new ArrayList<String>();
 
-        assignments.add(testServer2.nodeId());
-        assignments.add(testServer.nodeId());
+        assignments.add(testServer2.nodeName());
+        assignments.add(testServer.nodeName());
 
         initPartitionAssignment(assignments);
 
@@ -543,8 +543,8 @@ public class PartitionAwarenessTest extends AbstractClientTest {
         // Update partition assignment.
         var assignments = new ArrayList<String>();
 
-        assignments.add(testServer2.nodeId());
-        assignments.add(testServer.nodeId());
+        assignments.add(testServer2.nodeName());
+        assignments.add(testServer.nodeName());
 
         initPartitionAssignment(assignments);
 
@@ -612,10 +612,10 @@ public class PartitionAwarenessTest extends AbstractClientTest {
         if (assignments == null) {
             assignments = new ArrayList<>();
 
-            assignments.add(testServer.nodeId());
-            assignments.add(testServer2.nodeId());
-            assignments.add(testServer.nodeId());
-            assignments.add(testServer2.nodeId());
+            assignments.add(testServer.nodeName());
+            assignments.add(testServer2.nodeName());
+            assignments.add(testServer.nodeName());
+            assignments.add(testServer2.nodeName());
         }
 
         FakeIgniteTables tables = (FakeIgniteTables) ignite.tables();

--- a/modules/runner/build.gradle
+++ b/modules/runner/build.gradle
@@ -158,6 +158,7 @@ dependencies {
     integrationTestImplementation libs.typesafe.config
     integrationTestImplementation libs.auto.service.annotations
     integrationTestImplementation libs.netty.common
+    integrationTestImplementation libs.netty.handler
 
     testFixturesImplementation project(':ignite-core')
     testFixturesImplementation project(':ignite-api')

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItAbstractThinClientTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItAbstractThinClientTest.java
@@ -142,16 +142,12 @@ public abstract class ItAbstractThinClientTest extends IgniteAbstractTest {
         IgniteUtils.closeAll(closeables);
     }
 
-    protected String getNodeAddress() {
+    String getNodeAddress() {
         return getClientAddresses().get(0);
     }
 
-    protected List<String> getClientAddresses() {
+    List<String> getClientAddresses() {
         return getClientAddresses(startedNodes);
-    }
-
-    protected List<Integer> getClientPorts() {
-        return getClientPorts(startedNodes);
     }
 
     /**
@@ -164,6 +160,10 @@ public abstract class ItAbstractThinClientTest extends IgniteAbstractTest {
         return getClientPorts(nodes).stream()
                 .map(port -> "127.0.0.1" + ":" + port)
                 .collect(toList());
+    }
+
+    List<Integer> getClientPorts() {
+        return getClientPorts(startedNodes);
     }
 
     private static List<Integer> getClientPorts(List<Ignite> nodes) {

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItAbstractThinClientTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItAbstractThinClientTest.java
@@ -150,6 +150,10 @@ public abstract class ItAbstractThinClientTest extends IgniteAbstractTest {
         return getClientAddresses(startedNodes);
     }
 
+    protected List<Integer> getClientPorts() {
+        return getClientPorts(startedNodes);
+    }
+
     /**
      * Gets client connector addresses for the specified nodes.
      *
@@ -157,15 +161,15 @@ public abstract class ItAbstractThinClientTest extends IgniteAbstractTest {
      * @return List of client addresses.
      */
     public static List<String> getClientAddresses(List<Ignite> nodes) {
-        List<String> res = new ArrayList<>(nodes.size());
+        return getClientPorts(nodes).stream()
+                .map(port -> "127.0.0.1" + ":" + port)
+                .collect(toList());
+    }
 
-        for (Ignite ignite : nodes) {
-            int port = ((IgniteImpl) ignite).clientAddress().port();
-
-            res.add("127.0.0.1:" + port);
-        }
-
-        return res;
+    private static List<Integer> getClientPorts(List<Ignite> nodes) {
+        return nodes.stream()
+                .map(ignite -> ((IgniteImpl) ignite).clientAddress().port())
+                .collect(toList());
     }
 
     protected IgniteClient client() {

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItAbstractThinClientTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItAbstractThinClientTest.java
@@ -180,6 +180,10 @@ public abstract class ItAbstractThinClientTest extends IgniteAbstractTest {
         return startedNodes.get(0);
     }
 
+    protected Ignite server(int idx) {
+        return startedNodes.get(idx);
+    }
+
     /**
      * Test class.
      */

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientPartitionAwarenessTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientPartitionAwarenessTest.java
@@ -36,7 +36,7 @@ public class ItThinClientPartitionAwarenessTest extends ItAbstractThinClientTest
             adds.add("127.0.0.1:" + proxy.listenPort());
         }
 
-        var client = IgniteClient.builder().addresses(adds.toArray(new String[0])).build();
+        var client = IgniteClient.builder().addresses(adds.get(0)).build();
 
         var nodes = client.clusterNodes();
     }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientPartitionAwarenessTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientPartitionAwarenessTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.ignite.internal.runner.app.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.ignite.client.IgniteClient;
@@ -34,10 +36,13 @@ public class ItThinClientPartitionAwarenessTest extends ItAbstractThinClientTest
         for (int port : getClientPorts()) {
             var proxy = IgniteClientProxy.start(port, port + 1000);
             adds.add("127.0.0.1:" + proxy.listenPort());
+            proxies.add(proxy);
         }
 
         var client = IgniteClient.builder().addresses(adds.get(0)).build();
 
+        proxies.get(0).resetRequestCount();
         var nodes = client.clusterNodes();
+        assertEquals(1, proxies.get(0).requestCount());
     }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientPartitionAwarenessTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientPartitionAwarenessTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.ignite.internal.runner.app.client;
 
-import static org.apache.ignite.internal.testframework.IgniteTestUtils.testNodeName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
@@ -29,15 +28,12 @@ import org.apache.ignite.compute.ComputeJob;
 import org.apache.ignite.compute.JobExecutionContext;
 import org.apache.ignite.internal.runner.app.client.proxy.IgniteClientProxy;
 import org.apache.ignite.table.RecordView;
-import org.apache.ignite.table.Table;
 import org.apache.ignite.table.Tuple;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Thin client partition awareness test with real cluster.

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientPartitionAwarenessTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientPartitionAwarenessTest.java
@@ -17,9 +17,27 @@
 
 package org.apache.ignite.internal.runner.app.client;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.internal.runner.app.client.proxy.IgniteClientProxy;
+import org.junit.jupiter.api.Test;
+
 /**
  * Thin client partition awareness test with real cluster.
  */
-public class ItThinClientPartitionAwarenessTest {
-    // TODO: Use Netty proxy https://github.com/netty/netty/tree/4.1/example/src/main/java/io/netty/example/proxy
+public class ItThinClientPartitionAwarenessTest extends ItAbstractThinClientTest {
+    @Test
+    void testClusterNodes() throws Exception {
+        List<String> adds = new ArrayList<>();
+        List<IgniteClientProxy> proxies = new ArrayList<>();
+        for (int port : getClientPorts()) {
+            var proxy = IgniteClientProxy.start(port, port + 1000);
+            adds.add("127.0.0.1:" + proxy.listenPort());
+        }
+
+        var client = IgniteClient.builder().addresses(adds.toArray(new String[0])).build();
+
+        var nodes = client.clusterNodes();
+    }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientPartitionAwarenessTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientPartitionAwarenessTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.runner.app.client;
+
+/**
+ * Thin client partition awareness test with real cluster.
+ */
+public class ItThinClientPartitionAwarenessTest {
+    // TODO: Use Netty proxy https://github.com/netty/netty/tree/4.1/example/src/main/java/io/netty/example/proxy
+}

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxy.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxy.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.runner.app.client.proxy;
+
+public final class IgniteClientProxy implements AutoCloseable {
+    private final EventLoopGroup bossGroup = new NioEventLoopGroup(1);
+    private final EventLoopGroup workerGroup = new NioEventLoopGroup();
+    private final int targetPort;
+
+    private IgniteClientProxy(int targetPort) {
+        this.targetPort = targetPort;
+    }
+
+    private void start() {
+        ServerBootstrap b = new ServerBootstrap();
+        b.group(bossGroup, workerGroup)
+                .channel(NioServerSocketChannel.class)
+                .handler(new LoggingHandler(LogLevel.INFO))
+                .childHandler(new IgniteClientProxyInitializer(targetPort))
+                .childOption(ChannelOption.AUTO_READ, false)
+                .bind(LOCAL_PORT).sync().channel().closeFuture().sync();
+    }
+
+    public static AutoCloseable start(int serverPort) throws Exception {
+        IgniteClientProxy proxy = new IgniteClientProxy(serverPort);
+        proxy.start();
+
+        return proxy;
+    }
+
+    @Override
+    public void close() throws Exception {
+        bossGroup.shutdownGracefully();
+        workerGroup.shutdownGracefully();
+    }
+}

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxy.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxy.java
@@ -26,6 +26,10 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 
+/**
+ * Proxy for Ignite client with request tracking.
+ * Provides a way to test request routing while using real Ignite cluster.
+ */
 public final class IgniteClientProxy implements AutoCloseable {
     private final EventLoopGroup bossGroup = new NioEventLoopGroup(1);
     private final EventLoopGroup workerGroup = new NioEventLoopGroup();

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxy.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxy.java
@@ -32,7 +32,9 @@ import io.netty.handler.logging.LoggingHandler;
  */
 public final class IgniteClientProxy implements AutoCloseable {
     private final EventLoopGroup bossGroup = new NioEventLoopGroup(1);
+
     private final EventLoopGroup workerGroup = new NioEventLoopGroup();
+
     private final int listenPort;
 
     private final ChannelFuture chFut;

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxy.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxy.java
@@ -17,6 +17,14 @@
 
 package org.apache.ignite.internal.runner.app.client.proxy;
 
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+
 public final class IgniteClientProxy implements AutoCloseable {
     private final EventLoopGroup bossGroup = new NioEventLoopGroup(1);
     private final EventLoopGroup workerGroup = new NioEventLoopGroup();

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxy.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxy.java
@@ -50,11 +50,19 @@ public final class IgniteClientProxy implements AutoCloseable {
         chFut.channel().closeFuture().sync();
     }
 
-    public static AutoCloseable start(int targetPort, int listenPort) throws Exception {
+    public static IgniteClientProxy start(int targetPort, int listenPort) throws Exception {
         IgniteClientProxy proxy = new IgniteClientProxy(targetPort, listenPort);
         proxy.start();
 
         return proxy;
+    }
+
+    public int targetPort() {
+        return targetPort;
+    }
+
+    public int listenPort() {
+        return listenPort;
     }
 
     @Override

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxyBackendHandler.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxyBackendHandler.java
@@ -22,7 +22,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 
-public class IgniteClientProxyBackendHandler extends ChannelInboundHandlerAdapter {
+class IgniteClientProxyBackendHandler extends ChannelInboundHandlerAdapter {
     private final Channel inboundChannel;
 
     IgniteClientProxyBackendHandler(Channel inboundChannel) {

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxyBackendHandler.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxyBackendHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.runner.app.client.proxy;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+public class IgniteClientProxyBackendHandler extends ChannelInboundHandlerAdapter {
+    private final Channel inboundChannel;
+
+    IgniteClientProxyBackendHandler(Channel inboundChannel) {
+        this.inboundChannel = inboundChannel;
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) {
+        if (!inboundChannel.isActive()) {
+            IgniteClientProxyFrontendHandler.closeOnFlush(ctx.channel());
+        } else {
+            ctx.read();
+        }
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        inboundChannel.writeAndFlush(msg).addListener((ChannelFutureListener) future -> {
+            if (future.isSuccess()) {
+                ctx.channel().read();
+            } else {
+                future.channel().close();
+            }
+        });
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        IgniteClientProxyFrontendHandler.closeOnFlush(inboundChannel);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        cause.printStackTrace();
+        IgniteClientProxyFrontendHandler.closeOnFlush(ctx.channel());
+    }
+}

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxyFrontendHandler.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxyFrontendHandler.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.runner.app.client.proxy;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOption;
+
+public class IgniteClientProxyFrontendHandler extends ChannelInboundHandlerAdapter {
+    private final int remotePort;
+
+    private Channel outboundChannel;
+
+    public IgniteClientProxyFrontendHandler(int remotePort) {
+        this.remotePort = remotePort;
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) {
+        final Channel inboundChannel = ctx.channel();
+
+        // Start the connection attempt.
+        Bootstrap b = new Bootstrap();
+        b.group(inboundChannel.eventLoop())
+                .channel(ctx.channel().getClass())
+                .handler(new IgniteClientProxyBackendHandler(inboundChannel))
+                .option(ChannelOption.AUTO_READ, false);
+        ChannelFuture f = b.connect("127.0.0.1", remotePort);
+        outboundChannel = f.channel();
+        f.addListener((ChannelFutureListener) future -> {
+            if (future.isSuccess()) {
+                // connection complete start to read first data
+                inboundChannel.read();
+            } else {
+                // Close the connection if the connection attempt has failed.
+                inboundChannel.close();
+            }
+        });
+    }
+
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, Object msg) {
+        if (outboundChannel.isActive()) {
+            outboundChannel.writeAndFlush(msg).addListener((ChannelFutureListener) future -> {
+                if (future.isSuccess()) {
+                    // was able to flush out data, start to read the next chunk
+                    ctx.channel().read();
+                } else {
+                    future.channel().close();
+                }
+            });
+        }
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        if (outboundChannel != null) {
+            closeOnFlush(outboundChannel);
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        cause.printStackTrace();
+        closeOnFlush(ctx.channel());
+    }
+
+    /**
+     * Closes the specified channel after all queued write requests are flushed.
+     */
+    static void closeOnFlush(Channel ch) {
+        if (ch.isActive()) {
+            ch.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+}

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxyInitializer.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxyInitializer.java
@@ -22,12 +22,10 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 
-public class IgniteClientProxyInitializer {
-    private final String remoteHost;
+public class IgniteClientProxyInitializer extends ChannelInitializer<SocketChannel> {
     private final int remotePort;
 
-    public IgniteClientProxyInitializer(String remoteHost, int remotePort) {
-        this.remoteHost = remoteHost;
+    IgniteClientProxyInitializer(int remotePort) {
         this.remotePort = remotePort;
     }
 
@@ -35,6 +33,6 @@ public class IgniteClientProxyInitializer {
     public void initChannel(SocketChannel ch) {
         ch.pipeline().addLast(
                 new LoggingHandler(LogLevel.INFO),
-                new IgniteClientProxyFrontendHandler(remoteHost, remotePort));
+                new IgniteClientProxyFrontendHandler(remotePort));
     }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxyInitializer.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxyInitializer.java
@@ -21,8 +21,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.handler.logging.LogLevel;
-import io.netty.handler.logging.LoggingHandler;
 import java.util.concurrent.atomic.AtomicInteger;
 
 class IgniteClientProxyInitializer extends ChannelInitializer<SocketChannel> {

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxyInitializer.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/proxy/IgniteClientProxyInitializer.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.runner.app.client.proxy;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+
+public class IgniteClientProxyInitializer {
+    private final String remoteHost;
+    private final int remotePort;
+
+    public IgniteClientProxyInitializer(String remoteHost, int remotePort) {
+        this.remoteHost = remoteHost;
+        this.remotePort = remotePort;
+    }
+
+    @Override
+    public void initChannel(SocketChannel ch) {
+        ch.pipeline().addLast(
+                new LoggingHandler(LogLevel.INFO),
+                new IgniteClientProxyFrontendHandler(remoteHost, remotePort));
+    }
+}


### PR DESCRIPTION
There was a confusion between *Local Node ID* (`protocolContext().clusterNode().id()`) and *Consistent Node ID* (which is the same as Node Name, comes from `protocolContext().clusterNode().name()`). Partition assignment (returned by `ClientTablePartitionAssignmentGetRequest` on the server) must be based on *Consistent Node ID*.

All partition awareness tests use `FakeIgnite`, so we never tested it on real clusters.

* Remove `ReliableChannel.nodeChannelsById` and related logic, identify nodes only by Name (consistent id)
* Add `IgniteClientProxy` to track request routing on real cluster, and compare results to the primary node calculated on the server side (via Compute)