### PR TITLE
IGNITE-19838 .NET: Retry outdated schema error 

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests.Table;
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests for client table schema synchronization.
+/// </summary>
+public class SchemaSynchronizationTest : IgniteTestsBase
+{
+    [Test]
+    public async Task TestClientUsesLatestSchemaOnWrite()
+    {
+        // Create table, insert data.
+        var tableName = TestContext.CurrentContext.Test.Name;
+        await Client.Sql.ExecuteAsync(null, $"CREATE TABLE {tableName} (ID INT NOT NULL PRIMARY KEY, NAME VARCHAR NOT NULL)");
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -48,7 +48,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
 
         await view.InsertAsync(null, rec);
 
-        // Modify table, insert data - client will use old schema, receive error, retry with new schema, fail due to an extra column.
+        // Modify table, insert data - client will use old schema, receive error, retry with new schema.
         // The process is transparent for the user: updated schema is in effect immediately.
         await Client.Sql.ExecuteAsync(null, $"ALTER TABLE {TestTableName} DROP COLUMN NAME");
 
@@ -58,6 +58,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
             ["NAME"] = "name2"
         };
 
+        // TODO this should fail when we implement IGNITE-19836 Reject Tuples and POCOs with unmapped fields
         await view.InsertAsync(null, rec2);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -55,7 +55,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
         var rec2 = new IgniteTuple
         {
             ["ID"] = 2,
-            ["NAME"] = "nam2"
+            ["NAME"] = "name2"
         };
 
         await view.InsertAsync(null, rec2);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -167,6 +167,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
         var res = await pocoView.GetAsync(null, new Poco(1, string.Empty));
 
         Assert.IsTrue(res.HasValue);
+        Assert.AreEqual(1, res.Value.Id);
         Assert.AreEqual("name1", res.Value.Name);
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -429,7 +429,10 @@ namespace Apache.Ignite.Internal
                         ExceptionMapper.GetException(traceId, code, className, message, javaStackTrace));
                 }
 
