### PR TITLE
IGNITE-21030 Dump debug info if the ExecutionService could not be stopped within a timeout

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/SqlQueryProcessor.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/SqlQueryProcessor.java
@@ -148,6 +148,8 @@ public class SqlQueryProcessor implements QueryProcessor {
 
     private static final CacheFactory CACHE_FACTORY = CaffeineCacheFactory.INSTANCE;
 
+    private static final long EXECUTION_SERVICE_SHUTDOWN_TIMEOUT = 60_000;
+
     private final ParserService parserService = new ParserServiceImpl(
             PARSED_RESULT_CACHE_SIZE, CACHE_FACTORY
     );
@@ -322,7 +324,8 @@ public class SqlQueryProcessor implements QueryProcessor {
                 mailboxRegistry,
                 exchangeService,
                 mappingService,
-                dependencyResolver
+                dependencyResolver,
+                EXECUTION_SERVICE_SHUTDOWN_TIMEOUT
         ));
 
         clusterSrvc.topologyService().addEventHandler(executionSrvc);

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImpl.java
@@ -26,22 +26,28 @@ import static org.apache.ignite.lang.ErrorGroups.Common.INTERNAL_ERR;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.tools.Frameworks;
@@ -49,6 +55,7 @@ import org.apache.ignite.configuration.ConfigurationChangeException;
 import org.apache.ignite.internal.lang.IgniteBiTuple;
 import org.apache.ignite.internal.lang.IgniteInternalCheckedException;
 import org.apache.ignite.internal.lang.IgniteInternalException;
+import org.apache.ignite.internal.lang.IgniteStringBuilder;
 import org.apache.ignite.internal.logger.IgniteLogger;
 import org.apache.ignite.internal.logger.Loggers;
 import org.apache.ignite.internal.replicator.TablePartitionId;
@@ -134,6 +141,8 @@ public class ExecutionServiceImpl<RowT> implements ExecutionService, TopologyEve
 
     private final Map<UUID, DistributedQueryManager> queryManagerMap = new ConcurrentHashMap<>();
 
+    private final long shutdownTimeout;
+
     /**
      * Creates the execution services.
      *
@@ -158,7 +167,8 @@ public class ExecutionServiceImpl<RowT> implements ExecutionService, TopologyEve
             MailboxRegistry mailboxRegistry,
             ExchangeService exchangeSrvc,
             MappingService mappingService,
-            ExecutionDependencyResolver dependencyResolver
+            ExecutionDependencyResolver dependencyResolver,
+            long shutdownTimeout
     ) {
         HashFunctionFactoryImpl<RowT> rowHashFunctionFactory = new HashFunctionFactoryImpl<>(handler);
 
@@ -176,7 +186,8 @@ public class ExecutionServiceImpl<RowT> implements ExecutionService, TopologyEve
                         rowHashFunctionFactory,
                         mailboxRegistry,
                         exchangeSrvc,
-                        deps)
+                        deps),
+                shutdownTimeout
         );
     }
 
@@ -201,7 +212,8 @@ public class ExecutionServiceImpl<RowT> implements ExecutionService, TopologyEve
             QueryTaskExecutor taskExecutor,
             RowHandler<RowT> handler,
             ExecutionDependencyResolver dependencyResolver,
-            ImplementorFactory<RowT> implementorFactory
+            ImplementorFactory<RowT> implementorFactory,
+            long shutdownTimeout
     ) {
         this.localNode = topSrvc.localMember();
         this.handler = handler;
@@ -213,6 +225,7 @@ public class ExecutionServiceImpl<RowT> implements ExecutionService, TopologyEve
         this.ddlCmdHnd = ddlCmdHnd;
         this.dependencyResolver = dependencyResolver;
         this.implementorFactory = implementorFactory;
+        this.shutdownTimeout = shutdownTimeout;
     }
 
     /** {@inheritDoc} */
