### PR TITLE
IGNITE-20056 .NET: Track observable timestamp

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/.editorconfig
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/.editorconfig
@@ -46,3 +46,6 @@ dotnet_diagnostic.NUnit2005.severity = none # Consider using the constraint mode
 dotnet_diagnostic.NUnit2006.severity = none # Consider using the constraint model
 dotnet_diagnostic.NUnit2015.severity = none # Consider using the constraint model
 dotnet_diagnostic.NUnit2031.severity = none # Consider using the constraint model
+
+# ReSharper (refer to https://www.jetbrains.com/help/resharper/Reference__Code_Inspections_CSHARP.html)
+resharper_using_statement_resource_initialization_highlighting = none # Do not use object initializer for 'using' variable

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ClientSocketTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ClientSocketTests.cs
@@ -93,7 +93,7 @@ namespace Apache.Ignite.Tests
                 // No-op.
             }
 
-            public void OnObservableTimestampChanged(ClientSocket clientSocket, long timestamp)
+            public void OnObservableTimestampChanged(long timestamp)
             {
                 // No-op.
             }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ClientSocketTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ClientSocketTests.cs
@@ -30,10 +30,12 @@ namespace Apache.Ignite.Tests
     /// </summary>
     public class ClientSocketTests : IgniteTestsBase
     {
+        private static readonly IClientSocketEventListener Listener = new NoOpListener();
+
         [Test]
         public async Task TestConnectAndSendRequestReturnsResponse()
         {
-            using var socket = await ClientSocket.ConnectAsync(GetEndPoint(), new(), _ => {});
+            using var socket = await ClientSocket.ConnectAsync(GetEndPoint(), new(), Listener);
 
             using var requestWriter = ProtoCommon.GetMessageWriter();
             requestWriter.MessageWriter.Write("non-existent-table");
@@ -45,7 +47,7 @@ namespace Apache.Ignite.Tests
         [Test]
         public async Task TestConnectAndSendRequestWithInvalidOpCodeThrowsError()
         {
-            using var socket = await ClientSocket.ConnectAsync(GetEndPoint(), new(), _ => {});
+            using var socket = await ClientSocket.ConnectAsync(GetEndPoint(), new(), Listener);
 
             using var requestWriter = ProtoCommon.GetMessageWriter();
             requestWriter.MessageWriter.Write(123);
@@ -59,7 +61,7 @@ namespace Apache.Ignite.Tests
         [Test]
         public async Task TestDisposedSocketThrowsExceptionOnSend()
         {
-            var socket = await ClientSocket.ConnectAsync(GetEndPoint(), new(), _ => {});
+            var socket = await ClientSocket.ConnectAsync(GetEndPoint(), new(), Listener);
 
             socket.Dispose();
 
@@ -78,10 +80,23 @@ namespace Apache.Ignite.Tests
         [Test]
         public void TestConnectWithoutServerThrowsException()
         {
-            Assert.CatchAsync(async () => await ClientSocket.ConnectAsync(GetEndPoint(569), new(), _ => { }));
+            Assert.CatchAsync(async () => await ClientSocket.ConnectAsync(GetEndPoint(569), new(), Listener));
         }
 
         private static SocketEndpoint GetEndPoint(int? serverPort = null) =>
             new(new(IPAddress.Loopback, serverPort ?? ServerPort), string.Empty);
+
+        private class NoOpListener : IClientSocketEventListener
+        {
+            public void OnAssignmentChanged(ClientSocket clientSocket)
+            {
+                // No-op.
+            }
+
+            public void OnObservableTimestampChanged(ClientSocket clientSocket, long timestamp)
+            {
+                // No-op.
+            }
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -120,6 +120,10 @@ namespace Apache.Ignite.Tests
 
         public int RequestCount { get; set; }
 
+        public long ObservableTimestamp { get; set; }
+
+        public long LastClientObservableTimestamp { get; set; }
+
         internal IList<ClientOp> ClientOps => _ops?.ToList() ?? throw new Exception("Ops tracking is disabled");
 
         public async Task<IIgniteClient> ConnectClientAsync(IgniteClientConfiguration? cfg = null)
@@ -281,6 +285,9 @@ namespace Apache.Ignite.Tests
                         continue;
 
                     case ClientOp.TxBegin:
+                        reader.Skip(); // Read only.
+                        LastClientObservableTimestamp = reader.ReadInt64();
+
                         Send(handler, requestId, new byte[] { 0 }.AsMemory());
                         continue;
 
@@ -339,7 +346,7 @@ namespace Apache.Ignite.Tests
             writer.Write(0); // Message type.
             writer.Write(requestId);
             writer.Write(PartitionAssignmentChanged ? (int)ResponseFlags.PartitionAssignmentChanged : 0);
-            writer.Write(0); // Observable timestamp.
+            writer.Write(ObservableTimestamp); // Observable timestamp.
 
             if (!isError)
             {
@@ -410,6 +417,17 @@ namespace Apache.Ignite.Tests
 
             var sql = reader.ReadString();
             props["sql"] = sql;
+
+            if (!reader.TryReadNil())
+            {
+                var argCount = reader.ReadInt32();
+                if (argCount > 0)
+                {
+                    reader.Skip();
+                }
+            }
+
+            LastClientObservableTimestamp = reader.ReadInt64();
 
             LastSql = sql;
             LastSqlPageSize = pageSize;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -259,7 +259,7 @@ namespace Apache.Ignite.Internal
         }
 
         /// <inheritdoc/>
-        void IClientSocketEventListener.OnObservableTimestampChanged(ClientSocket clientSocket, long timestamp)
+        void IClientSocketEventListener.OnObservableTimestampChanged(long timestamp)
         {
             // TODO: Implement CAS-based timestamp update.
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -108,6 +108,11 @@ namespace Apache.Ignite.Internal
         public int PartitionAssignmentVersion => Interlocked.CompareExchange(ref _assignmentVersion, -1, -1);
 
         /// <summary>
+        /// Gets the observable timestamp.
+        /// </summary>
+        public long ObservableTimestamp => Interlocked.Read(ref _observableTimestamp);
+
+        /// <summary>
         /// Connects the socket.
         /// </summary>
         /// <param name="configuration">Client configuration.</param>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -92,8 +92,8 @@ namespace Apache.Ignite.Internal
         /** Logger. */
         private readonly IIgniteLogger? _logger;
 
-        /** Partition assignment change callback. */
-        private readonly Action<ClientSocket> _assignmentChangeCallback;
+        /** Event listener. */
+        private readonly IClientSocketEventListener _listener;
 
         /** Pre-allocated buffer for message size + op code + request id. To be used under <see cref="_sendLock"/>. */
         private readonly byte[] _prefixBuffer = new byte[ProtoCommon.MessagePrefixSize];
@@ -110,18 +110,18 @@ namespace Apache.Ignite.Internal
         /// <param name="stream">Network stream.</param>
         /// <param name="configuration">Configuration.</param>
         /// <param name="connectionContext">Connection context.</param>
-        /// <param name="assignmentChangeCallback">Partition assignment change callback.</param>
+        /// <param name="listener">Event listener.</param>
         /// <param name="logger">Logger.</param>
         private ClientSocket(
             Stream stream,
             IgniteClientConfiguration configuration,
             ConnectionContext connectionContext,
-            Action<ClientSocket> assignmentChangeCallback,
+            IClientSocketEventListener listener,
             IIgniteLogger? logger)
         {
             _stream = stream;
             ConnectionContext = connectionContext;
-            _assignmentChangeCallback = assignmentChangeCallback;
+            _listener = listener;
             _logger = logger;
             _socketTimeout = configuration.SocketTimeout;
 
@@ -154,7 +154,7 @@ namespace Apache.Ignite.Internal
         /// </summary>
         /// <param name="endPoint">Specific endpoint to connect to.</param>
         /// <param name="configuration">Configuration.</param>
-        /// <param name="assignmentChangeCallback">Partition assignment change callback.</param>
+        /// <param name="listener">Event listener.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
         [SuppressMessage(
             "Microsoft.Reliability",
@@ -163,7 +163,7 @@ namespace Apache.Ignite.Internal
         public static async Task<ClientSocket> ConnectAsync(
             SocketEndpoint endPoint,
             IgniteClientConfiguration configuration,
-            Action<ClientSocket> assignmentChangeCallback)
+            IClientSocketEventListener listener)
         {
             var socket = new Socket(SocketType.Stream, ProtocolType.Tcp)
             {
@@ -209,7 +209,7 @@ namespace Apache.Ignite.Internal
                     logger.Debug($"Handshake succeeded [remoteAddress={socket.RemoteEndPoint}]: {context}.");
                 }
 
-                return new ClientSocket(stream, configuration, context, assignmentChangeCallback, logger);
+                return new ClientSocket(stream, configuration, context, listener, logger);
             }
             catch (Exception e)
             {
@@ -697,7 +697,7 @@ namespace Apache.Ignite.Internal
                         $"Partition assignment change notification received [remoteAddress={ConnectionContext.ClusterNode.Address}]");
                 }
 
-                _assignmentChangeCallback(this);
+                _listener.OnAssignmentChanged(this);
             }
 
             // TODO IGNITE-20056 .NET: Thin 3.0: Track observable timestamp

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -700,8 +700,8 @@ namespace Apache.Ignite.Internal
                 _listener.OnAssignmentChanged(this);
             }
 
-            // TODO IGNITE-20056 .NET: Thin 3.0: Track observable timestamp
-            _ = reader.ReadInt64();
+            var observableTimestamp = reader.ReadInt64();
+            _listener.OnObservableTimestampChanged(this, observableTimestamp);
 
             var exception = ReadError(ref reader);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -701,7 +701,7 @@ namespace Apache.Ignite.Internal
             }
 
             var observableTimestamp = reader.ReadInt64();
-            _listener.OnObservableTimestampChanged(this, observableTimestamp);
+            _listener.OnObservableTimestampChanged(observableTimestamp);
 
             var exception = ReadError(ref reader);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/IClientSocketEventListener.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/IClientSocketEventListener.cs
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Internal;
+
+/// <summary>
+/// <see cref="ClientSocket"/> event listener.
+/// </summary>
+internal interface IClientSocketEventListener
+{
+    /// <summary>
+    /// Called when partition assignment changes.
+    /// </summary>
+    /// <param name="clientSocket">Source socket.</param>
+    void OnAssignmentChanged(ClientSocket clientSocket);
+
+    /// <summary>
+    /// Called when observable timestamp changes.
+    /// </summary>
+    /// <param name="clientSocket">Source socket.</param>
+    /// <param name="timestamp">Timestamp.</param>
+    void OnObservableTimestampChanged(ClientSocket clientSocket, long timestamp);
+}

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/IClientSocketEventListener.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/IClientSocketEventListener.cs
@@ -31,7 +31,6 @@ internal interface IClientSocketEventListener
     /// <summary>
     /// Called when observable timestamp changes.
     /// </summary>
-    /// <param name="clientSocket">Source socket.</param>
     /// <param name="timestamp">Timestamp.</param>
-    void OnObservableTimestampChanged(ClientSocket clientSocket, long timestamp);
+    void OnObservableTimestampChanged(long timestamp);
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/Sql.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/Sql.cs
@@ -190,8 +190,7 @@ namespace Apache.Ignite.Internal.Sql
                 w.Write(statement.Query);
                 w.WriteObjectCollectionAsBinaryTuple(args);
 
-                // TODO IGNITE-20056 .NET: Thin 3.0: Track observable timestamp
-                w.Write(0);
+                w.Write(_socket.ObservableTimestamp);
 
                 return writer;
             }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transactions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transactions.cs
@@ -59,9 +59,7 @@ namespace Apache.Ignite.Internal.Transactions
             {
                 var w = writer.MessageWriter;
                 w.Write(options.ReadOnly);
-
-                // TODO IGNITE-20056 .NET: Thin 3.0: Track observable timestamp
-                w.Write(0);
+                w.Write(_socket.ObservableTimestamp);
             }
         }
 


### PR DESCRIPTION
Track observable timestamp in .NET client:
* Maintain latest value in `ClientFailoverSocket`
* Send back to server in `TxBegin` and `SqlExec`