### PR TITLE
IGNITE-20832 .NET: Improve retry mechanism

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -72,7 +72,7 @@ public class ReconnectTests
     {
         var cfg = new IgniteClientConfiguration
         {
-            Logger = new ConsoleLogger { MinLevel = LogLevel.Trace }
+            Logger = new ConsoleLogger { MinLevel = LogLevel.Debug }
         };
 
         using var server = new FakeServer();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -70,8 +70,13 @@ public class ReconnectTests
     [Test]
     public async Task TestDroppedConnectionIsRestoredOnDemand()
     {
+        var cfg = new IgniteClientConfiguration
+        {
+            Logger = new ConsoleLogger { MinLevel = LogLevel.Trace }
+        };
+
         using var server = new FakeServer();
-        using var client = await server.ConnectClientAsync();
+        using var client = await server.ConnectClientAsync(cfg);
 
         Assert.DoesNotThrowAsync(async () => await client.Tables.GetTablesAsync());
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -555,14 +555,14 @@ namespace Apache.Ignite.Internal
         {
             var e = exception;
 
-            while (e != null && !(e is SocketException))
+            while (e != null && !IsConnectionError(e))
             {
                 e = e.InnerException;
             }
 
             if (e == null)
             {
-                // Only retry socket exceptions.
+                // Only retry connection errors.
                 return false;
             }
 
@@ -582,6 +582,11 @@ namespace Apache.Ignite.Internal
             var ctx = new RetryPolicyContext(new(Configuration), publicOpType.Value, attempt, exception);
 
             return retryPolicy.ShouldRetry(ctx);
+
+            static bool IsConnectionError(Exception e) =>
+                e is SocketException
+                    or IOException
+                    or IgniteClientConnectionException { Code: ErrorGroups.Client.Connection };
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -496,7 +496,7 @@ namespace Apache.Ignite.Internal
                 {
                     // Disconnected.
                     throw new IgniteClientConnectionException(
-                        ErrorGroups.Client.Protocol,
+                        ErrorGroups.Client.Connection,
                         "Connection lost (failed to read data from socket)",
                         new SocketException((int) SocketError.ConnectionAborted));
                 }
@@ -673,7 +673,7 @@ namespace Apache.Ignite.Internal
                 var message = "Exception while writing to socket, connection closed: " + e.Message;
 
                 _logger?.Error(e, message);
-                var connEx = new IgniteClientConnectionException(ErrorGroups.Client.Connection, message, e);
+                var connEx = new IgniteClientConnectionException(ErrorGroups.Client.Connection, message, new SocketException());
 
                 Dispose(connEx);
                 throw connEx;


### PR DESCRIPTION
`TestDroppedConnectionIsRestoredOnDemand` was flaky because in some cases we failed to retry a broken connection error.

* Close client socket immediately on write error
* Improve `ShouldRetry` logic