### PR TITLE
IGNITE-19667 Make ClientTableCommon.readTable async

### DIFF
--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -247,6 +247,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
                 metrics.bytesReceivedAdd(ClientMessageCommon.MAGIC_BYTES.length);
                 handshake(ctx, unpacker, packer);
             } else {
+                // TODO: Some operations may use unpacker asynchronously, outside of this try block.
+                // We should increase the reference count of the buffer in this case, and release it in the future completion callback.
                 processOperation(ctx, unpacker, packer);
             }
         }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -237,20 +237,17 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
         ByteBuf byteBuf = (ByteBuf) msg;
 
         // Each inbound handler in a pipeline has to release the received messages.
-        try (var unpacker = getUnpacker(byteBuf)) {
-            metrics.bytesReceivedAdd(byteBuf.readableBytes() + ClientMessageCommon.HEADER_SIZE);
+        var unpacker = getUnpacker(byteBuf);
+        metrics.bytesReceivedAdd(byteBuf.readableBytes() + ClientMessageCommon.HEADER_SIZE);
 
-            // Packer buffer is released by Netty on send, or by inner exception handlers below.
-            var packer = getPacker(ctx.alloc());
+        // Packer buffer is released by Netty on send, or by inner exception handlers below.
+        var packer = getPacker(ctx.alloc());
 
-            if (clientContext == null) {
-                metrics.bytesReceivedAdd(ClientMessageCommon.MAGIC_BYTES.length);
-                handshake(ctx, unpacker, packer);
-            } else {
-                // TODO: Some operations may use unpacker asynchronously, outside of this try block.
-                // We should increase the reference count of the buffer in this case, and release it in the future completion callback.
-                processOperation(ctx, unpacker, packer);
-            }
+        if (clientContext == null) {
+            metrics.bytesReceivedAdd(ClientMessageCommon.MAGIC_BYTES.length);
+            handshake(ctx, unpacker, packer);
+        } else {
+            processOperation(ctx, unpacker, packer);
         }
     }
 
@@ -327,6 +324,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
             }
 
             metrics.sessionsRejectedIncrement();
+        } finally {
+            unpacker.close();
         }
     }
 
