### PR TITLE
IGNITE-19840 .NET: Reload schema when unmapped columns are detected

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ProjectFilesTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ProjectFilesTests.cs
@@ -92,11 +92,14 @@ namespace Apache.Ignite.Tests
                         continue;
                     }
 
+                    int lineNum = 0;
                     foreach (var line in File.ReadAllLines(file))
                     {
+                        lineNum++;
+
                         if (line.Contains("TODO", StringComparison.Ordinal))
                         {
-                            StringAssert.Contains("IGNITE-", line, "TODOs should be linked to tickets: " + file);
+                            StringAssert.Contains("IGNITE-", line, $"TODOs should be linked to tickets in {file}:line {lineNum}");
                         }
                     }
                 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -148,8 +148,9 @@ public class SchemaSynchronizationTest : IgniteTestsBase
                 break;
 
             case TestMode.Compute:
+                // ExecuteColocated requires key part only.
                 await Client.Compute.ExecuteColocatedAsync<string>(
-                    table.Name, rec2, Array.Empty<DeploymentUnit>(), ComputeTests.NodeNameJob);
+                    table.Name, rec, Array.Empty<DeploymentUnit>(), ComputeTests.NodeNameJob);
                 break;
 
             default:

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -155,7 +155,6 @@ public class SchemaSynchronizationTest : IgniteTestsBase
     }
 
     [Test]
-    [Ignore("IGNITE-19840")]
     public async Task TestClientUsesLatestSchemaOnReadPoco()
     {
         // Create table, insert data.
@@ -169,7 +168,6 @@ public class SchemaSynchronizationTest : IgniteTestsBase
 
         await Client.Sql.ExecuteAsync(null, $"ALTER TABLE {TestTableName} ADD COLUMN NAME VARCHAR NOT NULL DEFAULT 'name1'");
 
-        // TODO IGNITE-19840 Reload schema when unmapped POCO column is detected
         var pocoView = table.GetRecordView<Poco>();
         var res = await pocoView.GetAsync(null, new Poco(1, string.Empty));
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -258,13 +258,6 @@ public class SchemaSynchronizationTest : IgniteTestsBase
     }
 
     [Test]
-    public async Task TestClientUsesLatestSchemaOnReadPocoKv([ValueSource(nameof(ReadTestModes))] TestMode testMode)
-    {
-        await Task.Delay(1);
-        Assert.Fail("TODO");
-    }
-
-    [Test]
     public async Task TestClientUsesLatestSchemaOnWritePoco([ValueSource(nameof(TestModes))] TestMode testMode)
     {
         // Create table, insert data.
@@ -301,7 +294,8 @@ public class SchemaSynchronizationTest : IgniteTestsBase
                 break;
 
             default:
-                throw new ArgumentOutOfRangeException(nameof(testMode), testMode, null);
+                Assert.Fail("Invalid test mode: " + testMode);
+                break;
         }
 
         if (testMode is TestMode.One or TestMode.Multiple)
@@ -309,13 +303,6 @@ public class SchemaSynchronizationTest : IgniteTestsBase
             var res = await view.GetAsync(null, rec);
             Assert.AreEqual("foo", res.Value["NAME"]);
         }
