### PR TITLE
IGNITE-20399 .NET: Fix TestSchemaUpdateWhileStreaming flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -285,18 +285,12 @@ public class MetricsTests
         };
 
     private void AssertMetric(string name, int value, int timeoutMs = 1000) =>
-        TestUtils.WaitForCondition(
-            condition: () => _listener.GetMetric(name) == value,
-            timeoutMs: timeoutMs,
-            messageFactory: () => $"{name}: expected '{value}', but was '{_listener.GetMetric(name)}'");
+        _listener.AssertMetric(name, value, timeoutMs);
 
     private void AssertMetricGreaterOrEqual(string name, int value, int timeoutMs = 1000) =>
-        TestUtils.WaitForCondition(
-            condition: () => _listener.GetMetric(name) >= value,
-            timeoutMs: timeoutMs,
-            messageFactory: () => $"{name}: expected '>= {value}', but was '{_listener.GetMetric(name)}'");
+        _listener.AssertMetricGreaterOrEqual(name, value, timeoutMs);
 
-    private sealed class Listener : IDisposable
+    internal sealed class Listener : IDisposable
     {
         private readonly MeterListener _listener = new();
 
@@ -322,6 +316,18 @@ public class MetricsTests
             _listener.RecordObservableInstruments();
             return _metrics.TryGetValue(name, out var val) ? (int)val : 0;
         }
+
+        public void AssertMetric(string name, int value, int timeoutMs = 1000) =>
+            TestUtils.WaitForCondition(
+                condition: () => GetMetric(name) == value,
+                timeoutMs: timeoutMs,
+                messageFactory: () => $"{name}: expected '{value}', but was '{GetMetric(name)}'");
+
+        public void AssertMetricGreaterOrEqual(string name, int value, int timeoutMs = 1000) =>
+            TestUtils.WaitForCondition(
+                condition: () => GetMetric(name) >= value,
+                timeoutMs: timeoutMs,
+                messageFactory: () => $"{name}: expected '>= {value}', but was '{GetMetric(name)}'");
 
         public void Dispose()
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -337,7 +337,6 @@ public class SchemaSynchronizationTest : IgniteTestsBase
     }
 
     [Test]
-    [Ignore("https://issues.apache.org/jira/browse/IGNITE-20399")]
     public async Task TestSchemaUpdateWhileStreaming([Values(true, false)] bool insertNewColumn)
     {
         await Client.Sql.ExecuteAsync(null, $"CREATE TABLE {TestTableName} (KEY bigint PRIMARY KEY)");

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -366,9 +366,12 @@ public class SchemaSynchronizationTest : IgniteTestsBase
                 yield return GetTuple(i);
             }
 
+            // Wait for background streaming to complete.
+            // TODO: Remove this workaround when IGNITE-20416 is fixed.
+            metricListener.AssertMetric("streamer-items-sent", 6, 3000);
+
             // Update schema.
             // New schema has a new column with a default value, so it is not required to provide it in the streamed data.
-            metricListener.AssertMetric("streamer-items-sent", 6, 3000);
             await Client.Sql.ExecuteAsync(null, $"ALTER TABLE {TestTableName} ADD COLUMN VAL varchar DEFAULT 'FOO'");
             await WaitForNewSchemaOnAllNodes(TestTableName, 2);
 


### PR DESCRIPTION
To work around `IncompatibleSchemaException`, ensure that we don't perform schema updates while streamer upserts data in the background.