-                // TODO: return ClientSchemaVersionMismatchException
+                var ex = ExceptionMapper.GetException(traceId, code, className, message, javaStackTrace);
+                ex.Data[ErrorExtensions.ExpectedSchemaVersion] = expectedSchemaVersion;
+
+                return ex;
             }
             else
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -404,9 +404,10 @@ namespace Apache.Ignite.Internal
             int extensionCount = reader.TryReadNil() ? 0 : reader.ReadMapHeader();
             for (int i = 0; i < extensionCount; i++)
             {
-                if (reader.ReadString() == ErrorExtensions.ExpectedSchemaVersion)
+                var key = reader.ReadString();
+                if (key == ErrorExtensions.ExpectedSchemaVersion)
                 {
-                    ex.Data[ErrorExtensions.ExpectedSchemaVersion] = reader.ReadInt32();
+                    ex.Data[key] = reader.ReadInt32();
                 }
                 else
                 {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -400,6 +400,7 @@ namespace Apache.Ignite.Internal
             string? message = reader.ReadStringNullable();
             string? javaStackTrace = reader.ReadStringNullable();
 
+            // TODO: Always read all known extensions here - simplify the code.
             if (code == ErrorGroups.Table.SchemaVersionMismatch)
             {
                 int extSize = reader.TryReadNil() ? 0 : reader.ReadMapHeader();

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/ExceptionExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/ExceptionExtensions.cs
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Internal.Common;
+
+using System;
+using System.Diagnostics;
+using Proto;
+
+/// <summary>
+/// Exception extensions.
+/// </summary>
+internal static class ExceptionExtensions
+{
+    /// <summary>
+    /// Gets expected schema version from the error data.
+    /// </summary>
+    /// <param name="e">Exception.</param>
+    /// <returns>Expected schema version.</returns>
+    /// <exception cref="IgniteException">When specified exception does not have schema version in <see cref="Exception.Data"/>.</exception>
+    public static int GetExpectedSchemaVersion(this IgniteException e)
+    {
+        Debug.Assert(
+            e.Code == ErrorGroups.Table.SchemaVersionMismatch,
+            $"e.Code == ErrorGroups.Table.SchemaVersionMismatch: expected {ErrorGroups.Table.SchemaVersionMismatch}, actual {e.Code}");
+
+        if (e.Data[ErrorExtensions.ExpectedSchemaVersion] is int schemaVer)
+        {
+            return schemaVer;
+        }
+
+        throw new IgniteException(
+            e.TraceId,
+            ErrorGroups.Client.Protocol,
+            "Expected schema version is not specified in error extension map.",
+            e);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -260,6 +260,7 @@ namespace Apache.Ignite.Internal.Compute
 
             while (true)
             {
+                // TODO: Reuse logic from RecordView? But we have our own retry here.
                 var table = await GetTableAsync(tableName).ConfigureAwait(false);
                 var schema = await table.GetLatestSchemaAsync().ConfigureAwait(false);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -284,7 +284,6 @@ namespace Apache.Ignite.Internal.Compute
                 }
                 catch (IgniteException e) when (e.Code == ErrorGroups.Table.SchemaVersionMismatch)
                 {
-                    // ReSharper disable once PossibleMultipleEnumeration (we have to retry, but this is very rare)
                     schemaVersion = e.GetExpectedSchemaVersion();
                 }
             }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -257,12 +257,12 @@ namespace Apache.Ignite.Internal.Compute
             IgniteArgumentCheck.NotNull(jobClassName, nameof(jobClassName));
 
             var units0 = units as ICollection<DeploymentUnit> ?? units.ToList(); // Avoid multiple enumeration.
+            int? schemaVersion = null;
 
             while (true)
             {
-                // TODO: Reuse logic from RecordView? But we have our own retry here.
                 var table = await GetTableAsync(tableName).ConfigureAwait(false);
-                var schema = await table.GetLatestSchemaAsync().ConfigureAwait(false);
+                var schema = await table.GetSchemaAsync(schemaVersion).ConfigureAwait(false);
 
                 using var bufferWriter = ProtoCommon.GetMessageWriter();
                 var colocationHash = Write(bufferWriter, table, schema);
@@ -280,6 +280,12 @@ namespace Apache.Ignite.Internal.Compute
                     // Table was dropped - remove from cache.
                     // Try again in case a new table with the same name exists.
                     _tableCache.TryRemove(tableName, out _);
+                    schemaVersion = null;
+                }
+                catch (IgniteException e) when (e.Code == ErrorGroups.Table.SchemaVersionMismatch)
+                {
+                    // ReSharper disable once PossibleMultipleEnumeration (we have to retry, but this is very rare)
+                    schemaVersion = e.GetExpectedSchemaVersion();
                 }
             }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ErrorExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/ErrorExtensions.cs
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Internal.Proto;
+
+/// <summary>
+/// Error data extensions. When the server returns an error response, it may contain additional data in a map. Keys are defined here.
+/// </summary>
+internal static class ErrorExtensions
+{
+    /// <summary>
+    /// Expected schema version for <see cref="ErrorGroups.Table.SchemaVersionMismatch"/> error.
+    /// </summary>
+    public const string ExpectedSchemaVersion = "expected-schema-ver";
+}

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -172,21 +172,7 @@ namespace Apache.Ignite.Internal.Table
         {
             IgniteArgumentCheck.NotNull(records, nameof(records));
 
-            using var iterator = records.GetEnumerator();
-
-            if (!iterator.MoveNext())
-            {
-                return;
-            }
-
-            var schema = await _table.GetLatestSchemaAsync().ConfigureAwait(false);
-            var tx = transaction.ToInternal();
-
-            using var writer = ProtoCommon.GetMessageWriter();
-            var colocationHash = _ser.WriteMultiple(writer, tx, schema, iterator);
-            var preferredNode = await _table.GetPreferredNode(colocationHash, transaction).ConfigureAwait(false);
-
-            using var resBuf = await DoOutInOpAsync(ClientOp.TupleUpsertAll, tx, writer, preferredNode).ConfigureAwait(false);
+            using var resBuf = await DoMultiRecordOutOpAsync(ClientOp.TupleUpsertAll, transaction, records).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -385,20 +385,6 @@ namespace Apache.Ignite.Internal.Table
             return reader.ReadBoolean();
         }
 
-        private static int GetExpectedSchemaVersion(IgniteException e)
-        {
-            if (e.Data[ErrorExtensions.ExpectedSchemaVersion] is int schemaVer)
-            {
-                return schemaVer;
-            }
-
-            throw new IgniteException(
-                e.TraceId,
-                ErrorGroups.Client.Protocol,
-                "Expected schema version is not specified in error extension map.",
-                e);
-        }
-
         private async Task<PooledBuffer> DoOutInOpAsync(
             ClientOp clientOp,
             Transaction? tx,
@@ -432,7 +418,7 @@ namespace Apache.Ignite.Internal.Table
             }
             catch (IgniteException e) when (e.Code == ErrorGroups.Table.SchemaVersionMismatch)
             {
-                return await DoRecordOutOpAsync(op, transaction, record, keyOnly, GetExpectedSchemaVersion(e)).ConfigureAwait(false);
+                return await DoRecordOutOpAsync(op, transaction, record, keyOnly, e.GetExpectedSchemaVersion()).ConfigureAwait(false);
             }
         }
 
@@ -457,7 +443,7 @@ namespace Apache.Ignite.Internal.Table
             }
             catch (IgniteException e) when (e.Code == ErrorGroups.Table.SchemaVersionMismatch)
             {
-                return await DoTwoRecordOutOpAsync(op, transaction, record, record2, keyOnly, GetExpectedSchemaVersion(e))
+                return await DoTwoRecordOutOpAsync(op, transaction, record, record2, keyOnly, e.GetExpectedSchemaVersion())
                     .ConfigureAwait(false);
             }
         }
