### PR TITLE
IGNITE-20129 Fix CMake configuration

### DIFF
--- a/modules/platforms/build.gradle
+++ b/modules/platforms/build.gradle
@@ -57,11 +57,11 @@ task copyNativeLibs(type: Copy) {
 cmake {
     workingFolder=file("$buildDir/cpp")
     sourceFolder=file("$projectDir/cpp")
-    generator='Unix Makefiles'
     buildConfig='Release'
     buildTarget='install'
     getDef().CMAKE_INSTALL_PREFIX="$buildDir/install"
     getDef().CMAKE_BUILD_TYPE='Release'
+    getDef().CMAKE_CONFIGURATION_TYPES='Release'
 }
 
 task cmakeConfigureClient(type: net.freudasoft.CMakeConfigureTask) {

--- a/modules/platforms/cpp/CMakeLists.txt
+++ b/modules/platforms/cpp/CMakeLists.txt
@@ -41,8 +41,13 @@ get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 
 set(conan_packages
     msgpack-c/4.0.0
-    gtest/1.12.1
 )
+
+if (${ENABLE_TESTS})
+    list(APPEND conan_packages
+        gtest/1.12.1
+    )
+endif()
 
 # Install required libraries.
 if (${ENABLE_CONAN})


### PR DESCRIPTION
- Removed explicit CMake generator from Gradle config. This way it's up to the user system to decide wthich generator to use - now it works on Windows as well;
- Added `CMAKE_CONFIGURATION_TYPES` for multi config generators (this is apparently a root cause of the initial issue);
- GTest now only downloaded and used if tests are enabled.