### PR TITLE
IGNITE-20264 Sql. Races in BaseAggregateTest::countOfEmptyWithRewind

### DIFF
--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/BaseAggregateTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/BaseAggregateTest.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.sql.engine.exec.rel;
 
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.assertThrowsWithCause;
+import static org.apache.ignite.internal.testframework.IgniteTestUtils.await;
 import static org.apache.ignite.internal.util.ArrayUtils.asList;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,7 +37,6 @@ import java.util.stream.IntStream;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
@@ -53,14 +53,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 /**
- * BaseAggregateTest.
- * TODO Documentation https://issues.apache.org/jira/browse/IGNITE-15859
+ * A test class that defines basic test scenarios to verify the execution of each type of aggregate.
  */
+@SuppressWarnings("resource")
 public abstract class BaseAggregateTest extends AbstractExecutionTest {
-    /**
-     * Count.
-     * TODO Documentation https://issues.apache.org/jira/browse/IGNITE-15859
-     */
     @ParameterizedTest
     @EnumSource
     public void count(TestAggregateType testAgg) {
@@ -113,10 +109,6 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest {
         assertFalse(root.hasNext());
     }
 
-    /**
-     * Min.
-     * TODO Documentation https://issues.apache.org/jira/browse/IGNITE-15859
-     */
     @ParameterizedTest
     @EnumSource
     public void min(TestAggregateType testAgg) {
@@ -135,8 +127,10 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest {
                 false,
                 false,
                 false,
+                List.of(),
                 ImmutableIntList.of(1),
                 -1,
+                 null,
                 RelCollations.EMPTY,
                 tf.createJavaType(int.class),
                 null);
@@ -167,10 +161,6 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest {
         assertFalse(root.hasNext());
     }
 
-    /**
-     * Max.
-     * TODO Documentation https://issues.apache.org/jira/browse/IGNITE-15859
-     */
     @ParameterizedTest
     @EnumSource
     public void max(TestAggregateType testAgg) {
@@ -189,8 +179,10 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest {
                 false,
                 false,
                 false,
+                List.of(),
                 ImmutableIntList.of(1),
                 -1,
+                null,
                 RelCollations.EMPTY,
                 tf.createJavaType(int.class),
                 null);
@@ -221,10 +213,6 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest {
         assertFalse(root.hasNext());
     }
 
-    /**
-     * Avg.
-     * TODO Documentation https://issues.apache.org/jira/browse/IGNITE-15859
-     */
     @ParameterizedTest
     @EnumSource
     public void avg(TestAggregateType testAgg) {
@@ -246,8 +234,10 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest {
                 false,
                 false,
                 false,
+                List.of(),
                 ImmutableIntList.of(1),
                 -1,
+                null,
                 RelCollations.EMPTY,
                 tf.createJavaType(int.class),
                 null);
@@ -278,10 +268,6 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest {
         assertFalse(root.hasNext());
     }
 
-    /**
-     * Single.
-     * TODO Documentation https://issues.apache.org/jira/browse/IGNITE-15859
-     */
     @ParameterizedTest
     @EnumSource
     public void single(TestAggregateType testAgg) {
@@ -346,8 +332,10 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest {
                 false,
                 false,
                 false,
+                List.of(),
                 ImmutableIntList.of(1),
                 -1,
+                null,
                 RelCollations.EMPTY,
                 tf.createJavaType(Integer.class),
                 null);
@@ -386,10 +374,6 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest {
         }
     }
 
-    /**
-     * Distinct sum.
-     * TODO Documentation https://issues.apache.org/jira/browse/IGNITE-15859
-     */
     @ParameterizedTest
     @EnumSource
     public void distinctSum(TestAggregateType testAgg) {
@@ -415,8 +399,10 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest {
                 true,
                 false,
                 false,
+                List.of(),
                 ImmutableIntList.of(1),
                 -1,
+                null,
                 RelCollations.EMPTY,
                 tf.createJavaType(int.class),
                 null);
@@ -447,10 +433,6 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest {
         assertFalse(root.hasNext());
     }
 
-    /**
-     * SumOnDifferentRowsCount.
-     * TODO Documentation https://issues.apache.org/jira/browse/IGNITE-15859
-     */
     @ParameterizedTest
     @EnumSource
     public void sumOnDifferentRowsCount(TestAggregateType testAgg) {
@@ -482,8 +464,10 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest {
                         false,
                         false,
                         false,
+                        List.of(),
                         ImmutableIntList.of(1),
                         -1,
+                        null,
                         RelCollations.EMPTY,
                         tf.createJavaType(int.class),
                         null);
@@ -586,8 +570,10 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest {
                 false,
                 false,
                 false,
+                List.of(),
                 ImmutableIntList.of(1),
                 -1,
+                null,
                 RelCollations.EMPTY,
                 tf.createJavaType(BigDecimal.class),
                 null);
@@ -671,7 +657,7 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest {
             assertArrayEquals(row(0), root.next());
             assertFalse(root.hasNext());
 
-            aggChain.rewind();
+            await(ctx.submit(aggChain::rewind, root::onError));
         }
     }
 
@@ -731,18 +717,5 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest {
         COLOCATED,
 
         MAP_REDUCE
-    }
-
-    protected AggregateCall newAggCall(SqlAggFunction func, int arg, RelDataType resultType) {
-        return AggregateCall.create(
-                func,
-                false,
-                false,
-                false,
-                ImmutableIntList.of(arg),
-                -1,
-                RelCollations.EMPTY,
-                resultType,
-                null);
     }
 }


### PR DESCRIPTION
The race was caused by rewinding node from incorrect thread.

The problematic sequence of event was as follow:
1. main thread calls `hasNext` and waits on condition inside `RootNode`
2. task executor thread starts scanning empty iterator, which renders in an immediate call to `Downstream#end` on the entire tree
3. inside `SortAggregateNode#end` task executor calls to `downstream().end()` that notifies condition and releases main thread

next points go concurrently

4. task executor proceeds execution inside `SortAggregateNode#end` and nullifies `grp` field
5. main thread rewinds the node and reinitialise `grp` with new group

If main thread outruns task executor (p5 goes before p4), then `grp` will be incorrectly nullified, and root node will return empty result.

Besides fix of the race, in this patch I replace invocation of deprecated `AggregateCall#create` with proper one, improve class-level javadoc and remove unnecessary method-level javadocs.

----------------------------------------------

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)