-    }
-
-    [Test]
-    public async Task TestClientUsesLatestSchemaOnWritePocoKv([ValueSource(nameof(TestModes))] TestMode testMode)
-    {
-        await Task.Delay(1);
-        Assert.Fail("TODO");
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -128,6 +128,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
         // then force reload schema and retry.
         // The process is transparent for the user: updated schema is in effect immediately.
         await Client.Sql.ExecuteAsync(null, $"ALTER TABLE {TestTableName} ADD COLUMN NAME VARCHAR NOT NULL DEFAULT 'name2'");
+        await WaitForNewSchemaOnAllNodes(TestTableName, 2);
 
         var rec2 = new IgniteTuple
         {
@@ -272,6 +273,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
         await view.InsertAsync(null, rec);
 
         await Client.Sql.ExecuteAsync(null, $"ALTER TABLE {TestTableName} ADD COLUMN NAME VARCHAR NOT NULL DEFAULT 'name1'");
+        await WaitForNewSchemaOnAllNodes(TestTableName, 2);
 
         var pocoView = table.GetRecordView<Poco>();
 
@@ -349,7 +351,6 @@ public class SchemaSynchronizationTest : IgniteTestsBase
             while (true)
             {
                 var schema = await tableImpl.GetSchemaAsync(Apache.Ignite.Internal.Table.Table.SchemaVersionForceLatest);
-
                 if (schema.Version >= schemaVer)
                 {
                     break;
@@ -359,6 +360,8 @@ public class SchemaSynchronizationTest : IgniteTestsBase
                 {
                     Assert.Fail($"Schema version {schema.Version} is not available on node {cfg.Endpoints[0]} after {timeoutMs}ms");
                 }
+
+                await Task.Delay(50);
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -117,8 +117,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
 
         var rec = new IgniteTuple
         {
-            ["ID"] = 1,
-            ["NAME"] = "name"
+            ["ID"] = 1
         };
 
         await view.InsertAsync(null, rec);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Tests.Table;
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Compute;
 using Ignite.Compute;
@@ -330,16 +331,12 @@ public class SchemaSynchronizationTest : IgniteTestsBase
         Assert.AreEqual("name1", res.Value);
     }
 
-    private static async Task WaitForNewSchemaOnAllNodes(string tableName, int schemaVer, int timeoutMs = 5000)
+    private async Task WaitForNewSchemaOnAllNodes(string tableName, int schemaVer, int timeoutMs = 5000)
     {
         // TODO IGNITE-18733, IGNITE-18449: remove this workaround when issues are fixed.
         // Currently new schema version is not immediately available on all nodes.
-        // Use separate client to check schema sync.
-        var configs = new[]
-        {
-            new IgniteClientConfiguration("127.0.0.1:" + ServerPort),
-            new IgniteClientConfiguration("127.0.0.1:" + (ServerPort + 1))
-        };
+        // Use separate client to check schema sync without affecting the system under test.
+        var configs = Client.Configuration.Endpoints.Select(e => new IgniteClientConfiguration(e)).ToList();
 
         foreach (var cfg in configs)
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -103,7 +103,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
         });
 
         StringAssert.StartsWith("Tuple doesn't match schema", ex!.Message);
-        StringAssert.EndsWith("extraColumns=NAME (Parameter 'record')", ex.Message);
+        StringAssert.EndsWith("extraColumns=NAME", ex.Message);
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -71,6 +71,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
         // Modify table, insert data - client will use old schema, receive error, retry with new schema.
         // The process is transparent for the user: updated schema is in effect immediately.
         await Client.Sql.ExecuteAsync(null, $"ALTER TABLE {TestTableName} DROP COLUMN NAME");
+        await WaitForNewSchemaOnAllNodes(TestTableName, 2);
 
         var rec2 = new IgniteTuple
         {
@@ -178,6 +179,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
         // Modify table, insert data - client will use old schema, receive error, retry with new schema.
         // The process is transparent for the user: updated schema is in effect immediately.
         await Client.Sql.ExecuteAsync(null, $"ALTER TABLE {TestTableName} ADD COLUMN NAME VARCHAR NOT NULL DEFAULT 'name1'");
+        await WaitForNewSchemaOnAllNodes(TestTableName, 2);
 
         switch (testMode)
         {
@@ -224,6 +226,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
         await view.InsertAsync(null, rec);
 
         await Client.Sql.ExecuteAsync(null, $"ALTER TABLE {TestTableName} ADD COLUMN NAME VARCHAR NOT NULL DEFAULT 'name1'");
+        await WaitForNewSchemaOnAllNodes(TestTableName, 2);
 
         var pocoView = table.GetRecordView<Poco>();
         var poco = new Poco(1, string.Empty);
@@ -323,6 +326,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
         await view.InsertAsync(null, rec);
 
         await Client.Sql.ExecuteAsync(null, $"ALTER TABLE {TestTableName} ADD COLUMN NAME VARCHAR NOT NULL DEFAULT 'name1'");
+        await WaitForNewSchemaOnAllNodes(TestTableName, 2);
 
         var pocoView = table.GetKeyValueView<int, string>();
         var res = await pocoView.GetAsync(null, 1);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -258,6 +258,13 @@ public class SchemaSynchronizationTest : IgniteTestsBase
     }
 
     [Test]
+    public async Task TestClientUsesLatestSchemaOnReadPocoKv([ValueSource(nameof(ReadTestModes))] TestMode testMode)
+    {
+        await Task.Delay(1);
+        Assert.Fail("TODO");
+    }
+
+    [Test]
     public async Task TestClientUsesLatestSchemaOnWritePoco([ValueSource(nameof(TestModes))] TestMode testMode)
     {
         // Create table, insert data.
@@ -302,6 +309,13 @@ public class SchemaSynchronizationTest : IgniteTestsBase
             var res = await view.GetAsync(null, rec);
             Assert.AreEqual("foo", res.Value["NAME"]);
         }
+    }
+
+    [Test]
+    public async Task TestClientUsesLatestSchemaOnWritePocoKv([ValueSource(nameof(TestModes))] TestMode testMode)
+    {
+        await Task.Delay(1);
+        Assert.Fail("TODO");
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -111,6 +111,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
     {
         // TODO: Similar to above.
         await Task.Delay(1);
+        Assert.Fail("TODO");
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaValidationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaValidationTest.cs
@@ -57,7 +57,7 @@ public class SchemaValidationTest : IgniteTestsBase
         };
 
         var ex = Assert.ThrowsAsync<ArgumentException>(async () => await TupleView.UpsertAsync(null, igniteTuple));
-        StringAssert.StartsWith("Tuple doesn't match schema: schemaVersion=1, extraColumns=FOO, BAR ", ex!.Message);
+        Assert.AreEqual("Tuple doesn't match schema: schemaVersion=1, extraColumns=FOO, BAR", ex!.Message);
     }
 
     [Test]
@@ -76,7 +76,7 @@ public class SchemaValidationTest : IgniteTestsBase
 
         var kvView = Table.KeyValueBinaryView;
         var ex = Assert.ThrowsAsync<ArgumentException>(async () => await kvView.PutAsync(null, keyTuple, valTuple));
-        StringAssert.StartsWith("Tuple pair doesn't match schema: schemaVersion=1, extraColumns=BAR ", ex!.Message);
+        Assert.AreEqual("Tuple pair doesn't match schema: schemaVersion=1, extraColumns=BAR", ex!.Message);
     }
 
     [Test]
@@ -95,7 +95,7 @@ public class SchemaValidationTest : IgniteTestsBase
 
         var kvView = Table.KeyValueBinaryView;
         var ex = Assert.ThrowsAsync<ArgumentException>(async () => await kvView.PutAsync(null, keyTuple, valTuple));
-        StringAssert.StartsWith("Tuple pair doesn't match schema: schemaVersion=1, extraColumns=BAZ ", ex!.Message);
+        Assert.AreEqual("Tuple pair doesn't match schema: schemaVersion=1, extraColumns=BAZ", ex!.Message);
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -282,9 +282,15 @@ namespace Apache.Ignite.Internal.Compute
                     _tableCache.TryRemove(tableName, out _);
                     schemaVersion = null;
                 }
