### PR TITLE
IGNITE-21231 Delegate to parent lock manager in release and iterator

### DIFF
--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/HeapLockManager.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/HeapLockManager.java
@@ -200,6 +200,7 @@ public class HeapLockManager extends AbstractEventProducer<LockEvent, LockEventP
 
     @Override
     public void release(UUID txId, LockKey lockKey, LockMode lockMode) {
+        // TODO: Delegation to parentLockManager might change after https://issues.apache.org/jira/browse/IGNITE-20895 
         if (lockKey.contextId() == null) { // Treat this lock as a hierarchy lock.
             parentLockManager.release(txId, lockKey, lockMode);
 
@@ -253,6 +254,7 @@ public class HeapLockManager extends AbstractEventProducer<LockEvent, LockEventP
     public Iterator<Lock> locks(UUID txId) {
         ConcurrentLinkedQueue<LockState> lockStates = txMap.get(txId);
 
+        // TODO: Delegation to parentLockManager might change after https://issues.apache.org/jira/browse/IGNITE-20895
         if (lockStates == null) {
             return parentLockManager.locks(txId);
         }


### PR DESCRIPTION
Make HeapLockManager methods symmetrical in terms of delegating a parent lock manager.

https://issues.apache.org/jira/browse/IGNITE-21231