@@ -411,9 +424,17 @@ public class ExecutionServiceImpl<RowT> implements ExecutionService, TopologyEve
 
         try {
             // Using get() without a timeout to exclude situations when it's not clear whether the node has actually stopped or not.
-            f.get();
+            f.get(shutdownTimeout, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            String message = format("SQL execution service could not be stopped within the specified timeout ({} ms).", shutdownTimeout);
+
+            LOG.warn(message + dumpDebugInfo());
         } catch (CancellationException e) {
             LOG.warn("The stop future was cancelled, going to proceed the stop procedure", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+
+            LOG.warn("The stop future was interrupted, going to proceed the stop procedure", e);
         }
     }
 
@@ -452,6 +473,120 @@ public class ExecutionServiceImpl<RowT> implements ExecutionService, TopologyEve
 
             return new DistributedQueryManager(coordinatorNodeName, ctx);
         });
+    }
+
+    /**
+     * Collects debug information about current state of execution.
+     *
+     *<p>This information has the following format:
+     *
+     *<pre>
+     *Debug info for query: [uuid] (canceled=[true/false], stopped=[true/false])
+     *  Coordinator node: [nodeName] [(current node)]
+     *  Root node state: [opened/closed/absent/exception]
+     *
+     *  Fragments awaiting init completion:
+     *    id=[id], node=[nodeName]"
+     *    ...
+     *
+     *  Local fragments:
+     *    id=[id], state=[opened/closed], canceled=[true/false], class=[SimpleClassName]  [(root)]
+     *    ...
+     *
+     *...
+     *</pre>
+     *
+     * @return String containing debugging information.
+     */
+    String dumpDebugInfo() {
+        IgniteStringBuilder buf = new IgniteStringBuilder();
+
+        for (Map.Entry<UUID, DistributedQueryManager> entry : queryManagerMap.entrySet()) {
+            UUID queryId = entry.getKey();
+            DistributedQueryManager mgr = entry.getValue();
+
+            Long rootFragmentId = mgr.rootFragmentId;
+
+            if (rootFragmentId == null) {
+                continue;
+            }
+
+            buf.nl();
+            buf.app("Debug info for query: ").app(queryId)
+                    .app(" (canceled=").app(mgr.cancelled.get()).app(", stopped=").app(mgr.cancelFut.isDone()).app(")");
+            buf.nl();
+
+            buf.app("  Coordinator node: ").app(mgr.coordinatorNodeName);
+            if (mgr.coordinator) {
+                buf.app(" (current node)");
+            }
+            buf.nl();
+
+            buf.app("  Root node state: ");
+            CompletableFuture<AsyncRootNode<RowT, List<Object>>> rootNodeFut = mgr.root;
+            if (rootNodeFut != null && rootNodeFut.isDone()) {
+                try {
+                    AsyncRootNode<RowT, List<Object>> rootNode = rootNodeFut.getNow(null);
+
+                    if (rootNode != null) {
+                        if (rootNode.isClosed()) {
+                            buf.app("closed");
+                        } else {
+                            buf.app("opened");
+                        }
+                    } else {
+                        buf.app("absent");
+                    }
+                } catch (CompletionException ex) {
+                    buf.app("completed exceptionally ").app('(').app(ExceptionUtils.unwrapCause(ex)).app(')');
+                } catch (CancellationException ex) {
+                    buf.app("canceled");
+                }
+            }
+            buf.nl().nl();
+
+            List<RemoteFragmentKey> initFragments = mgr.remoteFragmentInitCompletion.entrySet().stream()
+                    .filter(entry0 -> !entry0.getValue().isDone())
+                    .map(Entry::getKey)
+                    .sorted(Comparator.comparingLong(RemoteFragmentKey::fragmentId))
+                    .collect(Collectors.toList());
+
+            if (!initFragments.isEmpty()) {
+                buf.app("  Fragments awaiting init completion:").nl();
+
+                for (RemoteFragmentKey fragmentKey : initFragments) {
+                    buf.app("    id=").app(fragmentKey.fragmentId()).app(", node=").app(fragmentKey.nodeName());
+                    buf.nl();
+                }
+
+                buf.nl();
+            }
+
+            List<AbstractNode<?>> localFragments = mgr.localFragments().stream()
+                    .sorted(Comparator.comparingLong(n -> n.context().fragmentId()))
+                    .collect(Collectors.toList());
+
+            if (!localFragments.isEmpty()) {
+                buf.app("  Local fragments:").nl();
+
+                for (AbstractNode<?> fragment : localFragments) {
+                    long fragmentId = fragment.context().fragmentId();
+
+                    buf.app("    id=").app(fragmentId)
+                            .app(", state=").app(fragment.isClosed() ? "closed" : "opened")
+                            .app(", canceled=").app(fragment.context().isCancelled())
+                            .app(", class=").app(fragment.getClass().getSimpleName());
+
+                    if (fragmentId == rootFragmentId) {
+                        buf.app("  (root)");
+                    }
+
+                    buf.nl();
+                }
+            }
+        }
+
+        return buf.length() > 0 ? buf.toString() : "No debug information available.";
     }
 
     /**

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImpl.java
@@ -524,11 +524,11 @@ public class ExecutionServiceImpl<RowT> implements ExecutionService, TopologyEve
             }
             buf.nl();
 
-            CompletableFuture<AsyncRootNode<RowT, List<Object>>> rootNodeFut = mgr.root;
+            CompletableFuture<AsyncRootNode<RowT, InternalSqlRow>> rootNodeFut = mgr.root;
             if (rootNodeFut != null) {
                 buf.app("  Root node state: ");
                 try {
-                    AsyncRootNode<RowT, List<Object>> rootNode = rootNodeFut.getNow(null);
+                    AsyncRootNode<RowT, InternalSqlRow> rootNode = rootNodeFut.getNow(null);
                     if (rootNode != null) {
                         if (rootNode.isClosed()) {
                             buf.app("closed");

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImpl.java
@@ -478,23 +478,23 @@ public class ExecutionServiceImpl<RowT> implements ExecutionService, TopologyEve
     /**
      * Collects debug information about current state of execution.
      *
-     *<p>This information has the following format:
+     * <p>This information has the following format:
      *
-     *<pre>
-     *Debug info for query: [uuid] (canceled=[true/false], stopped=[true/false])
-     *  Coordinator node: [nodeName] [(current node)]
-     *  Root node state: [opened/closed/absent/exception]
+     * <pre>
+     * Debug info for query: [uuid] (canceled=[true/false], stopped=[true/false])
+     *   Coordinator node: [nodeName] [(current node)]
+     *   Root node state: [opened/closed/absent/exception]
      *
-     *  Fragments awaiting init completion:
-     *    id=[id], node=[nodeName]"
-     *    ...
+     *   Fragments awaiting init completion:
+     *     id=[id], node=[nodeName]"
+     *     ...
      *
-     *  Local fragments:
-     *    id=[id], state=[opened/closed], canceled=[true/false], class=[SimpleClassName]  [(root)]
-     *    ...
+     *   Local fragments:
+     *     id=[id], state=[opened/closed], canceled=[true/false], class=[SimpleClassName]  [(root)]
+     *     ...
      *
-     *...
-     *</pre>
+     * ...
+     * </pre>
      *
      * @return String containing debugging information.
      */

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImpl.java
@@ -423,7 +423,7 @@ public class ExecutionServiceImpl<RowT> implements ExecutionService, TopologyEve
         );
 
         try {
-            // If the service was unable to stop within the provided timeout, debugging information will be output to the log.
+            // If the service was unable to stop within the provided timeout, debugging information will be printed to the log.
             f.get(shutdownTimeout, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
             String message = format("SQL execution service could not be stopped within the specified timeout ({} ms).", shutdownTimeout);

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/rel/AbstractNode.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/rel/AbstractNode.java
@@ -137,7 +137,7 @@ public abstract class AbstractNode<RowT> implements Node<RowT> {
     /**
      * Get closed flag: {@code true} if the subtree is canceled.
      */
-    protected boolean isClosed() {
+    public boolean isClosed() {
         return closed;
     }
 

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/rel/AsyncRootNode.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/rel/AsyncRootNode.java
@@ -205,6 +205,10 @@ public class AsyncRootNode<InRowT, OutRowT> implements Downstream<InRowT>, Async
         return prefetchFut;
     }
 
+    public boolean isClosed() {
+        return cancelFut.isDone();
+    }
+
     private void flush() throws Exception {
         completePrefetchFuture(null);
 

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/rel/RootNode.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/rel/RootNode.java
@@ -123,7 +123,7 @@ public class RootNode<RowT> extends AbstractNode<RowT> implements SingleNode<Row
 
     /** {@inheritDoc} */
     @Override
-    protected boolean isClosed() {
+    public boolean isClosed() {
         return closed;
     }
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImplTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImplTest.java
@@ -738,7 +738,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
         }));
 
         InternalTransaction tx = new NoOpTransaction(nodeNames.get(0));
-        AsyncCursor<List<Object>> cursor = execService.executePlan(tx, plan, ctx);
+        AsyncCursor<InternalSqlRow> cursor = execService.executePlan(tx, plan, ctx);
 
         startResponseLatch.await(TIMEOUT_IN_MS, TimeUnit.MILLISECONDS);
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImplTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImplTest.java
@@ -47,7 +47,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -60,6 +59,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -149,6 +149,9 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
 
     /** Timeout in ms for SQL planning phase. */
     public static final long PLANNING_TIMEOUT = 5_000;
+
+    /** Timeout in ms for stopping execution service.*/
+    private static final long SHUTDOWN_TIMEOUT = 5_000;
 
     private static final int SCHEMA_VERSION = -1;
 
@@ -698,6 +701,76 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
         cursor.closeAsync();
     }
 
+    /**
+     * Test checks the format of the debugging information dump obtained during query execution.
+     * To obtain verifiable results, all response messages are blocked while debugging information is obtained.
+     */
+    @Test
+    public void testDebugInfoFormat() throws InterruptedException {
+        ExecutionServiceImpl<?> execService = executionServices.get(0);
+        BaseQueryContext ctx = createContext();
+        QueryPlan plan = prepare("SELECT * FROM test_tbl", ctx);
+
+        CountDownLatch startResponseLatch = new CountDownLatch(4);
+        CountDownLatch continueLatch = new CountDownLatch(1);
+
+        nodeNames.stream().map(testCluster::node).forEach(node -> node.interceptor((senderNodeName, msg, original) -> {
+            if (msg instanceof QueryStartResponseImpl) {
+                startResponseLatch.countDown();
+
+                ForkJoinPool.commonPool().execute(() -> {
+                    try {
+                        continueLatch.await(TIMEOUT_IN_MS, TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException ignore) {
+                        // No-op.
+                    }
+
+                    original.onMessage(senderNodeName, msg);
+                });
+
+                return nullCompletedFuture();
+            } else {
+                original.onMessage(senderNodeName, msg);
+
+                return nullCompletedFuture();
+            }
+        }));
+
+        InternalTransaction tx = new NoOpTransaction(nodeNames.get(0));
+        AsyncCursor<List<Object>> cursor = execService.executePlan(tx, plan, ctx);
+
+        startResponseLatch.await(TIMEOUT_IN_MS, TimeUnit.MILLISECONDS);
+
+        String debugInfo = execService.dumpDebugInfo();
+
+        continueLatch.countDown();
+
+        await(cursor.closeAsync());
+
+        assertTrue(waitForCondition(
+                () -> executionServices.stream().map(es -> es.localFragments(ctx.queryId()).size())
+                        .mapToInt(i -> i).sum() == 0, TIMEOUT_IN_MS));
+
+        String nl = System.lineSeparator();
+
+        String expected = format(nl
+                + "Debug info for query: {} (canceled=false, stopped=false)" + nl
+                + "  Coordinator node: node_1 (current node)" + nl
+                + "  Root node state: opened" + nl
+                + nl
+                + "  Fragments awaiting init completion:" + nl
+                + "    id=0, node=node_1" + nl
+                + "    id=1, node=node_1" + nl
+                + "    id=1, node=node_2" + nl
+                + "    id=1, node=node_3" + nl
+                + nl
+                + "  Local fragments:" + nl
+                + "    id=0, state=opened, canceled=false, class=Inbox  (root)" + nl
+                + "    id=1, state=opened, canceled=false, class=Outbox" + nl, ctx.queryId());
+
+        assertThat(debugInfo, equalTo(expected));
+    }
+
     /** Creates an execution service instance for the node with given consistent id. */
     public ExecutionServiceImpl<Object[]> create(String nodeName) {
         if (!nodeNames.contains(nodeName)) {
@@ -774,7 +847,8 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
                 taskExecutor,
                 ArrayRowHandler.INSTANCE,
                 dependencyResolver,
-                (ctx, deps) -> node.implementor(ctx, mailboxRegistry, exchangeService, deps)
+                (ctx, deps) -> node.implementor(ctx, mailboxRegistry, exchangeService, deps),
+                SHUTDOWN_TIMEOUT
         );
 
         taskExecutor.start();
@@ -1037,8 +1111,8 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
     private static class CapturingMailboxRegistry implements MailboxRegistry {
         private final MailboxRegistry delegate;
 
-        private final Set<Inbox<?>> inboxes = Collections.newSetFromMap(new ConcurrentHashMap<>());
-        private final Set<Outbox<?>> outboxes = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        private final Set<Inbox<?>> inboxes = ConcurrentHashMap.newKeySet();
+        private final Set<Outbox<?>> outboxes = ConcurrentHashMap.newKeySet();
 
         CapturingMailboxRegistry(MailboxRegistry delegate) {
             this.delegate = delegate;

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImplTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImplTest.java
@@ -741,7 +741,9 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
 
         startResponseLatch.await(TIMEOUT_IN_MS, TimeUnit.MILLISECONDS);
 
-        String debugInfo = execService.dumpDebugInfo();
+        String debugInfoCoordinator = executionServices.get(0).dumpDebugInfo();
+        String debugInfo2 = executionServices.get(1).dumpDebugInfo();
+        String debugInfo3 = executionServices.get(2).dumpDebugInfo();
 
         continueLatch.countDown();
 
@@ -753,7 +755,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
 
         String nl = System.lineSeparator();
 
-        String expected = format(nl
+        String expectedOnCoordinator = format(nl
                 + "Debug info for query: {} (canceled=false, stopped=false)" + nl
                 + "  Coordinator node: node_1 (current node)" + nl
                 + "  Root node state: opened" + nl
@@ -768,7 +770,17 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
                 + "    id=0, state=opened, canceled=false, class=Inbox  (root)" + nl
                 + "    id=1, state=opened, canceled=false, class=Outbox" + nl, ctx.queryId());
 
-        assertThat(debugInfo, equalTo(expected));
+        assertThat(debugInfoCoordinator, equalTo(expectedOnCoordinator));
+
+        String expectedOnNonCoordinator = format(nl
+                + "Debug info for query: {} (canceled=false, stopped=false)" + nl
+                + "  Coordinator node: node_1" + nl
+                + nl
+                + "  Local fragments:" + nl
+                + "    id=1, state=opened, canceled=false, class=Outbox" + nl, ctx.queryId());
+
+        assertThat(debugInfo2, equalTo(expectedOnNonCoordinator));
+        assertThat(debugInfo3, equalTo(expectedOnNonCoordinator));
     }
 
     /** Creates an execution service instance for the node with given consistent id. */

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/TestNode.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/TestNode.java
@@ -127,7 +127,8 @@ public class TestNode implements LifecycleAware {
                 mailboxRegistry,
                 exchangeService,
                 mappingService,
-                dependencyResolver
+                dependencyResolver,
+                0
         ));
 
         registerService(new IgniteComponentLifecycleAwareAdapter(systemViewManager));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-21030

* added timeout for ExecutionService shutdown
* added diagnostic information output when a timeout occurs

Current timeout set as constant 60 seconds (debatable).
Configuration will be added separately.

Diagnostic info output example:

```
Debug info for query: 08034d4d-2586-474e-86dc-bd69a3a52bfd (canceled=false, stopped=false)
  Coordinator node: node_1 (current node)
  Root node state: opened

  Fragments awaiting init completion:
    id=0, node=node_1
    id=1, node=node_1
    id=1, node=node_2
    id=1, node=node_3

  Local fragments:
    id=0, state=opened, canceled=false, class=Inbox  (root)
    id=1, state=opened, canceled=false, class=Outbox
```