### PR TITLE
IGNITE-20019 Sql. Implement system views manager

### DIFF
--- a/modules/cluster-management/src/integrationTest/java/org/apache/ignite/internal/cluster/management/raft/ItCmgRaftServiceTest.java
+++ b/modules/cluster-management/src/integrationTest/java/org/apache/ignite/internal/cluster/management/raft/ItCmgRaftServiceTest.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -227,22 +226,22 @@ public class ItCmgRaftServiceTest extends BaseIgniteAbstractTest {
         assertThat(node1.logicalTopologyNodes(), willBe(empty()));
         assertThat(node1.validatedNodes(), willBe(empty()));
 
-        assertThat(node1.raftService.startJoinCluster(clusterState.clusterTag(), Collections.emptyMap()), willCompleteSuccessfully());
+        assertThat(node1.raftService.startJoinCluster(clusterState.clusterTag(), null), willCompleteSuccessfully());
 
         assertThat(node1.logicalTopologyNodes(), willBe(empty()));
         assertThat(node1.validatedNodes(), will(contains(clusterNode1)));
 
-        assertThat(node1.raftService.completeJoinCluster(Collections.emptyMap()), willCompleteSuccessfully());
+        assertThat(node1.raftService.completeJoinCluster(null), willCompleteSuccessfully());
 
         assertThat(node1.logicalTopologyNodes(), will(contains(clusterNode1)));
         assertThat(node1.validatedNodes(), will(contains(clusterNode1)));
 
-        assertThat(node2.raftService.startJoinCluster(clusterState.clusterTag(), Collections.emptyMap()), willCompleteSuccessfully());
+        assertThat(node2.raftService.startJoinCluster(clusterState.clusterTag(), null), willCompleteSuccessfully());
 
         assertThat(node1.logicalTopologyNodes(), willBe(contains(clusterNode1)));
         assertThat(node1.validatedNodes(), will(containsInAnyOrder(clusterNode1, clusterNode2)));
 
-        assertThat(node2.raftService.completeJoinCluster(Collections.emptyMap()), willCompleteSuccessfully());
+        assertThat(node2.raftService.completeJoinCluster(null), willCompleteSuccessfully());
 
         assertThat(node1.logicalTopologyNodes(), will(containsInAnyOrder(clusterNode1, clusterNode2)));
         assertThat(node1.validatedNodes(), will(containsInAnyOrder(clusterNode1, clusterNode2)));
@@ -259,8 +258,8 @@ public class ItCmgRaftServiceTest extends BaseIgniteAbstractTest {
     }
 
     private static CompletableFuture<Void> joinCluster(Node node, ClusterTag clusterTag) {
-        return node.raftService.startJoinCluster(clusterTag, Collections.emptyMap())
-                .thenCompose(v -> node.raftService.completeJoinCluster(Collections.emptyMap()));
+        return node.raftService.startJoinCluster(clusterTag, null)
+                .thenCompose(v -> node.raftService.completeJoinCluster(null));
     }
 
     /**
@@ -381,13 +380,13 @@ public class ItCmgRaftServiceTest extends BaseIgniteAbstractTest {
         assertThat(node1.raftService.initClusterState(state), willCompleteSuccessfully());
 
         // correct tag
-        assertThat(node1.raftService.startJoinCluster(state.clusterTag(), Collections.emptyMap()), willCompleteSuccessfully());
+        assertThat(node1.raftService.startJoinCluster(state.clusterTag(), null), willCompleteSuccessfully());
 
         // incorrect tag
         var incorrectTag = clusterTag(msgFactory, "invalid");
 
         assertThrowsWithCause(
-                () -> node2.raftService.startJoinCluster(incorrectTag, Collections.emptyMap()).get(10, TimeUnit.SECONDS),
+                () -> node2.raftService.startJoinCluster(incorrectTag, null).get(10, TimeUnit.SECONDS),
                 IgniteInternalException.class,
                 String.format(
                         "Join request denied, reason: Cluster tags do not match. Cluster tag: %s, cluster tag stored in CMG: %s",
@@ -415,7 +414,7 @@ public class ItCmgRaftServiceTest extends BaseIgniteAbstractTest {
         assertThat(raftService.initClusterState(state), willCompleteSuccessfully());
 
         assertThrowsWithCause(
-                () -> raftService.startJoinCluster(state.clusterTag(), Collections.emptyMap()).get(10, TimeUnit.SECONDS),
+                () -> raftService.startJoinCluster(state.clusterTag(), null).get(10, TimeUnit.SECONDS),
                 IgniteInternalException.class,
                 String.format(
                         "Join request denied, reason: Ignite versions do not match. Version: %s, version stored in CMG: %s",
@@ -448,15 +447,15 @@ public class ItCmgRaftServiceTest extends BaseIgniteAbstractTest {
         );
 
         assertThrowsWithCause(
-                () -> raftService.completeJoinCluster(Collections.emptyMap()).get(10, TimeUnit.SECONDS),
+                () -> raftService.completeJoinCluster(null).get(10, TimeUnit.SECONDS),
                 IgniteInternalException.class,
                 errMsg
         );
 
-        assertThat(raftService.startJoinCluster(state.clusterTag(), Collections.emptyMap()), willCompleteSuccessfully());
+        assertThat(raftService.startJoinCluster(state.clusterTag(), null), willCompleteSuccessfully());
 
         // Everything is ok after the node has passed validation.
-        assertThat(raftService.completeJoinCluster(Collections.emptyMap()), willCompleteSuccessfully());
+        assertThat(raftService.completeJoinCluster(null), willCompleteSuccessfully());
     }
 
     /**
@@ -571,14 +570,14 @@ public class ItCmgRaftServiceTest extends BaseIgniteAbstractTest {
 
         CmgRaftService service = cluster.get(1).raftService;
 
-        assertThat(service.startJoinCluster(state.clusterTag(), Collections.emptyMap()), willCompleteSuccessfully());
+        assertThat(service.startJoinCluster(state.clusterTag(), null), willCompleteSuccessfully());
 
-        assertThat(service.startJoinCluster(state.clusterTag(), Collections.emptyMap()), willCompleteSuccessfully());
+        assertThat(service.startJoinCluster(state.clusterTag(), null), willCompleteSuccessfully());
 
-        assertThat(service.completeJoinCluster(Collections.emptyMap()), willCompleteSuccessfully());
+        assertThat(service.completeJoinCluster(null), willCompleteSuccessfully());
 
-        assertThat(service.completeJoinCluster(Collections.emptyMap()), willCompleteSuccessfully());
+        assertThat(service.completeJoinCluster(null), willCompleteSuccessfully());
 
-        assertThat(service.completeJoinCluster(Collections.emptyMap()), willCompleteSuccessfully());
+        assertThat(service.completeJoinCluster(null), willCompleteSuccessfully());
     }
 }

--- a/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/NodeAttributes.java
+++ b/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/NodeAttributes.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.cluster.management;
+
+import java.util.Map;
+import org.apache.ignite.internal.cluster.management.topology.api.LogicalNode;
+
+/**
+ * Contains local attributes that are collected during node startup and become visible
+ * to all cluster nodes after the local node is added to the logical topology.
+ *
+ * @see LogicalNode#attributes()
+ * @see LogicalNode#systemAttributes()
+ */
+public interface NodeAttributes {
+    /**
+     * Returns configuration defined attributes.
+     */
+    Map<String, String> configAttributes();
+
+    /**
+     * Returns internal attributes provided by system components.
+     */
+    Map<String, String> systemAttributes();
+}

--- a/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/NodeAttributesCollector.java
+++ b/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/NodeAttributesCollector.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.cluster.management;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.ignite.configuration.NamedListView;
+import org.apache.ignite.internal.cluster.management.configuration.NodeAttributeView;
+import org.apache.ignite.internal.cluster.management.configuration.NodeAttributesConfiguration;
+
+/**
+ * This class is responsible for retrieving local node attributes
+ * from system components before the local node joins the cluster.
+ */
+public class NodeAttributesCollector implements NodeAttributes {
+    private final List<NodeAttributesProvider> systemAttributesProviders = new ArrayList<>();
+
+    private final NodeAttributesConfiguration nodeAttributesConfiguration;
+
+    public NodeAttributesCollector(NodeAttributesConfiguration nodeAttributesConfiguration) {
+        this.nodeAttributesConfiguration = nodeAttributesConfiguration;
+    }
+
+    /**
+     * Registers system attributes provider.
+     */
+    public void register(NodeAttributesProvider provider) {
+        systemAttributesProviders.add(provider);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Map<String, String> configAttributes() {
+        NamedListView<NodeAttributeView> attributes = nodeAttributesConfiguration.nodeAttributes().value();
+
+        return attributes.stream()
+                .collect(Collectors.toUnmodifiableMap(NodeAttributeView::name, NodeAttributeView::attribute));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Map<String, String> systemAttributes() {
+        Map<String, String> attributes = new HashMap<>();
+
+        for (NodeAttributesProvider provider : systemAttributesProviders) {
+            attributes.putAll(provider.nodeAttributes());
+        }
+
+        return attributes;
+    }
+}

--- a/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/NodeAttributesProvider.java
+++ b/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/NodeAttributesProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.cluster.management;
+
+import java.util.Map;
+import org.apache.ignite.internal.cluster.management.topology.api.LogicalNode;
+
+/**
+ * Local node attributes provider.
+ */
+public interface NodeAttributesProvider {
+    /**
+     * Returns a collection of internal local node attributes, that should be visible to other
+     * cluster nodes in logical topology using {@link LogicalNode#systemAttributes()} method.
+     *
+     * <p>Attributes must be prepared when the component is initialized and/or started. That is, before the
+     * local node finishes joining the cluster. Otherwise they will not be visible in the logical topology.
+     *
+     * @return Collection of attributes.
+     */
+    Map<String, String> nodeAttributes();
+}

--- a/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/raft/CmgRaftGroupListener.java
+++ b/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/raft/CmgRaftGroupListener.java
@@ -192,7 +192,7 @@ public class CmgRaftGroupListener implements RaftGroupListener {
             }
         }
 
-        LogicalNode logicalNode = new LogicalNode(node, command.node().nodeAttributes());
+        LogicalNode logicalNode = new LogicalNode(node, command.node().attributes(), command.node().systemAttributes());
 
         return validationManager.validateNode(storage.getClusterState(), logicalNode, command.igniteVersion(), command.clusterTag());
     }
@@ -201,7 +201,7 @@ public class CmgRaftGroupListener implements RaftGroupListener {
     private Serializable completeValidation(JoinReadyCommand command) {
         ClusterNode node = command.node().asClusterNode();
 
-        LogicalNode logicalNode = new LogicalNode(node, command.node().nodeAttributes());
+        LogicalNode logicalNode = new LogicalNode(node, command.node().attributes(), command.node().systemAttributes());
 
         if (validationManager.isNodeValidated(logicalNode)) {
             validationManager.completeValidation(logicalNode);
@@ -218,7 +218,8 @@ public class CmgRaftGroupListener implements RaftGroupListener {
         Set<ClusterNode> nodes = command.nodes().stream().map(ClusterNodeMessage::asClusterNode).collect(Collectors.toSet());
 
         // Nodes will be removed from a topology, so it is safe to set nodeAttributes to the default value
-        Set<LogicalNode> logicalNodes = nodes.stream().map(n -> new LogicalNode(n, Collections.emptyMap())).collect(Collectors.toSet());
+        Set<LogicalNode> logicalNodes = nodes.stream()
+                .map(n -> new LogicalNode(n, Collections.emptyMap(), Collections.emptyMap())).collect(Collectors.toSet());
 
         logicalTopology.removeNodes(logicalNodes);
         validationManager.removeValidatedNodes(logicalNodes);

--- a/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/raft/commands/ClusterNodeMessage.java
+++ b/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/raft/commands/ClusterNodeMessage.java
@@ -45,5 +45,8 @@ public interface ClusterNodeMessage extends NetworkMessage, Serializable {
     }
 
     @Nullable
-    Map<String, String> nodeAttributes();
+    Map<String, String> attributes();
+
+    @Nullable
+    Map<String, String> systemAttributes();
 }

--- a/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/topology/api/LogicalNode.java
+++ b/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/topology/api/LogicalNode.java
@@ -36,7 +36,10 @@ public class LogicalNode extends ClusterNodeImpl {
      *         documentation</a>
      */
     @IgniteToStringInclude
-    private final Map<String, String> nodeAttributes;
+    private final Map<String, String> attributes;
+
+    @IgniteToStringInclude
+    private final Map<String, String> systemAttributes;
 
     /**
      * Constructor.
@@ -52,19 +55,32 @@ public class LogicalNode extends ClusterNodeImpl {
     ) {
         super(id, name, address);
 
-        this.nodeAttributes = Collections.emptyMap();
+        this.attributes = Collections.emptyMap();
+        this.systemAttributes = Collections.emptyMap();
     }
 
     /**
      * Constructor.
      *
-     * @param clusterNode    Represents a node in a cluster.
-     * @param nodeAttributes Node attributes.
+     * @param clusterNode Represents a node in a cluster.
+     * @param attributes  Node attributes defined in configuration.
      */
-    public LogicalNode(ClusterNode clusterNode, Map<String, String> nodeAttributes) {
+    public LogicalNode(ClusterNode clusterNode, Map<String, String> attributes) {
+        this(clusterNode, attributes, Collections.emptyMap());
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param clusterNode Represents a node in a cluster.
+     * @param attributes Node attributes defined in configuration.
+     * @param systemAttributes Internal node attributes provided by system components at startup.
+     */
+    public LogicalNode(ClusterNode clusterNode, Map<String, String> attributes, Map<String, String> systemAttributes) {
         super(clusterNode.id(), clusterNode.name(), clusterNode.address(), clusterNode.nodeMetadata());
 
-        this.nodeAttributes = nodeAttributes;
+        this.attributes = attributes == null ? Collections.emptyMap() : attributes;
+        this.systemAttributes = systemAttributes == null ? Collections.emptyMap() : systemAttributes;
     }
 
     /**
@@ -73,18 +89,25 @@ public class LogicalNode extends ClusterNodeImpl {
      * @param clusterNode    Represents a node in a cluster.
      */
     public LogicalNode(ClusterNode clusterNode) {
-        super(clusterNode.id(), clusterNode.name(), clusterNode.address(), clusterNode.nodeMetadata());
-
-        this.nodeAttributes = Collections.emptyMap();
+        this(clusterNode, Collections.emptyMap(), Collections.emptyMap());
     }
 
     /**
-     * Returns node's attributes.
+     * Returns node's attributes defined in node's configuration.
      *
-     * @return Node's attributes.
+     * @return Node's attributes defined in node's configuration.
      */
-    public Map<String, String> nodeAttributes() {
-        return nodeAttributes;
+    public Map<String, String> attributes() {
+        return attributes;
+    }
+
+    /**
+     * Returns Internal node attributes provided by system components at startup.
+     *
+     * @return Internal node attributes provided by system components at startup.
+     */
+    public Map<String, String> systemAttributes() {
+        return systemAttributes;
     }
 
     /** {@inheritDoc} */

--- a/modules/cluster-management/src/testFixtures/java/org/apache/ignite/internal/cluster/management/MockNode.java
+++ b/modules/cluster-management/src/testFixtures/java/org/apache/ignite/internal/cluster/management/MockNode.java
@@ -66,7 +66,7 @@ public class MockNode {
 
     private final ClusterManagementConfiguration cmgConfiguration;
 
-    private final NodeAttributesConfiguration nodeAttributes;
+    private final NodeAttributesCollector nodeAttributes;
 
     private final List<IgniteComponent> components = new ArrayList<>();
 
@@ -89,7 +89,7 @@ public class MockNode {
         this.workDir = workDir;
         this.raftConfiguration = raftConfiguration;
         this.cmgConfiguration = cmgConfiguration;
-        this.nodeAttributes = nodeAttributes;
+        this.nodeAttributes = new NodeAttributesCollector(nodeAttributes);
 
         try {
             init(addr.port());

--- a/modules/distribution-zones/src/main/java/org/apache/ignite/internal/distributionzones/DistributionZonesUtil.java
+++ b/modules/distribution-zones/src/main/java/org/apache/ignite/internal/distributionzones/DistributionZonesUtil.java
@@ -381,7 +381,7 @@ public class DistributionZonesUtil {
      */
     public static Update updateLogicalTopologyAndVersion(Set<LogicalNode> logicalTopology, long topologyVersion) {
         Set<NodeWithAttributes> topologyFromCmg = logicalTopology.stream()
-                .map(n -> new NodeWithAttributes(n.name(), n.id(), n.nodeAttributes()))
+                .map(n -> new NodeWithAttributes(n.name(), n.id(), n.attributes()))
                 .collect(toSet());
 
         return ops(

--- a/modules/distribution-zones/src/testFixtures/java/org/apache/ignite/internal/distributionzones/DistributionZonesTestUtil.java
+++ b/modules/distribution-zones/src/testFixtures/java/org/apache/ignite/internal/distributionzones/DistributionZonesTestUtil.java
@@ -312,7 +312,7 @@ public class DistributionZonesTestUtil {
     ) throws InterruptedException {
         Set<NodeWithAttributes> nodes = clusterNodes == null
                 ? null
-                : clusterNodes.stream().map(n -> new NodeWithAttributes(n.name(), n.id(), n.nodeAttributes())).collect(toSet());
+                : clusterNodes.stream().map(n -> new NodeWithAttributes(n.name(), n.id(), n.attributes())).collect(toSet());
 
         assertValueInStorage(
                 keyValueStorage,
@@ -348,7 +348,7 @@ public class DistributionZonesTestUtil {
      */
     public static void mockVaultZonesLogicalTopologyKey(Set<LogicalNode> nodes, VaultManager vaultMgr, long appliedRevision) {
         Set<NodeWithAttributes> nodesWithAttributes = nodes.stream()
-                .map(n -> new NodeWithAttributes(n.name(), n.id(), n.nodeAttributes()))
+                .map(n -> new NodeWithAttributes(n.name(), n.id(), n.attributes()))
                 .collect(toSet());
 
         byte[] newLogicalTopology = toBytes(nodesWithAttributes);

--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMultipleNodesAbstractTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMultipleNodesAbstractTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.apache.ignite.internal.cluster.management.ClusterManagementGroupManager;
+import org.apache.ignite.internal.cluster.management.NodeAttributesCollector;
 import org.apache.ignite.internal.cluster.management.configuration.ClusterManagementConfiguration;
 import org.apache.ignite.internal.cluster.management.configuration.NodeAttributesConfiguration;
 import org.apache.ignite.internal.cluster.management.raft.ClusterStateStorage;
@@ -155,7 +156,7 @@ public abstract class ItMetaStorageMultipleNodesAbstractTest extends IgniteAbstr
                     clusterStateStorage,
                     logicalTopology,
                     cmgConfiguration,
-                    nodeAttributes,
+                    new NodeAttributesCollector(nodeAttributes),
                     new TestConfigurationValidator());
 
             var logicalTopologyService = new LogicalTopologyServiceImpl(logicalTopology, cmgManager);

--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageWatchTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageWatchTest.java
@@ -39,6 +39,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.ignite.internal.cluster.management.ClusterManagementGroupManager;
+import org.apache.ignite.internal.cluster.management.NodeAttributesCollector;
 import org.apache.ignite.internal.cluster.management.configuration.ClusterManagementConfiguration;
 import org.apache.ignite.internal.cluster.management.configuration.NodeAttributesConfiguration;
 import org.apache.ignite.internal.cluster.management.raft.TestClusterStateStorage;
@@ -136,7 +137,7 @@ public class ItMetaStorageWatchTest extends IgniteAbstractTest {
                     clusterStateStorage,
                     logicalTopology,
                     cmgConfiguration,
-                    nodeAttributes,
+                    new NodeAttributesCollector(nodeAttributes),
                     new TestConfigurationValidator());
 
             components.add(cmgManager);

--- a/modules/runner/build.gradle
+++ b/modules/runner/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     implementation project(':ignite-code-deployment')
     implementation project(':ignite-security')
     implementation project(':ignite-catalog')
+    implementation project(':ignite-system-view')
     implementation libs.jetbrains.annotations
     implementation libs.micronaut.inject
     implementation libs.micronaut.validation
@@ -146,6 +147,7 @@ dependencies {
     integrationTestImplementation project(':ignite-catalog')
     integrationTestImplementation project(':ignite-placement-driver')
     integrationTestImplementation project(':ignite-distribution-zones')
+    integrationTestImplementation project(':ignite-system-view')
     integrationTestImplementation testFixtures(project(":ignite-api"))
     integrationTestImplementation testFixtures(project(':ignite-core'))
     integrationTestImplementation testFixtures(project(':ignite-configuration'))

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/compute/ItLogicalTopologyTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/compute/ItLogicalTopologyTest.java
@@ -162,7 +162,7 @@ class ItLogicalTopologyTest extends ClusterPerTestIntegrationTest {
         assertThat(event, is(notNullValue()));
         assertThat(event.eventType, is(EventType.VALIDATED));
         assertThat(event.node.name(), is(secondIgnite.name()));
-        assertThat(event.node.nodeAttributes(), is(NODE_ATTRIBUTES_MAP));
+        assertThat(event.node.attributes(), is(NODE_ATTRIBUTES_MAP));
 
         event = events.poll(10, TimeUnit.SECONDS);
 
@@ -170,7 +170,7 @@ class ItLogicalTopologyTest extends ClusterPerTestIntegrationTest {
         assertThat(event.eventType, is(EventType.JOINED));
         assertThat(event.node.name(), is(secondIgnite.name()));
         assertThat(event.topologyVersion, is(2L));
-        assertThat(event.node.nodeAttributes(), is(NODE_ATTRIBUTES_MAP));
+        assertThat(event.node.attributes(), is(NODE_ATTRIBUTES_MAP));
 
         assertThat(events, is(empty()));
 
@@ -183,7 +183,7 @@ class ItLogicalTopologyTest extends ClusterPerTestIntegrationTest {
         assertThat(event.eventType, is(EventType.LEFT));
         assertThat(event.node.name(), is(secondIgnite.name()));
         assertThat(event.topologyVersion, is(3L));
-        assertThat(event.node.nodeAttributes(), is(Collections.emptyMap()));
+        assertThat(event.node.attributes(), is(Collections.emptyMap()));
 
         assertThat(events, is(empty()));
     }
@@ -206,7 +206,7 @@ class ItLogicalTopologyTest extends ClusterPerTestIntegrationTest {
 
         assertTrue(secondNode.isPresent());
 
-        assertThat(secondNode.get().nodeAttributes(), is(NODE_ATTRIBUTES_MAP));
+        assertThat(secondNode.get().attributes(), is(NODE_ATTRIBUTES_MAP));
     }
 
     @Test

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/configuration/ItDistributedConfigurationPropertiesTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/configuration/ItDistributedConfigurationPropertiesTest.java
@@ -38,6 +38,7 @@ import org.apache.ignite.configuration.annotation.ConfigurationRoot;
 import org.apache.ignite.configuration.annotation.ConfigurationType;
 import org.apache.ignite.configuration.annotation.Value;
 import org.apache.ignite.internal.cluster.management.ClusterManagementGroupManager;
+import org.apache.ignite.internal.cluster.management.NodeAttributesCollector;
 import org.apache.ignite.internal.cluster.management.configuration.ClusterManagementConfiguration;
 import org.apache.ignite.internal.cluster.management.configuration.NodeAttributesConfiguration;
 import org.apache.ignite.internal.cluster.management.raft.TestClusterStateStorage;
@@ -158,7 +159,7 @@ public class ItDistributedConfigurationPropertiesTest extends BaseIgniteAbstract
                     clusterStateStorage,
                     logicalTopology,
                     clusterManagementConfiguration,
-                    nodeAttributes,
+                    new NodeAttributesCollector(nodeAttributes),
                     new TestConfigurationValidator());
 
             var logicalTopologyService = new LogicalTopologyServiceImpl(logicalTopology, cmgManager);

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/configuration/storage/ItDistributedConfigurationStorageTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/configuration/storage/ItDistributedConfigurationStorageTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.apache.ignite.internal.cluster.management.ClusterManagementGroupManager;
+import org.apache.ignite.internal.cluster.management.NodeAttributesCollector;
 import org.apache.ignite.internal.cluster.management.configuration.ClusterManagementConfiguration;
 import org.apache.ignite.internal.cluster.management.configuration.NodeAttributesConfiguration;
 import org.apache.ignite.internal.cluster.management.raft.TestClusterStateStorage;
@@ -132,7 +133,7 @@ public class ItDistributedConfigurationStorageTest extends BaseIgniteAbstractTes
                     clusterStateStorage,
                     logicalTopology,
                     clusterManagementConfiguration,
-                    nodeAttributes,
+                    new NodeAttributesCollector(nodeAttributes),
                     new TestConfigurationValidator());
 
             var logicalTopologyService = new LogicalTopologyServiceImpl(logicalTopology, cmgManager);

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/distribution/zones/ItIgniteDistributionZoneManagerNodeRestartTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/distribution/zones/ItIgniteDistributionZoneManagerNodeRestartTest.java
@@ -329,7 +329,7 @@ public class ItIgniteDistributionZoneManagerNodeRestartTest extends BaseIgniteRe
         node.logicalTopology().putNode(C);
 
         Set<NodeWithAttributes> logicalTopology = Stream.of(A, B, C)
-                .map(n -> new NodeWithAttributes(n.name(), n.id(), n.nodeAttributes()))
+                .map(n -> new NodeWithAttributes(n.name(), n.id(), n.attributes()))
                 .collect(toSet());
 
         DistributionZoneManager distributionZoneManager = getDistributionZoneManager(node);

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/rebalance/ItRebalanceDistributedTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/rebalance/ItRebalanceDistributedTest.java
@@ -91,6 +91,7 @@ import org.apache.ignite.internal.catalog.descriptors.CatalogTableDescriptor;
 import org.apache.ignite.internal.catalog.descriptors.CatalogZoneDescriptor;
 import org.apache.ignite.internal.catalog.storage.UpdateLogImpl;
 import org.apache.ignite.internal.cluster.management.ClusterManagementGroupManager;
+import org.apache.ignite.internal.cluster.management.NodeAttributesCollector;
 import org.apache.ignite.internal.cluster.management.configuration.ClusterManagementConfiguration;
 import org.apache.ignite.internal.cluster.management.configuration.NodeAttributesConfiguration;
 import org.apache.ignite.internal.cluster.management.raft.TestClusterStateStorage;
@@ -814,7 +815,7 @@ public class ItRebalanceDistributedTest extends BaseIgniteAbstractTest {
                     clusterStateStorage,
                     logicalTopology,
                     clusterManagementConfiguration,
-                    nodeAttributes,
+                    new NodeAttributesCollector(nodeAttributes),
                     new TestConfigurationValidator());
 
             replicaManager = spy(new ReplicaManager(

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItIgniteNodeRestartTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItIgniteNodeRestartTest.java
@@ -62,6 +62,7 @@ import org.apache.ignite.internal.catalog.CatalogManagerImpl;
 import org.apache.ignite.internal.catalog.ClockWaiter;
 import org.apache.ignite.internal.catalog.storage.UpdateLogImpl;
 import org.apache.ignite.internal.cluster.management.ClusterManagementGroupManager;
+import org.apache.ignite.internal.cluster.management.NodeAttributesCollector;
 import org.apache.ignite.internal.cluster.management.configuration.ClusterManagementConfiguration;
 import org.apache.ignite.internal.cluster.management.configuration.NodeAttributesConfiguration;
 import org.apache.ignite.internal.cluster.management.raft.RocksDbClusterStateStorage;
@@ -257,7 +258,7 @@ public class ItIgniteNodeRestartTest extends BaseIgniteRestartTest {
                 clusterStateStorage,
                 logicalTopology,
                 clusterManagementConfiguration,
-                nodeAttributes,
+                new NodeAttributesCollector(nodeAttributes),
                 new TestConfigurationValidator());
 
         ReplicaManager replicaMgr = new ReplicaManager(

--- a/modules/system-view/build.gradle
+++ b/modules/system-view/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     testImplementation(testFixtures(project(':ignite-core')))
     testImplementation(testFixtures(project(':ignite-metastorage')))
     testImplementation(testFixtures(project(':ignite-vault')))
+    testImplementation(testFixtures(project(':ignite-schema')))
+    testImplementation project(':ignite-sql-engine')
     testImplementation libs.mockito.junit
     testImplementation libs.mockito.core
     testImplementation libs.hamcrest.core

--- a/modules/system-view/build.gradle
+++ b/modules/system-view/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     implementation project(':ignite-configuration')
     implementation project(':ignite-metastorage-api')
     implementation project(':ignite-vault')
+    implementation project(':ignite-catalog')
+    implementation project(':ignite-schema')
+    implementation project(':ignite-cluster-management')
 
     implementation libs.jetbrains.annotations
     implementation libs.auto.service.annotations

--- a/modules/system-view/src/main/java/org/apache/ignite/internal/systemview/ClusterSystemView.java
+++ b/modules/system-view/src/main/java/org/apache/ignite/internal/systemview/ClusterSystemView.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.systemview;
 
 import java.util.List;
 import java.util.function.Supplier;
+import org.apache.ignite.internal.catalog.descriptors.CatalogSystemViewDescriptor.SystemViewType;
 import org.apache.ignite.internal.tostring.S;
 import org.apache.ignite.internal.util.AsyncCursor;
 
@@ -53,6 +54,12 @@ public class ClusterSystemView<T> extends SystemView<T> {
             Supplier<AsyncCursor<T>> dataProvider) {
 
         super(name, columns, dataProvider);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public SystemViewType type() {
+        return SystemViewType.GLOBAL;
     }
 
     /** {@inheritDoc} */

--- a/modules/system-view/src/main/java/org/apache/ignite/internal/systemview/NodeSystemView.java
+++ b/modules/system-view/src/main/java/org/apache/ignite/internal/systemview/NodeSystemView.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.systemview;
 
 import java.util.List;
 import java.util.function.Supplier;
+import org.apache.ignite.internal.catalog.descriptors.CatalogSystemViewDescriptor.SystemViewType;
 import org.apache.ignite.internal.tostring.S;
 import org.apache.ignite.internal.util.AsyncCursor;
 import org.apache.ignite.internal.util.StringUtils;
@@ -72,6 +73,12 @@ public class NodeSystemView<T> extends SystemView<T> {
      */
     public String nodeNameColumnAlias() {
         return nodeNameColumnAlias;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public SystemViewType type() {
+        return SystemViewType.LOCAL;
     }
 
     /** {@inheritDoc} */

--- a/modules/system-view/src/main/java/org/apache/ignite/internal/systemview/SystemView.java
+++ b/modules/system-view/src/main/java/org/apache/ignite/internal/systemview/SystemView.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import org.apache.ignite.internal.catalog.descriptors.CatalogSystemViewDescriptor.SystemViewType;
 import org.apache.ignite.internal.util.AsyncCursor;
 import org.apache.ignite.internal.util.StringUtils;
 
@@ -123,6 +124,11 @@ public abstract class SystemView<T> {
     public Supplier<AsyncCursor<T>> dataProvider() {
         return dataProvider;
     }
+
+    /**
+     * Returns the {@link SystemViewType type} of the system view.
+     */
+    public abstract SystemViewType type();
 
     /**
      * System view builder.

--- a/modules/system-view/src/main/java/org/apache/ignite/internal/systemview/SystemViewManager.java
+++ b/modules/system-view/src/main/java/org/apache/ignite/internal/systemview/SystemViewManager.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.systemview;
+
+import org.apache.ignite.internal.manager.IgniteComponent;
+
+/**
+ * The system view manager is responsible for registering system views in the cluster.
+ */
+public interface SystemViewManager extends IgniteComponent {
+    /**
+     * Registers a system view.
+     *
+     * <p>Registration of views is completed when the system view manager starts. Therefore,
+     * it is necessary for other components to register the views before the manager is started.
+     *
+     * @param view System view to register.
+     */
+    void register(SystemView<?> view);
+}

--- a/modules/system-view/src/main/java/org/apache/ignite/internal/systemview/SystemViewManagerImpl.java
+++ b/modules/system-view/src/main/java/org/apache/ignite/internal/systemview/SystemViewManagerImpl.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.systemview;
+
+import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
+import static org.apache.ignite.internal.util.IgniteUtils.inBusyLock;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.ignite.internal.catalog.CatalogCommand;
+import org.apache.ignite.internal.catalog.CatalogManager;
+import org.apache.ignite.internal.catalog.commands.ColumnParams;
+import org.apache.ignite.internal.catalog.commands.CreateSystemViewCommand;
+import org.apache.ignite.internal.catalog.descriptors.CatalogSystemViewDescriptor.SystemViewType;
+import org.apache.ignite.internal.cluster.management.NodeAttributesProvider;
+import org.apache.ignite.internal.lang.NodeStoppingException;
+import org.apache.ignite.internal.logger.IgniteLogger;
+import org.apache.ignite.internal.logger.Loggers;
+import org.apache.ignite.internal.schema.NativeTypeSpec;
+import org.apache.ignite.internal.util.IgniteSpinBusyLock;
+import org.apache.ignite.sql.ColumnType;
+
+/**
+ * SQL system views manager implementation.
+ */
+public class SystemViewManagerImpl implements SystemViewManager, NodeAttributesProvider {
+    /** The logger. */
+    private static final IgniteLogger LOG = Loggers.forClass(SystemViewManagerImpl.class);
+
+    public static final String NODE_ATTRIBUTES_KEY = "sql-system-views";
+
+    public static final String NODE_ATTRIBUTES_LIST_SEPARATOR = ",";
+
+    private final CatalogManager catalogManager;
+
+    private final Map<String, String> nodeAttributes = new HashMap<>();
+
+    /** Collection of system views provided by components. */
+    private final Map<String, SystemView<?>> views = new LinkedHashMap<>();
+
+    /** Busy lock to stop synchronously. */
+    private final IgniteSpinBusyLock busyLock = new IgniteSpinBusyLock();
+
+    /** Prevents attempts to register a new system view after the component has started. */
+    private final AtomicBoolean startGuard = new AtomicBoolean();
+
+    /** Prevents double stopping of the component. */
+    private final AtomicBoolean stopGuard = new AtomicBoolean();
+
+    /** Future which is completed when system views are registered in the catalog. */
+    private final CompletableFuture<Void> viewsRegistrationFuture = new CompletableFuture<>();
+
+    /** Creates a system view manager. */
+    public SystemViewManagerImpl(CatalogManager catalogManager) {
+        this.catalogManager = catalogManager;
+    }
+
+    @Override
+    public void start() {
+        inBusyLock(busyLock, () -> {
+            if (!startGuard.compareAndSet(false, true)) {
+                throw new IllegalStateException("System view manager cannot be started twice");
+            }
+
+            if (views.isEmpty()) {
+                viewsRegistrationFuture.complete(null);
+
+                return;
+            }
+
+            catalogManager.execute(prepareCatalogCommands(views.values())).whenComplete(
+                    (r, t) -> {
+                        viewsRegistrationFuture.complete(null);
+
+                        if (t != null) {
+                            LOG.warn("Failed to register system views.", t);
+                        }
+                    }
+            );
+
+            nodeAttributes.put(NODE_ATTRIBUTES_KEY, String.join(NODE_ATTRIBUTES_LIST_SEPARATOR, views.keySet()));
+        });
+    }
+
+    @Override
+    public void stop() throws Exception {
+        if (!stopGuard.compareAndSet(false, true)) {
+            return;
+        }
+
+        viewsRegistrationFuture.completeExceptionally(new NodeStoppingException());
+
+        busyLock.block();
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void register(SystemView<?> view) {
+        if (views.containsKey(view.name())) {
+            throw new IllegalArgumentException(format("The view with name '{}' already registered", view.name()));
+        }
+
+        inBusyLock(busyLock, () -> {
+            if (startGuard.get()) {
+                throw new IllegalStateException(format("Unable to register view '{}', manager already started", view.name()));
+            }
+
+            views.put(view.name(), view);
+        });
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Map<String, String> nodeAttributes() {
+        return nodeAttributes;
+    }
+
+    /**
+     * Returns future which is completed when system views are registered in the catalog.
+     */
+    public CompletableFuture<Void> completeRegistration() {
+        return viewsRegistrationFuture;
+    }
+
+    private List<CatalogCommand> prepareCatalogCommands(Collection<SystemView<?>> views) {
+        List<CatalogCommand> catalogCommands = new ArrayList<>(views.size());
+
+        for (SystemView<?> view : views) {
+            catalogCommands.add(prepareCatalogCommand(view));
+        }
+
+        return catalogCommands;
+    }
+
+    private CatalogCommand prepareCatalogCommand(SystemView<?> view) {
+        List<ColumnParams> columnParams = new ArrayList<>(view.columns().size());
+
+        if (view.type() == SystemViewType.LOCAL) {
+            columnParams.add(
+                    ColumnParams.builder()
+                            .name(((NodeSystemView<?>) view).nodeNameColumnAlias())
+                            .type(ColumnType.STRING)
+                            .build()
+            );
+        }
+
+        for (SystemViewColumn<?, ?> col : view.columns()) {
+            columnParams.add(prepareColumnParams(col));
+        }
+
+        return CreateSystemViewCommand.builder()
+                .name(view.name())
+                .columns(columnParams)
+                .type(view.type())
+                .build();
+    }
+
+    private ColumnParams prepareColumnParams(SystemViewColumn<?, ?> column) {
+        NativeTypeSpec typeSpec = NativeTypeSpec.fromClass(column.type());
+
+        assert typeSpec != null : column.type();
+
+        return ColumnParams.builder()
+                .name(column.name())
+                .type(typeSpec.asColumnType())
+                .build();
+    }
+}

--- a/modules/system-view/src/main/java/org/apache/ignite/internal/systemview/utils/SystemViewUtils.java
+++ b/modules/system-view/src/main/java/org/apache/ignite/internal/systemview/utils/SystemViewUtils.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.systemview.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.ignite.internal.catalog.commands.CatalogUtils;
+import org.apache.ignite.internal.catalog.commands.ColumnParams;
+import org.apache.ignite.internal.catalog.commands.ColumnParams.Builder;
+import org.apache.ignite.internal.catalog.commands.CreateSystemViewCommand;
+import org.apache.ignite.internal.catalog.descriptors.CatalogSystemViewDescriptor.SystemViewType;
+import org.apache.ignite.internal.schema.NativeTypeSpec;
+import org.apache.ignite.internal.systemview.NodeSystemView;
+import org.apache.ignite.internal.systemview.SystemView;
+import org.apache.ignite.internal.systemview.SystemViewColumn;
+import org.apache.ignite.sql.ColumnType;
+
+/**
+ * System views utils.
+ */
+public class SystemViewUtils {
+    /** Default decimal precision. */
+    // TODO Remove after https://issues.apache.org/jira/browse/IGNITE-20513
+    private static final int DEFAULT_DECIMAL_PRECISION = 19;
+
+    /**
+     * Converts {@link SystemViewColumn} to a {@link CreateSystemViewCommand catalog command} to create a system view.
+     */
+    public static CreateSystemViewCommand toSystemViewCreateCommand(SystemView<?> view) {
+        List<ColumnParams> columnParams = new ArrayList<>(view.columns().size());
+
+        if (view.type() == SystemViewType.LOCAL) {
+            columnParams.add(
+                    ColumnParams.builder()
+                            .name(((NodeSystemView<?>) view).nodeNameColumnAlias())
+                            .type(ColumnType.STRING)
+                            .length(CatalogUtils.DEFAULT_VARLEN_LENGTH)
+                            .build()
+            );
+        }
+
+        for (SystemViewColumn<?, ?> col : view.columns()) {
+            columnParams.add(systemViewColumnToColumnParams(col));
+        }
+
+        return CreateSystemViewCommand.builder()
+                .name(view.name())
+                .columns(columnParams)
+                .type(view.type())
+                .build();
+    }
+
+    private static ColumnParams systemViewColumnToColumnParams(SystemViewColumn<?, ?> column) {
+        NativeTypeSpec typeSpec = NativeTypeSpec.fromClass(column.type());
+
+        Builder builder = ColumnParams.builder()
+                .name(column.name())
+                .type(typeSpec.asColumnType());
+
+        // TODO Don't use defaults after https://issues.apache.org/jira/browse/IGNITE-20513
+        switch (typeSpec) {
+            case INT8:
+            case INT16:
+            case INT32:
+            case INT64:
+            case FLOAT:
+            case DOUBLE:
+            case DATE:
+            case UUID:
+            case BOOLEAN:
+                break;
+            case NUMBER:
+                builder.precision(DEFAULT_DECIMAL_PRECISION);
+                break;
+            case DECIMAL:
+                builder.precision(DEFAULT_DECIMAL_PRECISION);
+                builder.scale(CatalogUtils.DEFAULT_SCALE);
+                break;
+            case STRING:
+            case BYTES:
+            case BITMASK:
+                builder.length(CatalogUtils.DEFAULT_VARLEN_LENGTH);
+                break;
+            case TIME:
+                builder.precision(CatalogUtils.DEFAULT_TIME_PRECISION);
+                break;
+            case DATETIME:
+            case TIMESTAMP:
+                builder.precision(CatalogUtils.DEFAULT_TIMESTAMP_PRECISION);
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported native type: " + typeSpec);
+        }
+
+        return builder.build();
+    }
+}

--- a/modules/system-view/src/test/java/org/apache/ignite/internal/systemview/SystemViewManagerTest.java
+++ b/modules/system-view/src/test/java/org/apache/ignite/internal/systemview/SystemViewManagerTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.systemview;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+import static org.apache.ignite.internal.systemview.SystemViewManagerImpl.NODE_ATTRIBUTES_KEY;
+import static org.apache.ignite.internal.systemview.SystemViewManagerImpl.NODE_ATTRIBUTES_LIST_SEPARATOR;
+import static org.apache.ignite.internal.testframework.IgniteTestUtils.assertThrowsWithCause;
+import static org.apache.ignite.internal.testframework.matchers.CompletableFutureExceptionMatcher.willThrowFast;
+import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willBe;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.apache.ignite.internal.catalog.CatalogManager;
+import org.apache.ignite.internal.catalog.CatalogValidationException;
+import org.apache.ignite.internal.lang.NodeStoppingException;
+import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
+import org.apache.ignite.internal.util.AsyncCursor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Test class for {@link SystemViewManagerImpl}.
+ */
+@ExtendWith(MockitoExtension.class)
+public class SystemViewManagerTest extends BaseIgniteAbstractTest {
+    @Mock
+    private CatalogManager catalog;
+
+    @InjectMocks
+    private SystemViewManagerImpl viewMgr;
+
+    @Test
+    public void registerDuplicateNameFails() {
+        String name = "testView1";
+
+        ClusterSystemView<Object> view = dummyView(name);
+        ClusterSystemView<Object> viewWithSameName = dummyView(name);
+
+        viewMgr.register(view);
+
+        assertThrows(IllegalArgumentException.class, () -> viewMgr.register(viewWithSameName));
+        verifyNoInteractions(catalog);
+    }
+
+    @Test
+    public void registerAfterStartFails() {
+        viewMgr.start();
+
+        assertThrows(IllegalStateException.class, () -> viewMgr.register(dummyView("test")));
+        verifyNoInteractions(catalog);
+    }
+
+    @Test
+    public void startAfterStartFails() {
+        Mockito.when(catalog.execute(anyList())).thenReturn(completedFuture(null));
+
+        viewMgr.register(dummyView("test"));
+
+        viewMgr.start();
+
+        verify(catalog, only()).execute(anyList());
+
+        assertThrows(IllegalStateException.class, viewMgr::start);
+
+        verifyNoMoreInteractions(catalog);
+    }
+
+    @Test
+    public void registrationCompletesWithoutViews() {
+        viewMgr.start();
+
+        verifyNoMoreInteractions(catalog);
+
+        assertTrue(viewMgr.completeRegistration().isDone());
+    }
+
+    @Test
+    public void managerStartsSuccessfullyEvenIfCatalogRespondsWithError() {
+        CatalogValidationException expected = new CatalogValidationException("Expected exception.");
+
+        Mockito.when(catalog.execute(anyList())).thenReturn(failedFuture(expected));
+
+        viewMgr.register(dummyView("test"));
+
+        viewMgr.start();
+
+        verify(catalog, only()).execute(anyList());
+
+        assertThat(viewMgr.completeRegistration(), willBe(nullValue()));
+    }
+
+    @Test
+    public void nodeAttributesUpdatedAfterStart() {
+        Mockito.when(catalog.execute(anyList())).thenReturn(completedFuture(null));
+
+        String name1 = "view1";
+        String name2 = "view2";
+
+        viewMgr.register(dummyView(name1));
+        viewMgr.register(dummyView(name2));
+
+        assertThat(viewMgr.nodeAttributes(), aMapWithSize(0));
+
+        viewMgr.start();
+
+        verify(catalog, only()).execute(anyList());
+        verifyNoMoreInteractions(catalog);
+
+        assertThat(viewMgr.nodeAttributes(), is(Map.of(NODE_ATTRIBUTES_KEY, String.join(NODE_ATTRIBUTES_LIST_SEPARATOR, name1, name2))));
+    }
+
+    @Test
+    public void registrationFutureCompletesWhenComponentStops() throws Exception {
+        viewMgr.stop();
+
+        assertThat(viewMgr.completeRegistration(), willThrowFast(NodeStoppingException.class));
+    }
+
+    @Test
+    public void startAfterStopFails() throws Exception {
+        viewMgr.stop();
+
+        //noinspection ThrowableNotThrown
+        assertThrowsWithCause(viewMgr::start, NodeStoppingException.class);
+    }
+
+    @Test
+    public void registerAfterStopFails() throws Exception {
+        viewMgr.stop();
+
+        //noinspection ThrowableNotThrown
+        assertThrowsWithCause(() -> viewMgr.register(dummyView("test")), NodeStoppingException.class);
+    }
+
+    @Test
+    public void stopAfterStopDoesNothing() throws Exception {
+        viewMgr.stop();
+        viewMgr.stop();
+    }
+
+    private static ClusterSystemView<Object> dummyView(String name) {
+        return SystemViews.clusterViewBuilder().name(name)
+                .addColumn("c1", int.class, (d) -> 1)
+                .dataProvider(() -> new AsyncCursor<>() {
+                    @Override
+                    public CompletableFuture<BatchedResult<Object>> requestNextAsync(int rows) {
+                        return completedFuture(null);
+                    }
+
+                    @Override
+                    public CompletableFuture<Void> closeAsync() {
+                        return completedFuture(null);
+                    }
+                })
+                .build();
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-20019

System views are registered when the views manager starts.

In order to understand at the planning phase on which node which system views are available, a list of system views is added to the attributes of the logical node.

To collect attributes from system components before a node joins the cluster, the `NodeAttributesCollector` class was introduced, which gets attributes from component and writes them to a `ClusterNodeMessage` when a node is joined.

Public node attributes (from configuration) may be used for filtering when creating distribution zones (see [zones-filter](https://github.com/apache/ignite-3/blob/main/modules/distribution-zones/tech-notes/filters.md#zones-filter) ), in order to minimize the possible risks of mixing user attributes and internal system attributes, they are divided into two separate collections.