### PR TITLE
IGNITE-20568 .NET: Add support for IgniteCheckedException in ExceptionsGenerator

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
@@ -78,21 +78,30 @@ namespace Apache.Ignite.Internal.Generators
             var template = GetExceptionClassTemplate();
 
             var classMap = new List<(string JavaClass, string DotNetClass)>();
+            var dotNetClassSet = new HashSet<string>();
 
             foreach (var javaException in javaExceptions)
             {
                 var className = javaException.Key;
+                var dotNetClassName = className.Replace("CheckedException", "Exception");
+
+                if (!dotNetClassSet.Add(dotNetClassName) || existingExceptions.Contains(dotNetClassName))
+                {
+                    // .NET does not have checked exceptions, so we map them to unchecked.
+                    // If there is already an unchecked exception with the same name - skip it.
+                    continue;
+                }
 
                 var (javaPackage, dotNetNamespace) = GetPackageAndNamespace(className, javaException.Value.Source);
 
                 var src = template
-                    .Replace("IgniteTemplateException", className)
-                    .Replace("XMLDOC", GetXmlDoc(className, javaException.Value.Source))
+                    .Replace("IgniteTemplateException", dotNetClassName)
+                    .Replace("XMLDOC", GetXmlDoc(dotNetClassName, javaException.Value.Source))
                     .Replace("NAMESPACE", dotNetNamespace);
 
-                yield return (className + ".g.cs", src);
+                yield return (dotNetClassName + ".g.cs", src);
 
-                classMap.Add((javaPackage + "." + className, dotNetNamespace + "." + className));
+                classMap.Add((javaPackage + "." + className, dotNetNamespace + "." + dotNetClassName));
             }
 
             yield return EmitClassMap(classMap);

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
@@ -99,7 +99,7 @@ namespace Apache.Ignite.Internal.Generators
 
             bool IsIgniteException(string? ex) =>
                 ex != null &&
-                (ex == "IgniteException" ||
+                (ex == "IgniteException" || ex == "IgniteCheckedException" ||
                  IsIgniteException(javaExceptionsWithParents.TryGetValue(ex, out var parent) ? parent.Parent : null));
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -350,13 +350,12 @@ namespace Apache.Ignite.Tests.Compute
             var ex = Assert.ThrowsAsync<IgniteException>(async () =>
                 await Client.Compute.ExecuteAsync<object>(await GetNodeAsync(1), Units, CheckedExceptionJob, "foo-bar"));
 
-            Assert.AreEqual("Test exception: foo-bar", ex!.Message);
+            // TODO: Check exception type
+            // TODO: Check Java exception type.
+            Assert.AreEqual("TestCheckedEx: foo-bar", ex!.Message);
             Assert.IsNotNull(ex.InnerException);
 
-            var str = ex.ToString();
-
-            // TODO IGNITE-20858: Fix once user errors are handled properly
-            StringAssert.Contains("Apache.Ignite.IgniteException: Test exception: foo-bar", str);
+            StringAssert.Contains("org.apache.ignite.lang.IgniteCheckedException: IGN-CMN-1", ex.ToString());
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -56,6 +56,8 @@ namespace Apache.Ignite.Tests.Compute
 
         private const string ExceptionJob = PlatformTestNodeRunner + "$ExceptionJob";
 
+        private const string CheckedExceptionJob = PlatformTestNodeRunner + "$CheckedExceptionJob";
+
         private static readonly IList<DeploymentUnit> Units = Array.Empty<DeploymentUnit>();
 
         [Test]
@@ -340,6 +342,21 @@ namespace Apache.Ignite.Tests.Compute
             StringAssert.Contains(
                 "at org.apache.ignite.internal.runner.app.PlatformTestNodeRunner$ExceptionJob.execute(PlatformTestNodeRunner.java:",
                 str);
+        }
+
+        [Test]
+        public void TestCheckedExceptionInJobPropagatesToClient()
+        {
+            var ex = Assert.ThrowsAsync<IgniteException>(async () =>
+                await Client.Compute.ExecuteAsync<object>(await GetNodeAsync(1), Units, CheckedExceptionJob, "foo-bar"));
+
+            Assert.AreEqual("Test exception: foo-bar", ex!.Message);
+            Assert.IsNotNull(ex.InnerException);
+
+            var str = ex.ToString();
+
+            // TODO IGNITE-20858: Fix once user errors are handled properly
+            StringAssert.Contains("Apache.Ignite.IgniteException: Test exception: foo-bar", str);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -350,12 +350,10 @@ namespace Apache.Ignite.Tests.Compute
             var ex = Assert.ThrowsAsync<IgniteException>(async () =>
                 await Client.Compute.ExecuteAsync<object>(await GetNodeAsync(1), Units, CheckedExceptionJob, "foo-bar"));
 
-            // TODO: Check exception type
-            // TODO: Check Java exception type.
             Assert.AreEqual("TestCheckedEx: foo-bar", ex!.Message);
             Assert.IsNotNull(ex.InnerException);
 
-            StringAssert.Contains("org.apache.ignite.lang.IgniteCheckedException: IGN-CMN-1", ex.ToString());
+            StringAssert.Contains("org.apache.ignite.lang.IgniteCheckedException: IGN-CMN-5", ex.ToString());
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Tests;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -91,6 +92,7 @@ public class MetricsTests
     }
 
     [Test]
