### PR TITLE
IGNITE-21147 Transaction finish fails with a timeout exception

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/table/ItTransactionConflictTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/table/ItTransactionConflictTest.java
@@ -119,11 +119,9 @@ public class ItTransactionConflictTest extends ClusterPerTestIntegrationTest {
 
                 recoveryTxMsgCaptureFut.complete(recoveryTxMsg.txId());
 
-                msgCount.incrementAndGet();
-
                 // Drop only the first recovery to emulate a lost message.
                 // Another one should be issued eventually.
-                return msgCount.get() == 1;
+                return msgCount.incrementAndGet() == 1;
             }
 
             return false;

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
@@ -166,6 +166,7 @@ import org.apache.ignite.internal.thread.StripedThreadPoolExecutor;
 import org.apache.ignite.internal.tx.HybridTimestampTracker;
 import org.apache.ignite.internal.tx.LockManager;
 import org.apache.ignite.internal.tx.TxManager;
+import org.apache.ignite.internal.tx.impl.TxMessageSender;
 import org.apache.ignite.internal.tx.storage.state.TxStateStorage;
 import org.apache.ignite.internal.tx.storage.state.TxStateTableStorage;
 import org.apache.ignite.internal.tx.storage.state.rocksdb.TxStateRocksDbTableStorage;
@@ -416,13 +417,15 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
 
         TopologyService topologyService = clusterService.topologyService();
 
+        TxMessageSender txMessageSender = new TxMessageSender(clusterService.messagingService(), replicaSvc, clock);
+
         transactionStateResolver = new TransactionStateResolver(
-                replicaSvc,
                 txManager,
                 clock,
                 topologyService,
                 clusterService.messagingService(),
-                placementDriver
+                placementDriver,
+                txMessageSender
         );
 
         schemaVersions = new SchemaVersionsImpl(schemaSyncService, catalogService, clock);

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/replicator/PartitionReplicaListener.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/replicator/PartitionReplicaListener.java
@@ -1977,14 +1977,7 @@ public class PartitionReplicaListener implements ReplicaListener {
             return failedFuture(new TransactionException(TX_FAILED_READ_WRITE_OPERATION_ERR, "Transaction is already finished."));
         }
 
