### PR TITLE
IGNITE-19919: org.apache.ignite.sql.ResultSet#close should close implicit transaction if any.

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlAsynchronousApiTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlAsynchronousApiTest.java
@@ -21,6 +21,7 @@ import static org.apache.ignite.internal.sql.engine.util.QueryChecker.containsIn
 import static org.apache.ignite.internal.sql.engine.util.QueryChecker.containsTableScan;
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.assertThrowsWithCause;
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.await;
+import static org.apache.ignite.internal.testframework.IgniteTestUtils.waitForCondition;
 import static org.apache.ignite.lang.ErrorGroups.Sql.CONSTRAINT_VIOLATION_ERR;
 import static org.apache.ignite.lang.ErrorGroups.Sql.STMT_VALIDATION_ERR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -743,6 +744,46 @@ public class ItSqlAsynchronousApiTest extends ClusterPerClassIntegrationTest {
         assertEquals(CONSTRAINT_VIOLATION_ERR, ex.code());
         assertEquals(err, ex.updateCounters().length);
         IntStream.range(0, ex.updateCounters().length).forEach(i -> assertEquals(1, ex.updateCounters()[i]));
+    }
+
+    @Test
+    public void resultSetCloseShouldFinishImplicitTransaction() throws InterruptedException {
+        sql("CREATE TABLE TEST(ID INT PRIMARY KEY, VAL0 INT)");
+        for (int i = 0; i < ROW_COUNT; ++i) {
+            sql("INSERT INTO TEST VALUES (?, ?)", i, i);
+        }
+
+        IgniteSql sql = igniteSql();
+
+        Session ses = sql.sessionBuilder().defaultPageSize(2).build();
+        CompletableFuture<AsyncResultSet<SqlRow>> f = ses.executeAsync(null, "SELECT * FROM TEST WHERE VAL0 >= ?", -1000);
+
+        AsyncResultSet<SqlRow> ars = f.join();
+        // There should be a pending transaction since not all data was read.
+        boolean txStarted = waitForCondition(() -> txManager().pending() == 1, 5000);
+        assertTrue(txStarted, "No pending transactions");
+
+        ars.closeAsync().join();
+        assertEquals(0, txManager().pending(), "Expected no pending transactions");
+    }
+
+    @Test
+    public void resultSetFullReadShouldFinishImplicitTransaction() {
+        sql("CREATE TABLE TEST(ID INT PRIMARY KEY, VAL0 INT)");
+        for (int i = 0; i < ROW_COUNT; ++i) {
+            sql("INSERT INTO TEST VALUES (?, ?)", i, i);
+        }
+
+        IgniteSql sql = igniteSql();
+
+        // Fetch all data in one read.
+        Session ses = sql.sessionBuilder().defaultPageSize(100).build();
+        CompletableFuture<AsyncResultSet<SqlRow>> f = ses.executeAsync(null, "SELECT * FROM TEST");
+
+        AsyncResultSet<SqlRow> ars = f.join();
+        assertFalse(ars.hasMorePages());
+
+        assertEquals(0, txManager().pending(), "Expected no pending transactions");
     }
 
     private static void checkDdl(boolean expectedApplied, Session ses, String sql, Transaction tx) {

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlAsynchronousApiTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlAsynchronousApiTest.java
@@ -756,7 +756,7 @@ public class ItSqlAsynchronousApiTest extends ClusterPerClassIntegrationTest {
         IgniteSql sql = igniteSql();
 
         Session ses = sql.sessionBuilder().defaultPageSize(2).build();
-        CompletableFuture<AsyncResultSet<SqlRow>> f = ses.executeAsync(null, "SELECT * FROM TEST WHERE VAL0 >= ?", -1000);
+        CompletableFuture<AsyncResultSet<SqlRow>> f = ses.executeAsync(null, "SELECT * FROM TEST");
 
         AsyncResultSet<SqlRow> ars = f.join();
         // There should be a pending transaction since not all data was read.

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlSynchronousApiTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlSynchronousApiTest.java
@@ -259,7 +259,6 @@ public class ItSqlSynchronousApiTest extends ClusterPerClassIntegrationTest {
     }
 
     @Test
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-19919")
     public void errors() throws InterruptedException {
         sql("CREATE TABLE TEST(ID INT PRIMARY KEY, VAL0 INT)");
         for (int i = 0; i < ROW_COUNT; ++i) {
@@ -439,9 +438,11 @@ public class ItSqlSynchronousApiTest extends ClusterPerClassIntegrationTest {
 
         // Fetch all data in one read.
         Session ses = sql.sessionBuilder().defaultPageSize(100).build();
-        ResultSet<?> rs = ses.execute(null, "SELECT * FROM TEST");
+        ResultSet<SqlRow> rs = ses.execute(null, "SELECT * FROM TEST");
 
-        rs.forEachRemaining(Object::hashCode);
+        while (rs.hasNext()) {
+            rs.next();
+        }
 
         assertEquals(0, txManager().pending(), "Expected no pending transactions");
     }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlSynchronousApiTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlSynchronousApiTest.java
@@ -56,7 +56,6 @@ import org.apache.ignite.sql.SqlRow;
 import org.apache.ignite.table.Table;
 import org.apache.ignite.tx.Transaction;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlSynchronousApiTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlSynchronousApiTest.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.sql.api;
 
 import static org.apache.ignite.internal.sql.api.ItSqlAsynchronousApiTest.assertThrowsPublicException;
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.assertThrowsWithCause;
+import static org.apache.ignite.lang.ErrorGroups.Sql.CURSOR_CLOSED_ERR;
 import static org.apache.ignite.lang.ErrorGroups.Sql.QUERY_NO_RESULT_SET_ERR;
 import static org.apache.ignite.lang.ErrorGroups.Sql.RUNTIME_ERR;
 import static org.apache.ignite.lang.ErrorGroups.Sql.STMT_PARSE_ERR;
@@ -49,6 +50,7 @@ import org.apache.ignite.lang.IndexNotFoundException;
 import org.apache.ignite.lang.TableAlreadyExistsException;
 import org.apache.ignite.lang.TableNotFoundException;
 import org.apache.ignite.sql.BatchedArguments;
+import org.apache.ignite.sql.CursorClosedException;
 import org.apache.ignite.sql.IgniteSql;
 import org.apache.ignite.sql.NoRowSetExpectedException;
 import org.apache.ignite.sql.ResultSet;
@@ -305,15 +307,14 @@ public class ItSqlSynchronousApiTest extends ClusterPerClassIntegrationTest {
             assertThrowsPublicException(rs::next, NoRowSetExpectedException.class, QUERY_NO_RESULT_SET_ERR, "Query has no result set");
         }
 
-        // TODO unmute after https://issues.apache.org/jira/browse/IGNITE-19919
         // Cursor closed error.
-        // {
-        //     ResultSet rs = ses.execute(null, "SELECT * FROM TEST");
-        //     Thread.sleep(300); // ResultSetImpl fetches next page in background, wait to it to complete to avoid flakiness.
-        //     rs.close();
-        //     assertThrowsPublicException(() -> rs.forEachRemaining(Object::hashCode),
-        //             CursorClosedException.class, CURSOR_CLOSED_ERR, null);
-        // }
+        {
+            ResultSet rs = ses.execute(null, "SELECT * FROM TEST");
+            Thread.sleep(300); // ResultSetImpl fetches next page in background, wait to it to complete to avoid flakiness.
+            rs.close();
+            assertThrowsPublicException(() -> rs.forEachRemaining(Object::hashCode),
+                    CursorClosedException.class, CURSOR_CLOSED_ERR, null);
+        }
     }
 
     /**

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/AsyncSqlCursorImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/AsyncSqlCursorImpl.java
@@ -91,6 +91,10 @@ public class AsyncSqlCursorImpl<T> implements AsyncSqlCursor<T> {
     /** {@inheritDoc} */
     @Override
     public CompletableFuture<Void> closeAsync() {
+        // Commit implicit transaction, if any.
+        if (implicitTx != null) {
+            implicitTx.commit();
+        }
         return dataCursor.closeAsync();
     }
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/AsyncSqlCursorImplTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/AsyncSqlCursorImplTest.java
@@ -50,7 +50,7 @@ public class AsyncSqlCursorImplTest {
 
     private static final ResultSetMetadata RESULT_SET_METADATA = new ResultSetMetadataImpl(Collections.emptyList());
 
-    /** Cursor should trigger commit of an implicit transaction (if any) only if when data is fully read. */
+    /** Cursor should trigger commit of an implicit transaction (if any) only if data is fully read. */
     @ParameterizedTest
     @MethodSource("transactions")
     public void testTriggerCommitAfterDataIsFullyRead(NoOpTransaction implicitTx) {

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/AsyncSqlCursorImplTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/AsyncSqlCursorImplTest.java
@@ -50,7 +50,7 @@ public class AsyncSqlCursorImplTest {
 
     private static final ResultSetMetadata RESULT_SET_METADATA = new ResultSetMetadataImpl(Collections.emptyList());
 
-    /** Cursor should trigger a commit of an implicit transaction (if any) only if when data is fully read. */
+    /** Cursor should trigger commit of an implicit transaction (if any) only if when data is fully read. */
     @ParameterizedTest
     @MethodSource("transactions")
     public void testTriggerCommitAfterDataIsFullyRead(NoOpTransaction implicitTx) {
@@ -77,7 +77,7 @@ public class AsyncSqlCursorImplTest {
         }
     }
 
-    /** Exception on read should trigger a rollback of an implicit transaction, if any. */
+    /** Exception on read should trigger rollback of an implicit transaction, if any. */
     @ParameterizedTest
     @MethodSource("transactions")
     public void testExceptionRollbacksImplicitTx(NoOpTransaction implicitTx) {
@@ -97,7 +97,7 @@ public class AsyncSqlCursorImplTest {
         assertEquals(err.codeAsString(), igniteErr.codeAsString());
     }
 
-    /** Cursor close should trigger a commit of an implicit transaction, if any. */
+    /** Cursor close should trigger commit of an implicit transaction, if any. */
     @ParameterizedTest
     @MethodSource("transactions")
     public void testCloseCommitsImplicitTx(NoOpTransaction implicitTx) {

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/AsyncSqlCursorImplTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/AsyncSqlCursorImplTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Stream;
+import org.apache.ignite.internal.sql.api.ResultSetMetadataImpl;
+import org.apache.ignite.internal.sql.engine.AsyncCursor.BatchedResult;
+import org.apache.ignite.internal.sql.engine.exec.AsyncWrapper;
+import org.apache.ignite.internal.sql.engine.framework.NoOpTransaction;
+import org.apache.ignite.lang.ErrorGroups.Common;
+import org.apache.ignite.lang.IgniteException;
+import org.apache.ignite.sql.ResultSetMetadata;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests for {@link AsyncSqlCursorImpl}.
+ */
+@ExtendWith(MockitoExtension.class)
+public class AsyncSqlCursorImplTest {
+
+    private static final ResultSetMetadata RESULT_SET_METADATA = new ResultSetMetadataImpl(Collections.emptyList());
+
+    /** Cursor should trigger a commit of an implicit transaction (if any) only if when data is fully read. */
+    @ParameterizedTest
+    @MethodSource("transactions")
+    public void testTriggerCommitAfterDataIsFullyRead(NoOpTransaction implicitTx) {
+        List<Integer> list = List.of(1, 2, 3);
+
+        AsyncSqlCursorImpl<Integer> cursor = new AsyncSqlCursorImpl<>(SqlQueryType.QUERY, RESULT_SET_METADATA, implicitTx,
+                new AsyncWrapper<>(CompletableFuture.completedFuture(list.iterator()), Runnable::run));
+
+        int requestRows = 2;
+        BatchedResult<Integer> in1 = cursor.requestNextAsync(requestRows).join();
+        assertEquals(in1.items(), list.subList(0, requestRows));
+
+        if (implicitTx != null) {
+            CompletableFuture<Void> f = implicitTx.commitFuture();
+            assertFalse(f.isDone(), "Implicit transaction should have not been committed because there is more data: " + f);
+        }
+
+        BatchedResult<Integer> in2 = cursor.requestNextAsync(requestRows).join();
+        assertEquals(in2.items(), list.subList(requestRows, list.size()));
+
+        if (implicitTx != null) {
+            CompletableFuture<Void> f = implicitTx.commitFuture();
+            assertTrue(f.isDone());
+        }
+    }
+
+    /** Exception on read should trigger a rollback of an implicit transaction, if any. */
+    @ParameterizedTest
+    @MethodSource("transactions")
+    public void testExceptionRollbacksImplicitTx(NoOpTransaction implicitTx) {
+        IgniteException err = new IgniteException(Common.INTERNAL_ERR);
+
+        AsyncSqlCursorImpl<Integer> cursor = new AsyncSqlCursorImpl<>(SqlQueryType.QUERY, RESULT_SET_METADATA, implicitTx,
+                new AsyncWrapper<>(CompletableFuture.failedFuture(err), Runnable::run));
+
+        CompletionException t = assertThrows(CompletionException.class, () -> cursor.requestNextAsync(1).join());
+
+        if (implicitTx != null) {
+            CompletableFuture<Void> f = implicitTx.rollbackFuture();
+            assertTrue(f.isDone(), "Implicit transaction should have been rolled back: " + f);
+        }
+
+        IgniteException igniteErr = assertInstanceOf(IgniteException.class, t.getCause());
+        assertEquals(err.codeAsString(), igniteErr.codeAsString());
+    }
+
+    /** Cursor close should trigger a commit of an implicit transaction, if any. */
+    @ParameterizedTest
+    @MethodSource("transactions")
+    public void testCloseCommitsImplicitTx(NoOpTransaction implicitTx) {
+        AsyncCursor<Integer> data = new AsyncWrapper<>(List.of(1, 2, 3, 4).iterator());
+        AsyncSqlCursorImpl<Integer> cursor = new AsyncSqlCursorImpl<>(SqlQueryType.QUERY, RESULT_SET_METADATA, implicitTx, data);
+        cursor.closeAsync().join();
+
+        if (implicitTx != null) {
+            CompletableFuture<Void> f = implicitTx.commitFuture();
+            assertTrue(f.isDone(), "Implicit transaction should have been committed: " + f);
+        }
+    }
+
+    private static Stream<Arguments> transactions() {
+        return Stream.of(
+                Arguments.of(Named.named("implicit-tx", NoOpTransaction.readOnly("TX"))),
+                Arguments.of(Named.named("no implicit-tx", null))
+        );
+    }
+}

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/AsyncSqlCursorImplTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/AsyncSqlCursorImplTest.java
@@ -65,7 +65,7 @@ public class AsyncSqlCursorImplTest {
 
         if (implicitTx != null) {
             CompletableFuture<Void> f = implicitTx.commitFuture();
-            assertFalse(f.isDone(), "Implicit transaction should have not been committed because there is more data: " + f);
+            assertFalse(f.isDone(), "Implicit transaction should have not been committed because there is more data.");
         }
 
         BatchedResult<Integer> in2 = cursor.requestNextAsync(requestRows).join();
@@ -73,7 +73,7 @@ public class AsyncSqlCursorImplTest {
 
         if (implicitTx != null) {
             CompletableFuture<Void> f = implicitTx.commitFuture();
-            assertTrue(f.isDone());
+            assertTrue(f.isDone(), "Implicit transaction should been committed because there is no more data");
         }
     }
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/AsyncSqlCursorImplTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/AsyncSqlCursorImplTest.java
@@ -36,16 +36,13 @@ import org.apache.ignite.lang.ErrorGroups.Common;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.sql.ResultSetMetadata;
 import org.junit.jupiter.api.Named;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Tests for {@link AsyncSqlCursorImpl}.
  */
-@ExtendWith(MockitoExtension.class)
 public class AsyncSqlCursorImplTest {
 
     private static final ResultSetMetadata RESULT_SET_METADATA = new ResultSetMetadataImpl(Collections.emptyList());

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/AsyncSqlCursorImplTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/AsyncSqlCursorImplTest.java
@@ -50,7 +50,7 @@ public class AsyncSqlCursorImplTest {
 
     private static final ResultSetMetadata RESULT_SET_METADATA = new ResultSetMetadataImpl(Collections.emptyList());
 
-    /** Cursor should trigger commit of an implicit transaction (if any) only if data is fully read. */
+    /** Cursor should trigger commit of implicit transaction (if any) only if data is fully read. */
     @ParameterizedTest
     @MethodSource("transactions")
     public void testTriggerCommitAfterDataIsFullyRead(NoOpTransaction implicitTx) {
@@ -77,7 +77,7 @@ public class AsyncSqlCursorImplTest {
         }
     }
 
-    /** Exception on read should trigger rollback of an implicit transaction, if any. */
+    /** Exception on read should trigger rollback of implicit transaction, if any. */
     @ParameterizedTest
     @MethodSource("transactions")
     public void testExceptionRollbacksImplicitTx(NoOpTransaction implicitTx) {
@@ -97,7 +97,7 @@ public class AsyncSqlCursorImplTest {
         assertEquals(err.codeAsString(), igniteErr.codeAsString());
     }
 
-    /** Cursor close should trigger commit of an implicit transaction, if any. */
+    /** Cursor close should trigger commit of implicit transaction, if any. */
     @ParameterizedTest
     @MethodSource("transactions")
     public void testCloseCommitsImplicitTx(NoOpTransaction implicitTx) {

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/NoOpTransaction.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/NoOpTransaction.java
@@ -46,6 +46,10 @@ public final class NoOpTransaction implements InternalTransaction {
 
     private final boolean readOnly;
 
+    private final CompletableFuture<Void> commitFut = new CompletableFuture<>();
+
+    private final CompletableFuture<Void> rollbackFut = new CompletableFuture<>();
+
     /** Creates a read-write transaction. */
     public static NoOpTransaction readWrite(String name) {
         return new NoOpTransaction(name, false);
@@ -84,22 +88,24 @@ public final class NoOpTransaction implements InternalTransaction {
 
     @Override
     public void commit() throws TransactionException {
-
+        commitAsync().join();
     }
 
     @Override
     public CompletableFuture<Void> commitAsync() {
-        return CompletableFuture.completedFuture(null);
+        commitFut.complete(null);
+        return commitFut;
     }
 
     @Override
     public void rollback() throws TransactionException {
-
+        rollbackAsync().join();
     }
 
     @Override
     public CompletableFuture<Void> rollbackAsync() {
-        return CompletableFuture.completedFuture(null);
+        rollbackFut.complete(null);
+        return rollbackFut;
     }
 
     @Override
@@ -154,5 +160,15 @@ public final class NoOpTransaction implements InternalTransaction {
     @Override
     public void enlistResultFuture(CompletableFuture<?> resultFuture) {
         resultFuture.complete(null);
+    }
+
+    /** Returns a {@link CompletableFuture} that completes when this transaction commits. */
+    public CompletableFuture<Void> commitFuture() {
+        return commitFut;
+    }
+
+    /** Returns a {@link CompletableFuture} that completes when this transaction rollbacks. */
+    public CompletableFuture<Void> rollbackFuture() {
+        return rollbackFut;
     }
 }


### PR DESCRIPTION
- Commits implicit transaction on AsyncCursor::close.
- Adds unit tests for AsyncCursorImpl.

https://issues.apache.org/jira/browse/IGNITE-19919

----

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)