+    [SuppressMessage("ReSharper", "DisposeOnUsingVariable", Justification = "Test")]
     public async Task TestConnectionsLost()
     {
         using var server = new FakeServer();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Tests.Sql
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Threading.Tasks;
     using Ignite.Sql;
@@ -28,6 +29,8 @@ namespace Apache.Ignite.Tests.Sql
     /// <summary>
     /// Tests for SQL API: <see cref="ISql"/>.
     /// </summary>
+    [SuppressMessage("ReSharper", "NotDisposedResource", Justification = "Tests")]
+    [SuppressMessage("ReSharper", "NotDisposedResourceIsReturned", Justification = "Tests")]
     public class SqlTests : IgniteTestsBase
     {
         [OneTimeSetUp]

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -53,6 +53,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgnitionManager;
@@ -76,6 +77,10 @@ import org.apache.ignite.internal.table.RecordBinaryViewImpl;
 import org.apache.ignite.internal.testframework.TestIgnitionManager;
 import org.apache.ignite.internal.type.NativeTypes;
 import org.apache.ignite.internal.util.IgniteUtils;
+import org.apache.ignite.lang.ErrorGroup;
+import org.apache.ignite.lang.ErrorGroups;
+import org.apache.ignite.lang.ErrorGroups.Common;
+import org.apache.ignite.lang.IgniteCheckedException;
 import org.apache.ignite.sql.Session;
 import org.apache.ignite.table.Table;
 import org.apache.ignite.table.Tuple;
@@ -543,6 +548,17 @@ public class PlatformTestNodeRunner {
         @Override
         public String execute(JobExecutionContext context, Object... args) {
             throw new RuntimeException("Test exception: " + args[0]);
+        }
+    }
+
+    /**
+     * Compute job that throws an exception.
+     */
+    @SuppressWarnings("unused") // Used by platform tests.
+    private static class CheckedExceptionJob implements ComputeJob<String> {
+        @Override
+        public String execute(JobExecutionContext context, Object... args) {
+            throw new CompletionException(new IgniteCheckedException(Common.NODE_STOPPING_ERR, "TestCheckedEx: " + args[0]));
         }
     }
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -77,8 +77,6 @@ import org.apache.ignite.internal.table.RecordBinaryViewImpl;
 import org.apache.ignite.internal.testframework.TestIgnitionManager;
 import org.apache.ignite.internal.type.NativeTypes;
 import org.apache.ignite.internal.util.IgniteUtils;
-import org.apache.ignite.lang.ErrorGroup;
-import org.apache.ignite.lang.ErrorGroups;
 import org.apache.ignite.lang.ErrorGroups.Common;
 import org.apache.ignite.lang.IgniteCheckedException;
 import org.apache.ignite.sql.Session;

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -558,7 +558,7 @@ public class PlatformTestNodeRunner {
     private static class CheckedExceptionJob implements ComputeJob<String> {
         @Override
         public String execute(JobExecutionContext context, Object... args) {
-            throw new CompletionException(new IgniteCheckedException(Common.NODE_STOPPING_ERR, "TestCheckedEx: " + args[0]));
+            throw new CompletionException(new IgniteCheckedException(Common.NODE_LEFT_ERR, "TestCheckedEx: " + args[0]));
         }
     }
 


### PR DESCRIPTION
Currently there are no public exceptions derived from `IgniteCheckedException`, but we don't want to miss them in .NET when they are added.