### PR TITLE
IGNITE-19217 Implement foreign keys query for ODBC 

### DIFF
--- a/modules/platforms/cpp/ignite/client/detail/utils.cpp
+++ b/modules/platforms/cpp/ignite/client/detail/utils.cpp
@@ -237,8 +237,8 @@ std::vector<std::byte> pack_tuple(
         unmapped_columns_str.pop_back();
 
         assert(!unmapped_columns_str.empty());
-        throw ignite_error("Key tuple doesn't match schema: schemaVersion="
-            + std::to_string(sch.version) + ", extraColumns=" + unmapped_columns_str);
+        throw ignite_error("Key tuple doesn't match schema: schemaVersion=" + std::to_string(sch.version)
+            + ", extraColumns=" + unmapped_columns_str);
     }
 
     return builder.build();

--- a/modules/platforms/cpp/ignite/odbc/CMakeLists.txt
+++ b/modules/platforms/cpp/ignite/odbc/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SOURCES
     meta/table_meta.cpp
     query/column_metadata_query.cpp
     query/data_query.cpp
+    query/foreign_keys_query.cpp
     query/table_metadata_query.cpp
     query/type_info_query.cpp
     odbc.cpp

--- a/modules/platforms/cpp/ignite/odbc/query/column_metadata_query.h
+++ b/modules/platforms/cpp/ignite/odbc/query/column_metadata_query.h
@@ -134,7 +134,7 @@ public:
      *
      * @return Number of rows affected by the statement.
      */
