### PR TITLE
IGNITE-20275 Fix race condition in ClientInboundMessageHandler

### DIFF
--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -154,7 +154,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
     private final JdbcQueryCursorHandler jdbcQueryCursorHandler;
 
     /** Cluster ID. */
-    private final UUID clusterId;
+    private final CompletableFuture<UUID> clusterId;
 
     /** Metrics. */
     private final ClientHandlerMetricSource metrics;
@@ -200,7 +200,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
             IgniteCompute compute,
             ClusterService clusterService,
             IgniteSql sql,
-            UUID clusterId,
+            CompletableFuture<UUID> clusterId,
             ClientHandlerMetricSource metrics,
             AuthenticationManager authenticationManager,
             HybridClock clock
@@ -303,7 +303,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
             ClusterNode localMember = clusterService.topologyService().localMember();
             packer.packString(localMember.id());
             packer.packString(localMember.name());
-            packer.packUuid(clusterId);
+            packer.packUuid(clusterId.join());
 
             packer.packBinaryHeader(0); // Features.
             packer.packMapHeader(0); // Extensions.

--- a/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
@@ -30,6 +30,7 @@ import io.netty.util.ReferenceCounted;
 import java.net.BindException;
 import java.net.SocketAddress;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.apache.ignite.Ignite;
@@ -198,7 +199,7 @@ public class TestClientHandlerModule implements IgniteComponent {
                                         compute,
                                         clusterService,
                                         ignite.sql(),
-                                        clusterId,
+                                        CompletableFuture.completedFuture(clusterId),
                                         metrics,
                                         authenticationManager(authenticationConfiguration),
                                         clock));


### PR DESCRIPTION
`clusterId` was initialized after we start the endpoint, so it was possible for client to connect quickly while we don't yet have an id.

Fix: pass `CompletableFuture<UUID>` to `ClientInboundMessageHandler`. This eliminates race condition, removes blocking wait in most cases (likely the future will complete before the first handshake), and simplifies the code.

Additionally:
* Fix other potential race conditions when accessing volatile fields
* Fix deprecated exception ctor calls