### PR TITLE
IGNITE-20058 Flaky distribution zone tests were fixed by fixing order of the meta storage watches deploying and a distribution zone manager start

### DIFF
--- a/modules/distribution-zones/src/main/java/org/apache/ignite/internal/distributionzones/DistributionZoneManager.java
+++ b/modules/distribution-zones/src/main/java/org/apache/ignite/internal/distributionzones/DistributionZoneManager.java
@@ -719,12 +719,12 @@ public class DistributionZoneManager implements IgniteComponent {
             if (newScaleDown != INFINITE_TIMER_VALUE) {
                 Optional<Long> highestRevision = zoneState.highestRevision(false);
 
-                assert highestRevision.isEmpty() || ctx.storageRevision() >= highestRevision.get() : "Expected revision that "
+                assert highestRevision.isEmpty() || revision >= highestRevision.get() : "Expected revision that "
                         + "is greater or equal to already seen meta storage events.";
 
                 zoneState.rescheduleScaleDown(
                         newScaleDown,
-                        () -> saveDataNodesToMetaStorageOnScaleDown(zoneId, ctx.storageRevision()),
+                        () -> saveDataNodesToMetaStorageOnScaleDown(zoneId, revision),
                         zoneId
                 );
             } else {
@@ -759,20 +759,18 @@ public class DistributionZoneManager implements IgniteComponent {
 
             VaultEntry filterUpdateRevision = vaultMgr.get(zonesFilterUpdateRevision()).join();
 
-            long eventRevision = ctx.storageRevision();
-
             if (filterUpdateRevision != null) {
                 // This means that we have already handled event with this revision.
                 // It is possible when node was restarted after this listener completed,
                 // but applied revision didn't have time to be propagated to the Vault.
-                if (bytesToLong(filterUpdateRevision.value()) >= eventRevision) {
+                if (bytesToLong(filterUpdateRevision.value()) >= revision) {
                     return completedFuture(null);
                 }
             }
 
-            vaultMgr.put(zonesFilterUpdateRevision(), longToBytes(eventRevision)).join();
+            vaultMgr.put(zonesFilterUpdateRevision(), longToBytes(revision)).join();
 
-            saveDataNodesToMetaStorageOnScaleUp(zoneId, eventRevision);
+            saveDataNodesToMetaStorageOnScaleUp(zoneId, revision);
 
             causalityDataNodesEngine.onUpdateFilter(revision, zoneId, filter);
 
@@ -800,7 +798,7 @@ public class DistributionZoneManager implements IgniteComponent {
 
             zoneState.stopTimers();
 
-            removeTriggerKeysAndDataNodes(zoneId, ctx.storageRevision());
+            removeTriggerKeysAndDataNodes(zoneId, revision);
 
             causalityDataNodesEngine.onDelete(revision, zoneId);
 

--- a/modules/distribution-zones/src/test/java/org/apache/ignite/internal/distributionzones/BaseDistributionZoneManagerTest.java
+++ b/modules/distribution-zones/src/test/java/org/apache/ignite/internal/distributionzones/BaseDistributionZoneManagerTest.java
@@ -18,7 +18,6 @@
 package org.apache.ignite.internal.distributionzones;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.apache.ignite.internal.distributionzones.DistributionZonesTestUtil.deployWatchesAndUpdateMetaStorageRevision;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -157,9 +156,9 @@ public class BaseDistributionZoneManagerTest extends BaseIgniteAbstractTest {
         generator.close();
     }
 
-    void startDistributionZoneManager() throws Exception {
-        deployWatchesAndUpdateMetaStorageRevision(metaStorageManager);
-
+    void startDistributionZoneManager() {
         distributionZoneManager.start();
+
+        metaStorageManager.deployWatches();
     }
 }

--- a/modules/distribution-zones/src/test/java/org/apache/ignite/internal/distributionzones/DistributionZoneManagerAlterFilterTest.java
+++ b/modules/distribution-zones/src/test/java/org/apache/ignite/internal/distributionzones/DistributionZoneManagerAlterFilterTest.java
@@ -41,7 +41,6 @@ import org.apache.ignite.internal.cluster.management.topology.api.LogicalNode;
 import org.apache.ignite.internal.metastorage.server.If;
 import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.NetworkAddress;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -86,7 +85,6 @@ public class DistributionZoneManagerAlterFilterTest  extends BaseDistributionZon
      *
      * @throws Exception If failed.
      */
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-20058")
     @ParameterizedTest
     @MethodSource("provideArgumentsForFilterAlteringTests")
     void testAlterFilter(int zoneId, String zoneName) throws Exception {
@@ -123,7 +121,6 @@ public class DistributionZoneManagerAlterFilterTest  extends BaseDistributionZon
      *
      * @throws Exception If failed.
      */
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-20058")
     @ParameterizedTest
     @MethodSource("provideArgumentsForFilterAlteringTests")
     void testAlterFilterToEmtpyNodes(int zoneId, String zoneName) throws Exception {
@@ -159,7 +156,6 @@ public class DistributionZoneManagerAlterFilterTest  extends BaseDistributionZon
      *
      * @throws Exception If failed.
      */
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-20058")
     @ParameterizedTest
     @MethodSource("provideArgumentsForFilterAlteringTests")
     void testAlterFilterDoNotAffectScaleDown(int zoneId, String zoneName) throws Exception {
@@ -217,7 +213,6 @@ public class DistributionZoneManagerAlterFilterTest  extends BaseDistributionZon
      *
      * @throws Exception If failed.
      */
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-20058")
     @ParameterizedTest
     @MethodSource("provideArgumentsForFilterAlteringTests")
     void testNodeAddedWhileAlteringFilter(int zoneId, String zoneName) throws Exception {

--- a/modules/distribution-zones/src/test/java/org/apache/ignite/internal/distributionzones/DistributionZoneManagerConfigurationChangesTest.java
+++ b/modules/distribution-zones/src/test/java/org/apache/ignite/internal/distributionzones/DistributionZoneManagerConfigurationChangesTest.java
@@ -144,8 +144,6 @@ public class DistributionZoneManagerConfigurationChangesTest extends IgniteAbstr
 
         assertThat(vaultMgr.put(zonesLogicalTopologyVersionKey(), longToBytes(0)), willCompleteSuccessfully());
 
-        metaStorageManager.put(zonesLogicalTopologyVersionKey(), longToBytes(0));
-
         Consumer<LongFunction<CompletableFuture<?>>> revisionUpdater = (LongFunction<CompletableFuture<?>> function) ->
                 metaStorageManager.registerRevisionUpdateListener(function::apply);
 
@@ -162,10 +160,9 @@ public class DistributionZoneManagerConfigurationChangesTest extends IgniteAbstr
         vaultMgr.start();
         clusterCfgMgr.start();
         metaStorageManager.start();
-
-        DistributionZonesTestUtil.deployWatchesAndUpdateMetaStorageRevision(metaStorageManager);
-
         distributionZoneManager.start();
+
+        metaStorageManager.deployWatches();
 
         clearInvocations(keyValueStorage);
     }

--- a/modules/distribution-zones/src/testFixtures/java/org/apache/ignite/internal/distributionzones/DistributionZonesTestUtil.java
+++ b/modules/distribution-zones/src/testFixtures/java/org/apache/ignite/internal/distributionzones/DistributionZonesTestUtil.java
@@ -39,7 +39,6 @@ import static org.apache.ignite.internal.util.ByteUtils.longToBytes;
 import static org.apache.ignite.internal.util.ByteUtils.toBytes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Map;
@@ -59,7 +58,6 @@ import org.apache.ignite.internal.distributionzones.DistributionZoneConfiguratio
 import org.apache.ignite.internal.metastorage.MetaStorageManager;
 import org.apache.ignite.internal.metastorage.dsl.Conditions;
 import org.apache.ignite.internal.metastorage.dsl.Iif;
-import org.apache.ignite.internal.metastorage.dsl.Operations;
 import org.apache.ignite.internal.metastorage.dsl.StatementResult;
 import org.apache.ignite.internal.metastorage.server.KeyValueStorage;
 import org.apache.ignite.internal.schema.configuration.storage.DataStorageChange;
@@ -308,33 +306,6 @@ public class DistributionZonesTestUtil {
                 topVer,
                 1000
         );
-    }
-
-    /**
-     * This method is used to initialize the meta storage revision before starting the distribution zone manager.
-     * TODO: IGNITE-19403 Watch listeners must be deployed after the zone manager starts.
-     *
-     * @param metaStorageManager Meta storage manager.
-     * @throws InterruptedException If thread was interrupted.
-     */
-    public static void deployWatchesAndUpdateMetaStorageRevision(MetaStorageManager metaStorageManager) throws InterruptedException {
-        // Watches are deployed before distributionZoneManager start in order to update Meta Storage revision before
-        // distributionZoneManager's recovery.
-        CompletableFuture<Void> deployWatchesFut = metaStorageManager.deployWatches();
-
-        // Bump Meta Storage applied revision by modifying a fake key. DistributionZoneManager breaks on start if Vault is not empty, but
-        // Meta Storage revision is equal to 0.
-        var fakeKey = new ByteArray("foobar");
-
-        CompletableFuture<Boolean> invokeFuture = deployWatchesFut.thenCompose(unused -> metaStorageManager.invoke(
-                Conditions.notExists(fakeKey),
-                Operations.put(fakeKey, fakeKey.bytes()),
-                Operations.noop()
-        ));
-
-        assertThat(invokeFuture, willBe(true));
-
-        assertTrue(waitForCondition(() -> metaStorageManager.appliedRevision() > 0, 10_000));
     }
 
     /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-20058