### PR TITLE
IGNITE-20308 Fix ItAbstractDataStreamerTest flakiness

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItAbstractDataStreamerTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItAbstractDataStreamerTest.java
@@ -141,14 +141,17 @@ public abstract class ItAbstractDataStreamerTest extends ClusterPerClassIntegrat
     @Test
     public void testAutoFlushByTimer() throws InterruptedException {
         RecordView<Tuple> view = this.defaultTable().recordView();
+        CompletableFuture<Void> streamerFut;
 
         try (var publisher = new SubmissionPublisher<Tuple>()) {
             var options = DataStreamerOptions.builder().autoFlushFrequency(100).build();
-            view.streamData(publisher, options);
+            streamerFut = view.streamData(publisher, options);
 
             publisher.submit(tuple(1, "foo"));
             waitForKey(view, tupleKey(1));
         }
+
+        assertThat(streamerFut, willSucceedIn(5, TimeUnit.SECONDS));
     }
 
     @Test


### PR DESCRIPTION
Wait for streamer completion in all tests to ensure that no updates happen after test exit, causing conflicts with SQL in `clearTable`.