@@ -455,6 +454,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
 
             if (fut == null) {
                 // Operation completed synchronously.
+                in.close();
                 write(out, ctx);
 
                 if (LOG.isTraceEnabled()) {
@@ -469,6 +469,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
                 var op = opCode;
 
                 fut.whenComplete((Object res, Object err) -> {
+                    in.close();
                     metrics.requestsActiveDecrement();
 
                     if (err != null) {
@@ -487,6 +488,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
                 });
             }
         } catch (Throwable t) {
+            in.close();
             out.close();
 
             writeError(requestId, opCode, t, ctx);

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteColocatedRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteColocatedRequest.java
@@ -19,7 +19,7 @@ package org.apache.ignite.client.handler.requests.compute;
 
 import static org.apache.ignite.client.handler.requests.compute.ClientComputeExecuteRequest.unpackArgs;
 import static org.apache.ignite.client.handler.requests.compute.ClientComputeExecuteRequest.unpackDeploymentUnits;
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuple;
 
 import java.util.List;
@@ -48,16 +48,17 @@ public class ClientComputeExecuteColocatedRequest {
             ClientMessagePacker out,
             IgniteCompute compute,
             IgniteTables tables) {
-        var table = readTable(in, tables);
-        var keyTuple = readTuple(in, table, true);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var keyTuple = readTuple(in, table, true);
 
-        List<DeploymentUnit> deploymentUnits = unpackDeploymentUnits(in);
-        String jobClassName = in.unpackString();
-        Object[] args = unpackArgs(in);
+            List<DeploymentUnit> deploymentUnits = unpackDeploymentUnits(in);
+            String jobClassName = in.unpackString();
+            Object[] args = unpackArgs(in);
 
-        return compute.executeColocated(table.name(), keyTuple, deploymentUnits, jobClassName, args).thenAccept(val -> {
-            out.packInt(table.schemaView().lastSchemaVersion());
-            out.packObjectAsBinaryTuple(val);
+            return compute.executeColocated(table.name(), keyTuple, deploymentUnits, jobClassName, args).thenAccept(val -> {
+                out.packInt(table.schemaView().lastSchemaVersion());
+                out.packObjectAsBinaryTuple(val);
+            });
         });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientSchemasGetRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientSchemasGetRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.writeSchema;
 
 import java.util.concurrent.CompletableFuture;
@@ -44,7 +44,7 @@ public class ClientSchemasGetRequest {
             ClientMessagePacker out,
             IgniteTables tables
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
 
         if (in.tryUnpackNil()) {
             // Return the latest schema.

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientSchemasGetRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientSchemasGetRequest.java
@@ -23,6 +23,7 @@ import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.
 import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.internal.client.proto.ClientMessagePacker;
 import org.apache.ignite.internal.client.proto.ClientMessageUnpacker;
+import org.apache.ignite.lang.ErrorGroups.Common;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.table.manager.IgniteTables;
 
@@ -39,35 +40,33 @@ public class ClientSchemasGetRequest {
      * @return Future.
      * @throws IgniteException When schema registry is no initialized.
      */
-    public static CompletableFuture<Object> process(
+    public static CompletableFuture<Void> process(
             ClientMessageUnpacker in,
             ClientMessagePacker out,
             IgniteTables tables
     ) {
-        var table = readTableAsync(in, tables);
+        return readTableAsync(in, tables).thenAccept(table -> {
+            if (in.tryUnpackNil()) {
+                // Return the latest schema.
+                out.packMapHeader(1);
 
-        if (in.tryUnpackNil()) {
-            // Return the latest schema.
-            out.packMapHeader(1);
+                var schema = table.schemaView().schema();
 
-            var schema = table.schemaView().schema();
+                if (schema == null) {
+                    throw new IgniteException(Common.COMPONENT_NOT_STARTED_ERR, "Schema registry is not initialized.");
+                }
 
-            if (schema == null) {
-                throw new IgniteException("Schema registry is not initialized.");
+                writeSchema(out, schema.version(), schema);
+            } else {
+                var cnt = in.unpackArrayHeader();
+                out.packMapHeader(cnt);
+
+                for (var i = 0; i < cnt; i++) {
+                    var schemaVer = in.unpackInt();
+                    var schema = table.schemaView().schema(schemaVer);
+                    writeSchema(out, schemaVer, schema);
+                }
             }
-
-            writeSchema(out, schema.version(), schema);
-        } else {
-            var cnt = in.unpackArrayHeader();
-            out.packMapHeader(cnt);
-
-            for (var i = 0; i < cnt; i++) {
-                var schemaVer = in.unpackInt();
-                var schema = table.schemaView().schema(schemaVer);
-                writeSchema(out, schemaVer, schema);
-            }
-        }
-
-        return null;
+        });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTableCommon.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTableCommon.java
@@ -22,6 +22,7 @@ import static org.apache.ignite.lang.ErrorGroups.Client.TABLE_ID_NOT_FOUND_ERR;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.client.handler.ClientResourceRegistry;
 import org.apache.ignite.internal.binarytuple.BinaryTupleContainer;
 import org.apache.ignite.internal.binarytuple.BinaryTupleReader;
@@ -327,17 +328,18 @@ public class ClientTableCommon {
      *                             <li>the node is stopping.</li>
      *                         </ul>
      */
-    public static TableImpl readTable(ClientMessageUnpacker unpacker, IgniteTables tables) {
+    public static CompletableFuture<TableImpl> readTableAsync(ClientMessageUnpacker unpacker, IgniteTables tables) {
         int tableId = unpacker.unpackInt();
 
         try {
-            TableImpl table = ((IgniteTablesInternal) tables).table(tableId);
+            return ((IgniteTablesInternal) tables).tableAsync(tableId)
+                    .thenApply(t -> {
+                        if (t == null) {
+                            throw new IgniteException(TABLE_ID_NOT_FOUND_ERR, "Table does not exist: " + tableId);
+                        }
 
-            if (table == null) {
-                throw new IgniteException(TABLE_ID_NOT_FOUND_ERR, "Table does not exist: " + tableId);
-            }
-
-            return table;
+                        return t;
+                    });
         } catch (NodeStoppingException e) {
             throw new IgniteException(e.traceId(), e.code(), e.getMessage(), e);
         }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTablePartitionAssignmentGetRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTablePartitionAssignmentGetRequest.java
@@ -43,7 +43,7 @@ public class ClientTablePartitionAssignmentGetRequest {
             IgniteTablesInternal tables
     ) throws NodeStoppingException {
         int tableId = in.unpackInt();
-        var assignment = tables.assignments(tableId);
+        var assignment = tables.assignments(tableId); // TODO: Make async too.
 
         if (assignment == null) {
             out.packArrayHeader(0);

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTablePartitionAssignmentGetRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTablePartitionAssignmentGetRequest.java
@@ -37,25 +37,24 @@ public class ClientTablePartitionAssignmentGetRequest {
      * @return Future.
      * @throws IgniteException When schema registry is no initialized.
      */
-    public static CompletableFuture<Object> process(
+    public static CompletableFuture<Void> process(
             ClientMessageUnpacker in,
             ClientMessagePacker out,
             IgniteTablesInternal tables
     ) throws NodeStoppingException {
         int tableId = in.unpackInt();
-        var assignment = tables.assignments(tableId); // TODO: Make async too.
 
-        if (assignment == null) {
-            out.packArrayHeader(0);
-            return null;
-        }
+        return tables.assignmentsAsync(tableId).thenAccept(assignment -> {
+            if (assignment == null) {
+                out.packArrayHeader(0);
+                return;
+            }
 
-        out.packArrayHeader(assignment.size());
+            out.packArrayHeader(assignment.size());
 
-        for (String leaderNodeId : assignment) {
-            out.packString(leaderNodeId);
-        }
-
-        return null;
+            for (String leaderNodeId : assignment) {
+                out.packString(leaderNodeId);
+            }
+        });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleContainsKeyRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleContainsKeyRequest.java
@@ -46,14 +46,15 @@ public class ClientTupleContainsKeyRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var keyTuple = readTuple(in, table, true);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var keyTuple = readTuple(in, table, true);
 
-        return table.recordView().getAsync(tx, keyTuple)
-                .thenAccept(t -> {
-                    out.packInt(table.schemaView().lastSchemaVersion());
-                    out.packBoolean(t != null);
-                });
+            return table.recordView().getAsync(tx, keyTuple)
+                    .thenAccept(t -> {
+                        out.packInt(table.schemaView().lastSchemaVersion());
+                        out.packBoolean(t != null);
+                    });
+        });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleContainsKeyRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleContainsKeyRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuple;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 
@@ -46,7 +46,7 @@ public class ClientTupleContainsKeyRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var keyTuple = readTuple(in, table, true);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteAllExactRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteAllExactRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuples;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.writeTuples;
@@ -47,7 +47,7 @@ public class ClientTupleDeleteAllExactRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var tuples = readTuples(in, table, false);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteAllExactRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteAllExactRequest.java
@@ -47,11 +47,12 @@ public class ClientTupleDeleteAllExactRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var tuples = readTuples(in, table, false);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var tuples = readTuples(in, table, false);
 
-        return table.recordView().deleteAllExactAsync(tx, tuples)
-                .thenAccept(skippedTuples -> writeTuples(out, skippedTuples, table.schemaView()));
+            return table.recordView().deleteAllExactAsync(tx, tuples)
+                    .thenAccept(skippedTuples -> writeTuples(out, skippedTuples, table.schemaView()));
+        });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteAllRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteAllRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuples;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.writeTuples;
@@ -48,7 +48,7 @@ public class ClientTupleDeleteAllRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var tuples = readTuples(in, table, true);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteAllRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteAllRequest.java
@@ -48,11 +48,12 @@ public class ClientTupleDeleteAllRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var tuples = readTuples(in, table, true);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var tuples = readTuples(in, table, true);
 
-        return table.recordView().deleteAllAsync(tx, tuples).thenAccept(skippedTuples ->
-            writeTuples(out, skippedTuples, TuplePart.KEY, table.schemaView()));
+            return table.recordView().deleteAllAsync(tx, tuples).thenAccept(skippedTuples ->
+                    writeTuples(out, skippedTuples, TuplePart.KEY, table.schemaView()));
+        });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteExactRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteExactRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuple;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 
@@ -46,7 +46,7 @@ public class ClientTupleDeleteExactRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var tuple = readTuple(in, table, false);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteExactRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteExactRequest.java
@@ -46,13 +46,14 @@ public class ClientTupleDeleteExactRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var tuple = readTuple(in, table, false);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var tuple = readTuple(in, table, false);
 
-        return table.recordView().deleteExactAsync(tx, tuple).thenAccept(res -> {
-            out.packInt(table.schemaView().lastSchemaVersion());
-            out.packBoolean(res);
+            return table.recordView().deleteExactAsync(tx, tuple).thenAccept(res -> {
+                out.packInt(table.schemaView().lastSchemaVersion());
+                out.packBoolean(res);
+            });
         });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteRequest.java
@@ -46,13 +46,14 @@ public class ClientTupleDeleteRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var tuple = readTuple(in, table, true);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var tuple = readTuple(in, table, true);
 
-        return table.recordView().deleteAsync(tx, tuple).thenAccept(res -> {
-            out.packInt(table.schemaView().lastSchemaVersion());
-            out.packBoolean(res);
+            return table.recordView().deleteAsync(tx, tuple).thenAccept(res -> {
+                out.packInt(table.schemaView().lastSchemaVersion());
+                out.packBoolean(res);
+            });
         });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleDeleteRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuple;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 
@@ -46,7 +46,7 @@ public class ClientTupleDeleteRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var tuple = readTuple(in, table, true);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAllRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAllRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuples;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.writeTuplesNullable;
@@ -48,7 +48,7 @@ public class ClientTupleGetAllRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var keyTuples = readTuples(in, table, true);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAllRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAllRequest.java
@@ -48,11 +48,12 @@ public class ClientTupleGetAllRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var keyTuples = readTuples(in, table, true);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var keyTuples = readTuples(in, table, true);
 
-        return table.recordView().getAllAsync(tx, keyTuples).thenAccept(tuples ->
-            writeTuplesNullable(out, tuples, TuplePart.KEY_AND_VAL, table.schemaView()));
+            return table.recordView().getAllAsync(tx, keyTuples).thenAccept(tuples ->
+                    writeTuplesNullable(out, tuples, TuplePart.KEY_AND_VAL, table.schemaView()));
+        });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAndDeleteRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAndDeleteRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuple;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 
@@ -47,7 +47,7 @@ public class ClientTupleGetAndDeleteRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var tuple = readTuple(in, table, true);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAndDeleteRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAndDeleteRequest.java
@@ -47,11 +47,12 @@ public class ClientTupleGetAndDeleteRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var tuple = readTuple(in, table, true);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var tuple = readTuple(in, table, true);
 
-        return table.recordView().getAndDeleteAsync(tx, tuple).thenAccept(
-                resTuple -> ClientTableCommon.writeTupleOrNil(out, resTuple, TuplePart.KEY_AND_VAL, table.schemaView()));
+            return table.recordView().getAndDeleteAsync(tx, tuple).thenAccept(
+                    resTuple -> ClientTableCommon.writeTupleOrNil(out, resTuple, TuplePart.KEY_AND_VAL, table.schemaView()));
+        });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAndReplaceRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAndReplaceRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuple;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 
@@ -47,7 +47,7 @@ public class ClientTupleGetAndReplaceRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var tuple = readTuple(in, table, false);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAndReplaceRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAndReplaceRequest.java
@@ -47,11 +47,12 @@ public class ClientTupleGetAndReplaceRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var tuple = readTuple(in, table, false);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var tuple = readTuple(in, table, false);
 
-        return table.recordView().getAndReplaceAsync(tx, tuple).thenAccept(
-                resTuple -> ClientTableCommon.writeTupleOrNil(out, resTuple, TuplePart.KEY_AND_VAL, table.schemaView()));
+            return table.recordView().getAndReplaceAsync(tx, tuple).thenAccept(
+                    resTuple -> ClientTableCommon.writeTupleOrNil(out, resTuple, TuplePart.KEY_AND_VAL, table.schemaView()));
+        });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAndUpsertRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAndUpsertRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuple;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 
@@ -47,7 +47,7 @@ public class ClientTupleGetAndUpsertRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var tuple = readTuple(in, table, false);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAndUpsertRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetAndUpsertRequest.java
@@ -47,11 +47,12 @@ public class ClientTupleGetAndUpsertRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var tuple = readTuple(in, table, false);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var tuple = readTuple(in, table, false);
 
-        return table.recordView().getAndUpsertAsync(tx, tuple).thenAccept(
-                resTuple -> ClientTableCommon.writeTupleOrNil(out, resTuple, TuplePart.KEY_AND_VAL, table.schemaView()));
+            return table.recordView().getAndUpsertAsync(tx, tuple).thenAccept(
+                    resTuple -> ClientTableCommon.writeTupleOrNil(out, resTuple, TuplePart.KEY_AND_VAL, table.schemaView()));
+        });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetRequest.java
@@ -47,11 +47,12 @@ public class ClientTupleGetRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var keyTuple = readTuple(in, table, true);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var keyTuple = readTuple(in, table, true);
 
-        return table.recordView().getAsync(tx, keyTuple)
-                .thenAccept(t -> ClientTableCommon.writeTupleOrNil(out, t, TuplePart.KEY_AND_VAL, table.schemaView()));
+            return table.recordView().getAsync(tx, keyTuple)
+                    .thenAccept(t -> ClientTableCommon.writeTupleOrNil(out, t, TuplePart.KEY_AND_VAL, table.schemaView()));
+        });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleGetRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuple;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 
@@ -47,7 +47,7 @@ public class ClientTupleGetRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var keyTuple = readTuple(in, table, true);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleInsertAllRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleInsertAllRequest.java
@@ -47,11 +47,12 @@ public class ClientTupleInsertAllRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var tuples = readTuples(in, table, false);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var tuples = readTuples(in, table, false);
 
-        return table.recordView().insertAllAsync(tx, tuples).thenAccept(skippedTuples ->
-            writeTuples(out, skippedTuples, table.schemaView()));
+            return table.recordView().insertAllAsync(tx, tuples).thenAccept(skippedTuples ->
+                    writeTuples(out, skippedTuples, table.schemaView()));
+        });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleInsertAllRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleInsertAllRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuples;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.writeTuples;
@@ -47,7 +47,7 @@ public class ClientTupleInsertAllRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var tuples = readTuples(in, table, false);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleInsertRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleInsertRequest.java
@@ -46,13 +46,14 @@ public class ClientTupleInsertRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var tuple = readTuple(in, table, false);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var tuple = readTuple(in, table, false);
 
