### PR TITLE
IGNITE-20240 C++ 3.0: Reject Tuples with unmapped fields

### DIFF
--- a/modules/platforms/cpp/ignite/client/detail/utils.cpp
+++ b/modules/platforms/cpp/ignite/client/detail/utils.cpp
@@ -237,7 +237,7 @@ std::vector<std::byte> pack_tuple(
         unmapped_columns_str.pop_back();
 
         assert(!unmapped_columns_str.empty());
-        throw ignite_error("Tuple contains columns that are not present in a table: " + unmapped_columns_str);
+        throw ignite_error("Tuple contains columns that are not present in the table: " + unmapped_columns_str);
     }
 
     return builder.build();

--- a/modules/platforms/cpp/ignite/client/detail/utils.cpp
+++ b/modules/platforms/cpp/ignite/client/detail/utils.cpp
@@ -237,7 +237,8 @@ std::vector<std::byte> pack_tuple(
         unmapped_columns_str.pop_back();
 
         assert(!unmapped_columns_str.empty());
-        throw ignite_error("Tuple contains columns that are not present in the table: " + unmapped_columns_str);
+        throw ignite_error("Key tuple doesn't match schema: schemaVersion="
+            + std::to_string(sch.version) + ", extraColumns=" + unmapped_columns_str);
     }
 
     return builder.build();

--- a/modules/platforms/cpp/ignite/client/detail/utils.cpp
+++ b/modules/platforms/cpp/ignite/client/detail/utils.cpp
@@ -227,7 +227,7 @@ std::vector<std::byte> pack_tuple(
         }
 
         std::stringstream unmapped_columns;
-        for (std::uint32_t i = 0; i < tuple.column_count(); ++i) {
+        for (std::int32_t i = 0; i < tuple.column_count(); ++i) {
             if (written_ind[i])
                 continue;
             auto &name = tuple.column_name(i);

--- a/modules/platforms/cpp/ignite/client/detail/utils.cpp
+++ b/modules/platforms/cpp/ignite/client/detail/utils.cpp
@@ -201,17 +201,43 @@ std::vector<std::byte> pack_tuple(
             builder.claim_null();
     }
 
+    std::int32_t written = 0;
     builder.layout();
     for (std::int32_t i = 0; i < count; ++i) {
         const auto &col = sch.columns[i];
         auto col_idx = tuple.column_ordinal(col.name);
 
-        if (col_idx >= 0)
+        if (col_idx >= 0) {
             append_column(builder, col.type, tuple.get(col_idx), col.scale);
-        else {
+            ++written;
+        } else {
             builder.append_null();
             no_value.set(std::size_t(i));
         }
+    }
+
+    if (!key_only && written < tuple.column_count()) {
+        std::vector<bool> written_ind(tuple.column_count(), false);
+        for (std::int32_t i = 0; i < count; ++i) {
+            const auto &col = sch.columns[i];
+            auto col_idx = tuple.column_ordinal(col.name);
+
+            if (col_idx >= 0)
+                written_ind[col_idx] = true;
+        }
+
+        std::stringstream unmapped_columns;
+        for (std::uint32_t i = 0; i < tuple.column_count(); ++i) {
+            if (written_ind[i])
+                continue;
+            auto &name = tuple.column_name(i);
+            unmapped_columns << name << ",";
+        }
+        auto unmapped_columns_str = unmapped_columns.str();
+        unmapped_columns_str.pop_back();
+
+        assert(!unmapped_columns_str.empty());
+        throw ignite_error("Tuple contains columns that are not present in a table: " + unmapped_columns_str);
     }
 
     return builder.build();
@@ -225,8 +251,10 @@ ignite_tuple concat(const ignite_tuple &left, const ignite_tuple &right) {
     res.m_indices.insert(left.m_indices.begin(), left.m_indices.end());
 
     for (const auto &pair : right.m_pairs) {
-        res.m_pairs.emplace_back(pair);
-        res.m_indices.emplace(ignite_tuple::parse_name(pair.first), res.m_pairs.size() - 1);
+        bool inserted = res.m_indices.emplace(ignite_tuple::parse_name(pair.first), res.m_pairs.size()).second;
+        if (inserted) {
+            res.m_pairs.emplace_back(pair);
+        }
     }
 
     return res;

--- a/modules/platforms/cpp/tests/client-test/key_value_binary_view_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/key_value_binary_view_test.cpp
@@ -150,7 +150,7 @@ TEST_F(key_value_binary_view_test, put_extra_collumn_value_throws) {
                 kv_view.put(nullptr, key_tuple, val_tuple);
             } catch (const ignite_error &e) {
                 EXPECT_THAT(e.what_str(), testing::MatchesRegex(
-                    "Key tuple doesn't match schema: schemaVersion=\\d+, extraColumns=extra"));
+                    "Key tuple doesn't match schema: schemaVersion=.+, extraColumns=extra"));
                 throw;
             }
         },

--- a/modules/platforms/cpp/tests/client-test/key_value_binary_view_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/key_value_binary_view_test.cpp
@@ -22,6 +22,7 @@
 #include "ignite/client/ignite_client_configuration.h"
 
 #include <gtest/gtest.h>
+#include <gmock/gmock-matchers.h>
 
 #include <chrono>
 
@@ -148,7 +149,8 @@ TEST_F(key_value_binary_view_test, put_extra_collumn_value_throws) {
             try {
                 kv_view.put(nullptr, key_tuple, val_tuple);
             } catch (const ignite_error &e) {
-                EXPECT_STREQ("Tuple contains columns that are not present in the table: extra", e.what());
+                EXPECT_THAT(e.what_str(), testing::MatchesRegex(
+                    "Key tuple doesn't match schema: schemaVersion=\\d+, extraColumns=extra"));
                 throw;
             }
         },

--- a/modules/platforms/cpp/tests/client-test/key_value_binary_view_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/key_value_binary_view_test.cpp
@@ -139,6 +139,22 @@ TEST_F(key_value_binary_view_test, put_empty_value_throws) {
         ignite_error);
 }
 
