### PR TITLE
IGNITE-20288 .NET: Fix TestDroppedConnectionsAreRestoredInBackground flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/BasicAuthenticatorTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/BasicAuthenticatorTests.cs
@@ -112,8 +112,7 @@ public class BasicAuthenticatorTests : IgniteTestsBase
         }
 
         // Wait for the server to apply the configuration change and drop the client connection.
-        // ReSharper disable once AccessToDisposedClosure
-        TestUtils.WaitForCondition(() => client.GetConnections().Count == 0, 3000);
+        client.WaitForConnections(0, 3000);
 
         _authnEnabled = enable;
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
@@ -43,8 +43,6 @@ namespace Apache.Ignite.Tests.Compute
             };
 
             using var client = await IgniteClient.StartAsync(clientCfg);
-
-            // ReSharper disable once AccessToDisposedClosure
             client.WaitForConnections(3);
 
             var res2 = await client.Compute.ExecuteAsync<string>(
@@ -100,8 +98,6 @@ namespace Apache.Ignite.Tests.Compute
             };
 
             using var client = await IgniteClient.StartAsync(clientCfg);
-
-            // ReSharper disable once AccessToDisposedClosure
             client.WaitForConnections(2);
 
             var nodeNames = new HashSet<string>();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
@@ -45,7 +45,7 @@ namespace Apache.Ignite.Tests.Compute
             using var client = await IgniteClient.StartAsync(clientCfg);
 
             // ReSharper disable once AccessToDisposedClosure
-            TestUtils.WaitForCondition(() => client.GetConnections().Count == 3, 5000);
+            client.WaitForConnections(3);
 
             var res2 = await client.Compute.ExecuteAsync<string>(
                 new[] { server2.Node }, Array.Empty<DeploymentUnit>(), jobClassName: string.Empty);
@@ -102,7 +102,7 @@ namespace Apache.Ignite.Tests.Compute
             using var client = await IgniteClient.StartAsync(clientCfg);
 
             // ReSharper disable once AccessToDisposedClosure
