### PR TITLE
IGNITE-20511 Track and log client connection ID on the server

### DIFF
--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientHandlerModule.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientHandlerModule.java
@@ -31,6 +31,7 @@ import java.net.InetSocketAddress;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import org.apache.ignite.client.handler.configuration.ClientConnectorConfiguration;
 import org.apache.ignite.client.handler.configuration.ClientConnectorView;
@@ -63,6 +64,9 @@ import org.jetbrains.annotations.Nullable;
 public class ClientHandlerModule implements IgniteComponent {
     /** The logger. */
     private static final IgniteLogger LOG = Loggers.forClass(ClientHandlerModule.class);
+
+    /** Connection id generator. */
+    private static final AtomicLong CONNECTION_ID_GEN = new AtomicLong();
 
     /** Configuration registry. */
     private final ConfigurationRegistry registry;
@@ -241,8 +245,11 @@ public class ClientHandlerModule implements IgniteComponent {
         bootstrap.childHandler(new ChannelInitializer<>() {
                     @Override
                     protected void initChannel(Channel ch) {
+                        long connectionId = CONNECTION_ID_GEN.incrementAndGet();
+
                         if (LOG.isDebugEnabled()) {
-                            LOG.debug("New client connection [remoteAddress=" + ch.remoteAddress() + ']');
+                            LOG.debug("New client connection [connectionId=" + connectionId +
+                                    ", remoteAddress=" + ch.remoteAddress() + ']');
                         }
 
                         if (configuration.idleTimeout() > 0) {
@@ -250,14 +257,14 @@ public class ClientHandlerModule implements IgniteComponent {
                                     configuration.idleTimeout(), 0, 0, TimeUnit.MILLISECONDS);
 
                             ch.pipeline().addLast(idleStateHandler);
-                            ch.pipeline().addLast(new IdleChannelHandler(configuration.idleTimeout(), metrics));
+                            ch.pipeline().addLast(new IdleChannelHandler(configuration.idleTimeout(), metrics, connectionId));
                         }
 
                         if (sslContext != null) {
                             ch.pipeline().addFirst("ssl", sslContext.newHandler(ch.alloc()));
                         }
 
-                        ClientInboundMessageHandler messageHandler = createInboundMessageHandler(configuration, clusterId);
+                        ClientInboundMessageHandler messageHandler = createInboundMessageHandler(configuration, clusterId, connectionId);
                         authenticationManager.listen(messageHandler);
 
                         ch.pipeline().addLast(
@@ -265,9 +272,7 @@ public class ClientHandlerModule implements IgniteComponent {
                                 messageHandler
                         );
 
-                        ch.closeFuture().addListener(future -> {
-                            authenticationManager.stopListen(messageHandler);
-                        });
+                        ch.closeFuture().addListener(future -> authenticationManager.stopListen(messageHandler));
 
                         metrics.connectionsInitiatedIncrement();
                     }
@@ -303,7 +308,10 @@ public class ClientHandlerModule implements IgniteComponent {
         return ch.closeFuture();
     }
 
-    private ClientInboundMessageHandler createInboundMessageHandler(ClientConnectorView configuration, CompletableFuture<UUID> clusterId) {
+    private ClientInboundMessageHandler createInboundMessageHandler(
+            ClientConnectorView configuration,
+            CompletableFuture<UUID> clusterId,
+            long connectionId) {
         return new ClientInboundMessageHandler(
                 igniteTables,
                 igniteTransactions,
@@ -317,7 +325,8 @@ public class ClientHandlerModule implements IgniteComponent {
                 authenticationManager,
                 clock,
                 schemaSyncService,
-                catalogService
+                catalogService,
+                connectionId
         );
     }
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientHandlerModule.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientHandlerModule.java
@@ -249,8 +249,8 @@ public class ClientHandlerModule implements IgniteComponent {
                         long connectionId = CONNECTION_ID_GEN.incrementAndGet();
 
                         if (LOG.isDebugEnabled()) {
-                            LOG.debug("New client connection [connectionId=" + connectionId +
-                                    ", remoteAddress=" + ch.remoteAddress() + ']');
+                            LOG.debug("New client connection [connectionId=" + connectionId
+                                    + ", remoteAddress=" + ch.remoteAddress() + ']');
                         }
 
                         if (configuration.idleTimeout() > 0) {

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientHandlerModule.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientHandlerModule.java
@@ -65,7 +65,8 @@ public class ClientHandlerModule implements IgniteComponent {
     /** The logger. */
     private static final IgniteLogger LOG = Loggers.forClass(ClientHandlerModule.class);
 
-    /** Connection id generator. */
+    /** Connection id generator.
+     * The resulting connection id is local to the current node and is intended for logging, diagnostics, and management purposes. */
     private static final AtomicLong CONNECTION_ID_GEN = new AtomicLong();
 
     /** Configuration registry. */

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -131,9 +131,6 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
     /** The logger. */
     private static final IgniteLogger LOG = Loggers.forClass(ClientInboundMessageHandler.class);
 
-    /** Connection id generator. */
-    private static final AtomicLong CONNECTION_ID_GEN = new AtomicLong();
-
     /** Ignite tables API. */
     private final IgniteTablesInternal igniteTables;
 
@@ -187,7 +184,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
 
     private final SchemaVersions schemaVersions;
 
-    private final long connectionId = CONNECTION_ID_GEN.incrementAndGet();
+    private final long connectionId;
 
     /**
      * Constructor.
@@ -217,7 +214,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
             AuthenticationManager authenticationManager,
             HybridClock clock,
             SchemaSyncService schemaSyncService,
-            CatalogService catalogService
+            CatalogService catalogService,
+            long connectionId
     ) {
         assert igniteTables != null;
         assert igniteTransactions != null;
@@ -256,6 +254,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
         igniteTables.addAssignmentsChangeListener(partitionAssignmentsChangeListener);
 
         schemaVersions = new SchemaVersionsImpl(schemaSyncService, catalogService, clock);
+        this.connectionId = connectionId;
     }
 
     @Override
@@ -263,6 +262,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
         channelHandlerContext = ctx;
         super.channelRegistered(ctx);
 
+        // TODO: Check if debug enabled here and below
         LOG.debug("Connection registered [connectionId=" + connectionId + ", remoteAddress=" + ctx.channel().remoteAddress() + "]");
     }
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -410,7 +410,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
     }
 
     private void writeError(long requestId, int opCode, Throwable err, ChannelHandlerContext ctx) {
-        LOG.warn("Error processing client request [id=" + requestId + ", op=" + opCode
+        LOG.warn("Error processing client request [connectionId=" + connectionId + ", id=" + requestId + ", op=" + opCode
                 + ", remoteAddress=" + ctx.channel().remoteAddress() + "]:" + err.getMessage(), err);
 
         var packer = getPacker(ctx.alloc());

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -318,7 +318,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
             clientContext = new ClientContext(clientVer, clientCode, features, userDetails);
 
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Handshake [remoteAddress=" + ctx.channel().remoteAddress() + "]: " + clientContext);
+                LOG.debug("Handshake [connectionId=" + connectionId + ", remoteAddress=" + ctx.channel().remoteAddress() + "]: " +
+                        clientContext);
             }
 
             // Response.
@@ -342,7 +343,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
 
             ctx.channel().closeFuture().addListener(f -> metrics.sessionsActiveDecrement());
         } catch (Throwable t) {
-            LOG.warn("Handshake failed [remoteAddress=" + ctx.channel().remoteAddress() + "]: " + t.getMessage(), t);
+            LOG.warn("Handshake failed [connectionId=" + connectionId + ", remoteAddress=" + ctx.channel().remoteAddress() + "]: " +
+                    t.getMessage(), t);
 
             packer.close();
 
@@ -355,7 +357,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
 
                 write(errPacker, ctx);
             } catch (Throwable t2) {
-                LOG.warn("Handshake failed [remoteAddress=" + ctx.channel().remoteAddress() + "]: " + t2.getMessage(), t2);
+                LOG.warn("Handshake failed [connectionId=" + connectionId + ", remoteAddress=" + ctx.channel().remoteAddress() + "]: " +
+                        t2.getMessage(), t2);
 
                 errPacker.close();
                 exceptionCaught(ctx, t2);
@@ -686,7 +689,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
         boolean assignmentChanged = partitionAssignmentChanged.compareAndSet(true, false);
 
         if (assignmentChanged && LOG.isInfoEnabled()) {
-            LOG.info("Partition assignment changed, notifying client [remoteAddress=" + ctx.channel().remoteAddress() + ']');
+            LOG.info("Partition assignment changed, notifying client [connectionId=" + connectionId + ", remoteAddress=" +
+                    ctx.channel().remoteAddress() + ']');
         }
 
         var flags = ResponseFlags.getFlags(assignmentChanged);
@@ -718,8 +722,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
             }
         }
 
-        LOG.warn("Exception in client connector pipeline [remoteAddress=" + ctx.channel().remoteAddress() + "]: "
-                + cause.getMessage(), cause);
+        LOG.warn("Exception in client connector pipeline [connectionId=" + connectionId + ", remoteAddress=" +
+                ctx.channel().remoteAddress() + "]: " + cause.getMessage(), cause);
 
         ctx.close();
     }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import javax.net.ssl.SSLException;
 import org.apache.ignite.client.handler.configuration.ClientConnectorView;
@@ -321,8 +320,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
             clientContext = new ClientContext(clientVer, clientCode, features, userDetails);
 
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Handshake [connectionId=" + connectionId + ", remoteAddress=" + ctx.channel().remoteAddress() + "]: " +
-                        clientContext);
+                LOG.debug("Handshake [connectionId=" + connectionId + ", remoteAddress=" + ctx.channel().remoteAddress() + "]: "
+                        + clientContext);
             }
 
             // Response.
@@ -346,8 +345,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
 
             ctx.channel().closeFuture().addListener(f -> metrics.sessionsActiveDecrement());
         } catch (Throwable t) {
-            LOG.warn("Handshake failed [connectionId=" + connectionId + ", remoteAddress=" + ctx.channel().remoteAddress() + "]: " +
-                    t.getMessage(), t);
+            LOG.warn("Handshake failed [connectionId=" + connectionId + ", remoteAddress=" + ctx.channel().remoteAddress() + "]: "
+                    + t.getMessage(), t);
 
             packer.close();
 
@@ -360,8 +359,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
 
                 write(errPacker, ctx);
             } catch (Throwable t2) {
-                LOG.warn("Handshake failed [connectionId=" + connectionId + ", remoteAddress=" + ctx.channel().remoteAddress() + "]: " +
-                        t2.getMessage(), t2);
+                LOG.warn("Handshake failed [connectionId=" + connectionId + ", remoteAddress=" + ctx.channel().remoteAddress() + "]: "
+                        + t2.getMessage(), t2);
 
                 errPacker.close();
                 exceptionCaught(ctx, t2);
@@ -694,8 +693,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
         boolean assignmentChanged = partitionAssignmentChanged.compareAndSet(true, false);
 
         if (assignmentChanged && LOG.isInfoEnabled()) {
-            LOG.info("Partition assignment changed, notifying client [connectionId=" + connectionId + ", remoteAddress=" +
-                    ctx.channel().remoteAddress() + ']');
+            LOG.info("Partition assignment changed, notifying client [connectionId=" + connectionId + ", remoteAddress="
+                    + ctx.channel().remoteAddress() + ']');
         }
 
         var flags = ResponseFlags.getFlags(assignmentChanged);
@@ -727,8 +726,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
             }
         }
 
-        LOG.warn("Exception in client connector pipeline [connectionId=" + connectionId + ", remoteAddress=" +
-                ctx.channel().remoteAddress() + "]: " + cause.getMessage(), cause);
+        LOG.warn("Exception in client connector pipeline [connectionId=" + connectionId + ", remoteAddress="
+                + ctx.channel().remoteAddress() + "]: " + cause.getMessage(), cause);
 
         ctx.close();
     }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -262,8 +262,9 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
         channelHandlerContext = ctx;
         super.channelRegistered(ctx);
 
-        // TODO: Check if debug enabled here and below
-        LOG.debug("Connection registered [connectionId=" + connectionId + ", remoteAddress=" + ctx.channel().remoteAddress() + "]");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Connection registered [connectionId=" + connectionId + ", remoteAddress=" + ctx.channel().remoteAddress() + "]");
+        }
     }
 
     /** {@inheritDoc} */
@@ -294,7 +295,9 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
 
         super.channelInactive(ctx);
 
-        LOG.debug("Connection closed [connectionId=" + connectionId + ", remoteAddress=" + ctx.channel().remoteAddress() + "]");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Connection closed [connectionId=" + connectionId + ", remoteAddress=" + ctx.channel().remoteAddress() + "]");
+        }
     }
 
     private void handshake(ChannelHandlerContext ctx, ClientMessageUnpacker unpacker, ClientMessagePacker packer) {
@@ -533,8 +536,10 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
 
                         metrics.requestsProcessedIncrement();
 
-                        LOG.trace("Client request processed [id=" + reqId + ", op=" + op
-                                + ", remoteAddress=" + ctx.channel().remoteAddress() + "]");
+                        if (LOG.isTraceEnabled()) {
+                            LOG.trace("Client request processed [id=" + reqId + ", op=" + op
+                                    + ", remoteAddress=" + ctx.channel().remoteAddress() + "]");
+                        }
                     }
                 });
             }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/IdleChannelHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/IdleChannelHandler.java
@@ -34,7 +34,7 @@ class IdleChannelHandler extends ChannelDuplexHandler {
 
     private final ClientHandlerMetricSource metrics;
 
-    IdleChannelHandler(long idleTimeout, ClientHandlerMetricSource metrics) {
+    IdleChannelHandler(long idleTimeout, ClientHandlerMetricSource metrics, long connectionId) {
         this.idleTimeout = idleTimeout;
         this.metrics = metrics;
     }

--- a/modules/client-handler/src/test/java/org/apache/ignite/client/handler/ClientInboundMessageHandlerTest.java
+++ b/modules/client-handler/src/test/java/org/apache/ignite/client/handler/ClientInboundMessageHandlerTest.java
@@ -35,6 +35,7 @@ import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.ignite.client.handler.configuration.ClientConnectorConfiguration;
 import org.apache.ignite.compute.IgniteCompute;
 import org.apache.ignite.internal.catalog.CatalogService;
@@ -142,6 +143,7 @@ class ClientInboundMessageHandlerTest extends BaseIgniteAbstractTest {
         }).when(ctx).close();
 
         AuthenticationManager authenticationManager = new AuthenticationManagerImpl();
+        AtomicLong clientIdGen = new AtomicLong(0);
 
         handler = new ClientInboundMessageHandler(
                 igniteTables,
@@ -156,7 +158,8 @@ class ClientInboundMessageHandlerTest extends BaseIgniteAbstractTest {
                 authenticationManager,
                 clock,
                 schemaSyncService,
-                catalogService
+                catalogService,
+                clientIdGen.incrementAndGet()
         );
 
         authenticationManager.listen(handler);

--- a/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
@@ -32,6 +32,7 @@ import java.net.SocketAddress;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.client.handler.ClientHandlerMetricSource;
@@ -183,6 +184,7 @@ public class TestClientHandlerModule implements IgniteComponent {
         var configuration = registry.getConfiguration(ClientConnectorConfiguration.KEY).value();
 
         var requestCounter = new AtomicInteger();
+        var connectionIdGen = new AtomicLong();
 
         ServerBootstrap bootstrap = bootstrapFactory.createServerBootstrap();
 
@@ -206,7 +208,8 @@ public class TestClientHandlerModule implements IgniteComponent {
                                         authenticationManager(securityConfiguration),
                                         clock,
                                         new AlwaysSyncedSchemaSyncService(),
-                                        TestServer.mockCatalogService()
+                                        TestServer.mockCatalogService(),
+                                        connectionIdGen.incrementAndGet()
                                 )
                         );
                     }


### PR DESCRIPTION
Generate an ID for every client connection for diagnostics (logging, monitoring) and management purposes.