### PR TITLE
IGNITE-19542 .NET: Add BinaryTupleIgniteTupleAdapter

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Program.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Program.cs
@@ -18,7 +18,6 @@
 namespace Apache.Ignite.Benchmarks;
 
 using BenchmarkDotNet.Running;
-using Table;
 using Table.Serialization;
 
 internal static class Program

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Program.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Program.cs
@@ -19,8 +19,9 @@ namespace Apache.Ignite.Benchmarks;
 
 using BenchmarkDotNet.Running;
 using Table;
+using Table.Serialization;
 
 internal static class Program
 {
-    private static void Main() => BenchmarkRunner.Run<DataStreamerBenchmark>();
+    private static void Main() => BenchmarkRunner.Run<SerializerHandlerReadBenchmarks>();
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/Serialization/SerializerHandlerReadBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/Serialization/SerializerHandlerReadBenchmarks.cs
@@ -109,9 +109,9 @@ namespace Apache.Ignite.Benchmarks.Table.Serialization
             var reader = new MsgPackReader(SerializedData);
             var res = TupleSerializerHandler.Instance.Read(ref reader, Schema);
 
-            Consumer.Consume(res[nameof(Car.Id)]);
-            Consumer.Consume(res[nameof(Car.BodyType)]);
-            Consumer.Consume(res[nameof(Car.Seats)]);
+            Consumer.Consume(res[0]);
+            Consumer.Consume(res[1]);
+            Consumer.Consume(res[2]);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/Serialization/SerializerHandlerReadBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/Serialization/SerializerHandlerReadBenchmarks.cs
@@ -26,44 +26,14 @@ namespace Apache.Ignite.Benchmarks.Table.Serialization
     /// <summary>
     /// Benchmarks for <see cref="IRecordSerializerHandler{T}.Read"/> implementations.
     ///
-    /// Results on Intel Core i7-9700K, .NET SDK 3.1.416, Ubuntu 20.04:
-    /// |           Method |       Mean |   Error |  StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
-    /// |----------------- |-----------:|--------:|--------:|------:|--------:|-------:|----------:|
-    /// | ReadObjectManual |   210.9 ns | 0.73 ns | 0.65 ns |  1.00 |    0.00 | 0.0126 |      80 B |
-    /// |       ReadObject |   257.5 ns | 1.41 ns | 1.25 ns |  1.22 |    0.01 | 0.0124 |      80 B |
-    /// |        ReadTuple |   561.0 ns | 3.09 ns | 2.89 ns |  2.66 |    0.01 | 0.0849 |     536 B |
-    /// |    ReadObjectOld | 1,020.9 ns | 9.05 ns | 8.47 ns |  4.84 |    0.05 | 0.0744 |     472 B |.
+    /// Results on i9-12900H, .NET SDK 6.0.405, Ubuntu 22.04:
     ///
-    /// Results on i7-7700HQ, .NET SDK 6.0.400, Ubuntu 20.04:
-    /// MsgPack (old)
-    /// |           Method |     Mean |   Error |  StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
-    /// |----------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|
-    /// | ReadObjectManual | 289.4 ns | 2.92 ns | 2.59 ns |  1.00 |    0.00 | 0.0024 |      80 B |
-    /// |       ReadObject | 364.3 ns | 3.28 ns | 3.07 ns |  1.26 |    0.02 | 0.0024 |      80 B |
-    /// |        ReadTuple | 755.4 ns | 2.82 ns | 2.35 ns |  2.61 |    0.03 | 0.0181 |     536 B |
-    ///
-    /// BinaryTuple (new)
-    /// |           Method |     Mean |   Error |  StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
-    /// |----------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|
-    /// | ReadObjectManual | 299.3 ns | 3.42 ns | 3.20 ns |  1.00 |    0.00 | 0.0024 |      80 B |
-    /// |       ReadObject | 382.9 ns | 2.49 ns | 2.21 ns |  1.28 |    0.02 | 0.0024 |      80 B |
-    /// |        ReadTuple | 769.0 ns | 6.06 ns | 5.37 ns |  2.57 |    0.04 | 0.0181 |     536 B |.
-    ///
-    /// Comparison of MessagePack library and our own implementation, i9-12900H, .NET SDK 6.0.405, Ubuntu 22.04:
-    ///
-    /// MessagePack 2.1.90 (old)
-    /// |           Method |     Mean |   Error |  StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
-    /// |----------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|
-    /// | ReadObjectManual | 100.3 ns | 0.46 ns | 0.41 ns |  1.00 |    0.00 | 0.0002 |      80 B |
-    /// |       ReadObject | 142.3 ns | 0.35 ns | 0.31 ns |  1.42 |    0.01 | 0.0002 |      80 B |
-    /// |        ReadTuple | 266.8 ns | 2.52 ns | 2.35 ns |  2.66 |    0.03 | 0.0019 |     544 B |.
-    ///
-    /// Custom MsgPackReader (new)
-    /// |           Method |      Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
-    /// |----------------- |----------:|---------:|---------:|------:|--------:|-------:|----------:|
-    /// | ReadObjectManual |  38.30 ns | 0.265 ns | 0.247 ns |  1.00 |    0.00 | 0.0003 |      80 B |
-    /// |       ReadObject |  80.51 ns | 0.158 ns | 0.124 ns |  2.10 |    0.01 | 0.0002 |      80 B |
-    /// |        ReadTuple | 208.63 ns | 0.654 ns | 0.611 ns |  5.45 |    0.04 | 0.0019 |     544 B |.
+    /// |             Method |      Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
+    /// |------------------- |----------:|---------:|---------:|------:|--------:|-------:|----------:|
+    /// |   ReadObjectManual |  53.23 ns | 0.320 ns | 0.268 ns |  1.00 |    0.00 | 0.0003 |      80 B |
+    /// |         ReadObject |  88.01 ns | 0.484 ns | 0.453 ns |  1.65 |    0.01 | 0.0002 |      80 B |
+    /// |          ReadTuple |  23.66 ns | 0.274 ns | 0.257 ns |  0.44 |    0.00 | 0.0004 |     120 B |
+    /// | ReadTupleAndFields | 136.34 ns | 2.014 ns | 1.884 ns |  2.56 |    0.04 | 0.0007 |     208 B |.
     /// </summary>
     [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Benchmarks.")]
     [MemoryDiagnoser]

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/Serialization/SerializerHandlerReadBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/Serialization/SerializerHandlerReadBenchmarks.cs
@@ -102,5 +102,16 @@ namespace Apache.Ignite.Benchmarks.Table.Serialization
 
             Consumer.Consume(res);
         }
+
+        [Benchmark]
+        public void ReadTupleAndFields()
+        {
+            var reader = new MsgPackReader(SerializedData);
+            var res = TupleSerializerHandler.Instance.Read(ref reader, Schema);
+
+            Consumer.Consume(res[nameof(Car.Id)]);
+            Consumer.Consume(res[nameof(Car.BodyType)]);
+            Consumer.Consume(res[nameof(Car.Seats)]);
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/BinaryTupleIgniteTupleAdapterTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/BinaryTupleIgniteTupleAdapterTests.cs
@@ -31,6 +31,40 @@ using NUnit.Framework;
 [TestFixture]
 public class BinaryTupleIgniteTupleAdapterTests : IgniteTupleTests
 {
+    [Test]
+    public void TestUpdate()
+    {
+        var tuple = CreateTuple(new IgniteTuple
+        {
+            ["A"] = 1,
+            ["B"] = "2",
+            ["C"] = 3L,
+            ["D"] = null
+        });
+
+        Assert.AreEqual(4, tuple.FieldCount);
+
+        Assert.AreEqual(1, tuple["A"]);
+        Assert.AreEqual("2", tuple["B"]);
+        Assert.AreEqual(3L, tuple["C"]);
+        Assert.IsNull(tuple["D"]);
+
+        Assert.IsNull(tuple.GetFieldValue<object>("_tuple"));
+        Assert.IsNotNull(tuple.GetFieldValue<object>("_schema"));
+
+        tuple["A"] = 11;
+
+        Assert.AreEqual(4, tuple.FieldCount);
+
+        Assert.AreEqual(11, tuple["A"]);
+        Assert.AreEqual("2", tuple["B"]);
+        Assert.AreEqual(3L, tuple["C"]);
+        Assert.IsNull(tuple["D"]);
+
+        Assert.IsNotNull(tuple.GetFieldValue<object>("_tuple"));
+        Assert.IsNull(tuple.GetFieldValue<object>("_schema"));
+    }
+
     protected override string GetShortClassName() => nameof(BinaryTupleIgniteTupleAdapter);
 
     protected override IIgniteTuple CreateTuple(IIgniteTuple source)

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/BinaryTupleIgniteTupleAdapterTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/BinaryTupleIgniteTupleAdapterTests.cs
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests.Table;
+
+using System;
+using Ignite.Table;
+using Internal.Proto.BinaryTuple;
+using Internal.Table;
+
+/// <summary>
+/// Tests for <see cref="BinaryTupleIgniteTupleAdapterTests"/>. Ensures consistency with <see cref="IgniteTuple"/>.
+/// </summary>
+public class BinaryTupleIgniteTupleAdapterTests : IgniteTupleTests
+{
+    protected override IIgniteTuple CreateTuple(IIgniteTuple source)
+    {
+        // TODO: Serialize to BinaryTuple and wrap.
+        return new BinaryTupleIgniteTupleAdapter(Array.Empty<byte>(), new Schema(0, 0, 0, 0, Array.Empty<Column>()), 0);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/BinaryTupleIgniteTupleAdapterTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/BinaryTupleIgniteTupleAdapterTests.cs
@@ -26,7 +26,7 @@ using Internal.Table;
 using NUnit.Framework;
 
 /// <summary>
-/// Tests for <see cref="BinaryTupleIgniteTupleAdapterTests"/>. Ensures consistency with <see cref="IgniteTuple"/>.
+/// Tests for <see cref="BinaryTupleIgniteTupleAdapter"/>. Ensures consistency with <see cref="IgniteTuple"/>.
 /// </summary>
 [TestFixture]
 public class BinaryTupleIgniteTupleAdapterTests : IgniteTupleTests

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/BinaryTupleIgniteTupleAdapterTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/BinaryTupleIgniteTupleAdapterTests.cs
@@ -31,6 +31,8 @@ using NUnit.Framework;
 [TestFixture]
 public class BinaryTupleIgniteTupleAdapterTests : IgniteTupleTests
 {
+    protected override string GetShortClassName() => nameof(BinaryTupleIgniteTupleAdapter);
+
     protected override IIgniteTuple CreateTuple(IIgniteTuple source)
     {
         var cols = new List<Column>();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
@@ -30,7 +30,7 @@ namespace Apache.Ignite.Tests.Table
         [Test]
         public void TestCreateUpdateRead()
         {
-            IIgniteTuple tuple = new IgniteTuple();
+            IIgniteTuple tuple = CreateTuple(new IgniteTuple());
             Assert.AreEqual(0, tuple.FieldCount);
 
             tuple["foo"] = 1;
@@ -68,7 +68,7 @@ namespace Apache.Ignite.Tests.Table
         [Test]
         public void TestGetNullOrEmptyNameThrowsException()
         {
-            var tuple = new IgniteTuple { ["Foo"] = 1 };
+            var tuple = CreateTuple(new IgniteTuple { ["Foo"] = 1 });
 
             var ex = Assert.Throws<ArgumentException>(() => tuple.GetOrdinal(string.Empty));
             Assert.AreEqual("Column name can not be null or empty.", ex!.Message);
@@ -92,7 +92,7 @@ namespace Apache.Ignite.Tests.Table
         [Test]
         public void TestGetNonExistingNameThrowsException()
         {
-            var tuple = new IgniteTuple { ["Foo"] = 1 };
+            var tuple = CreateTuple(new IgniteTuple { ["Foo"] = 1 });
 
             var ex = Assert.Throws<KeyNotFoundException>(() =>
             {
@@ -104,24 +104,25 @@ namespace Apache.Ignite.Tests.Table
         [Test]
         public void TestToStringEmpty()
         {
-            Assert.AreEqual("IgniteTuple { }", new IgniteTuple().ToString());
+            var tuple = CreateTuple(new IgniteTuple());
+            Assert.AreEqual("IgniteTuple { }", tuple.ToString());
         }
 
         [Test]
         public void TestToStringOneField()
         {
-            var tuple = new IgniteTuple { ["foo"] = 1 };
+            var tuple = CreateTuple(new IgniteTuple { ["foo"] = 1 });
             Assert.AreEqual("IgniteTuple { FOO = 1 }", tuple.ToString());
         }
 
         [Test]
         public void TestToStringTwoFields()
         {
-            var tuple = new IgniteTuple
+            var tuple = CreateTuple(new IgniteTuple
             {
                 ["foo"] = 1,
                 ["b"] = "abcd"
-            };
+            });
 
             Assert.AreEqual("IgniteTuple { FOO = 1, B = abcd }", tuple.ToString());
         }
@@ -129,9 +130,9 @@ namespace Apache.Ignite.Tests.Table
         [Test]
         public void TestEquality()
         {
-            var t1 = new IgniteTuple(2) { ["k"] = 1, ["v"] = "2" };
-            var t2 = new IgniteTuple(3) { ["k"] = 1, ["v"] = "2" };
-            var t3 = new IgniteTuple(4) { ["k"] = 1, ["v"] = null };
+            var t1 = CreateTuple(new IgniteTuple(2) { ["k"] = 1, ["v"] = "2" });
+            var t2 = CreateTuple(new IgniteTuple(3) { ["k"] = 1, ["v"] = "2" });
+            var t3 = CreateTuple(new IgniteTuple(4) { ["k"] = 1, ["v"] = null });
 
             Assert.AreEqual(t1, t2);
             Assert.AreEqual(t2, t1);
@@ -147,11 +148,13 @@ namespace Apache.Ignite.Tests.Table
         [Test]
         public void TestCustomTupleEquality()
         {
-            var tuple = new IgniteTuple { ["key"] = 42L, ["val"] = "Val1" };
+            var tuple = CreateTuple(new IgniteTuple { ["key"] = 42L, ["val"] = "Val1" });
             var customTuple = new CustomTestIgniteTuple();
 
             Assert.IsTrue(IIgniteTuple.Equals(tuple, customTuple));
             Assert.AreEqual(IIgniteTuple.GetHashCode(tuple), IIgniteTuple.GetHashCode(customTuple));
         }
+
+        protected virtual IIgniteTuple CreateTuple(IIgniteTuple source) => source;
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
@@ -102,14 +102,14 @@ namespace Apache.Ignite.Tests.Table
         public void TestToStringEmpty()
         {
             var tuple = CreateTuple(new IgniteTuple());
-            Assert.AreEqual("IgniteTuple { }", tuple.ToString());
+            Assert.AreEqual(GetShortClassName() + " { }", tuple.ToString());
         }
 
         [Test]
         public void TestToStringOneField()
         {
             var tuple = CreateTuple(new IgniteTuple { ["foo"] = 1 });
-            Assert.AreEqual("IgniteTuple { FOO = 1 }", tuple.ToString());
+            Assert.AreEqual(GetShortClassName() + " { FOO = 1 }", tuple.ToString());
         }
 
         [Test]
@@ -121,7 +121,7 @@ namespace Apache.Ignite.Tests.Table
                 ["b"] = "abcd"
             });
 
-            Assert.AreEqual("IgniteTuple { FOO = 1, B = abcd }", tuple.ToString());
+            Assert.AreEqual(GetShortClassName() + " { FOO = 1, B = abcd }", tuple.ToString());
         }
 
         [Test]
@@ -151,6 +151,8 @@ namespace Apache.Ignite.Tests.Table
             Assert.IsTrue(IIgniteTuple.Equals(tuple, customTuple));
             Assert.AreEqual(IIgniteTuple.GetHashCode(tuple), IIgniteTuple.GetHashCode(customTuple));
         }
+
+        protected virtual string GetShortClassName() => nameof(IgniteTuple);
 
         protected virtual IIgniteTuple CreateTuple(IIgniteTuple source) => source;
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
@@ -94,10 +94,7 @@ namespace Apache.Ignite.Tests.Table
         {
             var tuple = CreateTuple(new IgniteTuple { ["Foo"] = 1 });
 
-            var ex = Assert.Throws<KeyNotFoundException>(() =>
-            {
-                var unused = tuple["bar"];
-            });
+            var ex = Assert.Throws<KeyNotFoundException>(() => { _ = tuple["bar"]; });
             Assert.AreEqual("The given key 'BAR' was not present in the dictionary.", ex!.Message);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
@@ -53,7 +53,7 @@ public class ToStringTests
 
                 if (code.Contains("new IgniteToStringBuilder(", StringComparison.Ordinal) ||
                     code.Contains("IgniteToStringBuilder.Build(", StringComparison.Ordinal) ||
-                    code.Contains("IgniteTupleCommon.ToString(this)", StringComparison.Ordinal))
+                    code.Contains("IIgniteTuple.ToString(this)", StringComparison.Ordinal))
                 {
                     continue;
                 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ToStringTests.cs
@@ -52,7 +52,8 @@ public class ToStringTests
                 var code = File.ReadAllText(path);
 
                 if (code.Contains("new IgniteToStringBuilder(", StringComparison.Ordinal) ||
-                    code.Contains("IgniteToStringBuilder.Build(", StringComparison.Ordinal))
+                    code.Contains("IgniteToStringBuilder.Build(", StringComparison.Ordinal) ||
+                    code.Contains("IgniteTupleCommon.ToString(this)", StringComparison.Ordinal))
                 {
                     continue;
                 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
@@ -61,10 +61,9 @@ internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple
     /// <inheritdoc/>
     public object? this[int ordinal]
     {
-        get
-        {
-            throw new NotImplementedException();
-        }
+        get => _tuple != null
+            ? _tuple[ordinal]
+            : TupleSerializerHandler.ReadObject(_data.Span, _schema!, ordinal);
 
         set => InitTuple()[ordinal] = value;
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Internal.Proto.BinaryTuple;
+
+using System;
+using Ignite.Table;
+using Table;
+
+/// <summary>
+/// Adapts <see cref="BinaryTuple"/> to <see cref="IIgniteTuple"/>, so that we can avoid extra copying and allocations when
+/// reading data from the server.
+/// </summary>
+internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple
+{
+    private readonly Memory<byte> _data;
+
+    private readonly Schema _schema;
+
+    public BinaryTupleIgniteTupleAdapter(Memory<byte> data, Schema schema, int fieldCount)
+    {
+        _data = data;
+        _schema = schema;
+        FieldCount = fieldCount;
+    }
+
+    public int FieldCount { get; }
+
+    public object? this[int ordinal]
+    {
+        get => throw new System.NotImplementedException();
+        set => throw new System.NotImplementedException();
+    }
+
+    public object? this[string name]
+    {
+        get => throw new System.NotImplementedException();
+        set => throw new System.NotImplementedException();
+    }
+
+    public string GetName(int ordinal)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public int GetOrdinal(string name)
+    {
+        throw new System.NotImplementedException();
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
@@ -30,7 +30,6 @@ using Table.Serialization;
 /// </summary>
 internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple, IEquatable<BinaryTupleIgniteTupleAdapter>, IEquatable<IIgniteTuple>
 {
-    // TODO: Benchmarks
     // TODO: Comprehensive tests to ensure consistency with IgniteTuple
     private readonly int _schemaFieldCount; // Key-only tuples have less fields than schema.
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
@@ -30,7 +30,6 @@ using Table.Serialization;
 /// </summary>
 internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple, IEquatable<BinaryTupleIgniteTupleAdapter>, IEquatable<IIgniteTuple>
 {
-    // TODO: Comprehensive tests to ensure consistency with IgniteTuple
     private readonly int _schemaFieldCount; // Key-only tuples have less fields than schema.
 
     private Memory<byte> _data;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
@@ -30,7 +30,7 @@ using Table.Serialization;
 /// </summary>
 internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple
 {
-    private readonly int _schemaFieldCount; // TODO: Does it ever differ from _schema.Columns.Count?
+    private readonly int _schemaFieldCount;
 
     private Memory<byte> _data;
 
@@ -111,7 +111,7 @@ internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple
         Debug.Assert(_schema != null, "_schema != null");
 
         // Copy data to a mutable IgniteTuple.
-        _tuple = TupleSerializerHandler.Read(_data.Span, _schema, _schemaFieldCount);
+        _tuple = TupleSerializerHandler.ReadTuple(_data.Span, _schema, _schemaFieldCount);
 
         // Release schema and data.
         _schema = default;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
@@ -28,7 +28,7 @@ using Table.Serialization;
 /// Adapts <see cref="BinaryTuple"/> to <see cref="IIgniteTuple"/>, so that we can avoid extra copying and allocations when
 /// reading data from the server.
 /// </summary>
-internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple
+internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple, IEquatable<BinaryTupleIgniteTupleAdapter>, IEquatable<IIgniteTuple>
 {
     private readonly int _schemaFieldCount;
 
@@ -103,6 +103,18 @@ internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple
 
     /// <inheritdoc/>
     public override string ToString() => IgniteTupleCommon.ToString(this);
+
+    /// <inheritdoc />
+    public bool Equals(BinaryTupleIgniteTupleAdapter? other) => IIgniteTuple.Equals(this, other);
+
+    /// <inheritdoc />
+    public bool Equals(IIgniteTuple? other) => IIgniteTuple.Equals(this, other);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is IIgniteTuple other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => IIgniteTuple.GetHashCode(this);
 
     private IIgniteTuple InitTuple()
     {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
@@ -94,11 +94,11 @@ internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple
 
             for (var i = 0; i < _schema.Columns.Count; i++)
             {
-                _indexes[_schema.Columns[i].Name] = i;
+                _indexes[IgniteTupleCommon.ParseColumnName(_schema.Columns[i].Name)] = i;
             }
         }
 
-        return _indexes.TryGetValue(name, out var index) ? index : -1;
+        return _indexes.TryGetValue(IgniteTupleCommon.ParseColumnName(name), out var index) ? index : -1;
     }
 
     /// <inheritdoc/>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
@@ -65,7 +65,7 @@ internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple, IEquatable<B
     {
         get => _tuple != null
             ? _tuple[ordinal]
-            : TupleSerializerHandler.ReadObject(_data.Span, _schema!, ordinal);
+            : TupleSerializerHandler.ReadObject(_data.Span, _schema!, _schemaFieldCount, ordinal);
 
         set => InitTuple()[ordinal] = value;
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
@@ -32,7 +32,7 @@ internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple, IEquatable<B
 {
     // TODO: Benchmarks
     // TODO: Comprehensive tests to ensure consistency with IgniteTuple
-    private readonly int _schemaFieldCount;
+    private readonly int _schemaFieldCount; // Key-only tuples have less fields than schema.
 
     private Memory<byte> _data;
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
@@ -101,6 +101,9 @@ internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple
         return _indexes.TryGetValue(name, out var index) ? index : -1;
     }
 
+    /// <inheritdoc/>
+    public override string ToString() => IgniteTupleCommon.ToString(this);
+
     private IIgniteTuple InitTuple()
     {
         if (_tuple != null)

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Internal.Proto.BinaryTuple;
 
 using System;
+using System.Diagnostics;
 using Ignite.Table;
 using Table;
 
@@ -27,38 +28,53 @@ using Table;
 /// </summary>
 internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple
 {
+    // TODO: Copy on write.
     private readonly Memory<byte> _data;
 
     private readonly Schema _schema;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BinaryTupleIgniteTupleAdapter"/> class.
+    /// </summary>
+    /// <param name="data">Binary tuple data.</param>
+    /// <param name="schema">Schema.</param>
+    /// <param name="fieldCount">Field count.</param>
     public BinaryTupleIgniteTupleAdapter(Memory<byte> data, Schema schema, int fieldCount)
     {
+        Debug.Assert(fieldCount <= schema.Columns.Count, "fieldCount <= schema.Columns.Count");
+
         _data = data;
         _schema = schema;
         FieldCount = fieldCount;
     }
 
+    /// <inheritdoc/>
     public int FieldCount { get; }
 
+    /// <inheritdoc/>
     public object? this[int ordinal]
     {
         get => throw new System.NotImplementedException();
         set => throw new System.NotImplementedException();
     }
 
+    /// <inheritdoc/>
     public object? this[string name]
     {
         get => throw new System.NotImplementedException();
         set => throw new System.NotImplementedException();
     }
 
+    /// <inheritdoc/>
     public string GetName(int ordinal)
     {
-        throw new System.NotImplementedException();
+        // TODO: Range checks.
+        return _schema.Columns[ordinal].Name;
     }
 
+    /// <inheritdoc/>
     public int GetOrdinal(string name)
     {
-        throw new System.NotImplementedException();
+        throw new NotImplementedException();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
@@ -72,7 +72,12 @@ internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple, IEquatable<B
     /// <inheritdoc/>
     public object? this[string name]
     {
-        get => this[GetOrdinal(name)];
+        get => GetOrdinal(name) switch
+        {
+            var ordinal and >= 0 => this[ordinal],
+            _ => throw new KeyNotFoundException(
+                $"The given key '{IgniteTupleCommon.ParseColumnName(name)}' was not present in the dictionary.")
+        };
         set => InitTuple()[name] = value;
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
@@ -30,6 +30,8 @@ using Table.Serialization;
 /// </summary>
 internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple, IEquatable<BinaryTupleIgniteTupleAdapter>, IEquatable<IIgniteTuple>
 {
+    // TODO: Benchmarks
+    // TODO: Comprehensive tests to ensure consistency with IgniteTuple
     private readonly int _schemaFieldCount;
 
     private Memory<byte> _data;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
@@ -107,7 +107,7 @@ internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple, IEquatable<B
     }
 
     /// <inheritdoc/>
-    public override string ToString() => IgniteTupleCommon.ToString(this);
+    public override string ToString() => IIgniteTuple.ToString(this);
 
     /// <inheritdoc />
     public bool Equals(BinaryTupleIgniteTupleAdapter? other) => IIgniteTuple.Equals(this, other);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/IgniteTupleCommon.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/IgniteTupleCommon.cs
@@ -18,8 +18,6 @@
 namespace Apache.Ignite.Internal.Table;
 
 using System;
-using Common;
-using Ignite.Table;
 
 /// <summary>
 /// Common tuple utilities.
@@ -44,22 +42,5 @@ internal static class IgniteTupleCommon
         }
 
         return name.ToUpperInvariant();
-    }
-
-    /// <summary>
-    /// Converts tuple to string.
-    /// </summary>
-    /// <param name="tuple">Tuple.</param>
-    /// <returns>String representation.</returns>
-    public static string ToString(IIgniteTuple tuple)
-    {
-        var builder = new IgniteToStringBuilder(tuple.GetType());
-
-        for (var i = 0; i < tuple.FieldCount; i++)
-        {
-            builder.Append(tuple[i], tuple.GetName(i));
-        }
-
-        return builder.Build();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/IgniteTupleCommon.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/IgniteTupleCommon.cs
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Internal.Table;
+
+using System;
+using Common;
+using Ignite.Table;
+
+/// <summary>
+/// Common tuple utilities.
+/// </summary>
+internal static class IgniteTupleCommon
+{
+    /// <summary>
+    /// Parses column name. Removes quotes and converts to upper case.
+    /// </summary>
+    /// <param name="name">Name.</param>
+    /// <returns>Parsed name.</returns>
+    public static string ParseColumnName(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            throw new ArgumentException("Column name can not be null or empty.");
+        }
+
+        if (name.Length > 2 && name.StartsWith('"') && name.EndsWith('"'))
+        {
+            return name.Substring(1, name.Length - 2);
+        }
+
+        return name.ToUpperInvariant();
+    }
+
+    /// <summary>
+    /// Converts tuple to string.
+    /// </summary>
+    /// <param name="tuple">Tuple.</param>
+    /// <returns>String representation.</returns>
+    public static string ToString(IIgniteTuple tuple)
+    {
+        var builder = new IgniteToStringBuilder(tuple.GetType());
+
+        for (var i = 0; i < tuple.FieldCount; i++)
+        {
+            builder.Append(tuple[i], tuple.GetName(i));
+        }
+
+        return builder.Build();
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Schema.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Schema.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Internal.Table
 {
+    using System;
     using System.Collections.Generic;
     using Proto.BinaryTuple;
 
@@ -47,5 +48,25 @@ namespace Apache.Ignite.Internal.Table
         public int HashedColumnOrder(int index) => index < KeyColumnCount
             ? Columns[index].ColocationIndex
             : -1;
+
+        /// <summary>
+        /// Parses column name. Removes quotes and converts to upper case.
+        /// </summary>
+        /// <param name="name">Name.</param>
+        /// <returns>Parsed name.</returns>
+        public static string ParseColumnName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("Column name can not be null or empty.");
+            }
+
+            if (name.Length > 2 && name.StartsWith('"') && name.EndsWith('"'))
+            {
+                return name.Substring(1, name.Length - 2);
+            }
+
+            return name.ToUpperInvariant();
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Schema.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Schema.cs
@@ -17,7 +17,6 @@
 
 namespace Apache.Ignite.Internal.Table
 {
-    using System;
     using System.Collections.Generic;
     using Proto.BinaryTuple;
 
@@ -48,25 +47,5 @@ namespace Apache.Ignite.Internal.Table
         public int HashedColumnOrder(int index) => index < KeyColumnCount
             ? Columns[index].ColocationIndex
             : -1;
-
-        /// <summary>
-        /// Parses column name. Removes quotes and converts to upper case.
-        /// </summary>
-        /// <param name="name">Name.</param>
-        /// <returns>Parsed name.</returns>
-        public static string ParseColumnName(string name)
-        {
-            if (string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentException("Column name can not be null or empty.");
-            }
-
-            if (name.Length > 2 && name.StartsWith('"') && name.EndsWith('"'))
-            {
-                return name.Substring(1, name.Length - 2);
-            }
-
-            return name.ToUpperInvariant();
-        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TupleSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TupleSerializerHandler.cs
@@ -68,6 +68,21 @@ namespace Apache.Ignite.Internal.Table.Serialization
             return tuple;
         }
 
+        /// <summary>
+        /// Reads single column from the binary tuple.
+        /// </summary>
+        /// <param name="buf">Binary tuple buffer.</param>
+        /// <param name="schema">Schema.</param>
+        /// <param name="index">Column index.</param>
+        /// <returns>Column value.</returns>
+        public static object? ReadObject(ReadOnlySpan<byte> buf, Schema schema, int index)
+        {
+            var tupleReader = new BinaryTupleReader(buf, schema.Columns.Count);
+            var column = schema.Columns[index];
+
+            return tupleReader.GetObject(index, column.Type, column.Scale);
+        }
+
         /// <inheritdoc/>
         public IIgniteTuple Read(ref MsgPackReader reader, Schema schema, bool keyOnly = false)
         {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TupleSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TupleSerializerHandler.cs
@@ -73,11 +73,12 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// </summary>
         /// <param name="buf">Binary tuple buffer.</param>
         /// <param name="schema">Schema.</param>
+        /// <param name="count">Column count.</param>
         /// <param name="index">Column index.</param>
         /// <returns>Column value.</returns>
-        public static object? ReadObject(ReadOnlySpan<byte> buf, Schema schema, int index)
+        public static object? ReadObject(ReadOnlySpan<byte> buf, Schema schema, int count, int index)
         {
-            var tupleReader = new BinaryTupleReader(buf, schema.Columns.Count);
+            var tupleReader = new BinaryTupleReader(buf, count);
             var column = schema.Columns[index];
 
             return tupleReader.GetObject(index, column.Type, column.Scale);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TupleSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TupleSerializerHandler.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using Common;
     using Ignite.Table;
@@ -41,6 +42,30 @@ namespace Apache.Ignite.Internal.Table.Serialization
         private TupleSerializerHandler()
         {
             // No-op.
+        }
+
+        /// <summary>
+        /// Reads tuple from the buffer.
+        /// </summary>
+        /// <param name="buf">Buffer.</param>
+        /// <param name="schema">Schema.</param>
+        /// <param name="count">Column count to read.</param>
+        /// <returns>Tuple.</returns>
+        public static IgniteTuple Read(ReadOnlySpan<byte> buf, Schema schema, int count)
+        {
+            Debug.Assert(count <= schema.Columns.Count, "count <= schema.Columns.Count");
+
+            var tuple = new IgniteTuple(count);
+            var tupleReader = new BinaryTupleReader(buf, count);
+            var columns = schema.Columns;
+
+            for (var index = 0; index < count; index++)
+            {
+                var column = columns[index];
+                tuple[column.Name] = tupleReader.GetObject(index, column.Type, column.Scale);
+            }
+
+            return tuple;
         }
 
         /// <inheritdoc/>

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IIgniteTuple.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IIgniteTuple.cs
@@ -128,5 +128,23 @@ namespace Apache.Ignite.Table
 
             return true;
         }
+
+        /// <summary>
+        /// Converts tuple to string.
+        /// </summary>
+        /// <param name="tuple">Tuple.</param>
+        /// <returns>String representation.</returns>
+        public static string ToString(IIgniteTuple tuple)
+        {
+            IgniteArgumentCheck.NotNull(tuple, nameof(tuple));
+            var builder = new IgniteToStringBuilder(tuple.GetType());
+
+            for (var i = 0; i < tuple.FieldCount; i++)
+            {
+                builder.Append(tuple[i], tuple.GetName(i));
+            }
+
+            return builder.Build();
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
@@ -21,6 +21,7 @@ namespace Apache.Ignite.Table
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Internal.Common;
+    using Internal.Table;
 
     /// <summary>
     /// Ignite tuple.
@@ -57,10 +58,10 @@ namespace Apache.Ignite.Table
         /// <inheritdoc/>
         public object? this[string name]
         {
-            get => _pairs[_indexes[ParseName(name)]].Value;
+            get => _pairs[_indexes[Schema.ParseColumnName(name)]].Value;
             set
             {
-                name = ParseName(name);
+                name = Schema.ParseColumnName(name);
 
                 var pair = (name, value);
 
@@ -81,7 +82,7 @@ namespace Apache.Ignite.Table
         public string GetName(int ordinal) => _pairs[ordinal].Key;
 
         /// <inheritdoc/>
-        public int GetOrdinal(string name) => _indexes.TryGetValue(ParseName(name), out var index) ? index : -1;
+        public int GetOrdinal(string name) => _indexes.TryGetValue(Schema.ParseColumnName(name), out var index) ? index : -1;
 
         /// <inheritdoc />
         public override string ToString()
@@ -112,21 +113,6 @@ namespace Apache.Ignite.Table
         public override int GetHashCode()
         {
             return IIgniteTuple.GetHashCode(this);
-        }
-
-        private static string ParseName(string name)
-        {
-            if (string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentException("Column name can not be null or empty.");
-            }
-
-            if (name.Length > 2 && name.StartsWith('"') && name.EndsWith('"'))
-            {
-                return name.Substring(1, name.Length - 2);
-            }
-
-            return name.ToUpperInvariant();
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
@@ -58,10 +58,10 @@ namespace Apache.Ignite.Table
         /// <inheritdoc/>
         public object? this[string name]
         {
-            get => _pairs[_indexes[Schema.ParseColumnName(name)]].Value;
+            get => _pairs[_indexes[IgniteTupleCommon.ParseColumnName(name)]].Value;
             set
             {
-                name = Schema.ParseColumnName(name);
+                name = IgniteTupleCommon.ParseColumnName(name);
 
                 var pair = (name, value);
 
@@ -82,20 +82,10 @@ namespace Apache.Ignite.Table
         public string GetName(int ordinal) => _pairs[ordinal].Key;
 
         /// <inheritdoc/>
-        public int GetOrdinal(string name) => _indexes.TryGetValue(Schema.ParseColumnName(name), out var index) ? index : -1;
+        public int GetOrdinal(string name) => _indexes.TryGetValue(IgniteTupleCommon.ParseColumnName(name), out var index) ? index : -1;
 
         /// <inheritdoc />
-        public override string ToString()
-        {
-            var builder = new IgniteToStringBuilder(GetType());
-
-            for (var i = 0; i < FieldCount; i++)
-            {
-                builder.Append(this[i], GetName(i));
-            }
-
-            return builder.Build();
-        }
+        public override string ToString() => IgniteTupleCommon.ToString(this);
 
         /// <inheritdoc />
         public bool Equals(IgniteTuple? other)

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
@@ -25,7 +25,7 @@ namespace Apache.Ignite.Table
     /// <summary>
     /// Ignite tuple.
     /// </summary>
-    public sealed class IgniteTuple : IIgniteTuple, IEquatable<IgniteTuple>
+    public sealed class IgniteTuple : IIgniteTuple, IEquatable<IgniteTuple>, IEquatable<IIgniteTuple>
     {
         /** Key-value pairs. */
         [SuppressMessage("Microsoft.Design", "CA1002:DoNotExposeGenericLists", Justification = "Private.")]
@@ -87,21 +87,15 @@ namespace Apache.Ignite.Table
         public override string ToString() => IgniteTupleCommon.ToString(this);
 
         /// <inheritdoc />
-        public bool Equals(IgniteTuple? other)
-        {
-            return IIgniteTuple.Equals(this, other);
-        }
+        public bool Equals(IgniteTuple? other) => IIgniteTuple.Equals(this, other);
 
         /// <inheritdoc />
-        public override bool Equals(object? obj)
-        {
-            return obj is IgniteTuple other && Equals(other);
-        }
+        public bool Equals(IIgniteTuple? other) => IIgniteTuple.Equals(this, other);
 
         /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            return IIgniteTuple.GetHashCode(this);
-        }
+        public override bool Equals(object? obj) => obj is IIgniteTuple other && Equals(other);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => IIgniteTuple.GetHashCode(this);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
@@ -84,7 +84,7 @@ namespace Apache.Ignite.Table
         public int GetOrdinal(string name) => _indexes.TryGetValue(IgniteTupleCommon.ParseColumnName(name), out var index) ? index : -1;
 
         /// <inheritdoc />
-        public override string ToString() => IgniteTupleCommon.ToString(this);
+        public override string ToString() => IIgniteTuple.ToString(this);
 
         /// <inheritdoc />
         public bool Equals(IgniteTuple? other) => IIgniteTuple.Equals(this, other);

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IgniteTuple.cs
@@ -20,7 +20,6 @@ namespace Apache.Ignite.Table
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using Internal.Common;
     using Internal.Table;
 
     /// <summary>


### PR DESCRIPTION
When reading data from server, currently we unpack all elements of the incoming `BinaryTuple` into `IgniteTuple`. This is extra work and extra allocations. Instead, create an adapter from `BinaryTuple` to `IIgniteTuple` like `MutableRowTupleAdapter` does in Java.

**Benchmarks**

```
BEFORE

|             Method |      Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
|------------------- |----------:|---------:|---------:|------:|--------:|-------:|----------:|
|   ReadObjectManual |  52.66 ns | 0.326 ns | 0.305 ns |  1.00 |    0.00 | 0.0003 |      80 B |
|         ReadObject |  88.41 ns | 0.425 ns | 0.398 ns |  1.68 |    0.01 | 0.0002 |      80 B |
|          ReadTuple | 263.26 ns | 2.822 ns | 2.502 ns |  5.00 |    0.06 | 0.0019 |     544 B |
| ReadTupleAndFields | 268.03 ns | 3.866 ns | 3.616 ns |  5.09 |    0.09 | 0.0019 |     544 B |


AFTER

|             Method |      Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
|------------------- |----------:|---------:|---------:|------:|--------:|-------:|----------:|
|   ReadObjectManual |  53.23 ns | 0.320 ns | 0.268 ns |  1.00 |    0.00 | 0.0003 |      80 B |
|         ReadObject |  88.01 ns | 0.484 ns | 0.453 ns |  1.65 |    0.01 | 0.0002 |      80 B |
|          ReadTuple |  23.66 ns | 0.274 ns | 0.257 ns |  0.44 |    0.00 | 0.0004 |     120 B |
| ReadTupleAndFields | 136.34 ns | 2.014 ns | 1.884 ns |  2.56 |    0.04 | 0.0007 |     208 B |
```

After this change, `ReadTuple` simply performs a buffer copy, but does not deserialize individual fields. `ReadTupleAndFields` unpacks all fields, and it is still faster and allocates less than before.