### PR TITLE
IGNITE-21202 Un-deprecate PrimaryReplicaEventParameters.leaseholder

### DIFF
--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientPrimaryReplicaTracker.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientPrimaryReplicaTracker.java
@@ -303,7 +303,6 @@ public class ClientPrimaryReplicaTracker implements EventListener<EventParameter
 
         TablePartitionId tablePartitionId = (TablePartitionId) primaryReplicaEvent.groupId();
 
-        // TODO: IGNITE-21202 Use the leaseholder ID for thin clients as well.
         updatePrimaryReplica(tablePartitionId, primaryReplicaEvent.startTime(), primaryReplicaEvent.leaseholder());
 
         return falseCompletedFuture(); // false: don't remove listener.

--- a/modules/placement-driver-api/src/main/java/org/apache/ignite/internal/placementdriver/event/PrimaryReplicaEventParameters.java
+++ b/modules/placement-driver-api/src/main/java/org/apache/ignite/internal/placementdriver/event/PrimaryReplicaEventParameters.java
@@ -66,7 +66,6 @@ public class PrimaryReplicaEventParameters extends CausalEventParameters {
     }
 
     /** Returns leaseholder node consistent ID. */
-    @Deprecated
     public String leaseholder() {
         return leaseholder;
     }


### PR DESCRIPTION
Using `consistentId` for partition awareness is ok, we don't need to change it. See detailed explanation in the JIRA comments: https://issues.apache.org/jira/browse/IGNITE-21202