### PR TITLE
IGNITE-20219 Fix the typo of user name to username

### DIFF
--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/commands/connect/ItConnectWithBasicAuthenticationCommandTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/commands/connect/ItConnectWithBasicAuthenticationCommandTest.java
@@ -83,7 +83,7 @@ class ItConnectWithBasicAuthenticationCommandTest extends ItConnectToClusterTest
                 () -> assertOutputContains("Connected to http://localhost:10300")
         );
 
-        // And prompt shows user name and node name
+        // And prompt shows username and node name
         assertThat(getPrompt()).isEqualTo("[admin:" + nodeName() + "]> ");
     }
 
@@ -130,7 +130,7 @@ class ItConnectWithBasicAuthenticationCommandTest extends ItConnectToClusterTest
                 () -> assertOutputContains("Connected to http://localhost:10300")
         );
 
-        // And prompt shows user name and node name
+        // And prompt shows username and node name
         assertThat(getPrompt()).isEqualTo("[admin:" + nodeName() + "]> ");
     }
 
@@ -205,7 +205,7 @@ class ItConnectWithBasicAuthenticationCommandTest extends ItConnectToClusterTest
                         "Config saved" + System.lineSeparator() + "Connected to http://localhost:10300" + System.lineSeparator())
         );
 
-        // And prompt shows user name and node name
+        // And prompt shows username and node name
         assertThat(getPrompt()).isEqualTo("[admin:" + nodeName() + "]> ");
     }
 
@@ -258,7 +258,7 @@ class ItConnectWithBasicAuthenticationCommandTest extends ItConnectToClusterTest
                         "Config saved" + System.lineSeparator() + "Connected to http://localhost:10300" + System.lineSeparator())
         );
 
-        // And prompt shows user name and node name
+        // And prompt shows username and node name
         assertThat(getPrompt()).isEqualTo("[admin:" + nodeName() + "]> ");
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-20219

Fix the typo of "user name" to username, and we are using username in many pieces. Keep it consistent.