### PR TITLE
IGNITE-20036 Fix resource leaks in client tests and streamer

### DIFF
--- a/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTest.java
@@ -29,6 +29,7 @@ import org.apache.ignite.Ignite;
 import org.apache.ignite.client.fakes.FakeIgnite;
 import org.apache.ignite.client.fakes.FakeIgniteTables;
 import org.apache.ignite.client.fakes.FakeSchemaRegistry;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.NetworkAddress;
 import org.apache.ignite.table.Tuple;
@@ -73,8 +74,7 @@ public abstract class AbstractClientTest {
      */
     @AfterAll
     public static void afterAll() throws Exception {
-        client.close();
-        testServer.close();
+        IgniteUtils.closeAll(client, testServer);
 
         // Force GC to detect Netty buffer leaks.
         // noinspection CallToSystemGC

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientAuthenticationTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientAuthenticationTest.java
@@ -26,7 +26,6 @@ import org.apache.ignite.internal.configuration.testframework.InjectConfiguratio
 import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.security.AuthenticationException;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,7 +69,7 @@ public class ClientAuthenticationTest {
     public void testAuthnOnClientNoAuthnOnServer() {
         server = startServer(false);
 
-        startClient(BasicAuthenticator.builder().username("u").password("p").build());
+        client = startClient(BasicAuthenticator.builder().username("u").password("p").build());
     }
 
     @Test
@@ -93,7 +92,7 @@ public class ClientAuthenticationTest {
     public void testAuthnOnClientAuthnOnServer() {
         server = startServer(false);
 
-        startClient(BasicAuthenticator.builder().username("usr").password("pwd").build());
+        client = startClient(BasicAuthenticator.builder().username("usr").password("pwd").build());
     }
 
     private IgniteClient startClient(@Nullable IgniteClientAuthenticator authenticator) {
@@ -103,7 +102,6 @@ public class ClientAuthenticationTest {
                 .build();
     }
 
-    @NotNull
     private TestServer startServer(boolean basicAuthn) {
         var server = new TestServer(
                 1000,

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
@@ -35,6 +35,7 @@ import org.apache.ignite.client.fakes.FakeSession;
 import org.apache.ignite.internal.client.ClientMetricSource;
 import org.apache.ignite.internal.client.TcpIgniteClient;
 import org.apache.ignite.internal.testframework.IgniteTestUtils;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.sql.SqlException;
 import org.apache.ignite.table.Table;
 import org.apache.ignite.table.Tuple;
@@ -49,6 +50,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class ClientMetricsTest {
     private TestServer server;
     private IgniteClient client;
+
+    @AfterEach
+    public void afterEach() throws Exception {
+        IgniteUtils.closeAll(client, server);
+    }
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
@@ -227,35 +233,24 @@ public class ClientMetricsTest {
         Table table = oneColumnTable();
         CompletableFuture<Void> streamerFut;
 
-        var publisher = new SubmissionPublisher<Tuple>(ForkJoinPool.commonPool(), 1);
-        streamerFut = table.recordView().streamData(publisher, null);
+        try (var publisher = new SubmissionPublisher<Tuple>(ForkJoinPool.commonPool(), 1)) {
+            streamerFut = table.recordView().streamData(publisher, null);
 
-        publisher.submit(Tuple.create().set("ID", "1"));
-        publisher.submit(Tuple.create().set("ID", "2"));
+            publisher.submit(Tuple.create().set("ID", "1"));
+            publisher.submit(Tuple.create().set("ID", "2"));
 
-        assertTrue(IgniteTestUtils.waitForCondition(() -> metrics().streamerItemsQueued() == 2, 1000));
-        assertEquals(0, metrics().streamerItemsSent());
-        assertEquals(0, metrics().streamerBatchesSent());
-        assertEquals(0, metrics().streamerBatchesActive());
+            assertTrue(IgniteTestUtils.waitForCondition(() -> metrics().streamerItemsQueued() == 2, 1000));
+            assertEquals(0, metrics().streamerItemsSent());
+            assertEquals(0, metrics().streamerBatchesSent());
+            assertEquals(0, metrics().streamerBatchesActive());
+        }
 
-        publisher.close();
         streamerFut.orTimeout(3, TimeUnit.SECONDS).join();
 
         assertEquals(2, metrics().streamerItemsSent());
         assertEquals(1, metrics().streamerBatchesSent());
         assertEquals(0, metrics().streamerBatchesActive());
         assertEquals(0, metrics().streamerItemsQueued());
-    }
-
-    @AfterEach
-    public void afterAll() throws Exception {
-        if (client != null) {
-            client.close();
-        }
-
-        if (server != null) {
-            server.close();
-        }
     }
 
     private Table oneColumnTable() {

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.SubmissionPublisher;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -36,6 +37,7 @@ import org.apache.ignite.client.fakes.FakeInternalTable;
 import org.apache.ignite.compute.IgniteCompute;
 import org.apache.ignite.internal.table.TableImpl;
 import org.apache.ignite.internal.testframework.IgniteTestUtils;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.table.DataStreamerOptions;
 import org.apache.ignite.table.KeyValueView;
 import org.apache.ignite.table.RecordView;
@@ -77,9 +79,7 @@ public class PartitionAwarenessTest extends AbstractClientTest {
      * Before all.
      */
     @BeforeAll
-    public static void beforeAll() {
-        AbstractClientTest.beforeAll();
-
+    public static void startServer2() {
         ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
 
         server2 = new FakeIgnite("server-2");
@@ -96,18 +96,12 @@ public class PartitionAwarenessTest extends AbstractClientTest {
      * After all.
      */
     @AfterAll
-    public static void afterAll() throws Exception {
-        AbstractClientTest.afterAll();
-
-        testServer2.close();
+    public static void stopServer2() throws Exception {
+        IgniteUtils.closeAll(client2, testServer2);
     }
 
     @BeforeEach
-    @Override
-    public void beforeEach() throws InterruptedException {
-        super.beforeEach();
-
-        dropTables(server);
+    public void initAssignments() throws InterruptedException {
         dropTables(server2);
 
         initPartitionAssignment(null);
@@ -456,10 +450,13 @@ public class PartitionAwarenessTest extends AbstractClientTest {
         RecordView<Tuple> recordView = defaultTable().recordView();
 
         Consumer<Tuple> stream = t -> {
-            SubmissionPublisher<Tuple> publisher = new SubmissionPublisher<>();
-            var fut = recordView.streamData(publisher, null);
-            publisher.submit(t);
-            publisher.close();
+            CompletableFuture<Void> fut;
+
+            try (SubmissionPublisher<Tuple> publisher = new SubmissionPublisher<>()) {
+                fut = recordView.streamData(publisher, null);
+                publisher.submit(t);
+            }
+
             fut.join();
         };
 
@@ -474,10 +471,13 @@ public class PartitionAwarenessTest extends AbstractClientTest {
         RecordView<PersonPojo> pojoView = defaultTable().recordView(Mapper.of(PersonPojo.class));
 
         Consumer<PersonPojo> stream = t -> {
-            SubmissionPublisher<PersonPojo> publisher = new SubmissionPublisher<>();
-            var fut = pojoView.streamData(publisher, null);
-            publisher.submit(t);
-            publisher.close();
+            CompletableFuture<Void> fut;
+
+            try (SubmissionPublisher<PersonPojo> publisher = new SubmissionPublisher<>()) {
+                fut = pojoView.streamData(publisher, null);
+                publisher.submit(t);
+            }
+
             fut.join();
         };
 
@@ -492,10 +492,13 @@ public class PartitionAwarenessTest extends AbstractClientTest {
         KeyValueView<Tuple, Tuple> recordView = defaultTable().keyValueView();
 
         Consumer<Tuple> stream = t -> {
-            SubmissionPublisher<Entry<Tuple, Tuple>> publisher = new SubmissionPublisher<>();
-            var fut = recordView.streamData(publisher, null);
-            publisher.submit(Map.entry(t, t));
-            publisher.close();
+            CompletableFuture<Void> fut;
+
+            try (SubmissionPublisher<Entry<Tuple, Tuple>> publisher = new SubmissionPublisher<>()) {
+                fut = recordView.streamData(publisher, null);
+                publisher.submit(Map.entry(t, t));
+            }
+
             fut.join();
         };
 
@@ -510,10 +513,13 @@ public class PartitionAwarenessTest extends AbstractClientTest {
         KeyValueView<Long, String> kvView = defaultTable().keyValueView(Mapper.of(Long.class), Mapper.of(String.class));
 
         Consumer<Long> stream = t -> {
-            SubmissionPublisher<Entry<Long, String>> publisher = new SubmissionPublisher<>();
-            var fut = kvView.streamData(publisher, null);
-            publisher.submit(Map.entry(t, t.toString()));
-            publisher.close();
+            CompletableFuture<Void> fut;
+
+            try (SubmissionPublisher<Entry<Long, String>> publisher = new SubmissionPublisher<>()) {
+                fut = kvView.streamData(publisher, null);
+                publisher.submit(Map.entry(t, t.toString()));
+            }
+
             fut.join();
         };
 
@@ -531,44 +537,46 @@ public class PartitionAwarenessTest extends AbstractClientTest {
                 .autoFlushFrequency(50)
                 .build();
 
+        CompletableFuture<Void> fut;
+
         RecordView<Tuple> recordView = defaultTable().recordView();
-        SubmissionPublisher<Tuple> publisher = new SubmissionPublisher<>();
-        var fut = recordView.streamData(publisher, options);
+        try (SubmissionPublisher<Tuple> publisher = new SubmissionPublisher<>()) {
+            fut = recordView.streamData(publisher, options);
 
-        Consumer<Long> submit = id -> {
-            try {
-                publisher.submit(Tuple.create().set("ID", id));
-                assertTrue(IgniteTestUtils.waitForCondition(() -> lastOpServerName != null, 1000));
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        };
+            Consumer<Long> submit = id -> {
+                try {
+                    publisher.submit(Tuple.create().set("ID", id));
+                    assertTrue(IgniteTestUtils.waitForCondition(() -> lastOpServerName != null, 1000));
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            };
 
-        assertOpOnNode(nodeKey1, "upsertAll", x -> submit.accept(1L));
-        assertOpOnNode(nodeKey2, "upsertAll", x -> submit.accept(2L));
+            assertOpOnNode(nodeKey1, "upsertAll", x -> submit.accept(1L));
+            assertOpOnNode(nodeKey2, "upsertAll", x -> submit.accept(2L));
 
-        // Update partition assignment.
-        var assignments = new ArrayList<String>();
+            // Update partition assignment.
+            var assignments = new ArrayList<String>();
 
-        assignments.add(testServer2.nodeName());
-        assignments.add(testServer.nodeName());
+            assignments.add(testServer2.nodeName());
+            assignments.add(testServer.nodeName());
 
-        initPartitionAssignment(assignments);
+            initPartitionAssignment(assignments);
 
-        // Send some batches so that the client receives updated assignment.
-        lastOpServerName = null;
-        submit.accept(1L);
-        assertTrue(IgniteTestUtils.waitForCondition(() -> lastOpServerName != null, 1000));
+            // Send some batches so that the client receives updated assignment.
+            lastOpServerName = null;
+            submit.accept(1L);
+            assertTrue(IgniteTestUtils.waitForCondition(() -> lastOpServerName != null, 1000));
 
-        lastOpServerName = null;
-        submit.accept(2L);
-        assertTrue(IgniteTestUtils.waitForCondition(() -> lastOpServerName != null, 1000));
+            lastOpServerName = null;
+            submit.accept(2L);
+            assertTrue(IgniteTestUtils.waitForCondition(() -> lastOpServerName != null, 1000));
 
-        // Check updated assignment.
-        assertOpOnNode(nodeKey2, "upsertAll", x -> submit.accept(1L));
-        assertOpOnNode(nodeKey1, "upsertAll", x -> submit.accept(2L));
+            // Check updated assignment.
+            assertOpOnNode(nodeKey2, "upsertAll", x -> submit.accept(1L));
+            assertOpOnNode(nodeKey1, "upsertAll", x -> submit.accept(2L));
+        }
 
-        publisher.close();
         fut.join();
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/streamer/StreamerSubscriber.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/streamer/StreamerSubscriber.java
@@ -19,15 +19,19 @@ package org.apache.ignite.internal.streamer;
 
 import java.util.Collection;
 import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.ignite.internal.logger.IgniteLogger;
+import org.apache.ignite.internal.thread.NamedThreadFactory;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -61,7 +65,9 @@ public class StreamerSubscriber<T, P> implements Subscriber<T> {
 
     private @Nullable Flow.Subscription subscription;
 
-    private @Nullable Timer flushTimer;
+    private @Nullable ScheduledExecutorService flushTimer;
+
+    private @Nullable ScheduledFuture<?> flushTask;
 
     /**
      * Constructor.
@@ -103,9 +109,9 @@ public class StreamerSubscriber<T, P> implements Subscriber<T> {
                         log.error("Failed to refresh schemas and partition assignment: " + err.getMessage(), err);
                         close(err);
                     } else {
-                        requestMore();
+                        initFlushTimer();
 
-                        flushTimer = initFlushTimer();
+                        requestMore();
                     }
                 });
     }
@@ -196,7 +202,11 @@ public class StreamerSubscriber<T, P> implements Subscriber<T> {
 
     private void close(@Nullable Throwable throwable) {
         if (flushTimer != null) {
-            flushTimer.cancel();
+            assert flushTask != null;
+
+            flushTask.cancel(false);
+
+            IgniteUtils.shutdownAndAwaitTermination(flushTimer, 10, TimeUnit.SECONDS);
         }
 
         var s = subscription;
@@ -241,18 +251,18 @@ public class StreamerSubscriber<T, P> implements Subscriber<T> {
         pendingItemCount.addAndGet(count);
     }
 
-    private @Nullable Timer initFlushTimer() {
+    private void initFlushTimer() {
         int interval = options.autoFlushFrequency();
 
         if (interval <= 0) {
-            return null;
+            return;
         }
 
-        Timer timer = new Timer("client-data-streamer-flush-" + hashCode());
+        String threadPrefix = "client-data-streamer-flush-" + hashCode();
 
-        timer.schedule(new PeriodicFlushTask(), interval, interval);
+        flushTimer = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory(threadPrefix, log));
 
-        return timer;
+        flushTask = flushTimer.scheduleAtFixedRate(new PeriodicFlushTask(), interval, interval, TimeUnit.MILLISECONDS);
     }
 
     private static StreamerMetricSink getMetrics(@Nullable StreamerMetricSink metrics) {
@@ -284,7 +294,7 @@ public class StreamerSubscriber<T, P> implements Subscriber<T> {
     /**
      * Periodically flushes buffers.
      */
-    private class PeriodicFlushTask extends TimerTask {
+    private class PeriodicFlushTask implements Runnable {
         @Override
         public void run() {
             for (StreamerBuffer<T> buf : buffers.values()) {

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItClientDataStreamerTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItClientDataStreamerTest.java
@@ -26,15 +26,15 @@ import org.junit.jupiter.api.BeforeAll;
  * Integration test for client-side data streamer API.
  */
 public class ItClientDataStreamerTest extends ItAbstractDataStreamerTest {
-    private IgniteClient client;
+    private static IgniteClient client;
 
     @BeforeAll
-    public void startClient() {
+    public static void startClient() {
         client = IgniteClient.builder().addresses("localhost").build();
     }
 
     @AfterAll
-    public void stopClient() throws Exception {
+    public static void stopClient() throws Exception {
         client.close();
     }
 


### PR DESCRIPTION
* Use `IgniteUtils.closeAll` to close multiple resources reliably
* Use try-with-resources for `SubmissionPublisher` in all tests
* Use `scheduleAtFixedRate` instead of `Timer` in client streamer ([recommended approach for modern code](https://stackoverflow.com/questions/409932/java-timer-vs-executorservice))

https://issues.apache.org/jira/browse/IGNITE-20036