### PR TITLE
IGNITE-20026 Java client: Remove port range limitation

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -470,8 +470,6 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
 
         if (addr == null) {
             error = "At least one Ignite server node must be specified in the Ignite client configuration";
-        } else if (addr.getPort() < 1024 || addr.getPort() > 49151) {
-            error = String.format("Ignite client port %s is out of valid ports range 1024...49151", addr.getPort());
         }
 
         if (error != null) {


### PR DESCRIPTION
Remove the port limitation to support other dynamic port reverse proxys. Like testcontainers[1]

[1]
https://stackoverflow.com/questions/76746998/why-ignite-tcpclientchannel-port-can-not-larger-than-49151