### PR TITLE
IGNITE-21028 .NET: Fix pooled buffer leaks

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ByteArrayPoolTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ByteArrayPoolTest.cs
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests;
+
+using System.IO;
+using Internal.Buffers;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests for <see cref="ByteArrayPool"/>.
+/// </summary>
+public class ByteArrayPoolTest
+{
+    /// <summary>
+    /// Ensure that we don't use ArrayPool.Shared directly, but use our wrapper instead.
+    /// </summary>
+    [Test]
+    public void TestSharedArrayPoolIsNotUsedDirectly()
+    {
+        foreach (var file in ProjectFilesTests.GetCsFiles())
+        {
+            if (file.EndsWith("ByteArrayPool.cs", System.StringComparison.Ordinal) ||
+                file.EndsWith("ByteArrayPoolTest.cs", System.StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(file);
+
+            StringAssert.DoesNotContain(
+                expected: "ArrayPool<byte>",
+                actual: text,
+                message: "ArrayPool<byte> should not be used directly. Use ByteArrayPool instead: " + file);
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -217,7 +217,14 @@ namespace Apache.Ignite.Tests
             TestUtils.WaitForCondition(
                 condition: () => ByteArrayPool.CurrentlyRentedArrays.IsEmpty,
                 timeoutMs: 1000,
-                messageFactory: () => $"Leaked buffers: {ByteArrayPool.CurrentlyRentedArrays.Select(x => x.Value).StringJoin()}");
+                messageFactory: () =>
+                {
+                    var bufs = ByteArrayPool.CurrentlyRentedArrays
+                        .Select(x => $"{x.Value.DeclaringType?.Name}.{x.Value.Name}")
+                        .StringJoin();
+
+                    return $"Leaked buffers: {bufs}";
+                });
 #endif
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -22,8 +22,6 @@ namespace Apache.Ignite.Tests
     using System.Linq;
     using System.Threading.Tasks;
     using Ignite.Table;
-    using Internal.Buffers;
-    using Internal.Common;
     using Internal.Proto;
     using Microsoft.Extensions.Logging;
     using NUnit.Framework;

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -23,6 +23,7 @@ namespace Apache.Ignite.Tests
     using System.Threading.Tasks;
     using Ignite.Table;
     using Internal.Buffers;
+    using Internal.Common;
     using Internal.Proto;
     using Microsoft.Extensions.Logging;
     using NUnit.Framework;
@@ -213,7 +214,10 @@ namespace Apache.Ignite.Tests
                 messageFactory: () => $"rented = {listener.BuffersRented}, returned = {listener.BuffersReturned}");
 
 #if DEBUG
-            Assert.AreEqual(0, ByteArrayPool.CurrentlyRentedArraysCount);
+            TestUtils.WaitForCondition(
+                condition: () => ByteArrayPool.CurrentlyRentedArraysCount == 0,
+                timeoutMs: 1000,
+                messageFactory: () => $"Leaked buffers: {ByteArrayPool.RentedArrays.Select(x => x.Value).StringJoin()}");
 #endif
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -22,6 +22,7 @@ namespace Apache.Ignite.Tests
     using System.Linq;
     using System.Threading.Tasks;
     using Ignite.Table;
+    using Internal.Buffers;
     using Internal.Proto;
     using Microsoft.Extensions.Logging;
     using NUnit.Framework;
@@ -210,6 +211,10 @@ namespace Apache.Ignite.Tests
                 condition: () => listener.BuffersReturned == listener.BuffersRented,
                 timeoutMs: 1000,
                 messageFactory: () => $"rented = {listener.BuffersRented}, returned = {listener.BuffersReturned}");
+
+#if DEBUG
+            Assert.AreEqual(0, ByteArrayPool.CurrentlyRentedArraysCount);
+#endif
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -215,9 +215,9 @@ namespace Apache.Ignite.Tests
 
 #if DEBUG
             TestUtils.WaitForCondition(
-                condition: () => ByteArrayPool.CurrentlyRentedArraysCount == 0,
+                condition: () => ByteArrayPool.CurrentlyRentedArrays.IsEmpty,
                 timeoutMs: 1000,
-                messageFactory: () => $"Leaked buffers: {ByteArrayPool.RentedArrays.Select(x => x.Value).StringJoin()}");
+                messageFactory: () => $"Leaked buffers: {ByteArrayPool.CurrentlyRentedArrays.Select(x => x.Value).StringJoin()}");
 #endif
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -140,10 +140,10 @@ namespace Apache.Ignite.Tests
         {
             Console.WriteLine("TearDown start: " + TestContext.CurrentContext.Test.Name);
 
-            CheckPooledBufferLeak();
-
             _disposables.ForEach(x => x.Dispose());
             _disposables.Clear();
+
+            CheckPooledBufferLeak();
 
             Console.WriteLine("TearDown end: " + TestContext.CurrentContext.Test.Name);
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -213,19 +213,7 @@ namespace Apache.Ignite.Tests
                 timeoutMs: 1000,
                 messageFactory: () => $"rented = {listener.BuffersRented}, returned = {listener.BuffersReturned}");
 
-#if DEBUG
-            TestUtils.WaitForCondition(
-                condition: () => ByteArrayPool.CurrentlyRentedArrays.IsEmpty,
-                timeoutMs: 1000,
-                messageFactory: () =>
-                {
-                    var bufs = ByteArrayPool.CurrentlyRentedArrays
-                        .Select(x => $"{x.Value.DeclaringType}.{x.Value.Name}")
-                        .StringJoin();
-
-                    return $"Leaked buffers: {bufs}";
-                });
-#endif
+            TestUtils.CheckByteArrayPoolLeak();
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -220,7 +220,7 @@ namespace Apache.Ignite.Tests
                 messageFactory: () =>
                 {
                     var bufs = ByteArrayPool.CurrentlyRentedArrays
-                        .Select(x => $"{x.Value.DeclaringType?.Name}.{x.Value.Name}")
+                        .Select(x => $"{x.Value.DeclaringType}.{x.Value.Name}")
                         .StringJoin();
 
                     return $"Leaked buffers: {bufs}";

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -133,6 +133,7 @@ namespace Apache.Ignite.Tests
         public void SetUp()
         {
             Console.WriteLine("SetUp: " + TestContext.CurrentContext.Test.Name);
+            TestUtils.CheckByteArrayPoolLeak();
         }
 
         [TearDown]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqSqlGenerationTests.cs
@@ -432,6 +432,8 @@ public partial class LinqSqlGenerationTests
     {
         _client.Dispose();
         _server.Dispose();
+
+        TestUtils.CheckByteArrayPoolLeak();
     }
 
     private void AssertSql(string expectedSql, Func<IQueryable<Poco>, object?> query) =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
@@ -31,12 +31,19 @@ using NUnit.Framework;
 /// </summary>
 public class LoggingTests
 {
+    [TearDown]
+    public void TearDown() => TestUtils.CheckByteArrayPoolLeak(5000);
+
     [Test]
     [SuppressMessage("ReSharper", "AccessToDisposedClosure", Justification = "Reviewed.")]
     public async Task TestBasicLogging()
     {
         var logger = new ListLoggerFactory(Enum.GetValues<LogLevel>());
-        var cfg = new IgniteClientConfiguration { LoggerFactory = logger };
+        var cfg = new IgniteClientConfiguration
+        {
+            LoggerFactory = logger,
+            SocketTimeout = TimeSpan.FromSeconds(1)
+        };
 
         using var servers = FakeServerGroup.Create(3);
         using (var client = await servers.ConnectClientAsync(cfg))

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
@@ -51,7 +51,7 @@ public class LoggingTests
             client.WaitForConnections(3);
 
             await client.Tables.GetTablesAsync();
-            await client.Sql.ExecuteAsync(null, "select 1");
+            await using var cursor = await client.Sql.ExecuteAsync(null, "select 1");
         }
 
         var log = logger.GetLogString();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -46,6 +46,8 @@ public class MetricsTests
         AssertMetric("connections-active", 0);
 
         _listener.Dispose();
+
+        TestUtils.CheckByteArrayPoolLeak();
     }
 
     [OneTimeTearDown]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -47,7 +47,7 @@ public class MetricsTests
 
         _listener.Dispose();
 
-        TestUtils.CheckByteArrayPoolLeak();
+        TestUtils.CheckByteArrayPoolLeak(5000);
     }
 
     [OneTimeTearDown]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MultiClusterTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MultiClusterTest.cs
@@ -28,6 +28,9 @@ using NUnit.Framework;
 /// </summary>
 public class MultiClusterTest
 {
+    [TearDown]
+    public void TearDown() => TestUtils.CheckByteArrayPoolLeak();
+
     [Test]
     public async Task TestClientDropsConnectionOnClusterIdMismatch()
     {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessRealClusterTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessRealClusterTests.cs
@@ -38,8 +38,6 @@ public class PartitionAwarenessRealClusterTests : IgniteTestsBase
     [Test]
     public async Task TestPutRoutesRequestToPrimaryNode()
     {
-        TestUtils.CheckByteArrayPoolLeak();
-
         var proxies = GetProxies();
         using var client = await IgniteClient.StartAsync(GetConfig(proxies));
         var recordView = (await client.Tables.GetTableAsync(TableName))!.RecordBinaryView;

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessRealClusterTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessRealClusterTests.cs
@@ -38,6 +38,8 @@ public class PartitionAwarenessRealClusterTests : IgniteTestsBase
     [Test]
     public async Task TestPutRoutesRequestToPrimaryNode()
     {
+        TestUtils.CheckByteArrayPoolLeak();
+
         var proxies = GetProxies();
         using var client = await IgniteClient.StartAsync(GetConfig(proxies));
         var recordView = (await client.Tables.GetTableAsync(TableName))!.RecordBinaryView;

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ProjectFilesTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ProjectFilesTests.cs
@@ -36,6 +36,8 @@ namespace Apache.Ignite.Tests
         private static readonly string InternalDir =
             $"{Path.DirectorySeparatorChar}Internal{Path.DirectorySeparatorChar}";
 
+        public static IEnumerable<string> GetCsFiles() => Directory.GetFiles(TestUtils.SolutionDir, "*.cs", SearchOption.AllDirectories);
+
         [Test]
         public void TestInternalNamespaceHasNoPublicTypes()
         {
@@ -111,11 +113,6 @@ namespace Apache.Ignite.Tests
             {
                 throw new AggregateException(exceptions);
             }
-        }
-
-        private static IEnumerable<string> GetCsFiles()
-        {
-            return Directory.GetFiles(TestUtils.SolutionDir, "*.cs", SearchOption.AllDirectories);
         }
 
         [SuppressMessage("Design", "CA1064:Exceptions should be public", Justification = "Tests.")]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/MsgPack/MsgPackReaderTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/MsgPack/MsgPackReaderTests.cs
@@ -197,7 +197,7 @@ public class MsgPackReaderTests
     [Test]
     public void TestWriteJavaGuidReturnsIdenticalByteRepresentation()
     {
-        var bufferWriter = new PooledArrayBuffer();
+        using var bufferWriter = new PooledArrayBuffer();
         bufferWriter.MessageWriter.Write(Guid.Parse(JavaUuidString));
 
         var bytes = bufferWriter.GetWrittenMemory()
@@ -349,7 +349,7 @@ public class MsgPackReaderTests
 
     private static T WriteRead<T>(Action<PooledArrayBuffer> write, Func<ReadOnlyMemory<byte>, T> read)
     {
-        var bufferWriter = new PooledArrayBuffer();
+        using var bufferWriter = new PooledArrayBuffer();
         write(bufferWriter);
 
         var mem = bufferWriter.GetWrittenMemory();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlResultSetObjectMappingTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlResultSetObjectMappingTests.cs
@@ -68,7 +68,7 @@ public class SqlResultSetObjectMappingTests : IgniteTestsBase
     [Test]
     public async Task TestSelectOneColumnAsPrimitiveType()
     {
-        var resultSet = await Client.Sql.ExecuteAsync<int>(null, "select INT32 from TBL_ALL_COLUMNS_SQL where INT32 is not null order by 1");
+        await using var resultSet = await Client.Sql.ExecuteAsync<int>(null, "select INT32 from TBL_ALL_COLUMNS_SQL where INT32 is not null order by 1");
         var rows = await resultSet.ToListAsync();
 
         Assert.AreEqual(Count, rows.Count);
@@ -127,7 +127,7 @@ public class SqlResultSetObjectMappingTests : IgniteTestsBase
     [Test]
     public async Task TestSelectNullIntoNonNullablePrimitiveTypeThrows()
     {
-        var resultSet = await Client.Sql.ExecuteAsync<int>(null, "select INT32 from TBL_ALL_COLUMNS_SQL");
+        await using var resultSet = await Client.Sql.ExecuteAsync<int>(null, "select INT32 from TBL_ALL_COLUMNS_SQL");
 
         var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await resultSet.ToListAsync());
 
@@ -139,7 +139,7 @@ public class SqlResultSetObjectMappingTests : IgniteTestsBase
     [Test]
     public async Task TestSelectNullIntoNonNullablePrimitiveTypeFieldThrows()
     {
-        var resultSet = await Client.Sql.ExecuteAsync<IntRec>(null, "select INT32 from TBL_ALL_COLUMNS_SQL");
+        await using var resultSet = await Client.Sql.ExecuteAsync<IntRec>(null, "select INT32 from TBL_ALL_COLUMNS_SQL");
 
         var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await resultSet.ToListAsync());
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
@@ -397,7 +397,7 @@ namespace Apache.Ignite.Tests.Sql
                 pageSize: 987,
                 properties: new Dictionary<string, object?> { { "prop1", 10 }, { "prop-2", "xyz" } });
 
-            var res = await client.Sql.ExecuteAsync(null, sqlStatement);
+            await using var res = await client.Sql.ExecuteAsync(null, sqlStatement);
             var rows = await res.ToListAsync();
             var props = rows.ToDictionary(x => (string)x["NAME"]!, x => (string)x["VAL"]!);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
@@ -241,7 +241,6 @@ namespace Apache.Ignite.Tests.Sql
             Assert.ThrowsAsync<ObjectDisposedException>(async () => await resultSet.ToListAsync());
 
             var enumerator = resultSet2.GetAsyncEnumerator();
-            await enumerator.MoveNextAsync(); // Skip first element.
             Assert.ThrowsAsync<ObjectDisposedException>(async () => await enumerator.MoveNextAsync());
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
@@ -280,7 +280,7 @@ namespace Apache.Ignite.Tests.Sql
             // Insert data.
             for (var i = 0; i < 10; i++)
             {
-                var insertRes = await Client.Sql.ExecuteAsync(null, "INSERT INTO TestDdlDml VALUES (?, ?)", i, "hello " + i);
+                await using var insertRes = await Client.Sql.ExecuteAsync(null, "INSERT INTO TestDdlDml VALUES (?, ?)", i, "hello " + i);
 
                 Assert.IsFalse(insertRes.HasRowSet);
                 Assert.IsFalse(insertRes.WasApplied);
@@ -289,7 +289,7 @@ namespace Apache.Ignite.Tests.Sql
             }
 
             // Query data.
-            var selectRes = await Client.Sql.ExecuteAsync(null, "SELECT VAL as MYVALUE, ID, ID + 1 FROM TestDdlDml ORDER BY ID");
+            await using var selectRes = await Client.Sql.ExecuteAsync(null, "SELECT VAL as MYVALUE, ID, ID + 1 FROM TestDdlDml ORDER BY ID");
 
             Assert.IsTrue(selectRes.HasRowSet);
             Assert.IsFalse(selectRes.WasApplied);
@@ -319,7 +319,7 @@ namespace Apache.Ignite.Tests.Sql
             Assert.IsNull(columns[2].Origin);
 
             // Update data.
-            var updateRes = await Client.Sql.ExecuteAsync(null, "UPDATE TESTDDLDML SET VAL='upd' WHERE ID < 5");
+            await using var updateRes = await Client.Sql.ExecuteAsync(null, "UPDATE TESTDDLDML SET VAL='upd' WHERE ID < 5");
 
             Assert.IsFalse(updateRes.WasApplied);
             Assert.IsFalse(updateRes.HasRowSet);
@@ -327,7 +327,7 @@ namespace Apache.Ignite.Tests.Sql
             Assert.AreEqual(5, updateRes.AffectedRows);
 
             // Drop table.
-            var deleteRes = await Client.Sql.ExecuteAsync(null, "DROP TABLE TESTDDLDML");
+            await using var deleteRes = await Client.Sql.ExecuteAsync(null, "DROP TABLE TESTDDLDML");
 
             Assert.IsFalse(deleteRes.HasRowSet);
             Assert.IsNull(deleteRes.Metadata);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/BinaryTupleIgniteTupleAdapterTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/BinaryTupleIgniteTupleAdapterTests.cs
@@ -70,7 +70,7 @@ public class BinaryTupleIgniteTupleAdapterTests : IgniteTupleTests
     protected override IIgniteTuple CreateTuple(IIgniteTuple source)
     {
         var cols = new List<Column>();
-        var builder = new BinaryTupleBuilder(source.FieldCount);
+        using var builder = new BinaryTupleBuilder(source.FieldCount);
 
         for (var i = 0; i < source.FieldCount; i++)
         {
@@ -83,7 +83,7 @@ public class BinaryTupleIgniteTupleAdapterTests : IgniteTupleTests
             builder.AppendObject(val, type);
         }
 
-        var buf = builder.Build();
+        var buf = builder.Build().ToArray();
         var schema = new Schema(0, 0, 0, 0, cols);
 
         return new BinaryTupleIgniteTupleAdapter(buf, schema, cols.Count);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/DataStreamerTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/DataStreamerTests.cs
@@ -179,7 +179,7 @@ public class DataStreamerTests : IgniteTestsBase
         await table!.RecordBinaryView.StreamDataAsync(GetFakeServerData(count));
 
         Assert.AreEqual(count, server.UpsertAllRowCount);
-        Assert.AreEqual(count / DataStreamerOptions.Default.BatchSize, server.DroppedConnectionCount);
+        Assert.That(server.DroppedConnectionCount, Is.GreaterThanOrEqualTo(count / DataStreamerOptions.Default.BatchSize));
     }
 
     private static async IAsyncEnumerable<IIgniteTuple> GetFakeServerData(int count)

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
@@ -27,6 +27,12 @@ namespace Apache.Ignite.Tests.Table
     /// </summary>
     public class IgniteTupleTests
     {
+        [TearDown]
+        public void TearDown()
+        {
+            TestUtils.CheckByteArrayPoolLeak();
+        }
+
         [Test]
         public void TestCreateUpdateRead()
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/TestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/TestUtils.cs
@@ -79,12 +79,12 @@ namespace Apache.Ignite.Tests
 
         public static ILoggerFactory GetConsoleLoggerFactory(LogLevel minLevel) => new ConsoleLogger(minLevel);
 
-        public static void CheckByteArrayPoolLeak()
+        public static void CheckByteArrayPoolLeak(int timeoutMs = 1000)
         {
 #if DEBUG
             WaitForCondition(
                 condition: () => ByteArrayPool.CurrentlyRentedArrays.IsEmpty,
-                timeoutMs: 1000,
+                timeoutMs: timeoutMs,
                 messageFactory: () =>
                 {
                     var bufs = ByteArrayPool.CurrentlyRentedArrays

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/TestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/TestUtils.cs
@@ -20,9 +20,12 @@ namespace Apache.Ignite.Tests
     using System;
     using System.Diagnostics;
     using System.IO;
+    using System.Linq;
     using System.Reflection;
     using System.Runtime.InteropServices;
     using System.Threading.Tasks;
+    using Internal.Buffers;
+    using Internal.Common;
     using Microsoft.Extensions.Logging;
     using NUnit.Framework;
 
@@ -75,6 +78,23 @@ namespace Apache.Ignite.Tests
             GetNonPublicField(obj, fieldName).SetValue(obj, value);
 
         public static ILoggerFactory GetConsoleLoggerFactory(LogLevel minLevel) => new ConsoleLogger(minLevel);
+
+        public static void CheckByteArrayPoolLeak()
+        {
+#if DEBUG
+            WaitForCondition(
+                condition: () => ByteArrayPool.CurrentlyRentedArrays.IsEmpty,
+                timeoutMs: 1000,
+                messageFactory: () =>
+                {
+                    var bufs = ByteArrayPool.CurrentlyRentedArrays
+                        .Select(x => $"{x.Value.DeclaringType}.{x.Value.Name}")
+                        .StringJoin();
+
+                    return $"Leaked buffers: {bufs}";
+                });
+#endif
+        }
 
         private static FieldInfo GetNonPublicField(object obj, string fieldName)
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
@@ -300,7 +300,7 @@ namespace Apache.Ignite.Tests.Transactions
             // Transactional operations propagate timestamp.
             if (sql)
             {
-                await client.Sql.ExecuteAsync(null, "select 1");
+                await using var resultSet = await client.Sql.ExecuteAsync(null, "select 1");
             }
             else
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
@@ -35,7 +35,7 @@ namespace Apache.Ignite.Tests.Transactions
         [TearDown]
         public async Task CleanTable()
         {
-            await TupleView.DeleteAllAsync(null, Enumerable.Range(1, 2).Select(x => GetTuple(x)));
+            await TupleView.DeleteAllAsync(null, Enumerable.Range(1, 3).Select(x => GetTuple(x)));
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/ByteArrayPool.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/ByteArrayPool.cs
@@ -21,7 +21,6 @@ namespace Apache.Ignite.Internal.Buffers
     using System.Collections.Concurrent;
     using System.Diagnostics;
     using System.Reflection;
-    using System.Text;
 
     /// <summary>
     /// Wrapper for the standard <see cref="ArrayPool{T}.Shared"/> with safety checks in debug mode.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledBuffer.cs
@@ -53,6 +53,14 @@ namespace Apache.Ignite.Internal.Buffers
         }
 
         /// <summary>
+        /// Finalizes an instance of the <see cref="PooledBuffer"/> class.
+        /// </summary>
+        ~PooledBuffer()
+        {
+            Dispose();
+        }
+
+        /// <summary>
         /// Gets or sets the position.
         /// </summary>
         public int Position { get; set; }
@@ -96,6 +104,8 @@ namespace Apache.Ignite.Internal.Buffers
 
             ByteArrayPool.Return(_bytes);
             _disposed = true;
+
+            GC.SuppressFinalize(this);
         }
 
         private void CheckDisposed()

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledBuffer.cs
@@ -18,7 +18,6 @@
 namespace Apache.Ignite.Internal.Buffers
 {
     using System;
-    using System.Diagnostics;
     using Proto.MsgPack;
 
     /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledBuffer.cs
@@ -70,7 +70,7 @@ namespace Apache.Ignite.Internal.Buffers
         /// <returns><see cref="MsgPackReader"/> for this buffer.</returns>
         public MsgPackReader GetReader(int offset = 0)
         {
-            Debug.Assert(!_disposed, "Buffer is disposed");
+            CheckDisposed();
             return new MsgPackReader(_bytes.AsSpan(Position + offset, _length - offset - Position));
         }
 
@@ -81,7 +81,7 @@ namespace Apache.Ignite.Internal.Buffers
         /// <returns>Memory of byte.</returns>
         public ReadOnlyMemory<byte> AsMemory(int offset = 0)
         {
-            Debug.Assert(!_disposed, "Buffer is disposed");
+            CheckDisposed();
             return new ReadOnlyMemory<byte>(_bytes, Position + offset, _length - offset - Position);
         }
 
@@ -97,6 +97,14 @@ namespace Apache.Ignite.Internal.Buffers
 
             ByteArrayPool.Return(_bytes);
             _disposed = true;
+        }
+
+        private void CheckDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(PooledBuffer));
+            }
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -771,8 +771,7 @@ namespace Apache.Ignite.Internal
 
             Metrics.RequestsCompleted.Add(1);
 
-            taskCompletionSource.TrySetResult(response);
-            return true;
+            return taskCompletionSource.TrySetResult(response);
         }
 
         /// <summary>
@@ -801,8 +800,7 @@ namespace Apache.Ignite.Internal
                 return false;
             }
 
-            notificationHandler.TrySetResult(response);
-            return true;
+            return notificationHandler.TrySetResult(response);
         }
 
         private void HandleObservableTimestamp(ref MsgPackReader reader)

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -801,7 +801,7 @@ namespace Apache.Ignite.Internal
         {
             try
             {
-                await DoOutInOpAsync(ClientOp.Heartbeat).WaitAsync(_socketTimeout).ConfigureAwait(false);
+                using var buf = await DoOutInOpAsync(ClientOp.Heartbeat).WaitAsync(_socketTimeout).ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSet.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSet.cs
@@ -208,7 +208,7 @@ namespace Apache.Ignite.Internal.Sql
                     using var writer = ProtoCommon.GetMessageWriter();
                     WriteId(writer.MessageWriter);
 
-                    await _socket.DoOutInOpAsync(ClientOp.SqlCursorClose, writer).ConfigureAwait(false);
+                    using var buffer = await _socket.DoOutInOpAsync(ClientOp.SqlCursorClose, writer).ConfigureAwait(false);
                 }
                 catch (Exception)
                 {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSet.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSet.cs
@@ -77,7 +77,8 @@ namespace Apache.Ignite.Internal.Sql
 
             if (HasRowSet)
             {
-                _buffer = buf.Slice(reader.Consumed);
+                buf.Position += reader.Consumed;
+                _buffer = buf;
                 HasRows = reader.ReadInt32() > 0;
             }
             else
@@ -154,7 +155,7 @@ namespace Apache.Ignite.Internal.Sql
             var hasMore = _hasMorePages;
             TResult? res = default;
 
-            ReadPage(_buffer!.Value);
+            ReadPage(_buffer!);
             ReleaseBuffer();
 
             while (hasMore)
@@ -247,7 +248,7 @@ namespace Apache.Ignite.Internal.Sql
         {
             ValidateAndSetIteratorState();
 
-            yield return _buffer!.Value;
+            yield return _buffer!;
 
             ReleaseBuffer();
 
@@ -324,7 +325,7 @@ namespace Apache.Ignite.Internal.Sql
             var offset = 0;
 
             // First page.
-            foreach (var row in EnumeratePage(_buffer!.Value))
+            foreach (var row in EnumeratePage(_buffer!))
             {
                 yield return row;
             }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -158,10 +158,10 @@ namespace Apache.Ignite.Internal.Table
                 return resultFactory(0);
             }
 
-            var resSchema = await _table.ReadSchemaAsync(resBuf.Value).ConfigureAwait(false);
+            var resSchema = await _table.ReadSchemaAsync(resBuf).ConfigureAwait(false);
 
             // TODO: Read value parts only (IGNITE-16022).
-            return _ser.ReadMultipleNullable(resBuf.Value, resSchema, resultFactory, addAction);
+            return _ser.ReadMultipleNullable(resBuf, resSchema, resultFactory, addAction);
         }
 
         /// <inheritdoc/>
@@ -211,11 +211,11 @@ namespace Apache.Ignite.Internal.Table
                 return Array.Empty<T>();
             }
 
-            var resSchema = await _table.ReadSchemaAsync(resBuf.Value).ConfigureAwait(false);
+            var resSchema = await _table.ReadSchemaAsync(resBuf).ConfigureAwait(false);
 
             // TODO: Read value parts only (IGNITE-16022).
             return _ser.ReadMultiple(
-                buf: resBuf.Value,
+                buf: resBuf,
                 schema: resSchema,
                 keyOnly: false,
                 resultFactory: static count => count == 0
@@ -370,11 +370,11 @@ namespace Apache.Ignite.Internal.Table
                 return resultFactory(0);
             }
 
-            var resSchema = await _table.ReadSchemaAsync(resBuf.Value).ConfigureAwait(false);
+            var resSchema = await _table.ReadSchemaAsync(resBuf).ConfigureAwait(false);
 
             // TODO: Read value parts only (IGNITE-16022).
             return _ser.ReadMultiple(
-                buf: resBuf.Value,
+                buf: resBuf,
                 schema: resSchema,
                 keyOnly: !exact,
                 resultFactory: resultFactory,

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transaction.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transaction.cs
@@ -82,7 +82,7 @@ namespace Apache.Ignite.Internal.Transactions
                 using var writer = ProtoCommon.GetMessageWriter();
                 Write(writer.MessageWriter);
 
-                await Socket.DoOutInOpAsync(ClientOp.TxCommit, writer).ConfigureAwait(false);
+                using var buffer = await Socket.DoOutInOpAsync(ClientOp.TxCommit, writer).ConfigureAwait(false);
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transaction.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/Transaction.cs
@@ -120,7 +120,7 @@ namespace Apache.Ignite.Internal.Transactions
                 using var writer = ProtoCommon.GetMessageWriter();
                 Write(writer.MessageWriter);
 
-                await Socket.DoOutInOpAsync(ClientOp.TxRollback, writer).ConfigureAwait(false);
+                using var buffer = await Socket.DoOutInOpAsync(ClientOp.TxRollback, writer).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
* Add `TestSharedArrayPoolIsNotUsedDirectly` to ensure that all pooling goes through our own `ByteArrayPool` class
* Add pooled array tracking to `ByteArrayPool` and check after tests
* Fix detected leaks in core module:
  * `ClientSocket.HandleResponse` when there is an error from the server or an exception
  * `ClientSockeet.SendHeartbeatAsync`
  * `Sql.ExecuteAsyncInternal` when there is an exception during `ResultSet` initialization
  * `Transaction.CommitAsync`
* Fix many leaks in test code