### PR TITLE
IGNITE-20523 .NET: Restore generic IgniteArgumentCheck.NotNull

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClient.cs
@@ -17,9 +17,9 @@
 
 namespace Apache.Ignite
 {
-    using System;
     using System.Threading.Tasks;
     using Internal;
+    using Internal.Common;
 
     /// <summary>
     /// Ignite client builder.
@@ -33,7 +33,7 @@ namespace Apache.Ignite
         /// <returns>Started client.</returns>
         public static async Task<IIgniteClient> StartAsync(IgniteClientConfiguration configuration)
         {
-            ArgumentNullException.ThrowIfNull(configuration);
+            IgniteArgumentCheck.NotNull(configuration);
 
             var socket = await ClientFailoverSocket.ConnectAsync(configuration).ConfigureAwait(false);
 

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
@@ -21,6 +21,7 @@ namespace Apache.Ignite
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Linq;
+    using Internal.Common;
     using Log;
 
     /// <summary>
@@ -63,7 +64,7 @@ namespace Apache.Ignite
         public IgniteClientConfiguration(params string[] endpoints)
             : this()
         {
-            ArgumentNullException.ThrowIfNull(endpoints);
+            IgniteArgumentCheck.NotNull(endpoints);
 
             foreach (var endpoint in endpoints)
             {
@@ -77,7 +78,7 @@ namespace Apache.Ignite
         /// <param name="other">Other configuration.</param>
         public IgniteClientConfiguration(IgniteClientConfiguration other)
         {
-            ArgumentNullException.ThrowIfNull(other);
+            IgniteArgumentCheck.NotNull(other);
 
             Logger = other.Logger;
             SocketTimeout = other.SocketTimeout;

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteException.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteException.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Runtime.Serialization;
+    using Internal.Common;
 
     /// <summary>
     /// Ignite exception.
@@ -53,7 +54,7 @@ namespace Apache.Ignite
         protected IgniteException(SerializationInfo serializationInfo, StreamingContext streamingContext)
             : base(serializationInfo, streamingContext)
         {
-            ArgumentNullException.ThrowIfNull(serializationInfo);
+            IgniteArgumentCheck.NotNull(serializationInfo);
 
             TraceId = (Guid)serializationInfo.GetValue(nameof(TraceId), typeof(Guid))!;
             Code = serializationInfo.GetInt32(nameof(Code));

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteArgumentCheck.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteArgumentCheck.cs
@@ -30,6 +30,8 @@ namespace Apache.Ignite.Internal.Common
     {
         /// <summary>
         /// Throws an ArgumentNullException if specified arg is null.
+        /// <para />
+        /// Unlike <see cref="ArgumentNullException.ThrowIfNull"/>, this is a generic method and does not cause boxing allocations.
         /// </summary>
         /// <param name="arg">The argument.</param>
         /// <param name="argName">Name of the argument.</param>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteArgumentCheck.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteArgumentCheck.cs
@@ -36,7 +36,9 @@ namespace Apache.Ignite.Internal.Common
         /// <param name="arg">The argument.</param>
         /// <param name="argName">Name of the argument.</param>
         /// <typeparam name="T">Arg type.</typeparam>
-        public static void NotNull<T>([NoEnumeration] T arg, [CallerArgumentExpression("arg")] string? argName = null)
+        public static void NotNull<T>(
+            [NoEnumeration, System.Diagnostics.CodeAnalysis.NotNull] T arg,
+            [CallerArgumentExpression("arg")] string? argName = null)
         {
             if (arg == null)
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteArgumentCheck.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteArgumentCheck.cs
@@ -21,12 +21,32 @@ namespace Apache.Ignite.Internal.Common
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Runtime.CompilerServices;
+    using JetBrains.Annotations;
 
     /// <summary>
     /// Arguments check helpers.
     /// </summary>
     internal static class IgniteArgumentCheck
     {
+        /// <summary>
+        /// Throws an ArgumentNullException if specified arg is null.
+        /// </summary>
+        /// <param name="arg">The argument.</param>
+        /// <param name="argName">Name of the argument.</param>
+        /// <typeparam name="T">Arg type.</typeparam>
+        public static void NotNull<T>([NoEnumeration] T arg, [CallerArgumentExpression("arg")] string? argName = null)
+        {
+            if (arg == null)
+            {
+                Throw();
+            }
+
+            // Separate method to allow inlining of the parent method.
+            // Parent is called always to check arguments, so inlining it will improve perf.
+            [DoesNotReturn]
+            void Throw() => throw new ArgumentNullException(argName);
+        }
+
         /// <summary>
         /// Throws an ArgumentException if specified arg is null or empty string.
         /// </summary>
@@ -54,8 +74,11 @@ namespace Apache.Ignite.Internal.Common
         {
             if (!condition)
             {
-                throw new ArgumentException($"'{argName}' argument is invalid: {message}", argName);
+                Throw();
             }
+
+            [DoesNotReturn]
+            void Throw() => throw new ArgumentException($"'{argName}' argument is invalid: {message}", argName);
         }
 
         [DoesNotReturn]

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -67,7 +67,7 @@ internal record IgniteToStringBuilder
     /// <returns>This instance.</returns>
     public IgniteToStringBuilder Append(object? value, [CallerArgumentExpression("value")] string? name = null)
     {
-        ArgumentNullException.ThrowIfNull(name);
+        IgniteArgumentCheck.NotNull(name);
 
         CheckClosed();
         AppendComma();
@@ -88,7 +88,7 @@ internal record IgniteToStringBuilder
     /// <returns>This instance.</returns>
     public IgniteToStringBuilder AppendList<T>(IEnumerable<T> value, [CallerArgumentExpression("value")] string? name = null)
     {
-        ArgumentNullException.ThrowIfNull(name);
+        IgniteArgumentCheck.NotNull(name);
 
         CheckClosed();
         AppendComma();

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -66,8 +66,8 @@ namespace Apache.Ignite.Internal.Compute
             string jobClassName,
             params object?[]? args)
         {
-            ArgumentNullException.ThrowIfNull(nodes);
-            ArgumentNullException.ThrowIfNull(jobClassName);
+            IgniteArgumentCheck.NotNull(nodes);
+            IgniteArgumentCheck.NotNull(jobClassName);
 
             return await ExecuteOnOneNode<T>(GetRandomNode(nodes), units, jobClassName, args).ConfigureAwait(false);
         }
@@ -112,9 +112,9 @@ namespace Apache.Ignite.Internal.Compute
             string jobClassName,
             params object?[]? args)
         {
-            ArgumentNullException.ThrowIfNull(nodes);
-            ArgumentNullException.ThrowIfNull(jobClassName);
-            ArgumentNullException.ThrowIfNull(units);
+            IgniteArgumentCheck.NotNull(nodes);
+            IgniteArgumentCheck.NotNull(jobClassName);
+            IgniteArgumentCheck.NotNull(units);
 
             var res = new Dictionary<IClusterNode, Task<T>>();
             var units0 = units as ICollection<DeploymentUnit> ?? units.ToList(); // Avoid multiple enumeration.
@@ -188,7 +188,7 @@ namespace Apache.Ignite.Internal.Compute
             string jobClassName,
             object?[]? args)
         {
-            ArgumentNullException.ThrowIfNull(node);
+            IgniteArgumentCheck.NotNull(node);
 
             using var writer = ProtoCommon.GetMessageWriter();
             Write();
@@ -246,9 +246,9 @@ namespace Apache.Ignite.Internal.Compute
             params object?[]? args)
             where TKey : notnull
         {
-            ArgumentNullException.ThrowIfNull(tableName);
-            ArgumentNullException.ThrowIfNull(key);
-            ArgumentNullException.ThrowIfNull(jobClassName);
+            IgniteArgumentCheck.NotNull(tableName);
+            IgniteArgumentCheck.NotNull(key);
+            IgniteArgumentCheck.NotNull(jobClassName);
 
             var units0 = units as ICollection<DeploymentUnit> ?? units.ToList(); // Avoid multiple enumeration.
             int? schemaVersion = null;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSet.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSet.cs
@@ -132,8 +132,8 @@ namespace Apache.Ignite.Internal.Sql
             IEqualityComparer<TK>? comparer)
             where TK : notnull
         {
-            ArgumentNullException.ThrowIfNull(keySelector);
-            ArgumentNullException.ThrowIfNull(valSelector);
+            IgniteArgumentCheck.NotNull(keySelector);
+            IgniteArgumentCheck.NotNull(valSelector);
 
             return await CollectAsync(
                     constructor: capacity => new Dictionary<TK, TV>(capacity, comparer),
@@ -144,8 +144,8 @@ namespace Apache.Ignite.Internal.Sql
         /// <inheritdoc/>
         public async ValueTask<TResult> CollectAsync<TResult>(Func<int, TResult> constructor, Action<TResult, T> accumulator)
         {
-            ArgumentNullException.ThrowIfNull(constructor);
-            ArgumentNullException.ThrowIfNull(accumulator);
+            IgniteArgumentCheck.NotNull(constructor);
+            IgniteArgumentCheck.NotNull(accumulator);
 
             ValidateAndSetIteratorState();
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/Sql.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/Sql.cs
@@ -131,7 +131,7 @@ namespace Apache.Ignite.Internal.Sql
             RowReaderFactory<T> rowReaderFactory,
             ICollection<object?>? args)
         {
-            ArgumentNullException.ThrowIfNull(statement);
+            IgniteArgumentCheck.NotNull(statement);
 
             var tx = transaction.ToInternal();
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
@@ -71,7 +71,7 @@ internal static class DataStreamer
         DataStreamerOptions options,
         CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(data);
+        IgniteArgumentCheck.NotNull(data);
 
         IgniteArgumentCheck.Ensure(
             options.BatchSize > 0,

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
@@ -172,8 +172,8 @@ internal sealed class KeyValueView<TK, TV> : IKeyValueView<TK, TV>
 
     private static KvPair<TK, TV> ToKv(KeyValuePair<TK, TV> x)
     {
-        ArgumentNullException.ThrowIfNull(x);
-        ArgumentNullException.ThrowIfNull(x);
+        ArgumentNullException.ThrowIfNull(x.Key);
+        ArgumentNullException.ThrowIfNull(x.Value);
 
         return new(x.Key, x.Value);
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
@@ -172,8 +172,8 @@ internal sealed class KeyValueView<TK, TV> : IKeyValueView<TK, TV>
 
     private static KvPair<TK, TV> ToKv(KeyValuePair<TK, TV> x)
     {
-        ArgumentNullException.ThrowIfNull(x.Key);
-        ArgumentNullException.ThrowIfNull(x.Value);
+        IgniteArgumentCheck.NotNull(x.Key);
+        IgniteArgumentCheck.NotNull(x.Value);
 
         return new(x.Key, x.Value);
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
@@ -103,7 +103,7 @@ internal sealed class KeyValueView<TK, TV> : IKeyValueView<TK, TV>
     /// <inheritdoc/>
     public async Task<IList<TK>> RemoveAllAsync(ITransaction? transaction, IEnumerable<TK> keys)
     {
-        ArgumentNullException.ThrowIfNull(keys);
+        IgniteArgumentCheck.NotNull(keys);
 
         return await _recordView.DeleteAllAsync(
             transaction,
@@ -118,7 +118,7 @@ internal sealed class KeyValueView<TK, TV> : IKeyValueView<TK, TV>
     /// <inheritdoc/>
     public async Task<IList<TK>> RemoveAllAsync(ITransaction? transaction, IEnumerable<KeyValuePair<TK, TV>> pairs)
     {
-        ArgumentNullException.ThrowIfNull(pairs);
+        IgniteArgumentCheck.NotNull(pairs);
 
         return await _recordView.DeleteAllAsync(
             transaction,
@@ -180,15 +180,15 @@ internal sealed class KeyValueView<TK, TV> : IKeyValueView<TK, TV>
 
     private static KvPair<TK, TV> ToKv(TK key)
     {
-        ArgumentNullException.ThrowIfNull(key);
+        IgniteArgumentCheck.NotNull(key);
 
         return new(key);
     }
 
     private static KvPair<TK, TV> ToKv(TK key, TV val)
     {
-        ArgumentNullException.ThrowIfNull(key);
-        ArgumentNullException.ThrowIfNull(val);
+        IgniteArgumentCheck.NotNull(key);
+        IgniteArgumentCheck.NotNull(val);
 
         return new(key, val);
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -102,7 +102,7 @@ namespace Apache.Ignite.Internal.Table
         /// <inheritdoc/>
         public async Task<Option<T>> GetAsync(ITransaction? transaction, T key)
         {
-            ArgumentNullException.ThrowIfNull(key);
+            IgniteArgumentCheck.NotNull(key);
 
             using var resBuf = await DoRecordOutOpAsync(ClientOp.TupleGet, transaction, key, keyOnly: true).ConfigureAwait(false);
             var resSchema = await _table.ReadSchemaAsync(resBuf).ConfigureAwait(false);
@@ -113,7 +113,7 @@ namespace Apache.Ignite.Internal.Table
         /// <inheritdoc/>
         public async Task<bool> ContainsKeyAsync(ITransaction? transaction, T key)
         {
-            ArgumentNullException.ThrowIfNull(key);
+            IgniteArgumentCheck.NotNull(key);
 
             using var resBuf = await DoRecordOutOpAsync(ClientOp.TupleContainsKey, transaction, key, keyOnly: true).ConfigureAwait(false);
             return ReadSchemaAndBoolean(resBuf);
@@ -150,7 +150,7 @@ namespace Apache.Ignite.Internal.Table
             Func<int, TRes> resultFactory,
             Action<TRes, Option<T>> addAction)
         {
-            ArgumentNullException.ThrowIfNull(keys);
+            IgniteArgumentCheck.NotNull(keys);
 
             using var resBuf = await DoMultiRecordOutOpAsync(ClientOp.TupleGetAll, transaction, keys, true).ConfigureAwait(false);
             if (resBuf == null)
@@ -167,7 +167,7 @@ namespace Apache.Ignite.Internal.Table
         /// <inheritdoc/>
         public async Task UpsertAsync(ITransaction? transaction, T record)
         {
-            ArgumentNullException.ThrowIfNull(record);
+            IgniteArgumentCheck.NotNull(record);
 
             using var resBuf = await DoRecordOutOpAsync(ClientOp.TupleUpsert, transaction, record).ConfigureAwait(false);
         }
@@ -175,7 +175,7 @@ namespace Apache.Ignite.Internal.Table
         /// <inheritdoc/>
         public async Task UpsertAllAsync(ITransaction? transaction, IEnumerable<T> records)
         {
-            ArgumentNullException.ThrowIfNull(records);
+            IgniteArgumentCheck.NotNull(records);
 
             using var resBuf = await DoMultiRecordOutOpAsync(ClientOp.TupleUpsertAll, transaction, records).ConfigureAwait(false);
         }
@@ -183,7 +183,7 @@ namespace Apache.Ignite.Internal.Table
         /// <inheritdoc/>
         public async Task<Option<T>> GetAndUpsertAsync(ITransaction? transaction, T record)
         {
-            ArgumentNullException.ThrowIfNull(record);
+            IgniteArgumentCheck.NotNull(record);
 
             using var resBuf = await DoRecordOutOpAsync(ClientOp.TupleGetAndUpsert, transaction, record).ConfigureAwait(false);
             var resSchema = await _table.ReadSchemaAsync(resBuf).ConfigureAwait(false);
@@ -194,7 +194,7 @@ namespace Apache.Ignite.Internal.Table
         /// <inheritdoc/>
         public async Task<bool> InsertAsync(ITransaction? transaction, T record)
         {
-            ArgumentNullException.ThrowIfNull(record);
+            IgniteArgumentCheck.NotNull(record);
 
             using var resBuf = await DoRecordOutOpAsync(ClientOp.TupleInsert, transaction, record).ConfigureAwait(false);
             return ReadSchemaAndBoolean(resBuf);
@@ -203,7 +203,7 @@ namespace Apache.Ignite.Internal.Table
         /// <inheritdoc/>
         public async Task<IList<T>> InsertAllAsync(ITransaction? transaction, IEnumerable<T> records)
         {
-            ArgumentNullException.ThrowIfNull(records);
+            IgniteArgumentCheck.NotNull(records);
 
             using var resBuf = await DoMultiRecordOutOpAsync(ClientOp.TupleInsertAll, transaction, records).ConfigureAwait(false);
             if (resBuf == null)
@@ -227,7 +227,7 @@ namespace Apache.Ignite.Internal.Table
         /// <inheritdoc/>
         public async Task<bool> ReplaceAsync(ITransaction? transaction, T record)
         {
-            ArgumentNullException.ThrowIfNull(record);
+            IgniteArgumentCheck.NotNull(record);
 
             using var resBuf = await DoRecordOutOpAsync(ClientOp.TupleReplace, transaction, record).ConfigureAwait(false);
             return ReadSchemaAndBoolean(resBuf);
@@ -236,7 +236,7 @@ namespace Apache.Ignite.Internal.Table
         /// <inheritdoc/>
         public async Task<bool> ReplaceAsync(ITransaction? transaction, T record, T newRecord)
         {
-            ArgumentNullException.ThrowIfNull(record);
+            IgniteArgumentCheck.NotNull(record);
 
             using var resBuf = await DoTwoRecordOutOpAsync(ClientOp.TupleReplaceExact, transaction, record, newRecord)
                 .ConfigureAwait(false);
@@ -247,7 +247,7 @@ namespace Apache.Ignite.Internal.Table
         /// <inheritdoc/>
         public async Task<Option<T>> GetAndReplaceAsync(ITransaction? transaction, T record)
         {
-            ArgumentNullException.ThrowIfNull(record);
+            IgniteArgumentCheck.NotNull(record);
 
             using var resBuf = await DoRecordOutOpAsync(ClientOp.TupleGetAndReplace, transaction, record).ConfigureAwait(false);
             var resSchema = await _table.ReadSchemaAsync(resBuf).ConfigureAwait(false);
@@ -258,7 +258,7 @@ namespace Apache.Ignite.Internal.Table
         /// <inheritdoc/>
         public async Task<bool> DeleteAsync(ITransaction? transaction, T key)
         {
-            ArgumentNullException.ThrowIfNull(key);
+            IgniteArgumentCheck.NotNull(key);
 
             using var resBuf = await DoRecordOutOpAsync(ClientOp.TupleDelete, transaction, key, keyOnly: true).ConfigureAwait(false);
             return ReadSchemaAndBoolean(resBuf);
@@ -267,7 +267,7 @@ namespace Apache.Ignite.Internal.Table
         /// <inheritdoc/>
         public async Task<bool> DeleteExactAsync(ITransaction? transaction, T record)
         {
-            ArgumentNullException.ThrowIfNull(record);
+            IgniteArgumentCheck.NotNull(record);
 
             using var resBuf = await DoRecordOutOpAsync(ClientOp.TupleDeleteExact, transaction, record).ConfigureAwait(false);
             return ReadSchemaAndBoolean(resBuf);
@@ -276,7 +276,7 @@ namespace Apache.Ignite.Internal.Table
         /// <inheritdoc/>
         public async Task<Option<T>> GetAndDeleteAsync(ITransaction? transaction, T key)
         {
-            ArgumentNullException.ThrowIfNull(key);
+            IgniteArgumentCheck.NotNull(key);
 
             using var resBuf = await DoRecordOutOpAsync(ClientOp.TupleGetAndDelete, transaction, key, keyOnly: true).ConfigureAwait(false);
             var resSchema = await _table.ReadSchemaAsync(resBuf).ConfigureAwait(false);
@@ -361,7 +361,7 @@ namespace Apache.Ignite.Internal.Table
             Action<TRes, T> addAction,
             bool exact)
         {
-            ArgumentNullException.ThrowIfNull(records);
+            IgniteArgumentCheck.NotNull(records);
 
             var clientOp = exact ? ClientOp.TupleDeleteAllExact : ClientOp.TupleDeleteAll;
             using var resBuf = await DoMultiRecordOutOpAsync(clientOp, transaction, records, keyOnly: !exact).ConfigureAwait(false);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Tables.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Tables.cs
@@ -17,7 +17,6 @@
 
 namespace Apache.Ignite.Internal.Table
 {
-    using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Threading.Tasks;
@@ -101,7 +100,7 @@ namespace Apache.Ignite.Internal.Table
         /// <returns>Table.</returns>
         internal async Task<Table?> GetTableInternalAsync(string name)
         {
-            ArgumentNullException.ThrowIfNull(name);
+            IgniteArgumentCheck.NotNull(name);
 
             using var writer = ProtoCommon.GetMessageWriter();
             writer.MessageWriter.Write(name);

--- a/modules/platforms/dotnet/Apache.Ignite/Log/CategoryLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Log/CategoryLogger.cs
@@ -38,7 +38,7 @@ namespace Apache.Ignite.Log
         /// <param name="category">The category.</param>
         public CategoryLogger(IIgniteLogger logger, string category)
         {
-            ArgumentNullException.ThrowIfNull(logger);
+            IgniteArgumentCheck.NotNull(logger);
 
             // If logger is already a CategoryLogger, get underlying logger instead to avoid unnecessary nesting.
             _logger = logger is CategoryLogger catLogger ? catLogger._logger : logger;

--- a/modules/platforms/dotnet/Apache.Ignite/Log/LoggerExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Log/LoggerExtensions.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Log
 {
     using System;
     using System.Globalization;
+    using Internal.Common;
 
     /// <summary>
     /// Extension methods for <see cref="IIgniteLogger" />.
@@ -255,7 +256,7 @@ namespace Apache.Ignite.Log
         /// <param name="message">The message.</param>
         public static void Log(this IIgniteLogger logger, LogLevel level, string message)
         {
-            ArgumentNullException.ThrowIfNull(logger);
+            IgniteArgumentCheck.NotNull(logger);
 
             logger.Log(level, message, null, null, null, null, null);
         }
@@ -269,7 +270,7 @@ namespace Apache.Ignite.Log
         /// <param name="args">The arguments.</param>
         public static void Log(this IIgniteLogger logger, LogLevel level, string message, params object?[]? args)
         {
-            ArgumentNullException.ThrowIfNull(logger);
+            IgniteArgumentCheck.NotNull(logger);
 
             logger.Log(level, message, args, CultureInfo.InvariantCulture, null, null, null);
         }
@@ -283,7 +284,7 @@ namespace Apache.Ignite.Log
         /// <param name="message">The message.</param>
         public static void Log(this IIgniteLogger logger, LogLevel level, Exception? ex, string message)
         {
-            ArgumentNullException.ThrowIfNull(logger);
+            IgniteArgumentCheck.NotNull(logger);
 
             logger.Log(level, message, null, null, null, null, ex);
         }
@@ -298,7 +299,7 @@ namespace Apache.Ignite.Log
         /// <param name="args">The arguments.</param>
         public static void Log(this IIgniteLogger logger, LogLevel level, Exception? ex, string message, params object?[]? args)
         {
-            ArgumentNullException.ThrowIfNull(logger);
+            IgniteArgumentCheck.NotNull(logger);
 
             logger.Log(level, message, args, CultureInfo.InvariantCulture, null, null, ex);
         }
@@ -311,7 +312,7 @@ namespace Apache.Ignite.Log
         /// <returns>Logger that uses specified category when no other category is provided.</returns>
         public static IIgniteLogger? GetLogger(this IIgniteLogger? logger, string category)
         {
-            ArgumentNullException.ThrowIfNull(category);
+            IgniteArgumentCheck.NotNull(category);
 
             return logger == null ? null : new CategoryLogger(logger, category);
         }
@@ -324,7 +325,7 @@ namespace Apache.Ignite.Log
         /// <returns>Logger that uses specified category when no other category is provided.</returns>
         public static IIgniteLogger? GetLogger(this IIgniteLogger? logger, Type category)
         {
-            ArgumentNullException.ThrowIfNull(category);
+            IgniteArgumentCheck.NotNull(category);
 
             return logger == null ? null : new CategoryLogger(logger, category.Name);
         }

--- a/modules/platforms/dotnet/Apache.Ignite/RetryLimitPolicy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/RetryLimitPolicy.cs
@@ -17,7 +17,6 @@
 
 namespace Apache.Ignite
 {
-    using System;
     using Internal.Common;
 
     /// <summary>
@@ -39,7 +38,7 @@ namespace Apache.Ignite
         /// <inheritdoc />
         public virtual bool ShouldRetry(IRetryPolicyContext context)
         {
-            ArgumentNullException.ThrowIfNull(context);
+            IgniteArgumentCheck.NotNull(context);
 
             if (RetryLimit <= 0)
             {

--- a/modules/platforms/dotnet/Apache.Ignite/RetryReadPolicy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/RetryReadPolicy.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite
 {
     using System;
+    using Internal.Common;
 
     /// <summary>
     /// Retry policy that returns true for all read-only operations that do not modify data.
@@ -27,7 +28,7 @@ namespace Apache.Ignite
         /// <inheritdoc />
         public override bool ShouldRetry(IRetryPolicyContext context)
         {
-            ArgumentNullException.ThrowIfNull(context);
+            IgniteArgumentCheck.NotNull(context);
 
             if (!base.ShouldRetry(context))
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbDataReader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbDataReader.cs
@@ -272,7 +272,7 @@ public sealed class IgniteDbDataReader : DbDataReader, IDbColumnSchemaGenerator
     /// <inheritdoc/>
     public override int GetValues(object[] values)
     {
-        ArgumentNullException.ThrowIfNull(values);
+        IgniteArgumentCheck.NotNull(values);
 
         var cols = Metadata.Columns;
         var count = Math.Min(values.Length, cols.Count);

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteQueryableExtensions.Average.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteQueryableExtensions.Average.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
+using Internal.Common;
 using Table;
 
 /// <summary>
@@ -43,7 +44,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Average`1", typeof(Queryable))]
     public static async Task<double> AverageAsync(this IQueryable<int> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<int>, double>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -66,7 +67,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, int>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, int>>, double>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -85,7 +86,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Average`1", typeof(Queryable))]
     public static async Task<double?> AverageAsync(this IQueryable<int?> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<int?>, double?>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -108,7 +109,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, int?>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, int?>>, double?>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -127,7 +128,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Average`1", typeof(Queryable))]
     public static async Task<double> AverageAsync(this IQueryable<long> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<long>, double>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -150,7 +151,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, long>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, long>>, double>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -169,7 +170,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Average`1", typeof(Queryable))]
     public static async Task<double?> AverageAsync(this IQueryable<long?> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<long?>, double?>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -192,7 +193,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, long?>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, long?>>, double?>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -211,7 +212,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Average`1", typeof(Queryable))]
     public static async Task<double> AverageAsync(this IQueryable<double> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<double>, double>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -234,7 +235,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, double>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, double>>, double>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -253,7 +254,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Average`1", typeof(Queryable))]
     public static async Task<double?> AverageAsync(this IQueryable<double?> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<double?>, double?>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -276,7 +277,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, double?>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, double?>>, double?>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -295,7 +296,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Average`1", typeof(Queryable))]
     public static async Task<float> AverageAsync(this IQueryable<float> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<float>, float>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -318,7 +319,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, float>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, float>>, float>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -337,7 +338,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Average`1", typeof(Queryable))]
     public static async Task<float?> AverageAsync(this IQueryable<float?> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<float?>, float?>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -360,7 +361,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, float?>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, float?>>, float?>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -379,7 +380,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Average`1", typeof(Queryable))]
     public static async Task<decimal> AverageAsync(this IQueryable<decimal> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<decimal>, decimal>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -402,7 +403,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, decimal>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, decimal>>, decimal>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -421,7 +422,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Average`1", typeof(Queryable))]
     public static async Task<decimal?> AverageAsync(this IQueryable<decimal?> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<decimal?>, decimal?>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -444,7 +445,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, decimal?>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, decimal?>>, decimal?>(Queryable.Average).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteQueryableExtensions.Dml.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteQueryableExtensions.Dml.cs
@@ -21,6 +21,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using Internal.Common;
 using Internal.Linq.Dml;
 using Table;
 
@@ -43,7 +44,7 @@ public static partial class IgniteQueryableExtensions
     /// <returns>Affected row count.</returns>
     public static async Task<long> ExecuteDeleteAsync<T>(this IQueryable<T> query)
     {
-        ArgumentNullException.ThrowIfNull(query);
+        IgniteArgumentCheck.NotNull(query);
 
         var method = ExecuteDeleteExpressionNode.MethodInfo.MakeGenericMethod(typeof(T));
         var provider = query.ToQueryableInternal().Provider;
@@ -64,7 +65,7 @@ public static partial class IgniteQueryableExtensions
     /// <returns>Affected row count.</returns>
     public static async Task<long> ExecuteDeleteAsync<T>(this IQueryable<T> query, Expression<Func<T, bool>> predicate)
     {
-        ArgumentNullException.ThrowIfNull(query);
+        IgniteArgumentCheck.NotNull(query);
 
         var method = ExecuteDeleteExpressionNode.PredicateMethodInfo.MakeGenericMethod(typeof(T));
         var provider = query.ToQueryableInternal().Provider;
@@ -87,8 +88,8 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<T> query,
         Expression<Func<IUpdateDescriptor<T>, IUpdateDescriptor<T>>> updateDescriptor)
     {
-        ArgumentNullException.ThrowIfNull(query);
-        ArgumentNullException.ThrowIfNull(updateDescriptor);
+        IgniteArgumentCheck.NotNull(query);
+        IgniteArgumentCheck.NotNull(updateDescriptor);
 
         var method = ExecuteUpdateExpressionNode.MethodInfo.MakeGenericMethod(typeof(T));
         var provider = query.ToQueryableInternal().Provider;

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteQueryableExtensions.Sum.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteQueryableExtensions.Sum.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
+using Internal.Common;
 using Table;
 
 /// <summary>
@@ -43,7 +44,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Sum", typeof(Queryable))]
     public static async Task<int> SumAsync(this IQueryable<int> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<int>, int>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -66,7 +67,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, int>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, int>>, int>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -85,7 +86,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Sum", typeof(Queryable))]
     public static async Task<int?> SumAsync(this IQueryable<int?> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<int?>, int?>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -108,7 +109,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, int?>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, int?>>, int?>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -127,7 +128,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Sum", typeof(Queryable))]
     public static async Task<long> SumAsync(this IQueryable<long> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<long>, long>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -150,7 +151,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, long>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, long>>, long>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -169,7 +170,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Sum", typeof(Queryable))]
     public static async Task<long?> SumAsync(this IQueryable<long?> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<long?>, long?>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -192,7 +193,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, long?>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, long?>>, long?>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -211,7 +212,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Sum", typeof(Queryable))]
     public static async Task<float> SumAsync(this IQueryable<float> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<float>, float>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -234,7 +235,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, float>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, float>>, float>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -253,7 +254,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Sum", typeof(Queryable))]
     public static async Task<float?> SumAsync(this IQueryable<float?> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<float?>, float?>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -276,7 +277,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, float?>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, float?>>, float?>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -295,7 +296,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Sum", typeof(Queryable))]
     public static async Task<double> SumAsync(this IQueryable<double> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<double>, double>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -318,7 +319,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, double>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, double>>, double>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -337,7 +338,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Sum", typeof(Queryable))]
     public static async Task<double?> SumAsync(this IQueryable<double?> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<double?>, double?>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -360,7 +361,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, double?>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, double?>>, double?>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -379,7 +380,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Sum", typeof(Queryable))]
     public static async Task<decimal> SumAsync(this IQueryable<decimal> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<decimal>, decimal>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -402,7 +403,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, decimal>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, decimal>>, decimal>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -421,7 +422,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Sum", typeof(Queryable))]
     public static async Task<decimal?> SumAsync(this IQueryable<decimal?> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<decimal?>, decimal?>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -444,7 +445,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, decimal?>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, decimal?>>, decimal?>(Queryable.Sum).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteQueryableExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteQueryableExtensions.cs
@@ -24,6 +24,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
+using Internal.Common;
 using Internal.Linq;
 using Table;
 
@@ -44,7 +45,7 @@ public static partial class IgniteQueryableExtensions
     /// <returns>Result set.</returns>
     public static async Task<IResultSet<T>> ToResultSetAsync<T>(this IQueryable<T> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var queryableInternal = queryable.ToQueryableInternal();
         var model = queryableInternal.GetQueryModel();
@@ -62,7 +63,7 @@ public static partial class IgniteQueryableExtensions
     [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "False positive.")]
     public static async IAsyncEnumerable<T> AsAsyncEnumerable<T>(this IQueryable<T> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         await using var resultSet = await queryable.ToResultSetAsync().ConfigureAwait(false);
 
@@ -84,7 +85,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Any`1", typeof(Queryable))]
     public static async Task<bool> AnyAsync<TSource>(this IQueryable<TSource> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, bool>(Queryable.Any).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -107,7 +108,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Any`1", typeof(Queryable))]
     public static async Task<bool> AnyAsync<TSource>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, bool>>, bool>(Queryable.Any).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(predicate));
@@ -129,7 +130,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("All`1", typeof(Queryable))]
     public static async Task<bool> AllAsync<TSource>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, bool>>, bool>(Queryable.All).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(predicate));
@@ -148,7 +149,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Count`1", typeof(Queryable))]
     public static async Task<int> CountAsync<TSource>(this IQueryable<TSource> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, int>(Queryable.Count).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -168,7 +169,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Count`1", typeof(Queryable))]
     public static async Task<int> CountAsync<TSource>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, bool>>, int>(Queryable.Count).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(predicate));
@@ -187,7 +188,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("LongCount`1", typeof(Queryable))]
     public static async Task<long> LongCountAsync<TSource>(this IQueryable<TSource> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, long>(Queryable.LongCount).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -207,7 +208,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("LongCount`1", typeof(Queryable))]
     public static async Task<long> LongCountAsync<TSource>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, bool>>, long>(Queryable.LongCount).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(predicate));
@@ -226,7 +227,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("First`1", typeof(Queryable))]
     public static async Task<TSource> FirstAsync<TSource>(this IQueryable<TSource> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, TSource>(Queryable.First).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -246,7 +247,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("First`1", typeof(Queryable))]
     public static async Task<TSource> FirstAsync<TSource>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, bool>>, TSource>(Queryable.First).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(predicate));
@@ -267,7 +268,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("FirstOrDefault`1", typeof(Queryable))]
     public static async Task<TSource?> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, TSource?>(Queryable.FirstOrDefault).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -291,7 +292,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, bool>> predicate)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, bool>>, TSource?>(Queryable.FirstOrDefault).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(predicate));
@@ -311,7 +312,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Single`1", typeof(Queryable))]
     public static async Task<TSource> SingleAsync<TSource>(this IQueryable<TSource> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, TSource>(Queryable.Single).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -332,7 +333,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Single`1", typeof(Queryable))]
     public static async Task<TSource> SingleAsync<TSource>(this IQueryable<TSource> queryable, Expression<Func<TSource, bool>> predicate)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, bool>>, TSource>(Queryable.Single).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(predicate));
@@ -354,7 +355,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("SingleOrDefault`1", typeof(Queryable))]
     public static async Task<TSource?> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, TSource?>(Queryable.SingleOrDefault).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -379,7 +380,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, bool>> predicate)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, bool>>, TSource?>(Queryable.SingleOrDefault).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(predicate));
@@ -399,7 +400,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Min`1", typeof(Queryable))]
     public static async Task<TSource> MinAsync<TSource>(this IQueryable<TSource> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, TSource?>(Queryable.Min).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -425,7 +426,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, TResult>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, TResult>>, TResult?>(Queryable.Min).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -445,7 +446,7 @@ public static partial class IgniteQueryableExtensions
     [DynamicDependency("Max`1", typeof(Queryable))]
     public static async Task<TSource> MaxAsync<TSource>(this IQueryable<TSource> queryable)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, TSource?>(Queryable.Max).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression);
@@ -469,7 +470,7 @@ public static partial class IgniteQueryableExtensions
         this IQueryable<TSource> queryable,
         Expression<Func<TSource, TResult>> selector)
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         var method = new Func<IQueryable<TSource>, Expression<Func<TSource, TResult>>, TResult?>(Queryable.Max).GetMethodInfo();
         var expression = Expression.Call(null, method, queryable.Expression, Expression.Quote(selector));
@@ -490,7 +491,7 @@ public static partial class IgniteQueryableExtensions
     public static async Task<List<TSource>> ToListAsync<TSource>(this IQueryable<TSource> queryable)
     {
         // NOTE: ToArrayAsync counterpart is not implemented here, because it is just ToList().ToArray(), which is less efficient.
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         await using var resultSet = await queryable.ToResultSetAsync().ConfigureAwait(false);
 
@@ -518,7 +519,7 @@ public static partial class IgniteQueryableExtensions
         IEqualityComparer<TK>? comparer = null)
         where TK : notnull
     {
-        ArgumentNullException.ThrowIfNull(queryable);
+        IgniteArgumentCheck.NotNull(queryable);
 
         await using var resultSet = await queryable.ToResultSetAsync().ConfigureAwait(false);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/SqlStatement.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/SqlStatement.cs
@@ -62,7 +62,7 @@ namespace Apache.Ignite.Sql
             int? pageSize = null,
             IReadOnlyDictionary<string, object?>? properties = null)
         {
-            ArgumentNullException.ThrowIfNull(query);
+            IgniteArgumentCheck.NotNull(query);
             IgniteArgumentCheck.Ensure(pageSize is null or > 0, nameof(pageSize), "Page size must be positive.");
 
             Query = query;

--- a/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/SslStreamFactory.cs
@@ -17,7 +17,6 @@
 
 namespace Apache.Ignite;
 
-using System;
 using System.IO;
 using System.Net.Security;
 using System.Threading.Tasks;
@@ -36,7 +35,7 @@ public sealed class SslStreamFactory : ISslStreamFactory
     /// <inheritdoc />
     public async Task<SslStream?> CreateAsync(Stream stream, string targetHost)
     {
-        ArgumentNullException.ThrowIfNull(stream);
+        IgniteArgumentCheck.NotNull(stream);
 
         var sslStream = new SslStream(stream, false, null, null);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IIgniteTuple.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IIgniteTuple.cs
@@ -66,7 +66,7 @@ namespace Apache.Ignite.Table
         /// <returns>A hash code for the specified tuple.</returns>
         public static int GetHashCode(IIgniteTuple tuple)
         {
-            ArgumentNullException.ThrowIfNull(tuple);
+            IgniteArgumentCheck.NotNull(tuple);
 
             var hash = default(HashCode);
 
@@ -136,7 +136,7 @@ namespace Apache.Ignite.Table
         /// <returns>String representation.</returns>
         public static string ToString(IIgniteTuple tuple)
         {
-            ArgumentNullException.ThrowIfNull(tuple);
+            IgniteArgumentCheck.NotNull(tuple);
             var builder = new IgniteToStringBuilder(tuple.GetType());
 
             for (var i = 0; i < tuple.FieldCount; i++)


### PR DESCRIPTION
IGNITE-20479 (#2636) replaced custom null checks with standard `ArgumentNullException.ThrowIfNull`. However, `ThrowIfNull` takes *object*, which involves boxing for value types, resulting in heap allocations.

Bring back generic `NotNull` check which does not allocate.