+TEST_F(key_value_binary_view_test, put_extra_collumn_value_throws) {
+    auto key_tuple = get_tuple(1);
+    auto val_tuple = get_tuple("foo");
+    val_tuple.set("extra", std::string("extra"));
+    EXPECT_THROW(
+        {
+            try {
+                kv_view.put(nullptr, key_tuple, val_tuple);
+            } catch (const ignite_error &e) {
+                EXPECT_STREQ("Tuple contains columns that are not present in the table: extra", e.what());
+                throw;
+            }
+        },
+        ignite_error);
+}
+
 TEST_F(key_value_binary_view_test, get_empty_tuple_throws) {
     EXPECT_THROW(
         {

--- a/modules/platforms/cpp/tests/client-test/record_binary_view_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/record_binary_view_test.cpp
@@ -22,6 +22,7 @@
 #include "ignite/client/ignite_client_configuration.h"
 
 #include <gtest/gtest.h>
+#include <gmock/gmock-matchers.h>
 
 #include <chrono>
 
@@ -134,7 +135,8 @@ TEST_F(record_binary_view_test, upsert_tuple_with_extra_columns_throws) {
             try {
                 tuple_view.upsert(nullptr, val_tuple);
             } catch (const ignite_error &e) {
-                EXPECT_STREQ("Tuple contains columns that are not present in the table: extra", e.what());
+                EXPECT_THAT(e.what_str(), testing::MatchesRegex(
+                    "Key tuple doesn't match schema: schemaVersion=\\d+, extraColumns=extra"));
                 throw;
             }
         },

--- a/modules/platforms/cpp/tests/client-test/record_binary_view_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/record_binary_view_test.cpp
@@ -136,7 +136,7 @@ TEST_F(record_binary_view_test, upsert_tuple_with_extra_columns_throws) {
                 tuple_view.upsert(nullptr, val_tuple);
             } catch (const ignite_error &e) {
                 EXPECT_THAT(e.what_str(), testing::MatchesRegex(
-                    "Key tuple doesn't match schema: schemaVersion=\\d+, extraColumns=extra"));
+                    "Key tuple doesn't match schema: schemaVersion=.+, extraColumns=extra"));
                 throw;
             }
         },

