### PR TITLE
IGNITE-21203 Sql. Fix flaky ItSqlAsynchronousApiTest.closeSession

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/api/AsyncResultSetImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/api/AsyncResultSetImpl.java
@@ -55,8 +55,6 @@ public class AsyncResultSetImpl<T> implements AsyncResultSet<T> {
 
     private final int pageSize;
 
-    private final Runnable closeRun;
-
     /**
      * Constructor.
      *
@@ -65,20 +63,17 @@ public class AsyncResultSetImpl<T> implements AsyncResultSet<T> {
      * @param pageSize Size of the page to fetch.
      * @param expirationTracker A tracker to register any interaction with given result set.
      *      Used to prevent session from expiration.
-     * @param closeRun Callback to be invoked after result is closed.
      */
     AsyncResultSetImpl(
             AsyncSqlCursor<InternalSqlRow> cursor,
             BatchedResult<InternalSqlRow> page,
             int pageSize,
-            IdleExpirationTracker expirationTracker,
-            Runnable closeRun
+            IdleExpirationTracker expirationTracker
     ) {
         this.cursor = cursor;
         this.curPage = page;
         this.pageSize = pageSize;
         this.expirationTracker = expirationTracker;
-        this.closeRun = closeRun;
     }
 
     /** {@inheritDoc} */
@@ -171,7 +166,7 @@ public class AsyncResultSetImpl<T> implements AsyncResultSet<T> {
     /** {@inheritDoc} */
     @Override
     public CompletableFuture<Void> closeAsync() {
-        return cursor.closeAsync().thenRun(closeRun);
+        return cursor.closeAsync();
     }
 
     private void requireResultSet() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-21203

This patch addresses the race between session closing and cursor cancellation. The solution is to trigger cursors cancellation and proceed with session closing after all the cursors have been cancelled.

Also this patch fixes a race between cancellation of a query and the query initialisation when exception is thrown during root fragment initialisation.

-----------

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)