-                catch (IgniteException e) when (e.Code == ErrorGroups.Table.SchemaVersionMismatch)
+                catch (IgniteException e) when (e.Code == ErrorGroups.Table.SchemaVersionMismatch &&
+                                                schemaVersion != e.GetExpectedSchemaVersion())
                 {
                     schemaVersion = e.GetExpectedSchemaVersion();
+                }
+                catch (Exception e) when (e.CausedByUnmappedColumns() &&
+                                          schemaVersion == null)
+                {
+                    schemaVersion = Table.SchemaVersionForceLatest;
                 }
             }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -243,6 +243,7 @@ namespace Apache.Ignite.Internal.Compute
             throw new IgniteClientException(ErrorGroups.Client.TableIdNotFound, $"Table '{tableName}' does not exist.");
         }
 
+        [SuppressMessage("Maintainability", "CA1508:Avoid dead conditional code", Justification = "False positive")]
         private async Task<T> ExecuteColocatedAsync<T, TKey>(
             string tableName,
             TKey key,
@@ -264,12 +265,12 @@ namespace Apache.Ignite.Internal.Compute
                 var table = await GetTableAsync(tableName).ConfigureAwait(false);
                 var schema = await table.GetSchemaAsync(schemaVersion).ConfigureAwait(false);
 
-                using var bufferWriter = ProtoCommon.GetMessageWriter();
-                var colocationHash = Write(bufferWriter, table, schema);
-                var preferredNode = await table.GetPreferredNode(colocationHash, null).ConfigureAwait(false);
-
                 try
                 {
+                    using var bufferWriter = ProtoCommon.GetMessageWriter();
+                    var colocationHash = Write(bufferWriter, table, schema);
+                    var preferredNode = await table.GetPreferredNode(colocationHash, null).ConfigureAwait(false);
+
                     using var res = await _socket.DoOutInOpAsync(ClientOp.ComputeExecuteColocated, bufferWriter, preferredNode)
                         .ConfigureAwait(false);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Column.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Column.cs
@@ -30,10 +30,4 @@ internal record Column(
     int ColocationIndex,
     int SchemaIndex,
     int Scale,
-    int Precision)
-{
-    /// <summary>
-    /// Gets a value indicating whether this column participates in colocation.
-    /// </summary>
-    public bool IsColocation => ColocationIndex >= 0;
-}
+    int Precision);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Internal.Table
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -28,6 +29,7 @@ namespace Apache.Ignite.Internal.Table
     using Ignite.Table;
     using Ignite.Transactions;
     using Linq;
+    using Log;
     using Proto;
     using Serialization;
     using Sql;
@@ -49,6 +51,8 @@ namespace Apache.Ignite.Internal.Table
         /** SQL. */
         private readonly Sql _sql;
 
+        private readonly IIgniteLogger? _logger;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RecordView{T}"/> class.
         /// </summary>
@@ -60,6 +64,7 @@ namespace Apache.Ignite.Internal.Table
             _table = table;
             _ser = ser;
             _sql = sql;
+            _logger = table.Socket.Configuration.Logger.GetLogger(GetType());
         }
 
         /// <summary>
