### PR TITLE
IGNITE-19609 Java client: Add data streamer metrics

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientMetricSource.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientMetricSource.java
@@ -23,11 +23,12 @@ import org.apache.ignite.internal.metrics.AbstractMetricSource;
 import org.apache.ignite.internal.metrics.AtomicLongMetric;
 import org.apache.ignite.internal.metrics.Metric;
 import org.apache.ignite.internal.metrics.MetricSetBuilder;
+import org.apache.ignite.internal.streamer.StreamerMetricSink;
 
 /**
  * Client-side metrics.
  */
-public class ClientMetricSource extends AbstractMetricSource<ClientMetricSource.Holder> {
+public class ClientMetricSource extends AbstractMetricSource<ClientMetricSource.Holder> implements StreamerMetricSink {
     /**
      * Constructor.
      */
@@ -361,6 +362,7 @@ public class ClientMetricSource extends AbstractMetricSource<ClientMetricSource.
      *
      * @param batches Sent batches.
      */
+    @Override
     public void streamerBatchesSentAdd(long batches) {
         Holder h = holder();
 
@@ -383,6 +385,7 @@ public class ClientMetricSource extends AbstractMetricSource<ClientMetricSource.
      *
      * @param items Sent items.
      */
+    @Override
     public void streamerItemsSentAdd(long items) {
         Holder h = holder();
 
@@ -405,6 +408,7 @@ public class ClientMetricSource extends AbstractMetricSource<ClientMetricSource.
      *
      * @param batches Active batches.
      */
+    @Override
     public void streamerBatchesActiveAdd(long batches) {
         Holder h = holder();
 
@@ -427,6 +431,7 @@ public class ClientMetricSource extends AbstractMetricSource<ClientMetricSource.
      *
      * @param items Queued items.
      */
+    @Override
     public void streamerItemsQueuedAdd(long items) {
         Holder h = holder();
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientMetricSource.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientMetricSource.java
@@ -413,6 +413,28 @@ public class ClientMetricSource extends AbstractMetricSource<ClientMetricSource.
         }
     }
 
+    /**
+     * Gets streamer items queued.
+     */
+    public long streamerItemsQueued() {
+        Holder h = holder();
+
+        return h == null ? 0 : h.streamerItemsQueued.value();
+    }
+
+    /**
+     * Adds streamer items queued.
+     *
+     * @param items Queued items.
+     */
+    public void streamerItemsQueuedAdd(long items) {
+        Holder h = holder();
+
+        if (h != null) {
+            h.streamerItemsQueued.add(items);
+        }
+    }
+
     @Override
     protected Holder createHolder() {
         return new Holder();

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientMetricSource.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientMetricSource.java
@@ -399,6 +399,18 @@ public class ClientMetricSource extends AbstractMetricSource<ClientMetricSource.
 
         private final AtomicLongMetric bytesReceived = new AtomicLongMetric("BytesReceived", "Total bytes received");
 
+        private final AtomicLongMetric streamerBatchesSent = new AtomicLongMetric(
+                "StreamerBatchesSent", "Total data streamer batches sent");
+
+        private final AtomicLongMetric streamerItemsSent = new AtomicLongMetric(
+                "StreamerItemsSent", "Total number of data streamer items sent");
+
+        private final AtomicLongMetric streamerBatchesActive = new AtomicLongMetric(
+                "StreamerBatchesActive", "Total number of existing data streamer batches");
+
+        private final AtomicLongMetric streamerItemsQueued = new AtomicLongMetric(
+                "StreamerItemsQueued", "Total number of queued data streamer items (rows)");
+
         final List<Metric> metrics = Arrays.asList(
                 connectionsActive,
                 connectionsEstablished,

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientMetricSource.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientMetricSource.java
@@ -347,6 +347,50 @@ public class ClientMetricSource extends AbstractMetricSource<ClientMetricSource.
         }
     }
 
+    /**
+     * Gets streamer batches sent.
+     */
+    public long streamerBatchesSent() {
+        Holder h = holder();
+
+        return h == null ? 0 : h.streamerBatchesSent.value();
+    }
+
+    /**
+     * Adds streamer batches sent.
+     *
+     * @param batches Sent batches.
+     */
+    public void streamerBatchesSentAdd(long batches) {
+        Holder h = holder();
+
+        if (h != null) {
+            h.streamerBatchesSent.add(batches);
+        }
+    }
+
+    /**
+     * Gets streamer items sent.
+     */
+    public long streamerItemsSent() {
+        Holder h = holder();
+
+        return h == null ? 0 : h.streamerItemsSent.value();
+    }
+
+    /**
+     * Adds streamer items sent.
+     *
+     * @param items Sent items.
+     */
+    public void streamerItemsSentAdd(long items) {
+        Holder h = holder();
+
+        if (h != null) {
+            h.streamerItemsSent.add(items);
+        }
+    }
+
     @Override
     protected Holder createHolder() {
         return new Holder();

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientMetricSource.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientMetricSource.java
@@ -391,6 +391,28 @@ public class ClientMetricSource extends AbstractMetricSource<ClientMetricSource.
         }
     }
 
+    /**
+     * Gets streamer batches active.
+     */
+    public long streamerBatchesActive() {
+        Holder h = holder();
+
+        return h == null ? 0 : h.streamerBatchesActive.value();
+    }
+
+    /**
+     * Adds streamer batches active.
+     *
+     * @param batches Active batches.
+     */
+    public void streamerBatchesActiveAdd(long batches) {
+        Holder h = holder();
+
+        if (h != null) {
+            h.streamerBatchesActive.add(batches);
+        }
+    }
+
     @Override
     protected Holder createHolder() {
         return new Holder();

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -145,6 +145,15 @@ public final class ReliableChannel implements AutoCloseable {
     }
 
     /**
+     * Gets the metrics.
+     *
+     * @return Metrics.
+     */
+    public ClientMetricSource metrics() {
+        return metrics;
+    }
+
+    /**
      * Gets active client connections.
      *
      * @return List of connected cluster nodes.

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientDataStreamer.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientDataStreamer.java
@@ -19,7 +19,6 @@ package org.apache.ignite.internal.client.table;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow.Publisher;
-import org.apache.ignite.internal.client.ClientMetricSource;
 import org.apache.ignite.internal.client.ClientUtils;
 import org.apache.ignite.internal.logger.IgniteLogger;
 import org.apache.ignite.internal.streamer.StreamerBatchSender;

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientDataStreamer.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientDataStreamer.java
@@ -33,18 +33,17 @@ import org.jetbrains.annotations.NotNull;
  * Client data streamer.
  */
 class ClientDataStreamer {
+    @SuppressWarnings("resource")
     static <R> CompletableFuture<Void> streamData(
             Publisher<R> publisher,
             DataStreamerOptions options,
             StreamerBatchSender<R, String> batchSender,
             StreamerPartitionAwarenessProvider<R, String> partitionAwarenessProvider,
-            ClientTable tbl,
-            ClientMetricSource metrics) {
-        //noinspection resource
+            ClientTable tbl) {
         IgniteLogger log = ClientUtils.logger(tbl.channel().configuration(), StreamerSubscriber.class);
         StreamerOptions streamerOpts = streamerOptions(options);
         StreamerSubscriber<R, String> subscriber = new StreamerSubscriber<>(
-                batchSender, partitionAwarenessProvider, streamerOpts, log, metrics); // TODO: Interface for metrics, because subscriber is in core module
+                batchSender, partitionAwarenessProvider, streamerOpts, log, tbl.channel().metrics());
 
         publisher.subscribe(subscriber);
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientDataStreamer.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientDataStreamer.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.client.table;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow.Publisher;
+import org.apache.ignite.internal.client.ClientMetricSource;
 import org.apache.ignite.internal.client.ClientUtils;
 import org.apache.ignite.internal.logger.IgniteLogger;
 import org.apache.ignite.internal.streamer.StreamerBatchSender;
@@ -37,11 +38,13 @@ class ClientDataStreamer {
             DataStreamerOptions options,
             StreamerBatchSender<R, String> batchSender,
             StreamerPartitionAwarenessProvider<R, String> partitionAwarenessProvider,
-            ClientTable tbl) {
+            ClientTable tbl,
+            ClientMetricSource metrics) {
         //noinspection resource
         IgniteLogger log = ClientUtils.logger(tbl.channel().configuration(), StreamerSubscriber.class);
         StreamerOptions streamerOpts = streamerOptions(options);
-        StreamerSubscriber<R, String> subscriber = new StreamerSubscriber<>(batchSender, partitionAwarenessProvider, streamerOpts, log);
+        StreamerSubscriber<R, String> subscriber = new StreamerSubscriber<>(
+                batchSender, partitionAwarenessProvider, streamerOpts, log, metrics); // TODO: Interface for metrics, because subscriber is in core module
 
         publisher.subscribe(subscriber);
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueBinaryView.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientKeyValueBinaryView.java
@@ -458,6 +458,7 @@ public class ClientKeyValueBinaryView implements KeyValueView<Tuple, Tuple> {
                 PartitionAwarenessProvider.of(nodeName),
                 new RetryLimitPolicy().retryLimit(opts.retryLimit()));
 
+        //noinspection resource
         return ClientDataStreamer.streamData(publisher, opts, batchSender, provider, tbl);
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
@@ -228,18 +228,18 @@ public class ClientMetricsTest {
         Table table = oneColumnTable();
         CompletableFuture<Void> streamerFut;
 
-        var publisher = new SubmissionPublisher<Tuple>();
+        var publisher = new SubmissionPublisher<Tuple>(ForkJoinPool.commonPool(), 1);
         streamerFut = table.recordView().streamData(publisher, null);
 
         publisher.submit(Tuple.create().set("ID", "1"));
         publisher.submit(Tuple.create().set("ID", "2"));
-        publisher.close();
 
         assertEquals(0, metrics().streamerItemsSent());
         assertEquals(0, metrics().streamerBatchesSent());
         assertEquals(0, metrics().streamerBatchesActive());
         assertEquals(2, metrics().streamerItemsQueued());
 
+        publisher.close();
         streamerFut.orTimeout(3, TimeUnit.SECONDS).join();
 
         assertEquals(2, metrics().streamerItemsSent());

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
@@ -28,8 +28,6 @@ import java.util.concurrent.SubmissionPublisher;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import org.apache.commons.math3.stat.inference.TestUtils;
-import org.apache.ignite.client.AbstractClientTableTest.PersonPojo;
 import org.apache.ignite.client.IgniteClient.Builder;
 import org.apache.ignite.client.fakes.FakeIgnite;
 import org.apache.ignite.client.fakes.FakeIgniteTables;

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.SubmissionPublisher;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import org.apache.commons.math3.stat.inference.TestUtils;
 import org.apache.ignite.client.AbstractClientTableTest.PersonPojo;
 import org.apache.ignite.client.IgniteClient.Builder;
 import org.apache.ignite.client.fakes.FakeIgnite;
@@ -221,7 +222,7 @@ public class ClientMetricsTest {
     }
 
     @Test
-    public void testStreamer() {
+    public void testStreamer() throws InterruptedException {
         server = AbstractClientTest.startServer(0, new FakeIgnite());
         client = clientBuilder().build();
 
@@ -234,10 +235,10 @@ public class ClientMetricsTest {
         publisher.submit(Tuple.create().set("ID", "1"));
         publisher.submit(Tuple.create().set("ID", "2"));
 
+        assertTrue(IgniteTestUtils.waitForCondition(() -> metrics().streamerItemsQueued() == 2, 1000));
         assertEquals(0, metrics().streamerItemsSent());
         assertEquals(0, metrics().streamerBatchesSent());
         assertEquals(0, metrics().streamerBatchesActive());
-        assertEquals(2, metrics().streamerItemsQueued());
 
         publisher.close();
         streamerFut.orTimeout(3, TimeUnit.SECONDS).join();

--- a/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
@@ -74,6 +74,8 @@ public class TestServer implements AutoCloseable {
 
     private final ClientHandlerMetricSource metrics;
 
+    private final Ignite ignite;
+
     /**
      * Constructor.
      *
@@ -137,6 +139,7 @@ public class TestServer implements AutoCloseable {
         }
 
         this.nodeName = nodeName;
+        this.ignite = ignite;
 
         ClusterService clusterService = mock(ClusterService.class, RETURNS_DEEP_STUBS);
         Mockito.when(clusterService.topologyService().localMember().id()).thenReturn(getNodeId(nodeName));
@@ -195,6 +198,15 @@ public class TestServer implements AutoCloseable {
                 : ((TestClientHandlerModule) module).localAddress();
 
         return ((InetSocketAddress) Objects.requireNonNull(addr)).getPort();
+    }
+
+    /**
+     * Gets the Ignite.
+     *
+     * @return Ignite
+     */
+    public Ignite ignite() {
+        return ignite;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/streamer/StreamerMetricSink.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/streamer/StreamerMetricSink.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.streamer;
+
+/**
+ * Streamer metric sink.
+ */
+public interface StreamerMetricSink {
+    /**
+     * Adds streamer batches sent.
+     *
+     * @param batches Sent batches.
+     */
+    void streamerBatchesSentAdd(long batches);
+
+    /**
+     * Adds streamer items sent.
+     *
+     * @param items Sent items.
+     */
+    void streamerItemsSentAdd(long items);
+
+    /**
+     * Adds streamer batches active.
+     *
+     * @param batches Active batches.
+     */
+    void streamerBatchesActiveAdd(long batches);
+
+    /**
+     * Adds streamer items queued.
+     *
+     * @param items Queued items.
+     */
+    void streamerItemsQueuedAdd(long items);
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/streamer/StreamerSubscriber.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/streamer/StreamerSubscriber.java
@@ -166,13 +166,13 @@ public class StreamerSubscriber<T, P> implements Subscriber<T> {
                     log.error("Failed to send batch to partition " + partition + ": " + err.getMessage(), err);
                     close(err);
                 } else {
-                    fut.complete(null);
-                    pendingFuts.remove(fut);
-
                     this.metrics.streamerBatchesSentAdd(1);
                     this.metrics.streamerBatchesActiveAdd(-1);
                     this.metrics.streamerItemsSentAdd(batchSize);
                     this.metrics.streamerItemsQueuedAdd(-batchSize);
+
+                    fut.complete(null);
+                    pendingFuts.remove(fut);
 
                     inFlightItemCount.addAndGet(-batchSize);
                     requestMore();

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/DataStreamer.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/DataStreamer.java
@@ -38,7 +38,8 @@ class DataStreamer {
             StreamerBatchSender<R, Integer> batchSender,
             StreamerPartitionAwarenessProvider<R, Integer> partitionAwarenessProvider) {
         StreamerOptions streamerOpts = streamerOptions(options);
-        StreamerSubscriber<R, Integer> subscriber = new StreamerSubscriber<>(batchSender, partitionAwarenessProvider, streamerOpts, LOG);
+        StreamerSubscriber<R, Integer> subscriber = new StreamerSubscriber<>(
+                batchSender, partitionAwarenessProvider, streamerOpts, LOG, null);
 
         publisher.subscribe(subscriber);
 


### PR DESCRIPTION
Add data streamer metrics to .NET client:
* `StreamerBatchesSent`
* `StreamerItemsSent`
* `StreamerBatchesActive`
* `StreamerItemsQueued`

`StreamerMetricSink` is added because most of the streamer code is in `ignite-core` module, which is shared across client and server.