-        return table.recordView().insertAsync(tx, tuple).thenAccept(res -> {
-            out.packInt(table.schemaView().lastSchemaVersion());
-            out.packBoolean(res);
+            return table.recordView().insertAsync(tx, tuple).thenAccept(res -> {
+                out.packInt(table.schemaView().lastSchemaVersion());
+                out.packBoolean(res);
+            });
         });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleInsertRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleInsertRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuple;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 
@@ -46,7 +46,7 @@ public class ClientTupleInsertRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var tuple = readTuple(in, table, false);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleReplaceExactRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleReplaceExactRequest.java
@@ -47,16 +47,17 @@ public class ClientTupleReplaceExactRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var schema = readSchema(in, table);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var schema = readSchema(in, table);
 
-        var oldTuple = readTuple(in, false, schema);
-        var newTuple = readTuple(in, false, schema);
+            var oldTuple = readTuple(in, false, schema);
+            var newTuple = readTuple(in, false, schema);
 
-        return table.recordView().replaceAsync(tx, oldTuple, newTuple).thenAccept(res -> {
-            out.packInt(table.schemaView().lastSchemaVersion());
-            out.packBoolean(res);
+            return table.recordView().replaceAsync(tx, oldTuple, newTuple).thenAccept(res -> {
+                out.packInt(table.schemaView().lastSchemaVersion());
+                out.packBoolean(res);
+            });
         });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleReplaceExactRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleReplaceExactRequest.java