-        CompletableFuture<T> fut;
-        try {
-            fut = op.get();
-        } catch (Throwable ex) {
-            cleanupReadyFut.completeExceptionally(ex);
-
-            throw ex;
-        }
+        CompletableFuture<T> fut = op.get();
 
         fut.whenComplete((v, th) -> {
             if (th != null) {

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/replication/PartitionReplicaListenerTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/replication/PartitionReplicaListenerTest.java
@@ -168,6 +168,7 @@ import org.apache.ignite.internal.tx.TxMeta;
 import org.apache.ignite.internal.tx.TxState;
 import org.apache.ignite.internal.tx.TxStateMeta;
 import org.apache.ignite.internal.tx.impl.HeapLockManager;
+import org.apache.ignite.internal.tx.impl.TxMessageSender;
 import org.apache.ignite.internal.tx.message.TxFinishReplicaRequest;
 import org.apache.ignite.internal.tx.message.TxMessagesFactory;
 import org.apache.ignite.internal.tx.message.TxStateCoordinatorRequest;
@@ -476,12 +477,12 @@ public class PartitionReplicaListenerTest extends IgniteAbstractTest {
         };
 
         transactionStateResolver = new TransactionStateResolver(
-                mock(ReplicaService.class),
                 txManager,
                 clock,
                 clusterNodeResolver,
                 messagingService,
-                mock(PlacementDriver.class)
+                mock(PlacementDriver.class),
+                new TxMessageSender(messagingService, mock(ReplicaService.class), clock)
         );
 
         transactionStateResolver.start();

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/replication/PartitionReplicaListenerTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/replication/PartitionReplicaListenerTest.java
@@ -464,6 +464,20 @@ public class PartitionReplicaListenerTest extends IgniteAbstractTest {
             return CompletableFuture.failedFuture(new Exception("Test exception"));
         }).when(messagingService).invoke(any(ClusterNode.class), any(), anyLong());
 
+        doAnswer(invocation -> {
+            Object argument = invocation.getArgument(1);
+
+            if (argument instanceof TxStateCoordinatorRequest) {
+                TxStateCoordinatorRequest req = (TxStateCoordinatorRequest) argument;
+
+                var resp = new TxMessagesFactory().txStateResponse().txStateMeta(txManager.stateMeta(req.txId())).build();
+
+                return completedFuture(resp);
+            }
+
+            return CompletableFuture.failedFuture(new Exception("Test exception"));
+        }).when(messagingService).invoke(anyString(), any(), anyLong());
+
         ClusterNodeResolver clusterNodeResolver = new ClusterNodeResolver() {
             @Override
             public ClusterNode getById(String id) {

--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/TransactionResult.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/TransactionResult.java
@@ -22,6 +22,7 @@ import static org.apache.ignite.internal.hlc.HybridTimestamp.nullableHybridTimes
 
 import java.io.Serializable;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
+import org.apache.ignite.internal.tostring.S;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -47,5 +48,10 @@ public class TransactionResult implements Serializable {
 
     public @Nullable HybridTimestamp commitTimestamp() {
         return nullableHybridTimestamp(commitTimestamp);
+    }
+
+    @Override
+    public String toString() {
+        return S.toString(TransactionResult.class, this);
     }
 }

--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/HeapLockManager.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/HeapLockManager.java
@@ -687,6 +687,7 @@ public class HeapLockManager extends AbstractEventProducer<LockEvent, LockEventP
         private boolean conflictFound(UUID acquirerTx, UUID holderTx) {
             CompletableFuture<Void> eventResult = fireEvent(LockEvent.LOCK_CONFLICT, new LockEventParameters(acquirerTx, holderTx));
             // No async handling is expected.
+            // TODO: https://issues.apache.org/jira/browse/IGNITE-21153
             assert eventResult.isDone();
 
             return eventResult.isCompletedExceptionally();

--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/OrphanDetector.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/OrphanDetector.java
@@ -182,6 +182,7 @@ public class OrphanDetector {
             sentTxRecoveryMessage(txState.commitPartitionId(), txId);
         }
 
+        // TODO: https://issues.apache.org/jira/browse/IGNITE-21153
         return failedFuture(
                 new TransactionException(ACQUIRE_LOCK_ERR, "The lock is held by the abandoned transaction [abandonedTxId=" + txId + "]."));
     }

--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/TxManagerImpl.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/TxManagerImpl.java
@@ -541,7 +541,8 @@ public class TxManagerImpl implements TxManager, NetworkMessageHandler {
                                     txResult.commitTimestamp()
                             ));
 
-                    assert isFinalState(updatedMeta.txState());
+                    assert isFinalState(updatedMeta.txState()) :
+                            "Unexpected transaction state [id=" + txId + ", state=" + updatedMeta.txState() + "].";
 
                     txFinishFuture.complete(updatedMeta);
 

--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/TxMessageSender.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/TxMessageSender.java
@@ -27,8 +27,11 @@ import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.apache.ignite.internal.replicator.ReplicaService;
 import org.apache.ignite.internal.replicator.ReplicationGroupId;
 import org.apache.ignite.internal.replicator.TablePartitionId;
+import org.apache.ignite.internal.tx.TransactionMeta;
+import org.apache.ignite.internal.tx.TransactionResult;
 import org.apache.ignite.internal.tx.message.TxMessagesFactory;
-import org.apache.ignite.network.ClusterService;
+import org.apache.ignite.internal.tx.message.TxStateResponse;
+import org.apache.ignite.network.MessagingService;
 import org.apache.ignite.network.NetworkMessage;
 import org.jetbrains.annotations.Nullable;
 
@@ -42,8 +45,8 @@ public class TxMessageSender {
     /** Tx messages factory. */
     private static final TxMessagesFactory FACTORY = new TxMessagesFactory();
 
-    /** Cluster service. */
-    private final ClusterService clusterService;
+    /** Messaging service. */
+    private final MessagingService messagingService;
 
     /** Replica service. */
     private final ReplicaService replicaService;
@@ -54,12 +57,12 @@ public class TxMessageSender {
     /**
      * Constructor.
      *
-     * @param clusterService Cluster service.
+     * @param messagingService Messaging service.
      * @param replicaService Replica service.
      * @param clock A hybrid logical clock.
      */
-    public TxMessageSender(ClusterService clusterService, ReplicaService replicaService, HybridClock clock) {
-        this.clusterService = clusterService;
+    public TxMessageSender(MessagingService messagingService, ReplicaService replicaService, HybridClock clock) {
+        this.messagingService = messagingService;
         this.replicaService = replicaService;
         this.clock = clock;
     }
@@ -101,7 +104,7 @@ public class TxMessageSender {
      * @param txId Transaction id.
      * @param commit {@code True} if a commit requested.
      * @param commitTimestamp Commit timestamp ({@code null} if it's an abort).
-     * @return Completable future of Void.
+     * @return Completable future of {@link NetworkMessage}.
      */
     public CompletableFuture<NetworkMessage> cleanup(
             String primaryConsistentId,
@@ -110,7 +113,7 @@ public class TxMessageSender {
             boolean commit,
             @Nullable HybridTimestamp commitTimestamp
     ) {
-        return clusterService.messagingService().invoke(
+        return messagingService.invoke(
                 primaryConsistentId,
                 FACTORY.txCleanupMessage()
                         .txId(txId)
@@ -132,9 +135,9 @@ public class TxMessageSender {
      * @param term Raft term.
      * @param commit {@code true} if a commit requested.
      * @param commitTimestamp Commit timestamp ({@code null} if it's an abort).
-     * @return Completable future of Void.
+     * @return Completable future of {@link TransactionResult}.
      */
-    public CompletableFuture<Void> finish(
+    public CompletableFuture<TransactionResult> finish(
             String primaryConsistentId,
             TablePartitionId commitPartition,
             Collection<ReplicationGroupId> replicationGroupIds,
@@ -154,5 +157,56 @@ public class TxMessageSender {
                         .commitTimestampLong(hybridTimestampToLong(commitTimestamp))
                         .enlistmentConsistencyToken(term)
                         .build());
+    }
+
+    /**
+     * Send TxStateCommitPartitionRequest.
+     *
+     * @param primaryConsistentId Node id to send the request to.
+     * @param txId Transaction id.
+     * @param commitGrpId Partition to store a transaction state.
+     * @param term Raft term.
+     * @return Completable future of {@link TransactionMeta}.
+     */
+    public CompletableFuture<TransactionMeta> resolveTxStateFromCommitPartition(
+            String primaryConsistentId,
+            UUID txId,
+            TablePartitionId commitGrpId,
+            Long term
+    ) {
+        return replicaService.invoke(
+                primaryConsistentId,
+                FACTORY.txStateCommitPartitionRequest()
+                        .groupId(commitGrpId)
+                        .txId(txId)
+                        .enlistmentConsistencyToken(term)
+                        .build());
+    }
+
+    /**
+     * Send TxStateCoordinatorRequest.
+     *
+     * @param primaryConsistentId Node id to send the request to.
+     * @param txId Transaction id.
+     * @param timestamp Timestamp to pass to target node.
+     * @return Completable future of {@link TxStateResponse}.
+     */
+    public CompletableFuture<TxStateResponse> resolveTxStateFromCoordinator(
+            String primaryConsistentId,
+            UUID txId,
+            HybridTimestamp timestamp
+    ) {
+        return messagingService.invoke(
+                        primaryConsistentId,
+                        FACTORY.txStateCoordinatorRequest()
+                                .readTimestampLong(timestamp.longValue())
+                                .txId(txId)
+                                .build(),
+                        RPC_TIMEOUT)
+                .thenApply(resp -> {
+                    assert resp instanceof TxStateResponse : "Unsupported response type [type=" + resp.getClass().getSimpleName() + ']';
+
+                    return (TxStateResponse) resp;
+                });
     }
 }

--- a/modules/transactions/src/test/java/org/apache/ignite/internal/tx/AbstractLockManagerEventsTest.java
+++ b/modules/transactions/src/test/java/org/apache/ignite/internal/tx/AbstractLockManagerEventsTest.java
@@ -44,7 +44,7 @@ public abstract class AbstractLockManagerEventsTest extends AbstractLockingTest 
     private boolean listenerAdded;
 
     @BeforeEach
-    private void reset() {
+    public void reset() {
         eventParamsRef.set(null);
 
         if (!listenerAdded) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-21147

Fixed the bug with a TimeoutException on transaction finish:
See `PartitionReplicaListener.appendTxCommand`.
The issue was that an RW operation adds a cleanup future to `txOps.futures` map and the future is completed based on the result of the transaction operation future. If a transaction fails to build the latter, for example because of a lock conflict, the future in  `txOps.futures` map will never be completed. Thus a subsequent finish will wait on that future until a timeout expires.

Another bug fixed in this commit:
`TransactionStateResolver.resolveTxStateFromTxCoordinator`: If a request to a coordinator fails with an exception (see `send`), the fallback to get the state from commit partition will not be triggered.

Also added Tx state propagation from the server to the client