### PR TITLE
IGNITE-19859 Fix testAutoFlushByTimer flakiness

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItAbstractDataStreamerTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItAbstractDataStreamerTest.java
@@ -151,7 +151,7 @@ public abstract class ItAbstractDataStreamerTest extends ClusterPerClassIntegrat
                 e.printStackTrace();
                 return false;
             }
-        }, 1000));
+        }, 50, 5000));
     }
 
     @Test

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItAbstractDataStreamerTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItAbstractDataStreamerTest.java
@@ -143,6 +143,7 @@ public abstract class ItAbstractDataStreamerTest extends ClusterPerClassIntegrat
 
         publisher.submit(tuple(1, "foo"));
         assertTrue(waitForCondition(() -> {
+            @SuppressWarnings("resource")
             var tx = ignite().transactions().begin(new TransactionOptions().readOnly(true));
 
             try {


### PR DESCRIPTION
Increase timeout, use read-only tx instead of try-catch for concurrent reads.