@@ -18,7 +18,7 @@
 package org.apache.ignite.client.handler.requests.table;
 
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readSchema;
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuple;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 
@@ -47,7 +47,7 @@ public class ClientTupleReplaceExactRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var schema = readSchema(in, table);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleReplaceRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleReplaceRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuple;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 
@@ -46,7 +46,7 @@ public class ClientTupleReplaceRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var tuple = readTuple(in, table, false);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleReplaceRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleReplaceRequest.java
@@ -46,13 +46,14 @@ public class ClientTupleReplaceRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var tuple = readTuple(in, table, false);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var tuple = readTuple(in, table, false);
 
-        return table.recordView().replaceAsync(tx, tuple).thenAccept(res -> {
-            out.packInt(table.schemaView().lastSchemaVersion());
-            out.packBoolean(res);
+            return table.recordView().replaceAsync(tx, tuple).thenAccept(res -> {
+                out.packInt(table.schemaView().lastSchemaVersion());
+                out.packBoolean(res);
+            });
         });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleUpsertAllRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleUpsertAllRequest.java
@@ -46,11 +46,12 @@ public class ClientTupleUpsertAllRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var tuples = readTuples(in, table, false);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var tuples = readTuples(in, table, false);
 
-        return table.recordView().upsertAllAsync(tx, tuples)
-                .thenAccept(unused -> out.packInt(table.schemaView().lastSchemaVersion()));
+            return table.recordView().upsertAllAsync(tx, tuples)
+                    .thenAccept(unused -> out.packInt(table.schemaView().lastSchemaVersion()));
+        });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleUpsertAllRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleUpsertAllRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuples;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 
@@ -46,7 +46,7 @@ public class ClientTupleUpsertAllRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var tuples = readTuples(in, table, false);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleUpsertRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleUpsertRequest.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.client.handler.requests.table;
 
