### PR TITLE
IGNITE-19361: Sql. UUID. Add removed test cases.

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/engine/datatypes/uuid/ItUuidExpressionTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/engine/datatypes/uuid/ItUuidExpressionTest.java
@@ -17,11 +17,16 @@
 
 package org.apache.ignite.internal.sql.engine.datatypes.uuid;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.UUID;
 import org.apache.ignite.internal.sql.engine.datatypes.DataTypeTestSpecs;
 import org.apache.ignite.internal.sql.engine.datatypes.tests.BaseExpressionDataTypeTest;
 import org.apache.ignite.internal.sql.engine.datatypes.tests.DataTypeTestSpec;
 import org.apache.ignite.internal.sql.engine.type.UuidType;
+import org.apache.ignite.lang.IgniteException;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +49,20 @@ public class ItUuidExpressionTest extends BaseExpressionDataTypeTest<UUID> {
     public void testRandomUuidComparison() {
         assertQuery("SELECT RAND_UUID() = RAND_UUID()").returns(false).check();
         assertQuery("SELECT RAND_UUID() != RAND_UUID()").returns(true).check();
+    }
+
+    /** Invalid {@code UUID} string in literal parameter. */
+    @Test
+    public void testInvalidUuidString() {
+        IgniteException t = assertThrows(IgniteException.class, () -> runSql("SELECT '000000'::UUID"));
+        assertThat(t.getMessage(), containsString("Invalid UUID string"));
+    }
+
+    /** Invalid {@code UUID} string in dynamic parameter. */
+    @Test
+    public void testInvalidUuidStringInDynamicParams() {
+        IgniteException t = assertThrows(IgniteException.class, () -> runSql("SELECT ?::UUID", "00000"));
+        assertThat(t.getMessage(), containsString("Invalid UUID string"));
     }
 
     /** {@inheritDoc} **/


### PR DESCRIPTION
Add two test cases that conversion from invalid UUID string to UUID is not possible - one for literals, one for dynamic parameters.

https://issues.apache.org/jira/browse/IGNITE-19361

---
Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)