### PR TITLE
IGNITE-20197 .NET: Fix excessive dictionary lookups by GetFieldByColumnName usages

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/Serialization/ReflectionUtilsTests.cs
@@ -34,37 +34,37 @@ namespace Apache.Ignite.Tests.Table.Serialization
     {
         [Test]
         public void TestGetFieldByColumnNameReturnsFieldByName() =>
-            Assert.AreEqual("BaseFieldPublic", typeof(Derived).GetFieldByColumnName("BaseFieldPublic")!.Name);
+            Assert.AreEqual("BaseFieldPublic", GetFieldByColumnName(typeof(Derived), "BaseFieldPublic")!.Name);
 
         [Test]
         public void TestGetFieldByColumnNameReturnsFieldByPropertyName() =>
-            Assert.AreEqual("<BaseProp>k__BackingField", typeof(Derived).GetFieldByColumnName("BaseProp")!.Name);
+            Assert.AreEqual("<BaseProp>k__BackingField", GetFieldByColumnName(typeof(Derived), "BaseProp")!.Name);
 
         [Test]
         public void TestGetFieldByColumnNameReturnsFieldByColumnAttributeName() =>
-            Assert.AreEqual("BaseFieldCustomColumnName", typeof(Derived).GetFieldByColumnName("FldCol")!.Name);
+            Assert.AreEqual("BaseFieldCustomColumnName", GetFieldByColumnName(typeof(Derived), "FldCol")!.Name);
 
         [Test]
         public void TestGetFieldByColumnNameReturnsFieldByPropertyColumnAttributeName() =>
-            Assert.AreEqual("<BasePropCustomColumnName>k__BackingField", typeof(Derived).GetFieldByColumnName("PropCol")!.Name);
+            Assert.AreEqual("<BasePropCustomColumnName>k__BackingField", GetFieldByColumnName(typeof(Derived), "PropCol")!.Name);
 
         [Test]
         public void TestGetFieldByColumnNameReturnsNullForNonMatchingName() =>
-            Assert.IsNull(typeof(Derived).GetFieldByColumnName("foo"));
+            Assert.IsNull(GetFieldByColumnName(typeof(Derived), "foo"));
 
         [Test]
         public void TestGetFieldByColumnNameReturnsNullForNotMappedProperty() =>
-            Assert.IsNull(typeof(Derived).GetFieldByColumnName("NotMappedProp"));
+            Assert.IsNull(GetFieldByColumnName(typeof(Derived), "NotMappedProp"));
 
         [Test]
         public void TestGetFieldByColumnNameReturnsNullForNotMappedField() =>
-            Assert.IsNull(typeof(Derived).GetFieldByColumnName("NotMappedFld"));
+            Assert.IsNull(GetFieldByColumnName(typeof(Derived), "NotMappedFld"));
 
         [Test]
         public void TestGetFieldByColumnNameThrowsExceptionForDuplicateColumnName()
         {
-            var ex1 = Assert.Throws<ArgumentException>(() => typeof(DuplicateColumn1).GetFieldByColumnName("foo"));
-            var ex2 = Assert.Throws<ArgumentException>(() => typeof(DuplicateColumn2).GetFieldByColumnName("foo"));
+            var ex1 = Assert.Throws<ArgumentException>(() => GetFieldByColumnName(typeof(DuplicateColumn1), "foo"));
+            var ex2 = Assert.Throws<ArgumentException>(() => GetFieldByColumnName(typeof(DuplicateColumn2), "foo"));
 
             var expected1 = "Column 'MyCol' maps to more than one field of type " +
                             "Apache.Ignite.Tests.Table.Serialization.ReflectionUtilsTests+DuplicateColumn1: " +
@@ -150,6 +150,9 @@ namespace Apache.Ignite.Tests.Table.Serialization
         {
             Assert.AreEqual(expected, ReflectionUtilsCleanFieldName(name));
         }
+
+        private static FieldInfo? GetFieldByColumnName(Type type, string name) =>
+            ReflectionUtils.GetFieldsByColumnName(type).TryGetValue(name, out var fieldInfo) ? fieldInfo.Field : null;
 
         private static string? ReflectionUtilsCleanFieldName(string name) =>
             typeof(ReflectionUtils).GetMethod("CleanFieldName", BindingFlags.Static | BindingFlags.NonPublic)!

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/ResultSelector.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/ResultSelector.cs
@@ -187,6 +187,7 @@ internal static class ResultSelector
 
         var il = method.GetILGenerator();
         var resObj = il.DeclareAndInitLocal(typeof(T));
+        var colMap = typeof(T).GetFieldsByColumnName();
 
         int mappedCount = 0;
 
@@ -194,7 +195,7 @@ internal static class ResultSelector
         {
             var col = columns[index];
 
-            if (EmitFieldRead(il, resObj, col, index, defaultAsNull))
+            if (EmitFieldRead(il, resObj, colMap, col, index, defaultAsNull))
             {
                 mappedCount++;
             }
@@ -285,12 +286,15 @@ internal static class ResultSelector
         var key = il.DeclareAndInitLocal(keyType);
         var val = il.DeclareAndInitLocal(valType);
 
+        var keyColMap = keyType.GetFieldsByColumnName();
+        var valColMap = valType.GetFieldsByColumnName();
+
         for (var index = 0; index < columns.Count; index++)
         {
             var col = columns[index];
 
-            EmitFieldRead(il, key, col, index, defaultAsNull);
-            EmitFieldRead(il, val, col, index, defaultAsNull);
+            EmitFieldRead(il, key, keyColMap, col, index, defaultAsNull);
+            EmitFieldRead(il, val, valColMap, col, index, defaultAsNull);
         }
 
         il.Emit(OpCodes.Ldloc_0); // key
@@ -367,9 +371,15 @@ internal static class ResultSelector
         il.MarkLabel(endParamLabel);
     }
 
-    private static bool EmitFieldRead(ILGenerator il, LocalBuilder targetObj, IColumnMetadata col, int colIndex, bool defaultAsNull)
+    private static bool EmitFieldRead(
+        ILGenerator il,
+        LocalBuilder targetObj,
+        IReadOnlyDictionary<string, ReflectionUtils.ColumnInfo> columnMap,
+        IColumnMetadata col,
+        int colIndex,
+        bool defaultAsNull)
     {
-        if (targetObj.LocalType.GetFieldByColumnName(col.Name) is not { } field)
+        if (!columnMap.TryGetValue(col.Name, out var columnInfo))
         {
             return false;
         }
@@ -397,8 +407,8 @@ internal static class ResultSelector
         var colType = col.Type.ToClrType(col.Nullable);
         il.Emit(OpCodes.Call, BinaryTupleMethods.GetReadMethod(colType));
 
-        il.EmitConv(colType, field.FieldType, col.Name);
-        il.Emit(OpCodes.Stfld, field); // res.field = value
+        il.EmitConv(colType, columnInfo.Field.FieldType, col.Name);
+        il.Emit(OpCodes.Stfld, columnInfo.Field); // res.field = value
 
         il.MarkLabel(endFieldLabel);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
@@ -94,6 +94,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
             var il = method.GetILGenerator();
 
             var columns = schema.Columns;
+            var columnMap = type.GetFieldsByColumnName();
 
             if (BinaryTupleMethods.GetWriteMethodOrNull(type) is { } directWriteMethod)
             {
@@ -132,7 +133,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
             for (var index = 0; index < count; index++)
             {
                 var col = columns[index];
-                var fieldInfo = type.GetFieldByColumnName(col.Name);
+                var fieldInfo = columnMap.TryGetValue(col.Name, out var columnInfo) ? columnInfo.Field : null;
 
                 if (fieldInfo == null)
                 {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
@@ -178,6 +178,9 @@ namespace Apache.Ignite.Internal.Table.Serialization
             var keyWriteMethod = BinaryTupleMethods.GetWriteMethodOrNull(keyType);
             var valWriteMethod = BinaryTupleMethods.GetWriteMethodOrNull(valType);
 
+            var keyColumnMap = keyType.GetFieldsByColumnName();
+            var valColumnMap = valType.GetFieldsByColumnName();
+
             var il = method.GetILGenerator();
 
             var columns = schema.Columns;
@@ -204,7 +207,9 @@ namespace Apache.Ignite.Internal.Table.Serialization
                 }
                 else
                 {
-                    fieldInfo = (col.IsKey ? keyType : valType).GetFieldByColumnName(col.Name);
+                    fieldInfo = (col.IsKey ? keyColumnMap : valColumnMap).TryGetValue(col.Name, out var columnInfo)
+                        ? columnInfo.Field
+                        : null;
                 }
 
                 if (fieldInfo == null)

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
@@ -527,9 +527,10 @@ namespace Apache.Ignite.Internal.Table.Serialization
 
             var keyValTypes = type.GetGenericArguments();
             var keyColumnMap = keyValTypes[0].GetFieldsByColumnName();
-            var valColumnMap = keyValTypes[0].GetFieldsByColumnName();
+            var valColumnMap = keyValTypes[1].GetFieldsByColumnName();
+            var columnMap = type.GetFieldsByColumnName();
 
-            return (keyValTypes[0], keyValTypes[1], keyColumnMap["Key"].Field, valColumnMap["Val"].Field, keyColumnMap, valColumnMap);
+            return (keyValTypes[0], keyValTypes[1], columnMap["Key"].Field, columnMap["Val"].Field, keyColumnMap, valColumnMap);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
@@ -88,7 +88,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// </summary>
         /// <param name="type">Type to get the map for.</param>
         /// <returns>Map.</returns>
-        public static IReadOnlyDictionary<string, ColumnInfo> GetFieldsByColumnName(Type type)
+        public static IReadOnlyDictionary<string, ColumnInfo> GetFieldsByColumnName(this Type type)
         {
             // ReSharper disable once HeapView.CanAvoidClosure, HeapView.ClosureAllocation, HeapView.DelegateAllocation (false positive)
             return FieldsByColumnNameCache.GetOrAdd(type, static t => RetrieveFieldsByColumnName(t));

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
@@ -42,7 +42,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// </summary>
         public static readonly MethodInfo GetTypeFromHandleMethod = GetMethodInfo(() => Type.GetTypeFromHandle(default));
 
-        private static readonly ConcurrentDictionary<Type, IDictionary<string, ColumnInfo>> FieldsByColumnNameCache = new();
+        private static readonly ConcurrentDictionary<Type, IReadOnlyDictionary<string, ColumnInfo>> FieldsByColumnNameCache = new();
 
         /// <summary>
         /// Gets the field by column name. Ignores case, handles <see cref="ColumnAttribute"/> and <see cref="NotMappedAttribute"/>.
@@ -58,7 +58,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// </summary>
         /// <param name="type">Type.</param>
         /// <returns>Columns.</returns>
-        public static ICollection<ColumnInfo> GetColumns(this Type type) => GetFieldsByColumnName(type).Values;
+        public static ICollection<ColumnInfo> GetColumns(this Type type) => (ICollection<ColumnInfo>)GetFieldsByColumnName(type).Values;
 
         /// <summary>
         /// Gets a pair of types for <see cref="KeyValuePair{TKey,TValue}"/>.
@@ -97,12 +97,12 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// </summary>
         /// <param name="type">Type to get the map for.</param>
         /// <returns>Map.</returns>
-        private static IDictionary<string, ColumnInfo> GetFieldsByColumnName(Type type)
+        public static IReadOnlyDictionary<string, ColumnInfo> GetFieldsByColumnName(Type type)
         {
             // ReSharper disable once HeapView.CanAvoidClosure, HeapView.ClosureAllocation, HeapView.DelegateAllocation (false positive)
             return FieldsByColumnNameCache.GetOrAdd(type, static t => RetrieveFieldsByColumnName(t));
 
-            static IDictionary<string, ColumnInfo> RetrieveFieldsByColumnName(Type type)
+            static IReadOnlyDictionary<string, ColumnInfo> RetrieveFieldsByColumnName(Type type)
             {
                 var res = new Dictionary<string, ColumnInfo>(StringComparer.OrdinalIgnoreCase);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
@@ -45,15 +45,6 @@ namespace Apache.Ignite.Internal.Table.Serialization
         private static readonly ConcurrentDictionary<Type, IReadOnlyDictionary<string, ColumnInfo>> FieldsByColumnNameCache = new();
 
         /// <summary>
-        /// Gets the field by column name. Ignores case, handles <see cref="ColumnAttribute"/> and <see cref="NotMappedAttribute"/>.
-        /// </summary>
-        /// <param name="type">Type.</param>
-        /// <param name="name">Field name.</param>
-        /// <returns>Field info, or null when no matching fields exist.</returns>
-        public static FieldInfo? GetFieldByColumnName(this Type type, string name) =>
-            GetFieldsByColumnName(type).TryGetValue(name, out var fieldInfo) ? fieldInfo.Field : null;
-
-        /// <summary>
         /// Gets column names for all fields in the specified type.
         /// </summary>
         /// <param name="type">Type.</param>
@@ -93,7 +84,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         public static Type UnwrapEnum(this Type type) => type.IsEnum ? Enum.GetUnderlyingType(type) : type;
 
         /// <summary>
-        /// Gets a map of fields by column name.
+        /// Gets a map of fields by column name. Ignores case, handles <see cref="ColumnAttribute"/> and <see cref="NotMappedAttribute"/>.
         /// </summary>
         /// <param name="type">Type to get the map for.</param>
         /// <returns>Map.</returns>


### PR DESCRIPTION
`GetFieldByColumnName` was always called inside a loop, therefore inner call to `GetFieldsByColumnName` is repeated.

* Remove `GetFieldByColumnName` to avoid this mistake
* Call `GetFieldsByColumnName` outside of the loop instead