@@ -491,7 +477,7 @@ namespace Apache.Ignite.Internal.Table
             catch (IgniteException e) when (e.Code == ErrorGroups.Table.SchemaVersionMismatch)
             {
                 // ReSharper disable once PossibleMultipleEnumeration (we have to retry, but this is very rare)
-                return await DoMultiRecordOutOpAsync(op, transaction, recs, keyOnly, GetExpectedSchemaVersion(e)).ConfigureAwait(false);
+                return await DoMultiRecordOutOpAsync(op, transaction, recs, keyOnly, e.GetExpectedSchemaVersion()).ConfigureAwait(false);
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -464,7 +464,14 @@ namespace Apache.Ignite.Internal.Table
             }
             catch (IgniteException e) when (e.Code == ErrorGroups.Table.SchemaVersionMismatch)
             {
-                var schemaVer = e.Data[ErrorExtensions.ExpectedSchemaVersion] as int?;
+                if (e.Data[ErrorExtensions.ExpectedSchemaVersion] is not int schemaVer)
+                {
+                    throw new IgniteException(
+                        e.TraceId,
+                        ErrorGroups.Client.Protocol,
+                        "Expected schema version is not specified in error extension map.",
+                        e);
+                }
 
                 return await DoRecordOutOpAsync(op, transaction, record, keyOnly, schemaVer).ConfigureAwait(false);
             }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -167,7 +167,7 @@ namespace Apache.Ignite.Internal.Table
         }
 
         /// <summary>
-        /// Gets the latest schema.
+        /// Gets the schema by version.
         /// </summary>
         /// <param name="version">Schema version; when null, latest is used.</param>
         /// <returns>Schema.</returns>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -169,6 +169,13 @@ namespace Apache.Ignite.Internal.Table
         /// <summary>
         /// Gets the latest schema.
         /// </summary>
+        /// <param name="version">Schema version; when null, latest is used.</param>
+        /// <returns>Schema.</returns>
+        internal Task<Schema> GetSchemaAsync(int? version) => GetCachedSchemaAsync(version ?? _latestSchemaVersion);
+
+        /// <summary>
+        /// Gets the latest schema.
+        /// </summary>
         /// <returns>Schema.</returns>
         internal Task<Schema> GetLatestSchemaAsync()
         {

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSchemaSynchronizationTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSchemaSynchronizationTest.java
@@ -77,7 +77,7 @@ public class ItThinClientSchemaSynchronizationTest extends ItAbstractThinClientT
         Tuple rec = Tuple.create().set("ID", 1);
         recordView.insert(null, rec);
 
-        // Modify table, insert data - client will use old schema, receive error, retry with new schema.
+        // Modify table, read data - client will use old schema, receive error, retry with new schema.
         // The process is transparent for the user: updated schema is in effect immediately.
         ses.execute(null, "ALTER TABLE " + tableName + " ADD COLUMN NAME VARCHAR DEFAULT 'def_name'");
         assertEquals("def_name", recordView.get(null, rec).stringValue(1));


### PR DESCRIPTION
* Read known error extensions data from server
* Retry `SchemaVersionMismatch` error code with specified schema
* Improve code reuse in `RecordView` (there are still multiple methods which do the same retry logic; we could fix it with delegates `DoOp(() -> blabla)`, but this will increase allocations)