@@ -398,6 +403,7 @@ namespace Apache.Ignite.Internal.Table
             return buf;
         }
 
+        [SuppressMessage("Maintainability", "CA1508:Avoid dead conditional code", Justification = "False positive.")]
         private async Task<PooledBuffer> DoRecordOutOpAsync(
             ClientOp op,
             ITransaction? transaction,
@@ -405,9 +411,11 @@ namespace Apache.Ignite.Internal.Table
             bool keyOnly = false,
             int? schemaVersionOverride = null)
         {
+            Schema? schema = null;
+
             try
             {
-                var schema = await _table.GetSchemaAsync(schemaVersionOverride).ConfigureAwait(false);
+                schema = await _table.GetSchemaAsync(schemaVersionOverride).ConfigureAwait(false);
                 var tx = transaction.ToInternal();
 
                 using var writer = ProtoCommon.GetMessageWriter();
@@ -419,17 +427,29 @@ namespace Apache.Ignite.Internal.Table
             catch (IgniteException e) when (e.Code == ErrorGroups.Table.SchemaVersionMismatch &&
                                             schemaVersionOverride != e.GetExpectedSchemaVersion())
             {
+                if (_logger?.IsEnabled(LogLevel.Debug) == true)
+                {
+                    _logger.Debug($"Retrying SchemaVersionMismatch error [tableId={_table.Id}, schemaVersion={schema?.Version}, " +
+                                  $"expectedSchemaVersion={e.GetExpectedSchemaVersion()}]");
+                }
+
                 schemaVersionOverride = e.GetExpectedSchemaVersion();
                 return await DoRecordOutOpAsync(op, transaction, record, keyOnly, schemaVersionOverride).ConfigureAwait(false);
             }
             catch (Exception e) when (e.CausedByUnmappedColumns() &&
                                       schemaVersionOverride == null)
             {
+                if (_logger?.IsEnabled(LogLevel.Debug) == true)
+                {
+                    _logger.Debug($"Retrying unmapped columns error [tableId={_table.Id}, schemaVersion={schema?.Version}]");
+                }
+
                 schemaVersionOverride = Table.SchemaVersionForceLatest;
                 return await DoRecordOutOpAsync(op, transaction, record, keyOnly, schemaVersionOverride).ConfigureAwait(false);
             }
         }
 
+        [SuppressMessage("Maintainability", "CA1508:Avoid dead conditional code", Justification = "False positive.")]
         private async Task<PooledBuffer> DoTwoRecordOutOpAsync(
             ClientOp op,
             ITransaction? transaction,
@@ -438,9 +458,11 @@ namespace Apache.Ignite.Internal.Table
             bool keyOnly = false,
             int? schemaVersionOverride = null)
         {
+            Schema? schema = null;
+
             try
             {
-                var schema = await _table.GetSchemaAsync(schemaVersionOverride).ConfigureAwait(false);
+                schema = await _table.GetSchemaAsync(schemaVersionOverride).ConfigureAwait(false);
                 var tx = transaction.ToInternal();
 
                 using var writer = ProtoCommon.GetMessageWriter();
@@ -452,12 +474,23 @@ namespace Apache.Ignite.Internal.Table
             catch (IgniteException e) when (e.Code == ErrorGroups.Table.SchemaVersionMismatch &&
                                             schemaVersionOverride != e.GetExpectedSchemaVersion())
             {
+                if (_logger?.IsEnabled(LogLevel.Debug) == true)
+                {
+                    _logger.Debug($"Retrying SchemaVersionMismatch error [tableId={_table.Id}, schemaVersion={schema?.Version}, " +
+                                  $"expectedSchemaVersion={e.GetExpectedSchemaVersion()}]");
+                }
+
                 schemaVersionOverride = e.GetExpectedSchemaVersion();
                 return await DoTwoRecordOutOpAsync(op, transaction, record, record2, keyOnly, schemaVersionOverride).ConfigureAwait(false);
             }
             catch (Exception e) when (e.CausedByUnmappedColumns() &&
                                       schemaVersionOverride == null)
             {
+                if (_logger?.IsEnabled(LogLevel.Debug) == true)
+                {
+                    _logger.Debug($"Retrying unmapped columns error [tableId={_table.Id}, schemaVersion={schema?.Version}]");
+                }
+
                 schemaVersionOverride = Table.SchemaVersionForceLatest;
                 return await DoTwoRecordOutOpAsync(op, transaction, record, record2, keyOnly, schemaVersionOverride).ConfigureAwait(false);
             }
@@ -478,9 +511,11 @@ namespace Apache.Ignite.Internal.Table
                 return null;
             }
 
+            Schema? schema = null;
+
             try
             {
-                var schema = await _table.GetSchemaAsync(schemaVersionOverride).ConfigureAwait(false);
+                schema = await _table.GetSchemaAsync(schemaVersionOverride).ConfigureAwait(false);
                 var tx = transaction.ToInternal();
 
                 using var writer = ProtoCommon.GetMessageWriter();
@@ -492,6 +527,12 @@ namespace Apache.Ignite.Internal.Table
             catch (IgniteException e) when (e.Code == ErrorGroups.Table.SchemaVersionMismatch &&
                                             schemaVersionOverride != e.GetExpectedSchemaVersion())
             {
+                if (_logger?.IsEnabled(LogLevel.Debug) == true)
+                {
+                    _logger.Debug($"Retrying SchemaVersionMismatch error [tableId={_table.Id}, schemaVersion={schema?.Version}, " +
+                                  $"expectedSchemaVersion={e.GetExpectedSchemaVersion()}]");
+                }
+
                 schemaVersionOverride = e.GetExpectedSchemaVersion();
 
                 // ReSharper disable once PossibleMultipleEnumeration (we have to retry, but this is very rare)
@@ -500,6 +541,11 @@ namespace Apache.Ignite.Internal.Table
             catch (Exception e) when (e.CausedByUnmappedColumns() &&
                                       schemaVersionOverride == null)
             {
+                if (_logger?.IsEnabled(LogLevel.Debug) == true)
+                {
+                    _logger.Debug($"Retrying unmapped columns error [tableId={_table.Id}, schemaVersion={schema?.Version}]");
+                }
+
                 schemaVersionOverride = Table.SchemaVersionForceLatest;
 
                 // ReSharper disable once PossibleMultipleEnumeration (we have to retry, but this is very rare)

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -425,7 +425,7 @@ namespace Apache.Ignite.Internal.Table
             catch (Exception e) when (e.CausedByUnmappedColumns() &&
                                       schemaVersionOverride == null)
             {
-                schemaVersionOverride = Table.UnknownSchemaVersion;
+                schemaVersionOverride = Table.SchemaVersionForceLatest;
                 return await DoRecordOutOpAsync(op, transaction, record, keyOnly, schemaVersionOverride).ConfigureAwait(false);
             }
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -451,6 +451,7 @@ namespace Apache.Ignite.Internal.Table
             }
             catch (IgniteException e) when (e.Code == ErrorGroups.Table.SchemaVersionMismatch)
             {
+                // TODO: Handle unmapped
                 return await DoTwoRecordOutOpAsync(op, transaction, record, record2, keyOnly, e.GetExpectedSchemaVersion())
                     .ConfigureAwait(false);
             }
@@ -484,6 +485,7 @@ namespace Apache.Ignite.Internal.Table
             }
             catch (IgniteException e) when (e.Code == ErrorGroups.Table.SchemaVersionMismatch)
             {
+                // TODO: Handle unmapped
                 // ReSharper disable once PossibleMultipleEnumeration (we have to retry, but this is very rare)
                 return await DoMultiRecordOutOpAsync(op, transaction, recs, keyOnly, e.GetExpectedSchemaVersion()).ConfigureAwait(false);
             }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/KvPair.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/KvPair.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Internal.Table.Serialization;
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Ignite.Table;
 
 /// <summary>
@@ -29,4 +30,5 @@ using Ignite.Table;
 /// <param name="Val">Value.</param>
 /// <typeparam name="TK">Key type.</typeparam>
 /// <typeparam name="TV">Value type.</typeparam>
+[ExcludeFromCodeCoverage]
 internal readonly record struct KvPair<TK, TV>(TK Key, TV Val = default!);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
@@ -458,8 +458,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
                     extraColumns.Remove(column.Name);
                 }
 
-                throw new ArgumentException(
-                    $"Record of type {type} doesn't match schema: schemaVersion={schema.Version}, extraColumns={extraColumns.StringJoin()}");
+                throw SerializerExceptionExtensions.GetUnmappedColumnsException($"Record of type {type}", schema, extraColumns);
             }
         }
 
