### PR TITLE
IGNITE-19841 Add tests for schema validation consistency in client and embedded API

### DIFF
--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientBinaryTupleUtils.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientBinaryTupleUtils.java
@@ -282,7 +282,11 @@ public class ClientBinaryTupleUtils {
                     throw new IllegalArgumentException("Unsupported type: " + type);
             }
         } catch (ClassCastException e) {
-            throw new IgniteException(PROTOCOL_ERR, "Incorrect value type for column '" + name + "': " + e.getMessage(), e);
+            // Exception message is similar to embedded mode - see o.a.i.i.schema.Column#validate
+            throw new IgniteException(PROTOCOL_ERR, "Column's type mismatch ["
+                    + "column=" + name
+                    + ", expectedType=" + type
+                    + ", actualType=" + v.getClass() + ']', e);
         }
     }
 

--- a/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTableTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTableTest.java
@@ -199,7 +199,7 @@ public class AbstractClientTableTest extends AbstractClientTest {
     protected static class IncompletePojo {
         public byte zbyte;
         public String id;
-        public int gid;
+        public long gid;
         public String zstring;
         public byte[] zbytes;
     }
@@ -236,7 +236,7 @@ public class AbstractClientTableTest extends AbstractClientTest {
 
     /** Columns of all types. */
     protected static class AllColumnsPojo {
-        public int gid;
+        public long gid;
         public String id;
         public boolean zboolean;
         public byte zbyte;
@@ -258,7 +258,7 @@ public class AbstractClientTableTest extends AbstractClientTest {
 
     /** Columns of all types. */
     protected static class AllColumnsPojoNullable {
-        public Integer gid;
+        public Long gid;
         public String id;
         public Boolean zboolean;
         public Byte zbyte;
@@ -323,13 +323,13 @@ public class AbstractClientTableTest extends AbstractClientTest {
         public int id;
         public String str;
         public String strNonNull;
-        public BigDecimal num;
+        public Byte num;
     }
 
     /** Columns with default values. */
     protected static class DefaultValuesValPojo {
         public String str;
         public String strNonNull;
-        public BigDecimal num;
+        public Byte num;
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTableTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/AbstractClientTableTest.java
@@ -207,31 +207,7 @@ public class AbstractClientTableTest extends AbstractClientTest {
     /** Composite key. */
     protected static class CompositeKeyPojo {
         public String id;
-        public int gid;
-    }
-
-    /** Partial column set. */
-    protected static class IncompletePojoNullable {
-        public int gid;
-        public String id;
-        public Boolean zboolean;
-        public Byte zbyte;
-        public Short zshort;
-        public Integer zint;
-        public Long zlong;
-        public Float zfloat;
-        public Double zdouble;
-    }
-
-    /** Partial column set. */
-    protected static class IncompleteValPojoNullable {
-        public Boolean zboolean;
-        public Byte zbyte;
-        public Short zshort;
-        public Integer zint;
-        public Long zlong;
-        public Float zfloat;
-        public Double zdouble;
+        public long gid;
     }
 
     /** Columns of all types. */

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientRecordViewTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientRecordViewTest.java
@@ -115,7 +115,7 @@ public class ClientRecordViewTest extends AbstractClientTableTest {
         table.recordView().upsert(null, allColumnsTableVal("foo", false));
 
         var key = new AllColumnsPojo();
-        key.gid = (int) (long) DEFAULT_ID;
+        key.gid = DEFAULT_ID;
         key.id = String.valueOf(DEFAULT_ID);
 
         AllColumnsPojo res = pojoView.get(null, key);
@@ -205,7 +205,7 @@ public class ClientRecordViewTest extends AbstractClientTableTest {
 
         var rec = new AllColumnsPojoNullable();
         rec.id = "1";
-        rec.gid = 1;
+        rec.gid = 1L;
 
         pojoView.upsert(null, rec);
 

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientTableTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientTableTest.java
@@ -410,9 +410,7 @@ public class ClientTableTest extends AbstractClientTableTest {
         var tuple = Tuple.create().set("id", "str");
 
         var ex = assertThrows(IgniteException.class, () -> defaultTable().recordView().upsert(null, tuple));
-
-        String expectedErr = "Incorrect value type for column 'ID': class java.lang.String cannot be cast to class java.lang.Long";
-        assertThat(ex.getMessage(), containsString(expectedErr));
+        assertEquals("Column's type mismatch [column=ID, expectedType=INT64, actualType=class java.lang.String]", ex.getMessage());
     }
 
     @Test

--- a/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/FieldAccessor.java
+++ b/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/FieldAccessor.java
@@ -72,7 +72,7 @@ abstract class FieldAccessor {
     static FieldAccessor create(Class<?> type, String fldName, MarshallerColumn col, int colIdx) {
         try {
             final Field field = type.getDeclaredField(fldName);
-            MarshallerUtil.validateColumnType(col.type(), field.getType());
+            MarshallerUtil.validateColumnType(col, field.getType());
 
             BinaryMode mode = MarshallerUtil.mode(field.getType());
             final MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(type, MethodHandles.lookup());

--- a/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/FieldAccessor.java
+++ b/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/FieldAccessor.java
@@ -72,6 +72,7 @@ abstract class FieldAccessor {
     static FieldAccessor create(Class<?> type, String fldName, MarshallerColumn col, int colIdx) {
         try {
             final Field field = type.getDeclaredField(fldName);
+            MarshallerUtil.validateColumnType(col.type(), field.getType());
 
             BinaryMode mode = MarshallerUtil.mode(field.getType());
             final MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(type, MethodHandles.lookup());

--- a/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/MarshallerUtil.java
+++ b/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/MarshallerUtil.java
@@ -93,9 +93,10 @@ public class MarshallerUtil {
         return null;
     }
 
-    public static void validateColumnType(BinaryMode colType, Class<?> cls) {
-        if (!isColumnCompatible(colType, cls)) {
-            throw new IllegalArgumentException("Column type " + colType + " is not compatible with class " + cls);
+    static void validateColumnType(MarshallerColumn col, Class<?> cls) {
+        if (!isColumnCompatible(col.type(), cls)) {
+            throw new ClassCastException("Incorrect value type for column '" + col.name() + "': class " + cls +
+                    " cannot be cast to column type " + col.type());
         }
     }
 

--- a/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/MarshallerUtil.java
+++ b/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/MarshallerUtil.java
@@ -146,9 +146,9 @@ public class MarshallerUtil {
                 return cls == LocalDateTime.class;
             case TIMESTAMP:
                 return cls == Instant.class;
+            default:
+                return false;
         }
-
-        return false;
     }
 
     /**

--- a/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/MarshallerUtil.java
+++ b/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/MarshallerUtil.java
@@ -95,8 +95,11 @@ public class MarshallerUtil {
 
     static void validateColumnType(MarshallerColumn col, Class<?> cls) {
         if (!isColumnCompatible(col.type(), cls)) {
-            throw new ClassCastException("Incorrect value type for column '" + col.name() + "': " + cls +
-                    " cannot be cast to column type " + col.type());
+            // Exception message is similar to embedded mode - see o.a.i.i.schema.Column#validate
+            throw new ClassCastException("Column's type mismatch ["
+                    + "column=" + col.name()
+                    + ", expectedType=" + col.type()
+                    + ", actualType=" + cls + ']');
         }
     }
 

--- a/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/MarshallerUtil.java
+++ b/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/MarshallerUtil.java
@@ -95,7 +95,7 @@ public class MarshallerUtil {
 
     static void validateColumnType(MarshallerColumn col, Class<?> cls) {
         if (!isColumnCompatible(col.type(), cls)) {
-            throw new ClassCastException("Incorrect value type for column '" + col.name() + "': class " + cls +
+            throw new ClassCastException("Incorrect value type for column '" + col.name() + "': " + cls +
                     " cannot be cast to column type " + col.type());
         }
     }

--- a/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/MarshallerUtil.java
+++ b/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/MarshallerUtil.java
@@ -93,6 +93,60 @@ public class MarshallerUtil {
         return null;
     }
 
+    public static void validateColumnType(BinaryMode colType, Class<?> cls) {
+        if (!isColumnCompatible(colType, cls)) {
+            throw new IllegalArgumentException("Column type " + colType + " is not compatible with class " + cls);
+        }
+    }
+
+    private static boolean isColumnCompatible(BinaryMode colType, Class<?> cls) {
+        switch (colType) {
+            case P_BOOLEAN:
+            case BOOLEAN:
+                return cls == boolean.class || cls == Boolean.class;
+            case P_BYTE:
+            case BYTE:
+                return cls == byte.class || cls == Byte.class;
+            case P_SHORT:
+            case SHORT:
+                return cls == short.class || cls == Short.class;
+            case P_INT:
+            case INT:
+                return cls == int.class || cls == Integer.class;
+            case P_LONG:
+            case LONG:
+                return cls == long.class || cls == Long.class;
+            case P_FLOAT:
+            case FLOAT:
+                return cls == float.class || cls == Float.class;
+            case P_DOUBLE:
+            case DOUBLE:
+                return cls == double.class || cls == Double.class;
+            case STRING:
+                return cls == String.class;
+            case UUID:
+                return cls == UUID.class;
+            case BYTE_ARR:
+                return cls == byte[].class;
+            case BITSET:
+                return cls == BitSet.class;
+            case NUMBER:
+                return cls == BigInteger.class;
+            case DECIMAL:
+                return cls == BigDecimal.class;
+            case DATE:
+                return cls == LocalDate.class;
+            case TIME:
+                return cls == LocalTime.class;
+            case DATETIME:
+                return cls == LocalDateTime.class;
+            case TIMESTAMP:
+                return cls == Instant.class;
+        }
+
+        return false;
+    }
+
     /**
      * Stub.
      */

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -243,6 +243,31 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
         assertThat(ex.getMessage(), startsWith("Column's type mismatch"));
     }
 
+    @Test
+    public void testBoxedPrimitivePojo() {
+        Table table = ignite().tables().table(TABLE_NAME);
+        var pojoView = table.recordView(Mapper.of(BoxedPrimitivePojo.class));
+
+        BoxedPrimitivePojo rec = new BoxedPrimitivePojo();
+        rec.key = -1;
+        rec.val = "f";
+
+        pojoView.upsert(null, rec);
+        assertEquals("f", pojoView.get(null, rec).val);
+    }
+
+    @Test
+    public void testBoxedPrimitiveTuple() {
+        Table table = ignite().tables().table(TABLE_NAME);
+        var tupleView = table.recordView();
+
+        Integer key = -1;
+        Tuple rec = Tuple.create().set("KEY", key).set("VAL", "v");
+
+        tupleView.upsert(null, rec);
+        assertEquals("v", tupleView.get(null, Tuple.create().set("KEY", key)).value("VAL"));
+    }
+
     private static class TestPojo2 {
         public int key;
 
@@ -264,6 +289,11 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
 
     private static class IncompatibleFieldPojo2 {
         public short key; // Must be int.
+        public String val;
+    }
+
+    private static class BoxedPrimitivePojo {
+        public Integer key;
         public String val;
     }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -176,7 +176,7 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
 
     @Test
     public void testKvMissingValTupleFields() {
-        var tableName = "testMissingValTupleFields";
+        var tableName = "testKvMissingValTupleFields";
         ignite().sql().createSession().execute(null, "CREATE TABLE " + tableName + " (KEY INT PRIMARY KEY, VAL VARCHAR NOT NULL)");
 
         Table table = ignite().tables().table(tableName);

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -216,8 +216,8 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
         rec.key = "1";
         rec.val = BigDecimal.ONE;
 
-        Throwable ex = assertThrowsWithCause(() -> pojoView.upsert(null, rec), ClassCastException.class);
-        assertThat(ex.getMessage(), startsWith("class java.math.BigDecimal cannot be cast to class java.lang.CharSequence"));
+        Throwable ex = assertThrows(IgniteException.class, () -> pojoView.upsert(null, rec));
+        assertThat(ex.getMessage(), anyOf(startsWith("Column's type mismatch"), startsWith("Incorrect value type for column 'KEY'")));
     }
 
     @Test

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -220,6 +220,19 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
     }
 
     @Test
+    public void testIncompatiblePojoFieldType2() {
+        Table table = ignite().tables().table(TABLE_NAME);
+        var pojoView = table.recordView(Mapper.of(IncompatibleFieldPojo2.class));
+
+        IncompatibleFieldPojo2 rec = new IncompatibleFieldPojo2();
+        rec.key = -1;
+        rec.val = "f";
+
+        Throwable ex = assertThrows(IgniteException.class, () -> pojoView.upsert(null, rec));
+        assertThat(ex.getMessage(), startsWith("Column's type mismatch"));
+    }
+
+    @Test
     public void testIncompatibleTupleElementType() {
         Table table = ignite().tables().table(TABLE_NAME);
         var tupleView = table.recordView();
@@ -245,7 +258,12 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
     }
 
     private static class IncompatibleFieldPojo {
-        public String key;
+        public String key; // Must be int.
         public BigDecimal val;
+    }
+
+    private static class IncompatibleFieldPojo2 {
+        public short key; // Must be int.
+        public String val;
     }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -167,7 +167,11 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
 
     @Test
     public void testKvMissingKeyTupleFields() {
-        assert false : "TODO";
+        Table table = ignite().tables().table(TABLE_NAME);
+        var tupleView = table.keyValueView();
+
+        Throwable ex = assertThrowsWithCause(() -> tupleView.put(null, Tuple.create(), Tuple.create()), IgniteException.class);
+        assertEquals("Missed key column: KEY", ex.getMessage());
     }
 
     @Test

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -220,7 +220,15 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
 
     @Test
     public void testIncompatibleTupleElementType() {
-        assert false : "TODO";
+        Table table = ignite().tables().table(TABLE_NAME);
+        var tupleView = table.recordView();
+
+        Tuple rec = Tuple.create().set("KEY", "1").set("VAL", BigDecimal.ONE);
+
+        Throwable ex = assertThrowsWithCause(() -> tupleView.upsert(null, rec), ClassCastException.class);
+        assertThat(
+                ex.getMessage(),
+                startsWith("Incorrect value type for column 'KEY': class java.lang.String cannot be cast to class java.lang.Integer"));
     }
 
     // TODO: Add schema update tests - add column, drop column.

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -176,7 +176,18 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
 
     @Test
     public void testKvMissingValTupleFields() {
-        assert false : "TODO";
+        var tableName = "testMissingValTupleFields";
+        ignite().sql().createSession().execute(null, "CREATE TABLE " + tableName + " (KEY INT PRIMARY KEY, VAL VARCHAR NOT NULL)");
+
+        Table table = ignite().tables().table(tableName);
+        var tupleView = table.keyValueView();
+
+        Throwable ex = assertThrowsWithCause(
+                () -> tupleView.put(null, Tuple.create().set("KEY", 1), Tuple.create()),
+                IgniteException.class);
+
+        assertThat(ex.getMessage(), startsWith(
+                "Failed to set column (null was passed, but column is not nullable): [col=Column [schemaIndex=1, columnOrder=1, name=VAL"));
     }
 
     @Test

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -214,8 +214,8 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
         rec.key = "1";
         rec.val = BigDecimal.ONE;
 
-        Throwable ex = assertThrowsWithCause(() -> pojoView.upsert(null, rec), IgniteException.class);
-        assertEquals("TODO", ex.getMessage());
+        Throwable ex = assertThrowsWithCause(() -> pojoView.upsert(null, rec), ClassCastException.class);
+        assertThat(ex.getMessage(), startsWith("class java.math.BigDecimal cannot be cast to class java.lang.CharSequence"));
     }
 
     @Test

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -192,7 +192,15 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
 
     @Test
     public void testMissingTupleFieldsWithDefaultValue() {
-        assert false : "TODO";
+        var tableName = "testMissingTupleFieldsWithDefaultValue";
+        ignite().sql().createSession().execute(null,
+                "CREATE TABLE " + tableName + " (KEY INT PRIMARY KEY, VAL VARCHAR NOT NULL DEFAULT 'def')");
+
+        Table table = ignite().tables().table(tableName);
+        var tupleView = table.recordView();
+
+        tupleView.upsert(null, Tuple.create().set("KEY", 1));
+        assertEquals("def", tupleView.get(null, Tuple.create().set("KEY", 1)).value("VAL"));
     }
 
     @Test

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -22,10 +22,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.math.BigDecimal;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.table.Table;
 import org.apache.ignite.table.Tuple;
+import org.apache.ignite.table.mapper.Mapper;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -205,7 +207,15 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
 
     @Test
     public void testIncompatiblePojoFieldType() {
-        assert false : "TODO";
+        Table table = ignite().tables().table(TABLE_NAME);
+        var pojoView = table.recordView(Mapper.of(IncompatibleFieldPojo.class));
+
+        IncompatibleFieldPojo rec = new IncompatibleFieldPojo();
+        rec.key = "1";
+        rec.val = BigDecimal.ONE;
+
+        Throwable ex = assertThrowsWithCause(() -> pojoView.upsert(null, rec), IgniteException.class);
+        assertEquals("TODO", ex.getMessage());
     }
 
     @Test
@@ -227,5 +237,10 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
 
     private static class MissingFieldPojo {
         public int unknown;
+    }
+
+    private static class IncompatibleFieldPojo {
+        public String key;
+        public BigDecimal val;
     }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -19,7 +19,6 @@ package org.apache.ignite.internal.runner.app.client;
 
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.assertThrowsWithCause;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -119,7 +118,7 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
         Throwable ex = assertThrowsWithCause(() -> tupleView.put(null, key, tuple), IgniteException.class);
         assertEquals("Value tuple doesn't match schema: schemaVersion=1, extraColumns=[KEY]", ex.getMessage());
     }
-    
+
     @Test
     public void testMissingPojoFields() {
         Table table = ignite().tables().table(TABLE_NAME);
@@ -230,8 +229,6 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
         Throwable ex = assertThrows(IgniteException.class, () -> tupleView.upsert(null, rec));
         assertThat(ex.getMessage(), startsWith("Column's type mismatch"));
     }
-
-    // TODO: Add schema update tests - add column, drop column.
 
     private static class TestPojo2 {
         public int key;

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.runner.app.client;
 
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.assertThrowsWithCause;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -227,7 +228,7 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
         Tuple rec = Tuple.create().set("KEY", "1").set("VAL", BigDecimal.ONE);
 
         Throwable ex = assertThrows(IgniteException.class, () -> tupleView.upsert(null, rec));
-        assertThat(ex.getMessage(), startsWith("Column's type mismatch"));
+        assertThat(ex.getMessage(), anyOf(startsWith("Column's type mismatch"), startsWith("Incorrect value type for column 'KEY'")));
     }
 
     // TODO: Add schema update tests - add column, drop column.

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -204,14 +204,12 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
     }
 
     @Test
-    public void testIncorrectBitmaskSize() {
-        // TODO: Tuple, POJO
+    public void testIncompatiblePojoFieldType() {
         assert false : "TODO";
     }
 
     @Test
-    public void testIncompatibleFieldType() {
-        // TODO: Tuple, POJO
+    public void testIncompatibleTupleElementType() {
         assert false : "TODO";
     }
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -36,7 +36,7 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
     }
 
     @Test
-    public void testUnmappedPojoFieldsAreRejected() {
+    public void testUnmappedPojoFields() {
         Table table = ignite().tables().table(TABLE_NAME);
         var pojoView = table.recordView(TestPojo2.class);
 
@@ -53,7 +53,7 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
     }
 
     @Test
-    public void testKvUnmappedKeyPojoFieldsAreRejected() {
+    public void testKvUnmappedKeyPojoFields() {
         Table table = ignite().tables().table(TABLE_NAME);
         var kvPojoView = table.keyValueView(TestPojo.class, TestPojo.class);
 
@@ -67,7 +67,7 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
     }
 
     @Test
-    public void testKvUnmappedValPojoFieldsAreRejected() {
+    public void testKvUnmappedValPojoFields() {
         Table table = ignite().tables().table(TABLE_NAME);
         var kvPojoView = table.keyValueView(Integer.class, TestPojo.class);
 
@@ -81,7 +81,7 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
     }
 
     @Test
-    public void testUnmappedTupleFieldsAreRejected() {
+    public void testUnmappedTupleFields() {
         Table table = ignite().tables().table(TABLE_NAME);
         var tupleView = table.recordView();
 
@@ -92,7 +92,7 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
     }
 
     @Test
-    public void testKvUnmappedKeyTupleFieldsAreRejected() {
+    public void testKvUnmappedKeyTupleFields() {
         Table table = ignite().tables().table(TABLE_NAME);
         var tupleView = table.keyValueView();
 
@@ -103,7 +103,7 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
     }
 
     @Test
-    public void testKvUnmappedValTupleFieldsAreRejected() {
+    public void testKvUnmappedValTupleFields() {
         Table table = ignite().tables().table(TABLE_NAME);
         var tupleView = table.keyValueView();
 
@@ -112,6 +112,53 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
 
         Throwable ex = assertThrowsWithCause(() -> tupleView.put(null, key, tuple), IgniteException.class);
         assertEquals("Value tuple doesn't match schema: schemaVersion=1, extraColumns=[KEY]", ex.getMessage());
+    }
+    
+    @Test
+    public void testMissingPojoFields() {
+        assert false : "TODO";
+    }
+
+    @Test
+    public void testKvMissingKeyPojoFields() {
+        assert false : "TODO";
+    }
+
+    @Test
+    public void testKvMissingValPojoFields() {
+        assert false : "TODO";
+    }
+
+    @Test
+    public void testMissingTupleFields() {
+        assert false : "TODO";
+    }
+
+    @Test
+    public void testKvMissingKeyTupleFields() {
+        assert false : "TODO";
+    }
+
+    @Test
+    public void testKvMissingValTupleFields() {
+        assert false : "TODO";
+    }
+
+    @Test
+    public void testMissingTupleFieldsWithDefaultValue() {
+        assert false : "TODO";
+    }
+
+    @Test
+    public void testIncorrectBitmaskSize() {
+        // TODO: Tuple, POJO
+        assert false : "TODO";
+    }
+
+    @Test
+    public void testIncompatibleFieldType() {
+        // TODO: Tuple, POJO
+        assert false : "TODO";
     }
 
     private static class TestPojo2 {

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -116,7 +116,11 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
     
     @Test
     public void testMissingPojoFields() {
-        assert false : "TODO";
+        Table table = ignite().tables().table(TABLE_NAME);
+        var pojoView = table.recordView(MissingFieldPojo.class);
+
+        Throwable ex = assertThrowsWithCause(() -> pojoView.upsert(null, new MissingFieldPojo()), IllegalArgumentException.class);
+        assertEquals("No field found for column KEY", ex.getMessage());
     }
 
     @Test
@@ -169,5 +173,9 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
         public String unmapped;
 
         public String unmapped2;
+    }
+
+    private static class MissingFieldPojo {
+        public int unknown;
     }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -217,7 +217,7 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
         rec.val = BigDecimal.ONE;
 
         Throwable ex = assertThrows(IgniteException.class, () -> pojoView.upsert(null, rec));
-        assertThat(ex.getMessage(), anyOf(startsWith("Column's type mismatch"), startsWith("Incorrect value type for column 'KEY'")));
+        assertThat(ex.getMessage(), startsWith("Column's type mismatch"));
     }
 
     @Test
@@ -228,7 +228,7 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
         Tuple rec = Tuple.create().set("KEY", "1").set("VAL", BigDecimal.ONE);
 
         Throwable ex = assertThrows(IgniteException.class, () -> tupleView.upsert(null, rec));
-        assertThat(ex.getMessage(), anyOf(startsWith("Column's type mismatch"), startsWith("Incorrect value type for column 'KEY'")));
+        assertThat(ex.getMessage(), startsWith("Column's type mismatch"));
     }
 
     // TODO: Add schema update tests - add column, drop column.

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -125,12 +125,20 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
 
     @Test
     public void testKvMissingKeyPojoFields() {
-        assert false : "TODO";
+        Table table = ignite().tables().table(TABLE_NAME);
+        var kvPojoView = table.keyValueView(MissingFieldPojo.class, String.class);
+
+        Throwable ex = assertThrowsWithCause(() -> kvPojoView.put(null, new MissingFieldPojo(), ""), IllegalArgumentException.class);
+        assertEquals("No field found for column KEY", ex.getMessage());
     }
 
     @Test
     public void testKvMissingValPojoFields() {
-        assert false : "TODO";
+        Table table = ignite().tables().table(TABLE_NAME);
+        var kvPojoView = table.keyValueView(Integer.class, MissingFieldPojo.class);
+
+        Throwable ex = assertThrowsWithCause(() -> kvPojoView.put(null, 1, new MissingFieldPojo()), IllegalArgumentException.class);
+        assertEquals("No field found for column VAL", ex.getMessage());
     }
 
     @Test
@@ -164,6 +172,8 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
         // TODO: Tuple, POJO
         assert false : "TODO";
     }
+
+    // TODO: Add schema update tests - add column, drop column.
 
     private static class TestPojo2 {
         public int key;

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -21,6 +21,7 @@ import static org.apache.ignite.internal.testframework.IgniteTestUtils.assertThr
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
 import org.apache.ignite.Ignite;
@@ -225,10 +226,8 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
 
         Tuple rec = Tuple.create().set("KEY", "1").set("VAL", BigDecimal.ONE);
 
-        Throwable ex = assertThrowsWithCause(() -> tupleView.upsert(null, rec), ClassCastException.class);
-        assertThat(
-                ex.getMessage(),
-                startsWith("Incorrect value type for column 'KEY': class java.lang.String cannot be cast to class java.lang.Integer"));
+        Throwable ex = assertThrows(IgniteException.class, () -> tupleView.upsert(null, rec));
+        assertThat(ex.getMessage(), startsWith("Column's type mismatch"));
     }
 
     // TODO: Add schema update tests - add column, drop column.

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSqlTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSqlTest.java
@@ -516,7 +516,7 @@ public class ItThinClientSqlTest extends ItAbstractThinClientTest {
     }
 
     private static class Pojo {
-        public long num;
+        public int num;
 
         public String str;
     }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItAbstractDataStreamerTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItAbstractDataStreamerTest.java
@@ -262,7 +262,7 @@ public abstract class ItAbstractDataStreamerTest extends ClusterPerClassIntegrat
     private static class PersonPojo {
         int id;
         String name;
-        Integer salary;
+        Double salary;
 
         @SuppressWarnings("unused") // Required by serializer.
         private PersonPojo() {
@@ -281,7 +281,7 @@ public abstract class ItAbstractDataStreamerTest extends ClusterPerClassIntegrat
 
     private static class PersonValPojo {
         String name;
-        Integer salary;
+        Double salary;
 
         @SuppressWarnings("unused") // Required by serializer.
         private PersonValPojo() {

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/KvMarshallerImpl.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/KvMarshallerImpl.java
@@ -51,8 +51,8 @@ public class KvMarshallerImpl<K, V> implements KvMarshaller<K, V> {
     /**
      * Creates KV marshaller.
      *
-     * @param schema      Schema descriptor.
-     * @param keyMapper   Mapper for key objects.
+     * @param schema Schema descriptor.
+     * @param keyMapper Mapper for key objects.
      * @param valueMapper Mapper for value objects.
      */
     public KvMarshallerImpl(SchemaDescriptor schema, @NotNull Mapper<K> keyMapper, @NotNull Mapper<V> valueMapper) {
@@ -137,7 +137,11 @@ public class KvMarshallerImpl<K, V> implements KvMarshaller<K, V> {
      * @throws MarshallerException If failed to read key or value object content.
      */
     private RowAssembler createAssembler(Object key) throws MarshallerException {
-        return ObjectStatistics.createAssembler(schema, keyMarsh, key);
+        try {
+            return ObjectStatistics.createAssembler(schema, keyMarsh, key);
+        } catch (Throwable e) {
+            throw new MarshallerException(e.getMessage(), e);
+        }
     }
 
     /**
@@ -149,6 +153,10 @@ public class KvMarshallerImpl<K, V> implements KvMarshaller<K, V> {
      * @throws MarshallerException If failed to read key or value object content.
      */
     private RowAssembler createAssembler(Object key, Object val) throws MarshallerException {
-        return ObjectStatistics.createAssembler(schema, keyMarsh, valMarsh, key, val);
+        try {
+            return ObjectStatistics.createAssembler(schema, keyMarsh, valMarsh, key, val);
+        } catch (Throwable e) {
+            throw new MarshallerException(e.getMessage(), e);
+        }
     }
 }

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/ObjectStatistics.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/ObjectStatistics.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.schema.marshaller.reflection;
 
 import static org.apache.ignite.internal.schema.marshaller.MarshallerUtil.getValueSize;
 
+import org.apache.ignite.internal.schema.Column;
 import org.apache.ignite.internal.schema.Columns;
 import org.apache.ignite.internal.schema.NativeType;
 import org.apache.ignite.internal.schema.SchemaDescriptor;
@@ -58,11 +59,14 @@ class ObjectStatistics {
 
         for (int i = 0; i < cols.length(); i++) {
             Object val = marsh.value(obj, i);
-            NativeType colType = cols.column(i).type();
+            Column col = cols.column(i);
+            NativeType colType = col.type();
 
             if (val == null) {
                 continue;
             }
+
+            col.validate(val);
 
             if (colType.spec().fixedLength()) {
                 estimatedValueSize += colType.sizeInBytes();

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/RecordMarshallerImpl.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/RecordMarshallerImpl.java
@@ -141,6 +141,10 @@ public class RecordMarshallerImpl<R> implements RecordMarshaller<R> {
      * @throws MarshallerException If failed to read key or value object content.
      */
     private RowAssembler createAssembler(Object key, Object val) throws MarshallerException {
-        return ObjectStatistics.createAssembler(schema, keyMarsh, valMarsh, key, val);
+        try {
+            return ObjectStatistics.createAssembler(schema, keyMarsh, valMarsh, key, val);
+        } catch (Throwable e) {
+            throw new MarshallerException(e.getMessage(), e);
+        }
     }
 }

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/RecordMarshallerImpl.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/RecordMarshallerImpl.java
@@ -129,7 +129,11 @@ public class RecordMarshallerImpl<R> implements RecordMarshaller<R> {
      * @throws MarshallerException If failed to read key object content.
      */
     private RowAssembler createAssembler(Object key) throws MarshallerException {
-        return ObjectStatistics.createAssembler(schema, keyMarsh, key);
+        try {
+            return ObjectStatistics.createAssembler(schema, keyMarsh, key);
+        } catch (Throwable e) {
+            throw new MarshallerException(e.getMessage(), e);
+        }
     }
 
     /**

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/row/RowAssembler.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/row/RowAssembler.java
@@ -39,8 +39,6 @@ import org.apache.ignite.internal.schema.Columns;
 import org.apache.ignite.internal.schema.DecimalNativeType;
 import org.apache.ignite.internal.schema.InvalidTypeException;
 import org.apache.ignite.internal.schema.NativeType;
-import org.apache.ignite.internal.schema.NativeTypeSpec;
-import org.apache.ignite.internal.schema.NativeTypes;
 import org.apache.ignite.internal.schema.NumberNativeType;
 import org.apache.ignite.internal.schema.SchemaDescriptor;
 import org.apache.ignite.internal.schema.SchemaMismatchException;
@@ -75,15 +73,6 @@ public class RowAssembler {
 
     /** Current field index (the field is unset). */
     private int curCol;
-
-    private static boolean hasNulls(Columns columns) {
-        for (int i = 0; i < columns.length(); i++) {
-            if (columns.column(i).nullable()) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     /**
      * Helper method.
@@ -267,7 +256,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendBoolean(boolean val) throws SchemaMismatchException {
-        checkType(NativeTypes.BOOLEAN);
+        checkType(val);
 
         builder.appendBoolean(val);
 
@@ -288,7 +277,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendByte(byte val) throws SchemaMismatchException {
-        checkType(NativeTypes.INT8);
+        checkType(val);
 
         builder.appendByte(val);
 
@@ -309,7 +298,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendShort(short val) throws SchemaMismatchException {
-        checkType(NativeTypes.INT16);
+        checkType(val);
 
         builder.appendShort(val);
 
@@ -330,7 +319,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendInt(int val) throws SchemaMismatchException {
-        checkType(NativeTypes.INT32);
+        checkType(val);
 
         builder.appendInt(val);
 
@@ -351,7 +340,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendLong(long val) throws SchemaMismatchException {
-        checkType(NativeTypes.INT64);
+        checkType(val);
 
         builder.appendLong(val);
 
@@ -372,7 +361,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendFloat(float val) throws SchemaMismatchException {
-        checkType(NativeTypes.FLOAT);
+        checkType(val);
 
         builder.appendFloat(val);
 
@@ -393,7 +382,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendDouble(double val) throws SchemaMismatchException {
-        checkType(NativeTypes.DOUBLE);
+        checkType(val);
 
         builder.appendDouble(val);
 
@@ -414,7 +403,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendNumberNotNull(BigInteger val) throws SchemaMismatchException {
-        checkType(NativeTypeSpec.NUMBER);
+        checkType(val);
 
         Column col = curCols.column(curCol);
 
@@ -446,7 +435,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendDecimalNotNull(BigDecimal val) throws SchemaMismatchException {
-        checkType(NativeTypeSpec.DECIMAL);
+        checkType(val);
 
         Column col = curCols.column(curCol);
 
@@ -477,7 +466,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendStringNotNull(String val) throws SchemaMismatchException {
-        checkType(NativeTypeSpec.STRING);
+        checkType(val);
 
         builder.appendStringNotNull(val);
 
@@ -498,7 +487,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendBytesNotNull(byte[] val) throws SchemaMismatchException {
-        checkType(NativeTypeSpec.BYTES);
+        checkType(val);
 
         builder.appendBytesNotNull(val);
 
@@ -519,7 +508,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendUuidNotNull(UUID uuid) throws SchemaMismatchException {
-        checkType(NativeTypes.UUID);
+        checkType(uuid);
 
         builder.appendUuidNotNull(uuid);
 
@@ -542,7 +531,7 @@ public class RowAssembler {
     public RowAssembler appendBitmaskNotNull(BitSet bitSet) throws SchemaMismatchException {
         Column col = curCols.column(curCol);
 
-        checkType(NativeTypeSpec.BITMASK);
+        checkType(bitSet);
 
         BitmaskNativeType maskType = (BitmaskNativeType) col.type();
 
@@ -570,7 +559,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendDateNotNull(LocalDate val) throws SchemaMismatchException {
-        checkType(NativeTypes.DATE);
+        checkType(val);
 
         builder.appendDateNotNull(val);
 
@@ -591,7 +580,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendTimeNotNull(LocalTime val) throws SchemaMismatchException {
-        checkType(NativeTypeSpec.TIME);
+        checkType(val);
 
         builder.appendTimeNotNull(normalizeTime(val));
 
@@ -612,7 +601,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendDateTimeNotNull(LocalDateTime val) throws SchemaMismatchException {
-        checkType(NativeTypeSpec.DATETIME);
+        checkType(val);
 
         builder.appendDateTimeNotNull(LocalDateTime.of(val.toLocalDate(), normalizeTime(val.toLocalTime())));
 
@@ -633,7 +622,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendTimestampNotNull(Instant val) throws SchemaMismatchException {
-        checkType(NativeTypeSpec.TIMESTAMP);
+        checkType(val);
 
         builder.appendTimestampNotNull(Instant.ofEpochSecond(val.getEpochSecond(), normalizeNanos(val.getNano())));
 
@@ -708,29 +697,16 @@ public class RowAssembler {
     /**
      * Checks that the type being appended matches the column type.
      *
-     * @param type Type spec that is attempted to be appended.
+     * @param val Value that is attempted to be appended.
      * @throws SchemaMismatchException If given type doesn't match the current column type.
      */
-    private void checkType(NativeTypeSpec type) {
+    private void checkType(Object val) {
         if (curCols == null) {
-            throw new SchemaMismatchException("Failed to set column, expected key only but tried to add " + type.name());
+            throw new SchemaMismatchException("Failed to set column, expected key only but tried to add " + val);
         }
 
         Column col = curCols.column(curCol);
-
-        if (col.type().spec() != type) {
-            throw new SchemaMismatchException("Failed to set column (" + type.name() + " was passed, but column is of different "
-                    + "type): " + col);
-        }
-    }
-
-    /**
-     * Checks that the type being appended matches the column type.
-     *
-     * @param type Type that is attempted to be appended.
-     */
-    private void checkType(NativeType type) {
-        checkType(type.spec());
+        col.validate(val);
     }
 
     /**

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/row/RowAssembler.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/row/RowAssembler.java
@@ -39,6 +39,8 @@ import org.apache.ignite.internal.schema.Columns;
 import org.apache.ignite.internal.schema.DecimalNativeType;
 import org.apache.ignite.internal.schema.InvalidTypeException;
 import org.apache.ignite.internal.schema.NativeType;
+import org.apache.ignite.internal.schema.NativeTypeSpec;
+import org.apache.ignite.internal.schema.NativeTypes;
 import org.apache.ignite.internal.schema.NumberNativeType;
 import org.apache.ignite.internal.schema.SchemaDescriptor;
 import org.apache.ignite.internal.schema.SchemaMismatchException;
@@ -256,7 +258,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendBoolean(boolean val) throws SchemaMismatchException {
-        checkType(val);
+        checkType(NativeTypes.BOOLEAN);
 
         builder.appendBoolean(val);
 
@@ -277,7 +279,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendByte(byte val) throws SchemaMismatchException {
-        checkType(val);
+        checkType(NativeTypes.INT8);
 
         builder.appendByte(val);
 
@@ -298,7 +300,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendShort(short val) throws SchemaMismatchException {
-        checkType(val);
+        checkType(NativeTypes.INT16);
 
         builder.appendShort(val);
 
@@ -319,7 +321,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendInt(int val) throws SchemaMismatchException {
-        checkType(val);
+        checkType(NativeTypes.INT32);
 
         builder.appendInt(val);
 
@@ -340,7 +342,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendLong(long val) throws SchemaMismatchException {
-        checkType(val);
+        checkType(NativeTypes.INT64);
 
         builder.appendLong(val);
 
@@ -361,7 +363,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendFloat(float val) throws SchemaMismatchException {
-        checkType(val);
+        checkType(NativeTypes.FLOAT);
 
         builder.appendFloat(val);
 
@@ -382,7 +384,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendDouble(double val) throws SchemaMismatchException {
-        checkType(val);
+        checkType(NativeTypes.DOUBLE);
 
         builder.appendDouble(val);
 
@@ -403,7 +405,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendNumberNotNull(BigInteger val) throws SchemaMismatchException {
-        checkType(val);
+        checkType(NativeTypeSpec.NUMBER);
 
         Column col = curCols.column(curCol);
 
@@ -435,7 +437,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendDecimalNotNull(BigDecimal val) throws SchemaMismatchException {
-        checkType(val);
+        checkType(NativeTypeSpec.DECIMAL);
 
         Column col = curCols.column(curCol);
 
@@ -466,7 +468,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendStringNotNull(String val) throws SchemaMismatchException {
-        checkType(val);
+        checkType(NativeTypeSpec.STRING);
 
         builder.appendStringNotNull(val);
 
@@ -487,7 +489,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendBytesNotNull(byte[] val) throws SchemaMismatchException {
-        checkType(val);
+        checkType(NativeTypeSpec.BYTES);
 
         builder.appendBytesNotNull(val);
 
@@ -508,7 +510,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendUuidNotNull(UUID uuid) throws SchemaMismatchException {
-        checkType(uuid);
+        checkType(NativeTypes.UUID);
 
         builder.appendUuidNotNull(uuid);
 
@@ -531,7 +533,7 @@ public class RowAssembler {
     public RowAssembler appendBitmaskNotNull(BitSet bitSet) throws SchemaMismatchException {
         Column col = curCols.column(curCol);
 
-        checkType(bitSet);
+        checkType(NativeTypeSpec.BITMASK);
 
         BitmaskNativeType maskType = (BitmaskNativeType) col.type();
 
@@ -559,7 +561,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendDateNotNull(LocalDate val) throws SchemaMismatchException {
-        checkType(val);
+        checkType(NativeTypes.DATE);
 
         builder.appendDateNotNull(val);
 
@@ -580,7 +582,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendTimeNotNull(LocalTime val) throws SchemaMismatchException {
-        checkType(val);
+        checkType(NativeTypeSpec.TIME);
 
         builder.appendTimeNotNull(normalizeTime(val));
 
@@ -601,7 +603,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendDateTimeNotNull(LocalDateTime val) throws SchemaMismatchException {
-        checkType(val);
+        checkType(NativeTypeSpec.DATETIME);
 
         builder.appendDateTimeNotNull(LocalDateTime.of(val.toLocalDate(), normalizeTime(val.toLocalTime())));
 
@@ -622,7 +624,7 @@ public class RowAssembler {
      * @throws SchemaMismatchException If a value doesn't match the current column type.
      */
     public RowAssembler appendTimestampNotNull(Instant val) throws SchemaMismatchException {
-        checkType(val);
+        checkType(NativeTypeSpec.TIMESTAMP);
 
         builder.appendTimestampNotNull(Instant.ofEpochSecond(val.getEpochSecond(), normalizeNanos(val.getNano())));
 
@@ -697,16 +699,32 @@ public class RowAssembler {
     /**
      * Checks that the type being appended matches the column type.
      *
-     * @param val Value that is attempted to be appended.
+     * @param type Type spec that is attempted to be appended.
      * @throws SchemaMismatchException If given type doesn't match the current column type.
      */
-    private void checkType(Object val) {
+    private void checkType(NativeTypeSpec type) {
         if (curCols == null) {
-            throw new SchemaMismatchException("Failed to set column, expected key only but tried to add " + val);
+            throw new SchemaMismatchException("Failed to set column, expected key only but tried to add " + type.name());
         }
 
         Column col = curCols.column(curCol);
-        col.validate(val);
+
+        // Column#validate does not work here, because we must tolerate differences in precision, size, etc.
+        if (col.type().spec() != type) {
+            throw new InvalidTypeException("Column's type mismatch ["
+                    + "column=" + col
+                    + ", expectedType=" + col.type().spec()
+                    + ", actualType=" + type + ']');
+        }
+    }
+
+    /**
+     * Checks that the type being appended matches the column type.
+     *
+     * @param type Type that is attempted to be appended.
+     */
+    private void checkType(NativeType type) {
+        checkType(type.spec());
     }
 
     /**

--- a/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/KvMarshallerTest.java
+++ b/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/KvMarshallerTest.java
@@ -33,7 +33,6 @@ import static org.apache.ignite.internal.schema.NativeTypes.datetime;
 import static org.apache.ignite.internal.schema.NativeTypes.time;
 import static org.apache.ignite.internal.schema.NativeTypes.timestamp;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/KvMarshallerTest.java
+++ b/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/KvMarshallerTest.java
@@ -33,6 +33,7 @@ import static org.apache.ignite.internal.schema.NativeTypes.datetime;
 import static org.apache.ignite.internal.schema.NativeTypes.time;
 import static org.apache.ignite.internal.schema.NativeTypes.timestamp;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -280,10 +281,10 @@ public class KvMarshallerTest {
         TestSimpleObjectVal val = TestSimpleObjectVal.randomObject(rnd);
 
         Throwable ex = assertThrows(MarshallerException.class, () -> marshaller.marshal(key, val)).getCause();
-        assertThat(
-                ex.getMessage(),
-                startsWith("Failed to set column (INT64 was passed, but column is of different type): "
-                        + "Column [schemaIndex=0, columnOrder=-1, name=LONGCOL, type=BitmaskNativeType"));
+        assertThat(ex.getMessage(), startsWith("Column's type mismatch"));
+        assertThat(ex.getMessage(), containsString(
+                "expectedType=BitmaskNativeType [bits=42, typeSpec=NativeTypeSpec [name=BITMASK, fixed=true], len=6], "
+                        + "actualType=NativeType [name=INT64, sizeInBytes=8, fixed=true]"));
     }
 
     /**

--- a/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/KvMarshallerTest.java
+++ b/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/KvMarshallerTest.java
@@ -33,6 +33,7 @@ import static org.apache.ignite.internal.schema.NativeTypes.datetime;
 import static org.apache.ignite.internal.schema.NativeTypes.time;
 import static org.apache.ignite.internal.schema.NativeTypes.timestamp;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -281,6 +282,8 @@ public class KvMarshallerTest {
 
         Throwable ex = assertThrows(MarshallerException.class, () -> marshaller.marshal(key, val)).getCause();
         assertThat(ex.getMessage(), startsWith("Column's type mismatch"));
+        assertThat(ex.getMessage(), containsString("name=BITMASK"));
+        assertThat(ex.getMessage(), containsString("name=INT64"));
     }
 
     /**

--- a/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/KvMarshallerTest.java
+++ b/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/KvMarshallerTest.java
@@ -282,9 +282,6 @@ public class KvMarshallerTest {
 
         Throwable ex = assertThrows(MarshallerException.class, () -> marshaller.marshal(key, val)).getCause();
         assertThat(ex.getMessage(), startsWith("Column's type mismatch"));
-        assertThat(ex.getMessage(), containsString(
-                "expectedType=BitmaskNativeType [bits=42, typeSpec=NativeTypeSpec [name=BITMASK, fixed=true], len=6], "
-                        + "actualType=NativeType [name=INT64, sizeInBytes=8, fixed=true]"));
     }
 
     /**

--- a/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/RecordMarshallerTest.java
+++ b/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/RecordMarshallerTest.java
@@ -33,6 +33,7 @@ import static org.apache.ignite.internal.schema.NativeTypes.datetime;
 import static org.apache.ignite.internal.schema.NativeTypes.time;
 import static org.apache.ignite.internal.schema.NativeTypes.timestamp;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -213,10 +214,9 @@ public class RecordMarshallerTest {
         TestSimpleObject rec = TestSimpleObject.randomObject(rnd);
 
         Throwable ex = assertThrows(MarshallerException.class, () -> marshaller.marshal(rec)).getCause();
-        assertThat(
-                ex.getMessage(),
-                startsWith("Failed to set column (INT64 was passed, but column is of different type): "
-                        + "Column [schemaIndex=0, columnOrder=-1, name=LONGCOL, type=BitmaskNativeType"));
+        assertThat(ex.getMessage(), containsString(
+                "expectedType=BitmaskNativeType [bits=42, typeSpec=NativeTypeSpec [name=BITMASK, fixed=true], len=6], "
+                        + "actualType=NativeType [name=INT64, sizeInBytes=8, fixed=true]"));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
* Add `ItThinClientMarshallingTest` tests to ensure consistent schema validation across embedded and client APIs
* Fix inconsistent column type mismatch error messages 
* Add missing column type validation to client marshaller
* Add column type validation to `ObjectStatistics` to fix weird/inconsistent exceptions (statistics are collected before marshalling, so exceptions were different)