--- a/modules/platforms/cpp/tests/client-test/record_binary_view_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/record_binary_view_test.cpp
@@ -126,6 +126,21 @@ TEST_F(record_binary_view_test, upsert_empty_tuple_throws) {
         ignite_error);
 }
 
+TEST_F(record_binary_view_test, upsert_tuple_with_extra_columns_throws) {
+    auto val_tuple = get_tuple(1, "foo");
+    val_tuple.set("extra", std::string("some value"));
+    EXPECT_THROW(
+        {
+            try {
+                tuple_view.upsert(nullptr, val_tuple);
+            } catch (const ignite_error &e) {
+                EXPECT_STREQ("Tuple contains columns that are not present in the table: extra", e.what());
+                throw;
+            }
+        },
+        ignite_error);
+}
+
 TEST_F(record_binary_view_test, get_empty_tuple_throws) {
     EXPECT_THROW(
         {

--- a/modules/platforms/cpp/tests/client-test/record_binary_view_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/record_binary_view_test.cpp
@@ -781,7 +781,7 @@ TEST_F(record_binary_view_test, remove_exact_empty_throws) {
 }
 
 TEST_F(record_binary_view_test, get_and_remove_nonexisting) {
-    auto res = tuple_view.get_and_remove(nullptr, get_tuple(42, "foo"));
+    auto res = tuple_view.get_and_remove(nullptr, get_tuple(42));
     ASSERT_FALSE(res.has_value());
 
     auto res_tuple = tuple_view.get(nullptr, get_tuple(42));

--- a/modules/platforms/cpp/tests/client-test/record_view_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/record_view_test.cpp
@@ -267,8 +267,8 @@ TEST_F(record_view_test, extra_mapping_value_throws) {
             try {
                 wrong_view.upsert(nullptr, val);
             } catch (const ignite_error &e) {
-                EXPECT_THAT(e.what_str(), testing::HasSubstr(
-                      "Tuple contains columns that are not present in the table: extra"));
+                EXPECT_THAT(e.what_str(), testing::MatchesRegex(
+                    "Key tuple doesn't match schema: schemaVersion=\\d+, extraColumns=extra"));
                 throw;
             }
         },

--- a/modules/platforms/cpp/tests/client-test/record_view_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/record_view_test.cpp
@@ -50,16 +50,16 @@ struct test_type {
     std::string val;
 };
 
-struct wrong_mapping_key {
-    wrong_mapping_key() = default;
+struct missing_mapping_key {
+    missing_mapping_key() = default;
 
-    explicit wrong_mapping_key(std::int64_t key)
+    explicit missing_mapping_key(std::int64_t key)
         : key(key) {}
 
-    explicit wrong_mapping_key(std::string val)
+    explicit missing_mapping_key(std::string val)
         : val(std::move(val)) {}
 
-    explicit wrong_mapping_key(std::int64_t key, std::string val)
+    explicit missing_mapping_key(std::int64_t key, std::string val)
         : key(key)
         , val(std::move(val)) {}
 
@@ -67,16 +67,16 @@ struct wrong_mapping_key {
     std::string val;
 };
 
-struct wrong_mapping_value {
-    wrong_mapping_value() = default;
+struct missing_mapping_value {
+    missing_mapping_value() = default;
 
-    explicit wrong_mapping_value(std::int64_t key)
+    explicit missing_mapping_value(std::int64_t key)
         : key(key) {}
 
-    explicit wrong_mapping_value(std::string val)
+    explicit missing_mapping_value(std::string val)
         : val(std::move(val)) {}
 
-    explicit wrong_mapping_value(std::int64_t key, std::string val)
+    explicit missing_mapping_value(std::int64_t key, std::string val)
         : key(key)
         , val(std::move(val)) {}
 
@@ -109,45 +109,37 @@ test_type convert_from_tuple(ignite_tuple &&value) {
 }
 
 template<>
-ignite_tuple convert_to_tuple(wrong_mapping_key &&value) {
+ignite_tuple convert_to_tuple(missing_mapping_key &&value) {
     ignite_tuple tuple;
 
-    tuple.set("id", value.key);
     tuple.set("val", value.val);
 
     return tuple;
 }
 
 template<>
-wrong_mapping_key convert_from_tuple(ignite_tuple &&value) {
-    wrong_mapping_key res;
+missing_mapping_key convert_from_tuple(ignite_tuple &&value) {
+    missing_mapping_key res;
 
-    res.key = value.get<std::int64_t>("id");
-
-    if (value.column_count() > 1)
-        res.val = value.get<std::string>("val");
+    res.val = value.get<std::string>("val");
 
     return res;
 }
 
 template<>
-ignite_tuple convert_to_tuple(wrong_mapping_value &&value) {
+ignite_tuple convert_to_tuple(missing_mapping_value &&value) {
     ignite_tuple tuple;
 
     tuple.set("key", value.key);
-    tuple.set("str", value.val);
 
     return tuple;
 }
 
 template<>
-wrong_mapping_value convert_from_tuple(ignite_tuple &&value) {
-    wrong_mapping_value res;
+missing_mapping_value convert_from_tuple(ignite_tuple &&value) {
+    missing_mapping_value res;
 
     res.key = value.get<std::int64_t>("key");
-
-    if (value.column_count() > 1)
-        res.val = value.get<std::string>("str");
 
     return res;
 }
@@ -185,17 +177,17 @@ protected:
     record_view<test_type> view;
 };
 
-TEST_F(record_view_test, wrong_mapped_key_throws) {
+TEST_F(record_view_test, missing_mapping_key_throws) {
     {
         test_type val{1, "foo"};
         view.upsert(nullptr, val);
     }
 
     auto table = m_client.get_tables().get_table(TABLE_1);
-    auto wrong_view = table->get_record_view<wrong_mapping_key>();
+    auto wrong_view = table->get_record_view<missing_mapping_key>();
 
-    wrong_mapping_key key{1};
-    wrong_mapping_key val{1, "foo"};
+    missing_mapping_key key{1};
+    missing_mapping_key val{1, "foo"};
 
     EXPECT_THROW(
         {
@@ -220,31 +212,23 @@ TEST_F(record_view_test, wrong_mapped_key_throws) {
         ignite_error);
 }
 
-TEST_F(record_view_test, wrong_mapped_value_throws) {
+TEST_F(record_view_test, missing_mapped_value_dont_throw) {
     {
         test_type val{1, "foo"};
         view.upsert(nullptr, val);
     }
 
     auto table = m_client.get_tables().get_table(TABLE_1);
-    auto wrong_view = table->get_record_view<wrong_mapping_value>();
+    auto wrong_view = table->get_record_view<missing_mapping_value>();
 
-    wrong_mapping_value key{1};
-    wrong_mapping_value val{1, "foo"};
+    missing_mapping_value key{1};
+    missing_mapping_value val{1, "foo"};
 
     // Should work just fine. Having additional field and not providing value field is not an error.
     wrong_view.upsert(nullptr, val);
 
-    EXPECT_THROW(
-        {
-            try {
-                (void) wrong_view.get(nullptr, key);
-            } catch (const ignite_error &e) {
-                EXPECT_EQ(e.what_str(), "Can not find column with the name 'str' in the tuple");
-                throw;
-            }
-        },
-        ignite_error);
+    auto actual = wrong_view.get(nullptr, key);
+    EXPECT_TRUE(actual->val.empty());
 }
 
 TEST_F(record_view_test, upsert_get) {

--- a/modules/platforms/cpp/tests/client-test/record_view_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/record_view_test.cpp
@@ -268,7 +268,7 @@ TEST_F(record_view_test, extra_mapping_value_throws) {
                 wrong_view.upsert(nullptr, val);
             } catch (const ignite_error &e) {
                 EXPECT_THAT(e.what_str(), testing::MatchesRegex(
-                    "Key tuple doesn't match schema: schemaVersion=\\d+, extraColumns=extra"));
+                    "Key tuple doesn't match schema: schemaVersion=.+, extraColumns=extra"));
                 throw;
             }
         },


### PR DESCRIPTION
- Checked that number of written columns is no less than total number of columns in tuple. Reject tuple if there are any extra columns;
- Added tests.