@@ -502,9 +501,8 @@ namespace Apache.Ignite.Internal.Table.Serialization
                     extraColumns.Remove(column.Name);
                 }
 
-                throw new ArgumentException(
-                    $"KeyValue pair of type ({keyType}, {valType}) doesn't match schema: schemaVersion={schema.Version}, " +
-                    $"extraColumns={extraColumns.StringJoin()}");
+                throw SerializerExceptionExtensions.GetUnmappedColumnsException(
+                    $"KeyValue pair of type ({keyType}, {valType})", schema, extraColumns);
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/SerializerExceptionExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/SerializerExceptionExtensions.cs
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Internal.Table.Serialization;
+
+using System;
+using System.Collections.Generic;
+using Common;
+
+/// <summary>
+/// Serializer-related exception extensions.
+/// </summary>
+internal static class SerializerExceptionExtensions
+{
+    private const string UnmappedColumnsPresent = nameof(UnmappedColumnsPresent);
+
+    /// <summary>
+    /// Gets a value indicating whether the specified exception was caused by unmapped columns.
+    /// </summary>
+    /// <param name="e">Exception.</param>
+    /// <returns>True when the the specified exception was caused by unmapped columns; false otherwise.</returns>
+    public static bool CausedByUnmappedColumns(this Exception e) => e.Data[UnmappedColumnsPresent] is true;
+
+    /// <summary>
+    /// Gets an exception indicating schema mismatch due to unmapped (extra) columns.
+    /// </summary>
+    /// <param name="prefix">Message prefix (indicates what we are trying to serialize).</param>
+    /// <param name="schema">Schema.</param>
+    /// <param name="unmappedColumns">Unmapped columns.</param>
+    /// <returns>Exception.</returns>
+    public static ArgumentException GetUnmappedColumnsException(string prefix, Schema schema, IEnumerable<string> unmappedColumns) =>
+        new($"{prefix} doesn't match schema: schemaVersion={schema.Version}, extraColumns={unmappedColumns.StringJoin()}")
+        {
+            Data = { [UnmappedColumnsPresent] = true }
+        };
+}

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TuplePairSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TuplePairSerializerHandler.cs
@@ -148,9 +148,7 @@ internal class TuplePairSerializerHandler : IRecordSerializerHandler<KvPair<IIgn
 
             Debug.Assert(extraColumns.Count > 0, "extraColumns.Count > 0");
 
