### PR TITLE
IGNITE-20200 Ignore unit test failures with Gradle

### DIFF
--- a/buildscripts/java-core.gradle
+++ b/buildscripts/java-core.gradle
@@ -29,6 +29,8 @@ java {
 }
 
 test {
+    ignoreFailures = true
+
     finalizedBy(jacocoTestReport)
 }
 


### PR DESCRIPTION
Gradle returns non-zero exit code when at least 1 test fails, causing the build on TC go red, even if that test is muted. After this change test failures are still reported locally and on TC, but the exit code is `0`.

Before:
```
245 tests completed, 1 failed, 3 skipped

> Task :ignite-client:test FAILED

FAILURE: Build failed with an exception.
```

After:
```
245 tests completed, 1 failed, 3 skipped
There were failing tests. See the report at: file:///home/apolo/Work/ignite-3/modules/client/build/reports/tests/test/index.html

BUILD SUCCESSFUL in 36s
```