-    std::int64_t affected_rows() const override { return 0; }
+    [[nodiscard]] std::int64_t affected_rows() const override { return 0; }
 
     /**
      * Move to the next result set.

--- a/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.cpp
+++ b/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.cpp
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <utility>
+
+#include "ignite/odbc/type_traits.h"
+#include "ignite/odbc/query/foreign_keys_query.h"
+
+namespace ignite
+{
+
+foreign_keys_query::foreign_keys_query(diagnosable_adapter& m_diag, sql_connection& connection,
+    std::string primary_catalog, std::string primary_schema, std::string primary_table,
+    std::string foreign_catalog, std::string foreign_schema, std::string foreign_table)
+    : query(m_diag, query_type::FOREIGN_KEYS)
+    , m_connection(connection)
+    , m_primary_catalog(std::move(primary_catalog))
+    , m_primary_schema(std::move(primary_schema))
+    , m_primary_table(std::move(primary_table))
+    , m_foreign_catalog(std::move(foreign_catalog))
+    , m_foreign_schema(std::move(foreign_schema))
+    , m_foreign_table(std::move(foreign_table))
+{
+    m_columns_meta.reserve(14);
+
+    const std::string sch;
+    const std::string tbl;
+
+    m_columns_meta.emplace_back(sch, tbl, "PKTABLE_CAT",   ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "PKTABLE_SCHEM", ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "PKTABLE_NAME",  ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "PKCOLUMN_NAME", ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "FKTABLE_CAT",   ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "FKTABLE_SCHEM", ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "FKTABLE_NAME",  ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "FKCOLUMN_NAME", ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "KEY_SEQ",       ignite_type::INT16);
+    m_columns_meta.emplace_back(sch, tbl, "UPDATE_RULE",   ignite_type::INT16);
+    m_columns_meta.emplace_back(sch, tbl, "DELETE_RULE",   ignite_type::INT16);
+    m_columns_meta.emplace_back(sch, tbl, "FK_NAME",       ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "PK_NAME",       ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "DEFERRABILITY", ignite_type::INT16);
+}
+
+sql_result foreign_keys_query::execute()
+{
+    m_executed = true;
+
+    return sql_result::AI_SUCCESS;
+}
+
+sql_result foreign_keys_query::fetch_next_row(column_binding_map&)
+{
+    // TODO: Implement proper meta fetching
+    if (!m_executed)
+    {
+        m_diag.add_status_record(sql_state::SHY010_SEQUENCE_ERROR, "Query was not executed.");
+
+        return sql_result::AI_ERROR;
+    }
+
+    return sql_result::AI_NO_DATA;
+}
+
+sql_result foreign_keys_query::get_column(std::uint16_t, application_data_buffer&)
+{
+    // TODO: Implement proper meta fetching
+    if (!m_executed)
+    {
+        m_diag.add_status_record(sql_state::SHY010_SEQUENCE_ERROR, "Query was not executed.");
+
+        return sql_result::AI_ERROR;
+    }
+
+    return sql_result::AI_NO_DATA;
+}
+
+sql_result foreign_keys_query::close()
+{
+    m_executed = false;
+
+    return sql_result::AI_SUCCESS;
+}
+
+bool foreign_keys_query::is_data_available() const
+{
+    // TODO: Implement proper meta fetching
+    return false;
+}
+
+sql_result foreign_keys_query::next_result_set()
+{
+    // TODO: Implement proper meta fetching
+    return sql_result::AI_NO_DATA;
+}
+
+} // namespace ignite

--- a/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.cpp
+++ b/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.cpp
@@ -23,11 +23,10 @@
 namespace ignite
 {
 
-foreign_keys_query::foreign_keys_query(diagnosable_adapter& m_diag, sql_connection& connection,
+foreign_keys_query::foreign_keys_query(diagnosable_adapter& m_diag,
     std::string primary_catalog, std::string primary_schema, std::string primary_table,
     std::string foreign_catalog, std::string foreign_schema, std::string foreign_table)
     : query(m_diag, query_type::FOREIGN_KEYS)
-    , m_connection(connection)
     , m_primary_catalog(std::move(primary_catalog))
     , m_primary_schema(std::move(primary_schema))
     , m_primary_table(std::move(primary_table))
@@ -65,7 +64,6 @@ sql_result foreign_keys_query::execute()
 
 sql_result foreign_keys_query::fetch_next_row(column_binding_map&)
 {
-    // TODO: Implement proper meta fetching
     if (!m_executed)
     {
         m_diag.add_status_record(sql_state::SHY010_SEQUENCE_ERROR, "Query was not executed.");
@@ -78,7 +76,6 @@ sql_result foreign_keys_query::fetch_next_row(column_binding_map&)
 
 sql_result foreign_keys_query::get_column(std::uint16_t, application_data_buffer&)
 {
-    // TODO: Implement proper meta fetching
     if (!m_executed)
     {
         m_diag.add_status_record(sql_state::SHY010_SEQUENCE_ERROR, "Query was not executed.");
@@ -94,18 +91,6 @@ sql_result foreign_keys_query::close()
     m_executed = false;
 
     return sql_result::AI_SUCCESS;
-}
-
-bool foreign_keys_query::is_data_available() const
-{
-    // TODO: Implement proper meta fetching
-    return false;
-}
-
-sql_result foreign_keys_query::next_result_set()
-{
-    // TODO: Implement proper meta fetching
-    return sql_result::AI_NO_DATA;
 }
 
 } // namespace ignite

--- a/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.cpp
+++ b/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.cpp
@@ -17,23 +17,21 @@
 
 #include <utility>
 
-#include "ignite/odbc/type_traits.h"
 #include "ignite/odbc/query/foreign_keys_query.h"
+#include "ignite/odbc/type_traits.h"
 
-namespace ignite
-{
+namespace ignite {
 
-foreign_keys_query::foreign_keys_query(diagnosable_adapter& m_diag,
-    std::string primary_catalog, std::string primary_schema, std::string primary_table,
-    std::string foreign_catalog, std::string foreign_schema, std::string foreign_table)
+foreign_keys_query::foreign_keys_query(diagnosable_adapter &m_diag, std::string primary_catalog,
+    std::string primary_schema, std::string primary_table, std::string foreign_catalog, std::string foreign_schema,
+    std::string foreign_table)
     : query(m_diag, query_type::FOREIGN_KEYS)
     , m_primary_catalog(std::move(primary_catalog))
     , m_primary_schema(std::move(primary_schema))
     , m_primary_table(std::move(primary_table))
     , m_foreign_catalog(std::move(foreign_catalog))
     , m_foreign_schema(std::move(foreign_schema))
-    , m_foreign_table(std::move(foreign_table))
-{
+    , m_foreign_table(std::move(foreign_table)) {
     m_columns_meta.reserve(14);
 
     const std::string sch;
@@ -55,17 +53,14 @@ foreign_keys_query::foreign_keys_query(diagnosable_adapter& m_diag,
     m_columns_meta.emplace_back(sch, tbl, "DEFERRABILITY", ignite_type::INT16);
 }
 
-sql_result foreign_keys_query::execute()
-{
+sql_result foreign_keys_query::execute() {
     m_executed = true;
 
     return sql_result::AI_SUCCESS;
 }
 
-sql_result foreign_keys_query::fetch_next_row(column_binding_map&)
-{
-    if (!m_executed)
-    {
+sql_result foreign_keys_query::fetch_next_row(column_binding_map &) {
+    if (!m_executed) {
         m_diag.add_status_record(sql_state::SHY010_SEQUENCE_ERROR, "Query was not executed.");
 
         return sql_result::AI_ERROR;
@@ -74,10 +69,8 @@ sql_result foreign_keys_query::fetch_next_row(column_binding_map&)
     return sql_result::AI_NO_DATA;
 }
 
-sql_result foreign_keys_query::get_column(std::uint16_t, application_data_buffer&)
-{
-    if (!m_executed)
-    {
+sql_result foreign_keys_query::get_column(std::uint16_t, application_data_buffer &) {
+    if (!m_executed) {
         m_diag.add_status_record(sql_state::SHY010_SEQUENCE_ERROR, "Query was not executed.");
 
         return sql_result::AI_ERROR;
@@ -86,8 +79,7 @@ sql_result foreign_keys_query::get_column(std::uint16_t, application_data_buffer
     return sql_result::AI_NO_DATA;
 }
 
-sql_result foreign_keys_query::close()
-{
+sql_result foreign_keys_query::close() {
     m_executed = false;
 
     return sql_result::AI_SUCCESS;

--- a/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.cpp
+++ b/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.cpp
@@ -40,19 +40,19 @@ foreign_keys_query::foreign_keys_query(diagnosable_adapter& m_diag, sql_connecti
     const std::string sch;
     const std::string tbl;
 
-    m_columns_meta.emplace_back(sch, tbl, "PKTABLE_CAT",   ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "PKTABLE_CAT", ignite_type::STRING);
     m_columns_meta.emplace_back(sch, tbl, "PKTABLE_SCHEM", ignite_type::STRING);
-    m_columns_meta.emplace_back(sch, tbl, "PKTABLE_NAME",  ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "PKTABLE_NAME", ignite_type::STRING);
     m_columns_meta.emplace_back(sch, tbl, "PKCOLUMN_NAME", ignite_type::STRING);
-    m_columns_meta.emplace_back(sch, tbl, "FKTABLE_CAT",   ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "FKTABLE_CAT", ignite_type::STRING);
     m_columns_meta.emplace_back(sch, tbl, "FKTABLE_SCHEM", ignite_type::STRING);
-    m_columns_meta.emplace_back(sch, tbl, "FKTABLE_NAME",  ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "FKTABLE_NAME", ignite_type::STRING);
     m_columns_meta.emplace_back(sch, tbl, "FKCOLUMN_NAME", ignite_type::STRING);
-    m_columns_meta.emplace_back(sch, tbl, "KEY_SEQ",       ignite_type::INT16);
-    m_columns_meta.emplace_back(sch, tbl, "UPDATE_RULE",   ignite_type::INT16);
-    m_columns_meta.emplace_back(sch, tbl, "DELETE_RULE",   ignite_type::INT16);
-    m_columns_meta.emplace_back(sch, tbl, "FK_NAME",       ignite_type::STRING);
-    m_columns_meta.emplace_back(sch, tbl, "PK_NAME",       ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "KEY_SEQ", ignite_type::INT16);
+    m_columns_meta.emplace_back(sch, tbl, "UPDATE_RULE", ignite_type::INT16);
+    m_columns_meta.emplace_back(sch, tbl, "DELETE_RULE", ignite_type::INT16);
+    m_columns_meta.emplace_back(sch, tbl, "FK_NAME", ignite_type::STRING);
+    m_columns_meta.emplace_back(sch, tbl, "PK_NAME", ignite_type::STRING);
     m_columns_meta.emplace_back(sch, tbl, "DEFERRABILITY", ignite_type::INT16);
 }
 

--- a/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.h
+++ b/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.h
@@ -17,17 +17,15 @@
 
 #pragma once
 
-#include "ignite/odbc/sql_connection.h"
 #include "ignite/odbc/query/query.h"
+#include "ignite/odbc/sql_connection.h"
 
-namespace ignite
-{
+namespace ignite {
 
 /**
  * Foreign keys query.
  */
