### PR TITLE
IGNITE-19978 Java client: Change Gradle dependencies from implementation to api

### DIFF
--- a/modules/client/build.gradle
+++ b/modules/client/build.gradle
@@ -20,8 +20,8 @@ apply from: "$rootDir/buildscripts/publishing.gradle"
 apply from: "$rootDir/buildscripts/java-junit5.gradle"
 
 dependencies {
-    implementation project(':ignite-api')
-    implementation project(':ignite-core')
+    api project(':ignite-api')
+    api project(':ignite-core')
     implementation project(':ignite-binary-tuple')
     implementation project(':ignite-client-common')
     implementation project(':ignite-marshaller-common')


### PR DESCRIPTION
Change dependency type for `ignite-api` and `ignite-core` projects from `implementation` to `api`.

Those two projects contain public API types.
* With `implementation` dependency type, users have to explicitly add dependencies to all three modules to use those types
* With `api` dependency type, single `ignite-client` dependency is enough to use the entire public API