### PR TITLE
IGNITE-20920 .NET: Fix TestPutRoutesRequestToPrimaryNode flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteProxy.cs
@@ -135,7 +135,8 @@ public sealed class IgniteProxy : IgniteServerBase
             },
             cancellationToken);
 
-        Task.WhenAll(clientToServerRelay, serverToClientRelay).Wait(millisecondsTimeout: 5000, cancellationToken);
+        Task.WhenAll(clientToServerRelay, serverToClientRelay).Wait(cancellationToken);
+        handler.Disconnect(true);
     }
 
     protected override void Dispose(bool disposing)


### PR DESCRIPTION
Remove timeout from `IgniteProxy` - it was causing connection abort when test took longer than 5 seconds.