-            TestUtils.WaitForCondition(() => client.GetConnections().Count == 2, 5000);
+            client.WaitForConnections(2);
 
             var nodeNames = new HashSet<string>();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -247,8 +247,6 @@ namespace Apache.Ignite.Tests.Compute
         {
             var proxies = GetProxies();
             using var client = await IgniteClient.StartAsync(GetConfig(proxies));
-
-            // ReSharper disable once AccessToDisposedClosure
             client.WaitForConnections(proxies.Count);
 
             var keyTuple = new IgniteTuple { [KeyCol] = key };

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -249,7 +249,7 @@ namespace Apache.Ignite.Tests.Compute
             using var client = await IgniteClient.StartAsync(GetConfig(proxies));
 
             // ReSharper disable once AccessToDisposedClosure
-            TestUtils.WaitForCondition(() => client.GetConnections().Count == proxies.Count);
+            client.WaitForConnections(proxies.Count);
 
             var keyTuple = new IgniteTuple { [KeyCol] = key };
             var resNodeName = await client.Compute.ExecuteColocatedAsync<string>(TableName, keyTuple, Units, NodeNameJob);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteClientExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteClientExtensions.cs
@@ -27,9 +27,10 @@ public static class IgniteClientExtensions
     /// </summary>
     /// <param name="client">Client.</param>
     /// <param name="count">Connection count.</param>
-    public static void WaitForConnections(this IIgniteClient client, int count) =>
+    /// <param name="timeoutMs">Timeout.</param>
+    public static void WaitForConnections(this IIgniteClient client, int count, int timeoutMs = 5000) =>
         TestUtils.WaitForCondition(
             condition: () => client.GetConnections().Count == count,
-            timeoutMs: 5000,
+            timeoutMs: timeoutMs,
             messageFactory: () => $"Connection count: expected = {count}, actual = {client.GetConnections().Count}");
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteClientExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteClientExtensions.cs
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests;
+
+/// <summary>
+/// Extensions for <see cref="IIgniteClient"/>.
+/// </summary>
+public static class IgniteClientExtensions
+{
+    /// <summary>
+    /// Waits for the specified number of connections to be established. Throws an exception if the condition is not reached.
+    /// </summary>
+    /// <param name="client">Client.</param>
+    /// <param name="count">Connection count.</param>
+    public static void WaitForConnections(this IIgniteClient client, int count) =>
+        TestUtils.WaitForCondition(
+            condition: () => client.GetConnections().Count == count,
+            timeoutMs: 5000,
+            messageFactory: () => $"Connection count: expected = {count}, actual = {client.GetConnections().Count}");
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
@@ -42,7 +42,7 @@ public class LoggingTests
         using var servers = FakeServerGroup.Create(3);
         using (var client = await servers.ConnectClientAsync(cfg))
         {
-            TestUtils.WaitForCondition(() => client.GetConnections().Count == 3);
+            client.WaitForConnections(3);
 
             await client.Tables.GetTablesAsync();
             await client.Sql.ExecuteAsync(null, "select 1");

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessTests.cs
@@ -390,8 +390,7 @@ public class PartitionAwarenessTests
         };
 
         var client = await IgniteClient.StartAsync(cfg);
-
-        TestUtils.WaitForCondition(() => client.GetConnections().Count == 2);
+        client.WaitForConnections(2);
 
         return client;
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -92,16 +92,16 @@ public class ReconnectTests
         using var servers = FakeServerGroup.Create(10);
         using var client = await servers.ConnectClientAsync(cfg);
 
-        WaitForConnections(client, 10);
+        client.WaitForConnections(10);
         servers.DropNewConnections = true;
         servers.DropExistingConnections();
 
         // Dropped connections are detected by heartbeat.
-        WaitForConnections(client, 0);
+        client.WaitForConnections(0);
 
         // Connections are restored in background due to ReconnectInterval.
         servers.DropNewConnections = false;
-        WaitForConnections(client, 10);
+        client.WaitForConnections(10);
 
         Assert.DoesNotThrowAsync(async () => await client.Tables.GetTablesAsync());
     }
@@ -122,7 +122,7 @@ public class ReconnectTests
         servers.DropNewConnections = false;
 
         // When all servers are back online, connections are established in background due to ReconnectInterval.
-        WaitForConnections(client, 5);
+        client.WaitForConnections(5);
 
         Assert.DoesNotThrowAsync(async () => await client.Tables.GetTablesAsync());
     }
@@ -163,13 +163,6 @@ public class ReconnectTests
 
         // All connections are restored.
         logger.Debug("Waiting for all connections to be restored...");
-        WaitForConnections(client, 10);
+        client.WaitForConnections(10);
     }
-
-    // TODO:  Reuse in other test fixtures
-    private static void WaitForConnections(IIgniteClient client, int count) =>
-        TestUtils.WaitForCondition(
-            condition: () => client.GetConnections().Count == count,
-            timeoutMs: 5000,
-            messageFactory: () => $"Connection count: expected = {count}, actual = {client.GetConnections().Count}");
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -166,6 +166,7 @@ public class ReconnectTests
         WaitForConnections(client, 10);
     }
 
+    // TODO:  Reuse in other test fixtures
     private static void WaitForConnections(IIgniteClient client, int count) =>
         TestUtils.WaitForCondition(
             condition: () => client.GetConnections().Count == count,

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/RequestBalancingTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/RequestBalancingTests.cs
@@ -41,7 +41,7 @@ public class RequestBalancingTests
         };
 
         using var client = await IgniteClient.StartAsync(clientCfg);
-        client.WaitForConnections(2);
+        client.WaitForConnections(3);
 
         for (var i = 0; i < 10; i++)
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/RequestBalancingTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/RequestBalancingTests.cs
@@ -41,9 +41,7 @@ public class RequestBalancingTests
         };
 
         using var client = await IgniteClient.StartAsync(clientCfg);
-
-        // ReSharper disable once AccessToDisposedClosure
-        TestUtils.WaitForCondition(() => client.GetConnections().Count == 3, 5000);
+        client.WaitForConnections(2);
 
         for (var i = 0; i < 10; i++)
         {


### PR DESCRIPTION
* Increase timeout to fix flakiness
* Extract common method to wait for background client connections and reuse in all tests