### PR TITLE
IGNITE-20952 Ignore static and transient fields in MapperBuilder

### DIFF
--- a/modules/api/src/main/java/org/apache/ignite/table/mapper/MapperBuilder.java
+++ b/modules/api/src/main/java/org/apache/ignite/table/mapper/MapperBuilder.java
@@ -272,6 +272,7 @@ public final class MapperBuilder<T> {
 
         if (automapFlag) {
             Arrays.stream(targetType.getDeclaredFields())
+                    .filter(fld -> !Modifier.isStatic(fld.getModifiers()) && !Modifier.isTransient(fld.getModifiers()))
                     .map(Field::getName)
                     .filter(fldName -> !fields.contains(fldName))
                     // Ignore manually mapped fields/columns.

--- a/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/Marshaller.java
+++ b/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/Marshaller.java
@@ -152,7 +152,6 @@ public abstract class Marshaller {
                     fieldSet.remove(fieldName);
                 }
 
-                // TODO: Exclude static and transient fields from the list.
                 throw new IllegalArgumentException(
                         String.format("Fields %s of type %s are not mapped to columns", fieldSet, mapper.targetType().getName()),
                         new UnmappedColumnsException()

--- a/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/Marshaller.java
+++ b/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/Marshaller.java
@@ -152,6 +152,7 @@ public abstract class Marshaller {
                     fieldSet.remove(fieldName);
                 }
 
+                // TODO: Exclude static and transient fields from the list.
                 throw new IllegalArgumentException(
                         String.format("Fields %s of type %s are not mapped to columns", fieldSet, mapper.targetType().getName()),
                         new UnmappedColumnsException()

--- a/modules/marshaller-common/src/testFixtures/java/org/apache/ignite/internal/marshaller/testobjects/TestObjectWithAllTypes.java
+++ b/modules/marshaller-common/src/testFixtures/java/org/apache/ignite/internal/marshaller/testobjects/TestObjectWithAllTypes.java
@@ -146,6 +146,10 @@ public class TestObjectWithAllTypes {
 
     private BigDecimal decimalCol;
 
+    private static int staticField;
+
+    private transient int transientField;
+
     /** {@inheritDoc} */
     @Override
     public boolean equals(Object o) {

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -325,6 +325,10 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
         public String unmapped;
 
         public String unmapped2;
+
+        public static String staticField;
+
+        public transient String transientField;
     }
 
     private static class MissingFieldPojo {

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/asm/ObjectMarshallerCodeGenerator.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/asm/ObjectMarshallerCodeGenerator.java
@@ -67,7 +67,7 @@ class ObjectMarshallerCodeGenerator implements MarshallerCodeGenerator {
         Map<String, Field> flds = new HashMap<>();
         for (String fieldName : mapper.fields()) {
             try {
-                Field field = mapper.getClass().getDeclaredField(fieldName);
+                Field field = mapper.targetType().getDeclaredField(fieldName);
                 flds.put(fieldName.toUpperCase(), field);
             } catch (NoSuchFieldException e) {
                 throw new RuntimeException(e);

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/asm/ObjectMarshallerCodeGenerator.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/asm/ObjectMarshallerCodeGenerator.java
@@ -65,12 +65,14 @@ class ObjectMarshallerCodeGenerator implements MarshallerCodeGenerator {
         columnAccessors = new ColumnAccessCodeGenerator[columns.length];
 
         Map<String, Field> flds = new HashMap<>();
-        for (String fieldName : mapper.fields()) {
+        for (String fldName : mapper.fields()) {
             try {
-                Field field = mapper.targetType().getDeclaredField(fieldName);
-                flds.put(fieldName.toUpperCase(), field);
+                Field field = mapper.targetType().getDeclaredField(fldName);
+                flds.put(fldName.toUpperCase(), field);
             } catch (NoSuchFieldException e) {
-                throw new RuntimeException(e);
+                throw new IllegalArgumentException(
+                        "Field " + fldName + " is returned from mapper of type " + mapper.getClass().getName()
+                                + ", but is not present in target class " + mapper.targetType().getName(), e);
             }
         }
 

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/asm/ObjectMarshallerCodeGenerator.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/asm/ObjectMarshallerCodeGenerator.java
@@ -74,6 +74,7 @@ class ObjectMarshallerCodeGenerator implements MarshallerCodeGenerator {
 
             var fldNames = flds.values().stream().map(Field::getName).sorted().collect(Collectors.toList());
 
+            // TODO: Exclude static and transient fields from the list.
             throw new IllegalArgumentException(
                     "Fields " + fldNames + " of type " + targetClass.getName() + " are not mapped to columns");
         }


### PR DESCRIPTION
* Skip static and transient fields in `MapperBuilder`
* Propagate mapper to `ObjectMarshallerCodeGenerator` to reuse the field list