### PR TITLE
IGNITE-20183 Fix testNonNullTxDisablesPartitionAwareness flakiness

### DIFF
--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -153,7 +153,7 @@ public class PartitionAwarenessTest extends AbstractClientTest {
     @Test
     public void testNonNullTxDisablesPartitionAwareness() {
         RecordView<Tuple> recordView = defaultTable().recordView();
-        var tx = (ClientTransaction)client2.transactions().begin();
+        var tx = (ClientTransaction) client2.transactions().begin();
 
         @SuppressWarnings("resource") String expectedNode = tx.channel().protocolContext().clusterNode().name();
 

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -35,6 +35,7 @@ import org.apache.ignite.client.fakes.FakeIgnite;
 import org.apache.ignite.client.fakes.FakeIgniteTables;
 import org.apache.ignite.client.fakes.FakeInternalTable;
 import org.apache.ignite.compute.IgniteCompute;
+import org.apache.ignite.internal.client.tx.ClientTransaction;
 import org.apache.ignite.internal.table.TableImpl;
 import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.internal.util.IgniteUtils;
@@ -152,11 +153,13 @@ public class PartitionAwarenessTest extends AbstractClientTest {
     @Test
     public void testNonNullTxDisablesPartitionAwareness() {
         RecordView<Tuple> recordView = defaultTable().recordView();
-        var tx = client2.transactions().begin();
+        var tx = (ClientTransaction)client2.transactions().begin();
 
-        assertOpOnNode("server-1", "get", x -> recordView.get(tx, Tuple.create().set("ID", 0L)));
-        assertOpOnNode("server-1", "get", x -> recordView.get(tx, Tuple.create().set("ID", 1L)));
-        assertOpOnNode("server-1", "get", x -> recordView.get(tx, Tuple.create().set("ID", 2L)));
+        @SuppressWarnings("resource") String expectedNode = tx.channel().protocolContext().clusterNode().name();
+
+        assertOpOnNode(expectedNode, "get", x -> recordView.get(tx, Tuple.create().set("ID", 0L)));
+        assertOpOnNode(expectedNode, "get", x -> recordView.get(tx, Tuple.create().set("ID", 1L)));
+        assertOpOnNode(expectedNode, "get", x -> recordView.get(tx, Tuple.create().set("ID", 2L)));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Tx uses random connection, so don't use a hardcoded node name.