### PR TITLE
IGNITE-20962 .NET: Fix TestAuthnOnClientNoAuthnOnServer flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/BasicAuthenticatorTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/BasicAuthenticatorTests.cs
@@ -119,13 +119,9 @@ public class BasicAuthenticatorTests : IgniteTestsBase
                 try
                 {
                     // Ensure that all servers have applied the configuration change.
-                    for (int i = 0; i < 2; i++)
+                    foreach (var endpoint in GetConfig().Endpoints)
                     {
-                        var cfg = new IgniteClientConfiguration(GetEndpoint(i))
-                        {
-                            RetryPolicy = RetryNonePolicy.Instance
-                        };
-
+                        var cfg = new IgniteClientConfiguration(endpoint);
                         using var client2 = await IgniteClient.StartAsync(cfg);
                     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/BasicAuthenticatorTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/BasicAuthenticatorTests.cs
@@ -118,7 +118,7 @@ public class BasicAuthenticatorTests : IgniteTestsBase
             {
                 try
                 {
-                    await Client.Tables.GetTablesAsync();
+                    using var client2 = await IgniteClient.StartAsync(GetConfig(enableAuthn: false));
                     return true;
                 }
                 catch (Exception)

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/BasicAuthenticatorTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/BasicAuthenticatorTests.cs
@@ -29,7 +29,7 @@ public class BasicAuthenticatorTests : IgniteTestsBase
 {
     private const string EnableAuthnJob = "org.apache.ignite.internal.runner.app.PlatformTestNodeRunner$EnableAuthenticationJob";
 
-    private bool _authnEnabled;
+    private volatile bool _authnEnabled;
 
     [TearDown]
     public async Task DisableAuthenticationAfterTest() => await EnableAuthn(false);
@@ -118,7 +118,17 @@ public class BasicAuthenticatorTests : IgniteTestsBase
             {
                 try
                 {
-                    using var client2 = await IgniteClient.StartAsync(GetConfig(enableAuthn: false));
+                    // Ensure that all servers have applied the configuration change.
+                    for (int i = 0; i < 2; i++)
+                    {
+                        var cfg = new IgniteClientConfiguration(GetEndpoint(i))
+                        {
+                            RetryPolicy = RetryNonePolicy.Instance
+                        };
+
+                        using var client2 = await IgniteClient.StartAsync(cfg);
+                    }
+
                     return true;
                 }
                 catch (Exception)

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -175,13 +175,11 @@ namespace Apache.Ignite.Tests
 
         protected static IgniteClientConfiguration GetConfig() => new()
         {
-            Endpoints =
-            {
-                "127.0.0.1:" + ServerNode.Port,
-                "127.0.0.1:" + (ServerNode.Port + 1)
-            },
+            Endpoints = { GetEndpoint(0), GetEndpoint(1) },
             LoggerFactory = TestUtils.GetConsoleLoggerFactory(LogLevel.Trace)
         };
+
+        protected static string GetEndpoint(int index) => "127.0.0.1:" + (ServerNode.Port + index);
 
         protected static IgniteClientConfiguration GetConfig(IEnumerable<IgniteProxy> proxies) =>
             new(proxies.Select(x => x.Endpoint).ToArray())

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -175,11 +175,13 @@ namespace Apache.Ignite.Tests
 
         protected static IgniteClientConfiguration GetConfig() => new()
         {
-            Endpoints = { GetEndpoint(0), GetEndpoint(1) },
+            Endpoints =
+            {
+                "127.0.0.1:" + ServerNode.Port,
+                "127.0.0.1:" + (ServerNode.Port + 1)
+            },
             LoggerFactory = TestUtils.GetConsoleLoggerFactory(LogLevel.Trace)
         };
-
-        protected static string GetEndpoint(int index) => "127.0.0.1:" + (ServerNode.Port + index);
 
         protected static IgniteClientConfiguration GetConfig(IEnumerable<IgniteProxy> proxies) =>
             new(proxies.Select(x => x.Endpoint).ToArray())


### PR DESCRIPTION
Ensure that all servers have applied the configuration change, not only one.