-            throw new ArgumentException(
-                $"Tuple pair doesn't match schema: schemaVersion={schema.Version}, extraColumns={extraColumns.StringJoin()}",
-                nameof(record));
+            throw SerializerExceptionExtensions.GetUnmappedColumnsException("Tuple pair", schema, extraColumns);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TuplePairSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TuplePairSerializerHandler.cs
@@ -112,7 +112,7 @@ internal class TuplePairSerializerHandler : IRecordSerializerHandler<KvPair<IIgn
 
         if (recordFieldCount > written)
         {
-            var extraColumns = new HashSet<string>(recordFieldCount);
+            var extraColumns = new HashSet<string>(recordFieldCount, StringComparer.OrdinalIgnoreCase);
 
             for (int i = 0; i < record.Key.FieldCount; i++)
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TupleSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TupleSerializerHandler.cs
@@ -112,9 +112,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
                     extraColumns.Remove(schema.Columns[i].Name);
                 }
 
-                throw new ArgumentException(
-                    $"Tuple doesn't match schema: schemaVersion={schema.Version}, extraColumns={extraColumns.StringJoin()}",
-                    nameof(record));
+                throw SerializerExceptionExtensions.GetUnmappedColumnsException("Tuple", schema, extraColumns);
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TupleSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TupleSerializerHandler.cs
@@ -94,7 +94,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
 
             if (record.FieldCount > written)
             {
-                var extraColumns = new HashSet<string>(record.FieldCount);
+                var extraColumns = new HashSet<string>(record.FieldCount, StringComparer.OrdinalIgnoreCase);
                 for (int i = 0; i < record.FieldCount; i++)
                 {
                     var name = record.GetName(i);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -39,8 +39,10 @@ namespace Apache.Ignite.Internal.Table
     /// </summary>
     internal sealed class Table : ITable
     {
-        /** Unknown schema version. */
-        private const int UnknownSchemaVersion = -1;
+        /// <summary>
+        /// Unknown schema version.
+        /// </summary>
+        public const int UnknownSchemaVersion = -1;
 
         /** Socket. */
         private readonly ClientFailoverSocket _socket;


### PR DESCRIPTION
When unmapped columns are detected in a Tuple or a POCO, we must ensure that the latest schema is used before throwing an exception.

For example, right after `ALTER TABLE ADD COLUMN`, the user expects to be able to insert a tuple with the new column. However, the client still has the old schema in the cache, and previously would throw unmapped column error. Now we retry the operation with forced schema refresh.