-import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTable;
+import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTableAsync;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTuple;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 
@@ -46,7 +46,7 @@ public class ClientTupleUpsertRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTable(in, tables);
+        var table = readTableAsync(in, tables);
         var tx = readTx(in, resources);
         var tuple = readTuple(in, table, false);
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleUpsertRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTupleUpsertRequest.java
@@ -46,10 +46,11 @@ public class ClientTupleUpsertRequest {
             IgniteTables tables,
             ClientResourceRegistry resources
     ) {
-        var table = readTableAsync(in, tables);
-        var tx = readTx(in, resources);
-        var tuple = readTuple(in, table, false);
+        return readTableAsync(in, tables).thenCompose(table -> {
+            var tx = readTx(in, resources);
+            var tuple = readTuple(in, table, false);
 
-        return table.recordView().upsertAsync(tx, tuple).thenAccept(v -> out.packInt(table.schemaView().lastSchemaVersion()));
+            return table.recordView().upsertAsync(tx, tuple).thenAccept(v -> out.packInt(table.schemaView().lastSchemaVersion()));
+        });
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgniteTables.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgniteTables.java
@@ -168,8 +168,8 @@ public class FakeIgniteTables implements IgniteTablesInternal {
 
     /** {@inheritDoc} */
     @Override
-    public List<String> assignmentsAsync(int tableId) {
-        return partitionAssignments;
+    public CompletableFuture<List<String>> assignmentsAsync(int tableId) {
+        return CompletableFuture.completedFuture(partitionAssignments);
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgniteTables.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgniteTables.java
@@ -168,7 +168,7 @@ public class FakeIgniteTables implements IgniteTablesInternal {
 
     /** {@inheritDoc} */
     @Override
-    public List<String> assignments(int tableId) {
+    public List<String> assignmentsAsync(int tableId) {
         return partitionAssignments;
     }
 

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/IgniteTablesInternal.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/IgniteTablesInternal.java
@@ -87,11 +87,10 @@ public interface IgniteTablesInternal extends IgniteTables {
      * @param tableId Unique id of a table.
      * @return List of the current assignments.
      */
-    @Nullable
-    List<String> assignments(int tableId) throws NodeStoppingException;
+    CompletableFuture<List<String>> assignmentsAsync(int tableId) throws NodeStoppingException;
 
     /**
-     * Adds a listener to track changes in {@link #assignments(UUID)}.
+     * Adds a listener to track changes in {@link #assignmentsAsync}.
      *
      * @param listener Listener.
      */

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/IgniteTablesInternal.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/IgniteTablesInternal.java
@@ -18,13 +18,11 @@
 package org.apache.ignite.internal.table;
 
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.lang.NodeStoppingException;
 import org.apache.ignite.table.manager.IgniteTables;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Internal tables facade provides low-level methods for table operations.

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
@@ -1138,21 +1138,14 @@ public class TableManager extends Producer<TableEvent, TableEventParameters> imp
 
     /** {@inheritDoc} */
     @Override
-    public List<String> assignments(int tableId) throws NodeStoppingException {
-        if (!busyLock.enterBusy()) {
-            throw new NodeStoppingException();
-        }
-        try {
-            TableImpl table = table(tableId);
-
+    public CompletableFuture<List<String>> assignmentsAsync(int tableId) {
+        return tableAsync(tableId).thenApply(table -> {
             if (table == null) {
                 return null;
             }
 
             return table.internalTable().assignments();
-        } finally {
-            busyLock.leaveBusy();
-        }
+        });
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
* Make `ClientTableCommon.readTable` async to avoid blocking Netty threads
* Change `IgniteTablesInternal#assignments` to async too
* Extend unpacker lifetime in `ClientInboundMessageHandler` to allow unpacking in future continuations