-class foreign_keys_query : public query
-{
+class foreign_keys_query : public query {
 public:
     /**
      * Constructor.
@@ -40,9 +38,8 @@ public:
      * @param foreign_schema Foreign key schema name.
      * @param foreign_table Foreign key table name.
      */
-    foreign_keys_query(diagnosable_adapter &diag, std::string primary_catalog,
-        std::string primary_schema, std::string primary_table, std::string foreign_catalog,
-        std::string foreign_schema, std::string foreign_table);
+    foreign_keys_query(diagnosable_adapter &diag, std::string primary_catalog, std::string primary_schema,
+        std::string primary_table, std::string foreign_catalog, std::string foreign_schema, std::string foreign_table);
 
     /**
      * Destructor.
@@ -61,7 +58,7 @@ public:
      *
      * @return Column metadata.
      */
-    const column_meta_vector* get_meta() override { return &m_columns_meta; }
+    const column_meta_vector *get_meta() override { return &m_columns_meta; }
 
     /**
      * Fetch next result row to application buffers.

--- a/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.h
+++ b/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.h
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "ignite/odbc/sql_connection.h"
+#include "ignite/odbc/query/query.h"
+
+namespace ignite
+{
+
+/**
+ * Foreign keys query.
+ */
+class foreign_keys_query : public query
+{
+public:
+    /**
+     * Constructor.
+     *
+     * @param diag Diagnostics collector.
+     * @param connection Statement-associated connection.
+     * @param primary_catalog Primary key catalog name.
+     * @param primary_schema Primary key schema name.
+     * @param primary_table Primary key table name.
+     * @param foreign_catalog Foreign key catalog name.
+     * @param foreign_schema Foreign key schema name.
+     * @param foreign_table Foreign key table name.
+     */
+    foreign_keys_query(diagnosable_adapter &diag, sql_connection &connection, std::string primary_catalog,
+        std::string primary_schema, std::string primary_table, std::string foreign_catalog,
+        std::string foreign_schema, std::string foreign_table);
+
+    /**
+     * Destructor.
+     */
+    ~foreign_keys_query() override = default;
+
+    /**
+     * Execute query.
+     *
+     * @return True on success.
+     */
+    sql_result execute() override;
+
+    /**
+     * Get column metadata.
+     *
+     * @return Column metadata.
+     */
+    const column_meta_vector* get_meta() override { return &m_columns_meta; }
+
+    /**
+     * Fetch next result row to application buffers.
+     *
+     * @return Operation result.
+     */
+    sql_result fetch_next_row(column_binding_map &column_bindings) override;
+
+    /**
+     * Get data of the specified column in the result set.
+     *
+     * @param column_idx Column index.
+     * @param buffer Buffer to put column data to.
+     * @return Operation result.
+     */
+    sql_result get_column(std::uint16_t column_idx, application_data_buffer &buffer) override;
+
+    /**
+     * Close query.
+     *
+     * @return True on success.
+     */
+    sql_result close() override;
+
+    /**
+     * Check if data is available.
+     *
+     * @return True if data is available.
+     */
+    bool is_data_available() const override;
+
+    /**
+     * Get number of rows affected by the statement.
+     *
+     * @return Number of rows affected by the statement.
+     */
+    std::int64_t affected_rows() const override { return 0; }
+
+    /**
+     * Move to the next result set.
+     *
+     * @return Operation result.
+     */
+    sql_result next_result_set() override;
+
+private:
+    /** Connection associated with the statement. */
+    sql_connection& m_connection;
+
+    /** Primary key catalog name. */
+    std::string m_primary_catalog;
+
+    /** Primary key schema name. */
+    std::string m_primary_schema;
+
+    /** Primary key table name. */
+    std::string m_primary_table;
+
+    /** Foreign key catalog name. */
+    std::string m_foreign_catalog;
+
+    /** Foreign key schema name. */
+    std::string m_foreign_schema;
+
+    /** Foreign key table name. */
+    std::string m_foreign_table;
+
+    /** Query executed. */
+    bool m_executed{false};
+
+    /** Columns metadata. */
+    column_meta_vector m_columns_meta;
+};
+
+} // namespace ignite

--- a/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.h
+++ b/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.h
@@ -99,7 +99,7 @@ public:
      *
      * @return Number of rows affected by the statement.
      */
-    std::int64_t affected_rows() const override { return 0; }
+    [[nodiscard]] std::int64_t affected_rows() const override { return 0; }
 
     /**
      * Move to the next result set.

--- a/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.h
+++ b/modules/platforms/cpp/ignite/odbc/query/foreign_keys_query.h
@@ -33,7 +33,6 @@ public:
      * Constructor.
      *
      * @param diag Diagnostics collector.
-     * @param connection Statement-associated connection.
      * @param primary_catalog Primary key catalog name.
      * @param primary_schema Primary key schema name.
      * @param primary_table Primary key table name.
@@ -41,7 +40,7 @@ public:
      * @param foreign_schema Foreign key schema name.
      * @param foreign_table Foreign key table name.
      */
-    foreign_keys_query(diagnosable_adapter &diag, sql_connection &connection, std::string primary_catalog,
+    foreign_keys_query(diagnosable_adapter &diag, std::string primary_catalog,
         std::string primary_schema, std::string primary_table, std::string foreign_catalog,
         std::string foreign_schema, std::string foreign_table);
 
@@ -92,7 +91,7 @@ public:
      *
      * @return True if data is available.
      */
-    bool is_data_available() const override;
+    bool is_data_available() const override { return false; }
 
     /**
      * Get number of rows affected by the statement.
@@ -106,12 +105,9 @@ public:
      *
      * @return Operation result.
      */
-    sql_result next_result_set() override;
+    sql_result next_result_set() override { return sql_result::AI_NO_DATA; }
 
 private:
-    /** Connection associated with the statement. */
-    sql_connection& m_connection;
-
     /** Primary key catalog name. */
     std::string m_primary_catalog;
 

--- a/modules/platforms/cpp/ignite/odbc/query/query.h
+++ b/modules/platforms/cpp/ignite/odbc/query/query.h
@@ -39,6 +39,9 @@ enum class query_type {
 
     /** Type info. */
     TYPE_INFO,
+
+    /** Foreign keys. */
+    FOREIGN_KEYS,
 };
 
 /**

--- a/modules/platforms/cpp/ignite/odbc/query/table_metadata_query.cpp
+++ b/modules/platforms/cpp/ignite/odbc/query/table_metadata_query.cpp
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#include <utility>
+
 #include "ignite/odbc/query/table_metadata_query.h"
 #include "ignite/odbc/log.h"
 #include "ignite/odbc/odbc_error.h"
@@ -45,18 +47,18 @@ enum class result_column {
 
 namespace ignite {
 
-table_metadata_query::table_metadata_query(diagnosable_adapter &diag, sql_connection &connection,
-    const std::string &catalog, const std::string &schema, const std::string &table, const std::string &table_type)
+table_metadata_query::table_metadata_query(diagnosable_adapter &diag, sql_connection &connection, std::string catalog,
+    std::string schema, std::string table, std::string table_type)
     : query(diag, query_type::TABLE_METADATA)
     , m_connection(connection)
-    , m_catalog(catalog)
-    , m_schema(schema)
-    , m_table(table)
-    , m_table_type(table_type) {
+    , m_catalog(std::move(catalog))
+    , m_schema(std::move(schema))
+    , m_table(std::move(table))
+    , m_table_type(std::move(table_type)) {
     m_columns_meta.reserve(5);
 
-    const std::string sch("");
-    const std::string tbl("");
+    const std::string sch;
+    const std::string tbl;
 
     m_columns_meta.emplace_back(sch, tbl, "TABLE_CAT", ignite_type::STRING);
     m_columns_meta.emplace_back(sch, tbl, "TABLE_SCHEM", ignite_type::STRING);

--- a/modules/platforms/cpp/ignite/odbc/query/table_metadata_query.cpp
+++ b/modules/platforms/cpp/ignite/odbc/query/table_metadata_query.cpp
@@ -17,9 +17,9 @@
 
 #include <utility>
 
-#include "ignite/odbc/query/table_metadata_query.h"
 #include "ignite/odbc/log.h"
 #include "ignite/odbc/odbc_error.h"
+#include "ignite/odbc/query/table_metadata_query.h"
 #include "ignite/odbc/sql_connection.h"
 #include "ignite/odbc/string_utils.h"
 #include "ignite/odbc/type_traits.h"

--- a/modules/platforms/cpp/ignite/odbc/query/table_metadata_query.h
+++ b/modules/platforms/cpp/ignite/odbc/query/table_metadata_query.h
@@ -97,7 +97,7 @@ public:
      *
      * @return Number of rows affected by the statement.
      */
-    std::int64_t affected_rows() const override;
+    [[nodiscard]] std::int64_t affected_rows() const override;
 
     /**
      * Move to the next result set.

--- a/modules/platforms/cpp/ignite/odbc/query/table_metadata_query.h
+++ b/modules/platforms/cpp/ignite/odbc/query/table_metadata_query.h
@@ -40,8 +40,8 @@ public:
      * @param table Table search pattern.
      * @param table_type Table type search pattern.
      */
-    table_metadata_query(diagnosable_adapter &diag, sql_connection &connection, const std::string &catalog,
-        const std::string &schema, const std::string &table, const std::string &table_type);
+    table_metadata_query(diagnosable_adapter &diag, sql_connection &connection, std::string catalog,
+        std::string schema, std::string table, std::string table_type);
 
     /**
      * Destructor.

--- a/modules/platforms/cpp/ignite/odbc/query/table_metadata_query.h
+++ b/modules/platforms/cpp/ignite/odbc/query/table_metadata_query.h
@@ -40,8 +40,8 @@ public:
      * @param table Table search pattern.
      * @param table_type Table type search pattern.
      */
-    table_metadata_query(diagnosable_adapter &diag, sql_connection &connection, std::string catalog,
-        std::string schema, std::string table, std::string table_type);
+    table_metadata_query(diagnosable_adapter &diag, sql_connection &connection, std::string catalog, std::string schema,
+        std::string table, std::string table_type);
 
     /**
      * Destructor.

--- a/modules/platforms/cpp/ignite/odbc/query/type_info_query.h
+++ b/modules/platforms/cpp/ignite/odbc/query/type_info_query.h
@@ -88,7 +88,7 @@ public:
      *
      * @return Number of rows affected by the statement.
      */
-    std::int64_t affected_rows() const override { return 0; }
+    [[nodiscard]] std::int64_t affected_rows() const override { return 0; }
 
     /**
      * Move to the next result set.

--- a/modules/platforms/cpp/ignite/odbc/sql_statement.cpp
+++ b/modules/platforms/cpp/ignite/odbc/sql_statement.cpp
@@ -593,8 +593,8 @@ sql_result sql_statement::internal_execute_get_foreign_keys_query(const std::str
     if (m_current_query)
         m_current_query->close();
 
-    m_current_query = std::make_unique<foreign_keys_query>(*this, primary_catalog, primary_schema, primary_table,
-        foreign_catalog, foreign_schema, foreign_table);
+    m_current_query = std::make_unique<foreign_keys_query>(
+        *this, primary_catalog, primary_schema, primary_table, foreign_catalog, foreign_schema, foreign_table);
 
     return m_current_query->execute();
 }

--- a/modules/platforms/cpp/ignite/odbc/sql_statement.cpp
+++ b/modules/platforms/cpp/ignite/odbc/sql_statement.cpp
@@ -593,8 +593,8 @@ sql_result sql_statement::internal_execute_get_foreign_keys_query(const std::str
     if (m_current_query)
         m_current_query->close();
 
-    m_current_query = std::make_unique<foreign_keys_query>(*this, m_connection,
-        primary_catalog, primary_schema, primary_table, foreign_catalog, foreign_schema, foreign_table);
+    m_current_query = std::make_unique<foreign_keys_query>(*this, primary_catalog, primary_schema, primary_table,
+        foreign_catalog, foreign_schema, foreign_table);
 
     return m_current_query->execute();
 }

--- a/modules/platforms/cpp/ignite/odbc/sql_statement.cpp
+++ b/modules/platforms/cpp/ignite/odbc/sql_statement.cpp
@@ -21,6 +21,7 @@
 #include "ignite/odbc/odbc_error.h"
 #include "ignite/odbc/query/column_metadata_query.h"
 #include "ignite/odbc/query/data_query.h"
+#include "ignite/odbc/query/foreign_keys_query.h"
 #include "ignite/odbc/query/table_metadata_query.h"
 #include "ignite/odbc/query/type_info_query.h"
 #include "ignite/odbc/sql_statement.h"
@@ -588,19 +589,14 @@ void sql_statement::execute_get_foreign_keys_query(const std::string &primary_ca
 sql_result sql_statement::internal_execute_get_foreign_keys_query(const std::string &primary_catalog,
     const std::string &primary_schema, const std::string &primary_table, const std::string &foreign_catalog,
     const std::string &foreign_schema, const std::string &foreign_table) {
-    UNUSED_VALUE primary_catalog;
-    UNUSED_VALUE primary_schema;
-    UNUSED_VALUE primary_table;
-    UNUSED_VALUE foreign_catalog;
-    UNUSED_VALUE foreign_schema;
-    UNUSED_VALUE foreign_table;
 
     if (m_current_query)
         m_current_query->close();
 
-    // TODO: IGNITE-19217 Implement foreign keys query
-    add_status_record(sql_state::SHYC00_OPTIONAL_FEATURE_NOT_IMPLEMENTED, "Foreign keys query is not supported.");
-    return sql_result::AI_ERROR;
+    m_current_query = std::make_unique<foreign_keys_query>(*this, m_connection,
+        primary_catalog, primary_schema, primary_table, foreign_catalog, foreign_schema, foreign_table);
+
+    return m_current_query->execute();
 }
 
 void sql_statement::execute_get_primary_keys_query(

--- a/modules/platforms/cpp/ignite/odbc/sql_statement.h
+++ b/modules/platforms/cpp/ignite/odbc/sql_statement.h
@@ -280,7 +280,7 @@ public:
      *
      * @return Number of rows affected by the statement.
      */
-    std::int64_t affected_rows();
+    [[nodiscard]] std::int64_t affected_rows();
 
     /**
      * Set rows fetched buffer pointer.

--- a/modules/platforms/cpp/ignite/odbc/type_traits.h
+++ b/modules/platforms/cpp/ignite/odbc/type_traits.h
@@ -236,8 +236,8 @@ std::int32_t sql_type_decimal_digits(std::int16_t type, std::int32_t scale);
 /**
  * Get Ignite type decimal digits.
  *
-* @param typ Ignite type.
-* @param scale Scale if applies. Negative value means scale is not available.
+ * @param typ Ignite type.
+ * @param scale Scale if applies. Negative value means scale is not available.
  * @return big_decimal digits.
  */
 std::int32_t ignite_type_decimal_digits(ignite_type typ, std::int32_t scale);

--- a/modules/platforms/cpp/tests/client-test/key_value_binary_view_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/key_value_binary_view_test.cpp
@@ -21,8 +21,8 @@
 #include "ignite/client/ignite_client.h"
 #include "ignite/client/ignite_client_configuration.h"
 
-#include <gtest/gtest.h>
 #include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
 
 #include <chrono>
 
@@ -149,8 +149,8 @@ TEST_F(key_value_binary_view_test, put_extra_collumn_value_throws) {
             try {
                 kv_view.put(nullptr, key_tuple, val_tuple);
             } catch (const ignite_error &e) {
-                EXPECT_THAT(e.what_str(), testing::MatchesRegex(
-                    "Key tuple doesn't match schema: schemaVersion=.+, extraColumns=extra"));
+                EXPECT_THAT(e.what_str(),
+                    testing::MatchesRegex("Key tuple doesn't match schema: schemaVersion=.+, extraColumns=extra"));
                 throw;
             }
         },

--- a/modules/platforms/cpp/tests/client-test/record_binary_view_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/record_binary_view_test.cpp
@@ -21,8 +21,8 @@
 #include "ignite/client/ignite_client.h"
 #include "ignite/client/ignite_client_configuration.h"
 
-#include <gtest/gtest.h>
 #include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
 
 #include <chrono>
 
@@ -135,8 +135,8 @@ TEST_F(record_binary_view_test, upsert_tuple_with_extra_columns_throws) {
             try {
                 tuple_view.upsert(nullptr, val_tuple);
             } catch (const ignite_error &e) {
-                EXPECT_THAT(e.what_str(), testing::MatchesRegex(
-                    "Key tuple doesn't match schema: schemaVersion=.+, extraColumns=extra"));
+                EXPECT_THAT(e.what_str(),
+                    testing::MatchesRegex("Key tuple doesn't match schema: schemaVersion=.+, extraColumns=extra"));
                 throw;
             }
         },

--- a/modules/platforms/cpp/tests/client-test/record_view_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/record_view_test.cpp
@@ -101,7 +101,6 @@ struct extra_mapping_value {
     std::string val;
 };
 
-
 namespace ignite {
 
 template<>
@@ -267,8 +266,8 @@ TEST_F(record_view_test, extra_mapping_value_throws) {
             try {
                 wrong_view.upsert(nullptr, val);
             } catch (const ignite_error &e) {
-                EXPECT_THAT(e.what_str(), testing::MatchesRegex(
-                    "Key tuple doesn't match schema: schemaVersion=.+, extraColumns=extra"));
+                EXPECT_THAT(e.what_str(),
+                    testing::MatchesRegex("Key tuple doesn't match schema: schemaVersion=.+, extraColumns=extra"));
                 throw;
             }
         },

--- a/modules/platforms/cpp/tests/odbc-test/api_robustness_test.cpp
+++ b/modules/platforms/cpp/tests/odbc-test/api_robustness_test.cpp
@@ -489,9 +489,7 @@ TEST_F(api_robustness_test, sql_foreign_keys) {
         tableName, sizeof(tableName), catalogName, sizeof(catalogName), schemaName, sizeof(schemaName), tableName,
         sizeof(tableName));
 
-    UNUSED_VALUE ret;
-    // TODO IGNITE-19217: Uncomment once foreign keys query is implemented.
-    // ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, m_statement);
+    ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, m_statement);
 
     SQLCloseCursor(m_statement);
 


### PR DESCRIPTION
- Ported solution from Ignite 2. Currently, foreign keys request returns no rows in all cases, as we do not support foreign keys on SQL level right now;
- Un-commented related test.