### PR TITLE
IGNITE-21158 ODBC: Column metadata for the non-executed query

### DIFF
--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
@@ -316,7 +316,11 @@ public class ClientMessagePacker implements AutoCloseable {
         int headerSize = getStringHeaderSize(maxBytes);
         int headerPos = buf.writerIndex();
 
-        buf.writerIndex(headerPos + headerSize);
+        int index = headerPos + headerSize;
+        if (index > buf.capacity()) {
+            buf.capacity(buf.capacity() * 2);
+        }
+        buf.writerIndex(index);
 
         int bytesWritten = ByteBufUtil.writeUtf8(buf, s);
         int endPos = buf.writerIndex();

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientOp.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientOp.java
@@ -150,8 +150,8 @@ public class ClientOp {
     /** Execute SQL script. */
     public static final int SQL_EXEC_SCRIPT = 56;
 
-    /** SQL parameter metadata. */
-    public static final int SQL_PARAM_META = 57;
+    /** SQL query metadata. */
+    public static final int SQL_QUERY_META = 57;
 
     /** JDBC get more results command. */
     public static final int JDBC_MORE_RESULTS = 58;

--- a/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerTest.java
+++ b/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerTest.java
@@ -144,10 +144,10 @@ public class ClientMessagePackerTest {
     @Test
     public void testWriteStringCapacityGrow() {
         // This number is important! Exactly this number showed nasty bug before it was fixed. Do not change.
-        final int MAGIC_BYTES = 249;
+        int magicBytes = 249;
 
         byte[] ignored = packIgnite(p -> {
-            p.packByteBuffer(ByteBuffer.allocate(MAGIC_BYTES));
+            p.packByteBuffer(ByteBuffer.allocate(magicBytes));
             p.packString("Lorem Ipsum");
         });
     }

--- a/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerTest.java
+++ b/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/ClientMessagePackerTest.java
@@ -24,6 +24,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
@@ -138,6 +139,17 @@ public class ClientMessagePackerTest {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    @Test
+    public void testWriteStringCapacityGrow() {
+        // This number is important! Exactly this number showed nasty bug before it was fixed. Do not change.
+        final int MAGIC_BYTES = 249;
+
+        byte[] ignored = packIgnite(p -> {
+            p.packByteBuffer(ByteBuffer.allocate(MAGIC_BYTES));
+            p.packString("Lorem Ipsum");
+        });
     }
 
     @ParameterizedTest

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -65,7 +65,7 @@ import org.apache.ignite.client.handler.requests.sql.ClientSqlCursorCloseRequest
 import org.apache.ignite.client.handler.requests.sql.ClientSqlCursorNextPageRequest;
 import org.apache.ignite.client.handler.requests.sql.ClientSqlExecuteRequest;
 import org.apache.ignite.client.handler.requests.sql.ClientSqlExecuteScriptRequest;
-import org.apache.ignite.client.handler.requests.sql.ClientSqlParameterMetadataRequest;
+import org.apache.ignite.client.handler.requests.sql.ClientSqlQueryMetadataRequest;
 import org.apache.ignite.client.handler.requests.table.ClientSchemasGetRequest;
 import org.apache.ignite.client.handler.requests.table.ClientTableGetRequest;
 import org.apache.ignite.client.handler.requests.table.ClientTablePartitionPrimaryReplicasGetRequest;
@@ -758,8 +758,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
             case ClientOp.SQL_EXEC_SCRIPT:
                 return ClientSqlExecuteScriptRequest.process(in, sql, igniteTransactions);
 
-            case ClientOp.SQL_PARAM_META:
-                return ClientSqlParameterMetadataRequest.process(in, out, queryProcessor, resources);
+            case ClientOp.SQL_QUERY_META:
+                return ClientSqlQueryMetadataRequest.process(in, out, queryProcessor, resources);
 
             default:
                 throw new IgniteException(PROTOCOL_ERR, "Unexpected operation code: " + opCode);

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlCommon.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlCommon.java
@@ -17,7 +17,9 @@
 
 package org.apache.ignite.client.handler.requests.sql;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.ignite.internal.binarytuple.BinaryTupleBuilder;
 import org.apache.ignite.internal.binarytuple.BinaryTupleReader;
@@ -26,6 +28,7 @@ import org.apache.ignite.internal.client.proto.ClientMessagePacker;
 import org.apache.ignite.internal.client.proto.ClientMessageUnpacker;
 import org.apache.ignite.internal.sql.api.SessionBuilderImpl;
 import org.apache.ignite.sql.ColumnMetadata;
+import org.apache.ignite.sql.ColumnMetadata.ColumnOrigin;
 import org.apache.ignite.sql.IgniteSql;
 import org.apache.ignite.sql.ResultSetMetadata;
 import org.apache.ignite.sql.Session;
@@ -33,6 +36,7 @@ import org.apache.ignite.sql.Session.SessionBuilder;
 import org.apache.ignite.sql.SqlRow;
 import org.apache.ignite.sql.async.AsyncResultSet;
 import org.apache.ignite.tx.IgniteTransactions;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Common SQL request handling logic.
@@ -185,6 +189,67 @@ class ClientSqlCommon {
         for (int i = 0; i < propCount; i++) {
             //noinspection DataFlowIssue
             sessionBuilder.property(reader.stringValue(i * 4), ClientBinaryTupleUtils.readObject(reader, i * 4 + 1));
+        }
+    }
+
+    /**
+     * Pack columns metadata.
+     *
+     * @param out Message packer.
+     * @param cols Columns.
+     */
+    public static void packColumns(ClientMessagePacker out, @NotNull List<ColumnMetadata> cols) {
+        out.packInt(cols.size());
+
+        // In many cases there are multiple columns from the same table.
+        // Schema is the same for all columns in most cases.
+        // When table or schema name was packed before, pack index instead of string.
+        Map<String, Integer> schemas = new HashMap<>();
+        Map<String, Integer> tables = new HashMap<>();
+
+        for (int i = 0; i < cols.size(); i++) {
+            ColumnMetadata col = cols.get(i);
+            ColumnOrigin origin = col.origin();
+
+            int fieldsNum = origin == null ? 6 : 9;
+            out.packInt(fieldsNum);
+
+            out.packString(col.name());
+            out.packBoolean(col.nullable());
+            out.packInt(col.type().id());
+            out.packInt(col.scale());
+            out.packInt(col.precision());
+
+            if (origin == null) {
+                out.packBoolean(false);
+                continue;
+            }
+
+            out.packBoolean(true);
+
+            if (col.name().equals(origin.columnName())) {
+                out.packNil();
+            } else {
+                out.packString(origin.columnName());
+            }
+
+            Integer schemaIdx = schemas.get(origin.schemaName());
+
+            if (schemaIdx == null) {
+                schemas.put(origin.schemaName(), i);
+                out.packString(origin.schemaName());
+            } else {
+                out.packInt(schemaIdx);
+            }
+
+            Integer tableIdx = tables.get(origin.tableName());
+
+            if (tableIdx == null) {
+                tables.put(origin.tableName(), i);
+                out.packString(origin.tableName());
+            } else {
+                out.packInt(tableIdx);
+            }
         }
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlCommon.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlCommon.java
@@ -36,7 +36,6 @@ import org.apache.ignite.sql.Session.SessionBuilder;
 import org.apache.ignite.sql.SqlRow;
 import org.apache.ignite.sql.async.AsyncResultSet;
 import org.apache.ignite.tx.IgniteTransactions;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Common SQL request handling logic.
@@ -198,7 +197,7 @@ class ClientSqlCommon {
      * @param out Message packer.
      * @param cols Columns.
      */
-    public static void packColumns(ClientMessagePacker out, @NotNull List<ColumnMetadata> cols) {
+    public static void packColumns(ClientMessagePacker out, List<ColumnMetadata> cols) {
         out.packInt(cols.size());
 
         // In many cases there are multiple columns from the same table.

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlExecuteRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlExecuteRequest.java
@@ -22,9 +22,6 @@ import static org.apache.ignite.client.handler.requests.sql.ClientSqlCommon.read
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 import static org.apache.ignite.internal.util.CompletableFutures.nullCompletedFuture;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.apache.ignite.client.handler.ClientHandlerMetricSource;
@@ -37,15 +34,12 @@ import org.apache.ignite.internal.lang.IgniteInternalCheckedException;
 import org.apache.ignite.internal.lang.IgniteInternalException;
 import org.apache.ignite.internal.tx.impl.IgniteTransactionsImpl;
 import org.apache.ignite.internal.util.ArrayUtils;
-import org.apache.ignite.sql.ColumnMetadata;
-import org.apache.ignite.sql.ColumnMetadata.ColumnOrigin;
 import org.apache.ignite.sql.IgniteSql;
 import org.apache.ignite.sql.ResultSetMetadata;
 import org.apache.ignite.sql.Session;
 import org.apache.ignite.sql.Statement;
 import org.apache.ignite.sql.Statement.StatementBuilder;
 import org.apache.ignite.sql.async.AsyncResultSet;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlQueryMetadataRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlQueryMetadataRequest.java
@@ -32,7 +32,7 @@ import org.apache.ignite.internal.sql.engine.property.SqlPropertiesHelper;
 /**
  * Client SQL request for the parameter metadata.
  */
-public class ClientSqlParameterMetadataRequest {
+public class ClientSqlQueryMetadataRequest {
     /**
      * Processes the request.
      *
@@ -67,5 +67,7 @@ public class ClientSqlParameterMetadataRequest {
             out.packInt(param.scale());
             out.packInt(param.precision());
         }
+
+        ClientSqlCommon.packColumns(out, meta.columns());
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientUtils.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientUtils.java
@@ -245,7 +245,7 @@ public class ClientUtils {
             case ClientOp.JDBC_TX_FINISH:
                 return null;
 
-            case ClientOp.SQL_PARAM_META:
+            case ClientOp.SQL_QUERY_META:
                 return null;
 
             // Do not return null from default arm intentionally, so we don't forget to update this when new ClientOp values are added.

--- a/modules/platforms/cpp/ignite/client/detail/sql/result_set_impl.h
+++ b/modules/platforms/cpp/ignite/client/detail/sql/result_set_impl.h
@@ -154,7 +154,7 @@ public:
      *
      * @return Current page size.
      */
-    [[nodiscard]] const std::vector<ignite_tuple>& current_page() const & {
+    [[nodiscard]] const std::vector<ignite_tuple> &current_page() const & {
         require_result_set();
 
         return m_page;

--- a/modules/platforms/cpp/ignite/client/detail/sql/sql_impl.cpp
+++ b/modules/platforms/cpp/ignite/client/detail/sql/sql_impl.cpp
@@ -106,8 +106,8 @@ void sql_impl::execute_async(transaction *tx, const sql_statement &statement, st
         protocol::client_operation::SQL_EXEC, tx0.get(), writer_func, std::move(reader_func), std::move(callback));
 }
 
-void sql_impl::execute_script_async(const sql_statement &statement, std::vector<primitive> &&args,
-    ignite_callback<void> &&callback) {
+void sql_impl::execute_script_async(
+    const sql_statement &statement, std::vector<primitive> &&args, ignite_callback<void> &&callback) {
 
     auto writer_func = [this, &statement, args = std::move(args)](protocol::writer &writer) {
         write_statement(writer, statement);

--- a/modules/platforms/cpp/ignite/client/detail/sql/sql_impl.h
+++ b/modules/platforms/cpp/ignite/client/detail/sql/sql_impl.h
@@ -69,8 +69,9 @@ public:
      * @param args Arguments for the template (can be empty).
      * @param callback A callback called on operation completion with SQL result set.
      */
-    void execute_script_async(const sql_statement &statement, std::vector<primitive> &&args,
-        ignite_callback<void> &&callback);
+    void execute_script_async(
+        const sql_statement &statement, std::vector<primitive> &&args, ignite_callback<void> &&callback);
+
 private:
     /** Cluster connection. */
     std::shared_ptr<cluster_connection> m_connection;

--- a/modules/platforms/cpp/ignite/client/sql/result_set.cpp
+++ b/modules/platforms/cpp/ignite/client/sql/result_set.cpp
@@ -48,7 +48,7 @@ std::vector<ignite_tuple> result_set::current_page() && {
     return std::move(*m_impl).current_page();
 }
 
-const std::vector<ignite_tuple>& result_set::current_page() const& {
+const std::vector<ignite_tuple> &result_set::current_page() const & {
     return m_impl->current_page();
 }
 

--- a/modules/platforms/cpp/ignite/client/sql/result_set.h
+++ b/modules/platforms/cpp/ignite/client/sql/result_set.h
@@ -106,7 +106,7 @@ public:
      *
      * @return Current page.
      */
-    [[nodiscard]] IGNITE_API const std::vector<ignite_tuple>& current_page() const&;
+    [[nodiscard]] IGNITE_API const std::vector<ignite_tuple> &current_page() const &;
 
     /**
      * Checks whether there are more pages of results.

--- a/modules/platforms/cpp/ignite/client/sql/sql.cpp
+++ b/modules/platforms/cpp/ignite/client/sql/sql.cpp
@@ -26,8 +26,8 @@ void sql::execute_async(transaction *tx, const sql_statement &statement, std::ve
     m_impl->execute_async(tx, statement, std::move(args), std::move(callback));
 }
 
-void sql::execute_script_async(const sql_statement &statement, std::vector<primitive> args,
-    ignite_callback<void> callback) {
+void sql::execute_script_async(
+    const sql_statement &statement, std::vector<primitive> args, ignite_callback<void> callback) {
     m_impl->execute_script_async(statement, std::move(args), std::move(callback));
 }
 

--- a/modules/platforms/cpp/ignite/client/sql/sql.h
+++ b/modules/platforms/cpp/ignite/client/sql/sql.h
@@ -75,8 +75,8 @@ public:
      * @param args Arguments for the template (can be empty).
      * @param callback A callback called on operation completion with SQL result set.
      */
-    IGNITE_API void execute_script_async(const sql_statement &statement, std::vector<primitive> args,
-        ignite_callback<void> callback);
+    IGNITE_API void execute_script_async(
+        const sql_statement &statement, std::vector<primitive> args, ignite_callback<void> callback);
 
     /**
      * Executes a multi-statement SQL query.

--- a/modules/platforms/cpp/ignite/common/error_codes.h
+++ b/modules/platforms/cpp/ignite/common/error_codes.h
@@ -1,19 +1,19 @@
-/*                                                                          
- * Licensed to the Apache Software Foundation (ASF) under one or more       
- * contributor license agreements. See the NOTICE file distributed with     
- * this work for additional information regarding copyright ownership.      
- * The ASF licenses this file to You under the Apache License, Version 2.0  
- * (the "License"); you may not use this file except in compliance with   
- * the License. You may obtain a copy of the License at                     
- *                                                                          
- *      http://www.apache.org/licenses/LICENSE-2.0                          
- *                                                                          
- * Unless required by applicable law or agreed to in writing, software      
- * distributed under the License is distributed on an "AS IS" BASIS,      
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and      
- * limitations under the License.                                           
- */                                                                         
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 // THIS IS AUTO-GENERATED FILE. DO NOT EDIT.
 

--- a/modules/platforms/cpp/ignite/network/detail/linux/linux_async_client.h
+++ b/modules/platforms/cpp/ignite/network/detail/linux/linux_async_client.h
@@ -211,7 +211,7 @@ private:
     std::vector<std::byte> m_recv_packet;
 
     /** Closing error. */
-    std::optional<ignite_error> m_close_err {};
+    std::optional<ignite_error> m_close_err{};
 };
 
 } // namespace ignite::network::detail

--- a/modules/platforms/cpp/ignite/network/detail/win/sockets.cpp
+++ b/modules/platforms/cpp/ignite/network/detail/win/sockets.cpp
@@ -142,7 +142,7 @@ void init_wsa() {
 
             if (!network_inited)
                 throw ignite_error(
-                    status_code::NETWORK, "Networking initialisation failed: " + get_last_socket_error_message());
+                    error::code::CONNECTION, "Networking initialisation failed: " + get_last_socket_error_message());
         }
     }
 }

--- a/modules/platforms/cpp/ignite/network/detail/win/tcp_socket_client.h
+++ b/modules/platforms/cpp/ignite/network/detail/win/tcp_socket_client.h
@@ -77,7 +77,7 @@ public:
         int res = getaddrinfo(hostname, str_port.c_str(), &hints, &result);
 
         if (res != 0)
-            throw ignite_error(status_code::NETWORK,
+            throw ignite_error(error::code::CONNECTION,
                 "Can not resolve host: " + std::string(hostname) + ":" + str_port
                     + ", error_code=" + std::to_string(res));
 
@@ -96,7 +96,7 @@ public:
 
             if (m_socket_handle == INVALID_SOCKET)
                 throw ignite_error(
-                    status_code::OS, "Socket creation failed: " + detail::get_last_socket_error_message());
+                    error::code::CONNECTION, "Socket creation failed: " + detail::get_last_socket_error_message());
 
             detail::try_set_socket_options(m_socket_handle, BUFFER_SIZE, TRUE, TRUE, TRUE);
 
@@ -133,7 +133,7 @@ public:
             if (is_timeout)
                 return false;
 
-            throw ignite_error(status_code::NETWORK, last_err_msg);
+            throw ignite_error(error::code::CONNECTION, last_err_msg);
         }
 
         return true;

--- a/modules/platforms/cpp/ignite/network/detail/win/win_async_client_pool.cpp
+++ b/modules/platforms/cpp/ignite/network/detail/win/win_async_client_pool.cpp
@@ -46,7 +46,7 @@ win_async_client_pool::~win_async_client_pool() {
 
 void win_async_client_pool::start(std::vector<tcp_range> addrs, uint32_t connLimit) {
     if (!m_stopping)
-        throw ignite_error(status_code::GENERIC, "Client pool is already started");
+        throw ignite_error(error::code::CONNECTION, "Client pool is already started");
 
     m_stopping = false;
 
@@ -180,14 +180,8 @@ void win_async_client_pool::close_and_release(uint64_t id, std::optional<ignite_
     if (closed) {
         m_connecting_thread.notify_free_address(client->get_range());
 
-        ignite_error err0(client->get_close_error());
-        if (err0.get_status_code() == status_code::SUCCESS)
-            err0 = ignite_error(status_code::NETWORK, "Connection closed by server");
-
-        if (!err)
-            err = std::move(err0);
-
-        handle_connection_closed(id, std::move(err));
+        err = client->get_close_error();
+        handle_connection_closed(id, err);
     }
 }
 

--- a/modules/platforms/cpp/ignite/odbc/app/parameter_set.cpp
+++ b/modules/platforms/cpp/ignite/odbc/app/parameter_set.cpp
@@ -51,9 +51,6 @@ int *parameter_set::get_param_bind_offset_ptr() {
 }
 
 void parameter_set::prepare() {
-    m_sql_params.clear();
-
-    m_types_set = false;
     m_param_set_pos = 0;
 
     for (auto &param : m_params)
@@ -91,26 +88,6 @@ void parameter_set::set_params_status(int64_t idx, SQLUSMALLINT status) const {
 void parameter_set::set_params_processed(SQLULEN processed) const {
     if (m_processed_param_rows)
         *m_processed_param_rows = processed;
-}
-
-void parameter_set::update_sql_params(sql_parameter_vector &&meta) {
-    m_sql_params = meta;
-    m_types_set = true;
-}
-
-const sql_parameter *parameter_set::get_sql_param(std::int16_t idx) const {
-    if (idx > 0 && static_cast<std::size_t>(idx) <= m_sql_params.size())
-        return &m_sql_params.at(idx - 1);
-
-    return nullptr;
-}
-
-std::uint16_t parameter_set::get_expected_param_num() {
-    return static_cast<std::uint16_t>(m_sql_params.size());
-}
-
-bool parameter_set::is_metadata_set() const {
-    return m_types_set;
 }
 
 bool parameter_set::is_parameter_selected() const {

--- a/modules/platforms/cpp/ignite/odbc/app/parameter_set.h
+++ b/modules/platforms/cpp/ignite/odbc/app/parameter_set.h
@@ -27,24 +27,11 @@
 namespace ignite {
 
 /**
- * SQL parameter.
- */
-struct sql_parameter {
-    bool nullable;
-    ignite_type data_type;
-    std::int32_t scale;
-    std::int32_t precision;
-};
-
-/**
  * Parameter set.
  */
 class parameter_set {
     /** Parameter binging map type alias. */
     typedef std::map<std::uint16_t, parameter> parameter_binding_map;
-
-    /** SQL Parameter meta vector. */
-    typedef std::vector<sql_parameter> sql_parameter_vector;
 
 public:
     /**
@@ -117,36 +104,6 @@ public:
      * @return True if the data at execution is needed.
      */
     [[nodiscard]] bool is_data_at_exec_needed() const;
-
-    /**
-     * Update parameter types metadata.
-     *
-     * @param meta Types metadata.
-     */
-    void update_sql_params(sql_parameter_vector &&meta);
-
-    /**
-     * Get the parameter by index.
-     *
-     * @param idx Parameter index.
-     * @return Parameter.
-     */
-    const sql_parameter *get_sql_param(std::int16_t idx) const;
-
-    /**
-     * Get expected m_parameters number.
-     * Using metadata. If metadata was not updated returns zero.
-     *
-     * @return Expected m_parameters number.
-     */
-    std::uint16_t get_expected_param_num();
-
-    /**
-     * Check if the metadata was set for the parameter set.
-     *
-     * @return True if the metadata was set for the parameter set.
-     */
-    [[nodiscard]] bool is_metadata_set() const;
 
     /**
      * Check if the parameter selected for putting data at-execution.
@@ -267,9 +224,6 @@ private:
     /** Parameters. */
     parameter_binding_map m_params{};
 
-    /** parameter types. */
-    sql_parameter_vector m_sql_params{};
-
     /** Offset added to pointers to change binding of m_parameters. */
     int *m_param_bind_offset{nullptr};
 
@@ -287,9 +241,6 @@ private:
 
     /** Index of the parameter, which is currently being set. */
     std::uint16_t m_current_param_idx{0};
-
-    /** Parameter types are set. */
-    bool m_types_set{false};
 };
 
 } // namespace ignite

--- a/modules/platforms/cpp/ignite/odbc/meta/column_meta.cpp
+++ b/modules/platforms/cpp/ignite/odbc/meta/column_meta.cpp
@@ -282,4 +282,61 @@ bool column_meta::get_attribute(uint16_t field_id, SQLLEN &value) const {
     return true;
 }
 
+column_meta_vector read_result_set_meta(protocol::reader &reader) {
+    auto size = reader.read_int32();
+
+    column_meta_vector columns;
+    columns.reserve(size);
+
+    for (std::int32_t column_idx = 0; column_idx < size; ++column_idx) {
+        auto fields_cnt = reader.read_int32();
+
+        assert(fields_cnt >= 6); // Expect at least six fields.
+
+        auto name = reader.read_string();
+        auto nullable = reader.read_bool();
+        auto typ = ignite_type(reader.read_int32());
+        auto scale = reader.read_int32();
+        auto precision = reader.read_int32();
+
+        bool origin_present = reader.read_bool();
+
+        if (!origin_present) {
+            columns.emplace_back("", "", std::move(name), typ, precision, scale, nullable);
+            continue;
+        }
+
+        assert(fields_cnt >= 9); // Expect at least three more fields.
+        auto origin_name = reader.read_string_nullable();
+        auto origin_schema_id = reader.try_read_int32();
+        std::string origin_schema;
+        if (origin_schema_id) {
+            if (*origin_schema_id >= std::int32_t(columns.size())) {
+                throw ignite_error("Origin schema ID is too large: " + std::to_string(*origin_schema_id)
+                    + ", id=" + std::to_string(column_idx));
+            }
+            origin_schema = columns[*origin_schema_id].get_schema_name();
+        } else {
+            origin_schema = reader.read_string();
+        }
+
+        auto origin_table_id = reader.try_read_int32();
+        std::string origin_table;
+        if (origin_table_id) {
+            if (*origin_table_id >= std::int32_t(columns.size())) {
+                throw ignite_error("Origin table ID is too large: " + std::to_string(*origin_table_id)
+                    + ", id=" + std::to_string(column_idx));
+            }
+            origin_table = columns[*origin_table_id].get_table_name();
+        } else {
+            origin_table = reader.read_string();
+        }
+
+        columns.emplace_back(
+            std::move(origin_schema), std::move(origin_table), std::move(name), typ, precision, scale, nullable);
+    }
+
+    return columns;
+}
+
 } // namespace ignite

--- a/modules/platforms/cpp/ignite/odbc/meta/column_meta.cpp
+++ b/modules/platforms/cpp/ignite/odbc/meta/column_meta.cpp
@@ -223,6 +223,7 @@ bool column_meta::get_attribute(uint16_t field_id, SQLLEN &value) const {
             break;
         }
 
+        case SQL_COLUMN_NULLABLE:
         case SQL_DESC_NULLABLE: {
             value = nullability_to_sql(m_nullability);
 

--- a/modules/platforms/cpp/ignite/odbc/meta/column_meta.h
+++ b/modules/platforms/cpp/ignite/odbc/meta/column_meta.h
@@ -195,4 +195,12 @@ private:
 /** Column metadata vector alias. */
 typedef std::vector<column_meta> column_meta_vector;
 
+/**
+ * Reads result set metadata.
+ *
+ * @param reader Reader.
+ * @return Result set meta columns.
+ */
+column_meta_vector read_result_set_meta(protocol::reader &reader);
+
 } // namespace ignite

--- a/modules/platforms/cpp/ignite/odbc/query/column_metadata_query.cpp
+++ b/modules/platforms/cpp/ignite/odbc/query/column_metadata_query.cpp
@@ -71,7 +71,7 @@ using namespace ignite;
  * @param reader Reader.
  * @return Result set meta columns.
  */
-std::vector<odbc_column_meta> read_meta(protocol::reader &reader) {
+std::vector<odbc_column_meta> read_column_meta(protocol::reader &reader) {
     auto size = reader.read_int32();
 
     std::vector<odbc_column_meta> columns;
@@ -298,7 +298,7 @@ sql_result column_metadata_query::make_request_get_columns_meta() {
             throw odbc_error(response_status_to_sql_state(status), *err_msg);
 
         if (m_has_result_set) {
-            m_meta = read_meta(reader);
+            m_meta = read_column_meta(reader);
         }
 
         m_executed = true;

--- a/modules/platforms/cpp/ignite/odbc/query/data_query.h
+++ b/modules/platforms/cpp/ignite/odbc/query/data_query.h
@@ -26,6 +26,16 @@
 namespace ignite {
 
 /**
+ * SQL parameter.
+ */
+struct sql_parameter {
+    bool nullable;
+    ignite_type data_type;
+    std::int32_t scale;
+    std::int32_t precision;
+};
+
+/**
  * Data query.
  */
 class data_query : public query {
@@ -119,6 +129,40 @@ public:
      */
     [[nodiscard]] const std::string &get_query() const { return m_query; }
 
+    /**
+     * Make result set metadata request.
+     *
+     * @return Result.
+     */
+    sql_result update_meta();
+
+    /**
+     * Get the parameter by index.
+     *
+     * @param idx Parameter index.
+     * @return Parameter.
+     */
+    [[nodiscard]] const sql_parameter *get_sql_param(std::int16_t idx);
+
+    /**
+     * Get expected parameter number.
+     * Using metadata. If metadata was not updated returns zero.
+     *
+     * @return Expected parameters number.
+     */
+    [[nodiscard]] std::size_t get_expected_param_num() const {
+        return m_params_meta.size();
+    }
+
+    /**
+     * Check if parameters meta is available.
+     *
+     * @return @c true if available.
+     */
+    [[nodiscard]] bool is_param_meta_available() const {
+        return m_params_meta_available;
+    }
+
 private:
     /**
      * Check whether all cursors are closed remotely.
@@ -165,13 +209,6 @@ private:
     sql_result make_request_fetch(std::unique_ptr<result_page> &page);
 
     /**
-     * Make result set metadata request.
-     *
-     * @return Result.
-     */
-    sql_result make_request_resultset_meta();
-
-    /**
      * Process column conversion operation result.
      *
      * @param conv_res Conversion result.
@@ -186,7 +223,14 @@ private:
      *
      * @param value Metadata.
      */
-    void set_resultset_meta(const column_meta_vector &value);
+    void set_resultset_meta(column_meta_vector value);
+
+    /**
+     * Set metadata for params.
+     *
+     * @param value Metadata.
+     */
+    void set_params_meta(std::vector<sql_parameter> value);
 
     /**
      * Close query.
@@ -204,8 +248,14 @@ private:
     /** Parameter bindings. */
     const parameter_set &m_params;
 
+    /** Parameter types. */
+    std::vector<sql_parameter> m_params_meta{};
+
     /** Indicating if the query was executed. */
     bool m_executed{false};
+
+    /** Parameter metadata is available. */
+    volatile bool m_params_meta_available{false};
 
     /** Result set metadata is available */
     volatile bool m_result_meta_available{false};

--- a/modules/platforms/cpp/ignite/odbc/query/data_query.h
+++ b/modules/platforms/cpp/ignite/odbc/query/data_query.h
@@ -150,18 +150,14 @@ public:
      *
      * @return Expected parameters number.
      */
-    [[nodiscard]] std::size_t get_expected_param_num() const {
-        return m_params_meta.size();
-    }
+    [[nodiscard]] std::size_t get_expected_param_num() const { return m_params_meta.size(); }
 
     /**
      * Check if parameters meta is available.
      *
      * @return @c true if available.
      */
-    [[nodiscard]] bool is_param_meta_available() const {
-        return m_params_meta_available;
-    }
+    [[nodiscard]] bool is_param_meta_available() const { return m_params_meta_available; }
 
 private:
     /**

--- a/modules/platforms/cpp/ignite/odbc/query/data_query.h
+++ b/modules/platforms/cpp/ignite/odbc/query/data_query.h
@@ -208,7 +208,7 @@ private:
     bool m_executed{false};
 
     /** Result set metadata is available */
-    bool m_result_meta_available{false};
+    volatile bool m_result_meta_available{false};
 
     /** Result set metadata. */
     column_meta_vector m_result_meta;

--- a/modules/platforms/cpp/ignite/odbc/query/primary_keys_query.cpp
+++ b/modules/platforms/cpp/ignite/odbc/query/primary_keys_query.cpp
@@ -52,7 +52,7 @@ using namespace ignite;
  * @param reader Reader.
  * @return Primary keys meta.
  */
-primary_key_meta_vector read_meta(protocol::reader &reader) {
+primary_key_meta_vector read_key_meta(protocol::reader &reader) {
     auto has_no_data = reader.try_read_nil();
     if (has_no_data)
         return {};
@@ -138,7 +138,7 @@ sql_result primary_keys_query::make_request_get_primary_keys() {
             throw odbc_error(response_status_to_sql_state(status), *err_msg);
 
         if (has_result_set)
-            m_meta = read_meta(reader);
+            m_meta = read_key_meta(reader);
 
         m_executed = true;
     });

--- a/modules/platforms/cpp/ignite/odbc/sql_statement.cpp
+++ b/modules/platforms/cpp/ignite/odbc/sql_statement.cpp
@@ -457,7 +457,7 @@ void sql_statement::get_parameters_number(uint16_t &param_num) {
     IGNITE_ODBC_API_CALL(internal_get_parameters_number(param_num));
 }
 
-sql_result sql_statement::internal_get_parameters_number(uint16_t &param_num) {
+sql_result sql_statement::internal_get_parameters_number(std::uint16_t &param_num) {
     if (!m_current_query) {
         add_status_record(sql_state::SHY010_SEQUENCE_ERROR, "Query is not prepared.");
 
@@ -470,14 +470,15 @@ sql_result sql_statement::internal_get_parameters_number(uint16_t &param_num) {
         return sql_result::AI_SUCCESS;
     }
 
-    if (!m_parameters.is_metadata_set()) {
-        sql_result res = update_params_meta();
+    auto qry0 = static_cast<data_query*>(m_current_query.get());
+    if (!qry0->is_param_meta_available()) {
+        sql_result res = qry0->update_meta();
 
         if (res != sql_result::AI_SUCCESS)
             return res;
     }
 
-    param_num = m_parameters.get_expected_param_num();
+    param_num = std::uint16_t(qry0->get_expected_param_num());
 
     return sql_result::AI_SUCCESS;
 }
@@ -979,14 +980,19 @@ sql_result sql_statement::internal_describe_param(
         return sql_result::AI_ERROR;
     }
 
-    auto sql_param = m_parameters.get_sql_param(std::int16_t(param_num));
-    if (!sql_param) {
-        sql_result res = update_params_meta();
+    auto qry0 = static_cast<data_query*>(qry);
+    if (!qry0->is_param_meta_available()) {
+        sql_result res = qry0->update_meta();
 
         if (res != sql_result::AI_SUCCESS)
             return res;
+    }
 
-        sql_param = m_parameters.get_sql_param(std::int16_t(param_num));
+    auto sql_param = qry0->get_sql_param(std::int16_t(param_num));
+    if (!sql_param) {
+        add_status_record(sql_state::S07009_INVALID_DESCRIPTOR_INDEX, "Parameter index is out of range.");
+
+        return sql_result::AI_ERROR;
     }
 
     LOG_MSG("Type: " << (int) sql_param->data_type);
@@ -1004,64 +1010,6 @@ sql_result sql_statement::internal_describe_param(
         *nullable = sql_param->nullable ? SQL_NULLABLE : SQL_NO_NULLS;
 
     return sql_result::AI_SUCCESS;
-}
-
-sql_result sql_statement::update_params_meta() {
-    auto *qry0 = m_current_query.get();
-
-    assert(qry0);
-    assert(qry0->get_type() == query_type::DATA);
-
-    auto *qry = static_cast<data_query *>(qry0);
-
-    auto &schema = m_connection.get_schema();
-    auto &sql = qry->get_query();
-
-    auto success = catch_errors([&] {
-        auto tx = m_connection.get_transaction_id();
-        auto response =
-            m_connection.sync_request(protocol::client_operation::SQL_QUERY_META, [&](protocol::writer &writer) {
-                if (tx)
-                    writer.write(*tx);
-                else
-                    writer.write_nil();
-
-                writer.write(schema);
-                writer.write(sql);
-            });
-
-        if (tx) {
-            m_connection.mark_transaction_non_empty();
-        }
-
-        auto reader = std::make_unique<protocol::reader>(response.get_bytes_view());
-        auto num = reader->read_int32();
-
-        if (num < 0) {
-            throw odbc_error(
-                sql_state::SHY000_GENERAL_ERROR, "Unexpected number of parameters: " + std::to_string(num));
-        }
-
-        std::vector<sql_parameter> params;
-        params.reserve(num);
-
-        for (std::int32_t i = 0; i < num; ++i) {
-            sql_parameter param{};
-            param.nullable = reader->read_bool();
-            param.data_type = ignite_type(reader->read_int32());
-            param.scale = reader->read_int32();
-            param.precision = reader->read_int32();
-
-            params.emplace_back(param);
-        }
-
-        m_parameters.update_sql_params(std::move(params));
-
-//        auto columns = read_result_set_meta(*reader);
-//        set_resultset_meta(columns);
-    });
-
-    return success ? sql_result::AI_SUCCESS : sql_result::AI_ERROR;
 }
 
 uint16_t sql_statement::sql_result_to_row_result(sql_result value) {

--- a/modules/platforms/cpp/ignite/odbc/sql_statement.cpp
+++ b/modules/platforms/cpp/ignite/odbc/sql_statement.cpp
@@ -470,7 +470,7 @@ sql_result sql_statement::internal_get_parameters_number(std::uint16_t &param_nu
         return sql_result::AI_SUCCESS;
     }
 
-    auto qry0 = static_cast<data_query*>(m_current_query.get());
+    auto qry0 = static_cast<data_query *>(m_current_query.get());
     if (!qry0->is_param_meta_available()) {
         sql_result res = qry0->update_meta();
 
@@ -980,7 +980,7 @@ sql_result sql_statement::internal_describe_param(
         return sql_result::AI_ERROR;
     }
 
-    auto qry0 = static_cast<data_query*>(qry);
+    auto qry0 = static_cast<data_query *>(qry);
     if (!qry0->is_param_meta_available()) {
         sql_result res = qry0->update_meta();
 

--- a/modules/platforms/cpp/ignite/odbc/sql_statement.cpp
+++ b/modules/platforms/cpp/ignite/odbc/sql_statement.cpp
@@ -1020,7 +1020,7 @@ sql_result sql_statement::update_params_meta() {
     auto success = catch_errors([&] {
         auto tx = m_connection.get_transaction_id();
         auto response =
-            m_connection.sync_request(protocol::client_operation::SQL_PARAM_META, [&](protocol::writer &writer) {
+            m_connection.sync_request(protocol::client_operation::SQL_QUERY_META, [&](protocol::writer &writer) {
                 if (tx)
                     writer.write(*tx);
                 else
@@ -1056,6 +1056,9 @@ sql_result sql_statement::update_params_meta() {
         }
 
         m_parameters.update_sql_params(std::move(params));
+
+//        auto columns = read_result_set_meta(*reader);
+//        set_resultset_meta(columns);
     });
 
     return success ? sql_result::AI_SUCCESS : sql_result::AI_ERROR;

--- a/modules/platforms/cpp/ignite/odbc/sql_statement.h
+++ b/modules/platforms/cpp/ignite/odbc/sql_statement.h
@@ -623,11 +623,6 @@ private:
         std::int16_t *decimal_digits, std::int16_t *nullable);
 
     /**
-     * Make request to data source to update m_parameters metadata.
-     */
-    sql_result update_params_meta();
-
-    /**
      * Convert sql_result to SQL_ROW_RESULT.
      *
      * @return Operation result.

--- a/modules/platforms/cpp/ignite/protocol/client_operation.h
+++ b/modules/platforms/cpp/ignite/protocol/client_operation.h
@@ -119,8 +119,8 @@ enum class client_operation {
     /** Execute SQL script. */
     SQL_EXEC_SCRIPT = 56,
 
-    /** SQL parameter metadata. */
-    SQL_PARAM_META = 57,
+    /** SQL query metadata. */
+    SQL_QUERY_META = 57,
 };
 
 } // namespace ignite::protocol

--- a/modules/platforms/cpp/tests/client-test/sql_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/sql_test.cpp
@@ -404,8 +404,8 @@ TEST_F(sql_test, uuid_literal) {
 
 TEST_F(sql_test, uuid_argument) {
     uuid req{0x123e4567e89b12d3, 0x7456426614174000};
-    auto result_set = m_client.get_sql().execute(
-        nullptr, {R"(select MAX("UUID") from TBL_ALL_COLUMNS_SQL WHERE "UUID" = ?)"}, {req});
+    auto result_set =
+        m_client.get_sql().execute(nullptr, {R"(select MAX("UUID") from TBL_ALL_COLUMNS_SQL WHERE "UUID" = ?)"}, {req});
 
     EXPECT_TRUE(result_set.has_rowset());
 
@@ -428,11 +428,11 @@ TEST_F(sql_test, null_column) {
 }
 
 TEST_F(sql_test, execute_script_success) {
-    m_client.get_sql().execute_script({
-        "CREATE TABLE execute_script_success (id INT PRIMARY KEY, step INTEGER); "
-        "INSERT INTO execute_script_success VALUES(1, 0); "
-        "UPDATE execute_script_success SET step = 1; "
-        "UPDATE execute_script_success SET step = 2; "}, {});
+    m_client.get_sql().execute_script({"CREATE TABLE execute_script_success (id INT PRIMARY KEY, step INTEGER); "
+                                       "INSERT INTO execute_script_success VALUES(1, 0); "
+                                       "UPDATE execute_script_success SET step = 1; "
+                                       "UPDATE execute_script_success SET step = 2; "},
+        {});
 
     auto result_set = m_client.get_sql().execute(nullptr, {"SELECT step FROM execute_script_success"}, {});
     EXPECT_TRUE(result_set.has_rowset());
@@ -452,12 +452,13 @@ TEST_F(sql_test, execute_script_fail) {
     EXPECT_THROW(
         {
             try {
-                m_client.get_sql().execute_script({
-                    "CREATE TABLE execute_script_fail (id INT PRIMARY KEY, step INTEGER); "
-                    "INSERT INTO execute_script_fail VALUES(1, 0); "
-                    "UPDATE execute_script_fail SET step = 1; "
-                    "UPDATE execute_script_fail SET step = 3 WHERE step > 1/0; "
-                    "UPDATE execute_script_fail SET step = 2; "}, {});
+                m_client.get_sql().execute_script(
+                    {"CREATE TABLE execute_script_fail (id INT PRIMARY KEY, step INTEGER); "
+                     "INSERT INTO execute_script_fail VALUES(1, 0); "
+                     "UPDATE execute_script_fail SET step = 1; "
+                     "UPDATE execute_script_fail SET step = 3 WHERE step > 1/0; "
+                     "UPDATE execute_script_fail SET step = 2; "},
+                    {});
             } catch (const ignite_error &e) {
                 EXPECT_THAT(e.what_str(), ::testing::HasSubstr("Division by zero"));
                 throw;

--- a/modules/platforms/cpp/tests/odbc-test/connection_test.cpp
+++ b/modules/platforms/cpp/tests/odbc-test/connection_test.cpp
@@ -80,39 +80,9 @@ TEST_F(connection_test, connection_success) {
     odbc_connect(get_basic_connection_string());
 }
 
-TEST_F(connection_test, auth_connection_success) {
-    set_authentication_enabled(true);
-    EXPECT_NO_THROW(odbc_connect_throw(get_auth_connection_string()));
-}
-
 TEST_F(connection_test, auth_connection_disabled_on_server) {
     set_authentication_enabled(false);
     EXPECT_NO_THROW(odbc_connect_throw(get_auth_connection_string()));
-}
-
-TEST_F(connection_test, auth_connection_disabled_on_client) {
-    set_authentication_enabled(true);
-    EXPECT_THROW(
-        try { odbc_connect_throw(get_basic_connection_string()); } catch (const ignite_error &e) {
-            EXPECT_THAT(e.what_str(), testing::HasSubstr("Authentication failed"));
-            throw;
-        },
-        ignite_error);
-}
-
-TEST_F(connection_test, auth_connection_incorrect_creds) {
-    set_authentication_enabled(true);
-    auto test_conn_str = [this](const std::string &conn_str) {
-        EXPECT_THROW(
-            try { odbc_connect_throw(conn_str); } catch (const ignite_error &e) {
-                EXPECT_THAT(e.what_str(), testing::HasSubstr("Authentication failed"));
-                throw;
-            },
-            ignite_error);
-    };
-    test_conn_str(get_incorrect_identity_auth_connection_string());
-    test_conn_str(get_incorrect_secret_auth_connection_string());
-    test_conn_str(get_incorrect_auth_connection_string());
 }
 
 TEST_F(connection_test, odbc3_supported) {
@@ -145,6 +115,21 @@ TEST_F(connection_test, odbc3_supported) {
     }
 }
 
+TEST_F(connection_test, username_no_auth) {
+    set_authentication_enabled(false);
+    EXPECT_NO_THROW(odbc_connect_throw(get_basic_connection_string()));
+
+    SQLCHAR buffer[ODBC_BUFFER_SIZE];
+    SQLSMALLINT resLen = 0;
+
+    SQLRETURN ret = SQLGetInfo(m_conn, SQL_USER_NAME, buffer, ODBC_BUFFER_SIZE, &resLen);
+
+    if (!SQL_SUCCEEDED(ret))
+        FAIL() << (get_odbc_error_message(SQL_HANDLE_DBC, m_conn));
+
+    EXPECT_EQ(std::string(""), std::string(reinterpret_cast<char *>(buffer)));
+}
+
 TEST_F(connection_test, username) {
     set_authentication_enabled(true);
     EXPECT_NO_THROW(odbc_connect_throw(get_auth_connection_string()));
@@ -160,17 +145,32 @@ TEST_F(connection_test, username) {
     EXPECT_EQ(CORRECT_USERNAME, std::string(reinterpret_cast<char *>(buffer)));
 }
 
-TEST_F(connection_test, username_no_auth) {
-    set_authentication_enabled(false);
-    EXPECT_NO_THROW(odbc_connect_throw(get_basic_connection_string()));
+TEST_F(connection_test, auth_connection_success) {
+    set_authentication_enabled(true);
+    EXPECT_NO_THROW(odbc_connect_throw(get_auth_connection_string()));
+}
 
-    SQLCHAR buffer[ODBC_BUFFER_SIZE];
-    SQLSMALLINT resLen = 0;
+TEST_F(connection_test, auth_connection_disabled_on_client) {
+    set_authentication_enabled(true);
+    EXPECT_THROW(
+        try { odbc_connect_throw(get_basic_connection_string()); } catch (const ignite_error &e) {
+            EXPECT_THAT(e.what_str(), testing::HasSubstr("Authentication failed"));
+            throw;
+        },
+        ignite_error);
+}
 
-    SQLRETURN ret = SQLGetInfo(m_conn, SQL_USER_NAME, buffer, ODBC_BUFFER_SIZE, &resLen);
-
-    if (!SQL_SUCCEEDED(ret))
-        FAIL() << (get_odbc_error_message(SQL_HANDLE_DBC, m_conn));
-
-    EXPECT_EQ(std::string(""), std::string(reinterpret_cast<char *>(buffer)));
+TEST_F(connection_test, auth_connection_incorrect_creds) {
+    set_authentication_enabled(true);
+    auto test_conn_str = [this](const std::string &conn_str) {
+        EXPECT_THROW(
+            try { odbc_connect_throw(conn_str); } catch (const ignite_error &e) {
+                EXPECT_THAT(e.what_str(), testing::HasSubstr("Authentication failed"));
+                throw;
+            },
+            ignite_error);
+    };
+    test_conn_str(get_incorrect_identity_auth_connection_string());
+    test_conn_str(get_incorrect_secret_auth_connection_string());
+    test_conn_str(get_incorrect_auth_connection_string());
 }

--- a/modules/platforms/cpp/tests/odbc-test/meta_queries_test.cpp
+++ b/modules/platforms/cpp/tests/odbc-test/meta_queries_test.cpp
@@ -459,8 +459,6 @@ TEST_F(meta_queries_test, col_attributes_column_scale) {
         FAIL() << (get_odbc_error_message(SQL_HANDLE_STMT, m_statement));
 }
 
-// TODO: IGNITE-21158 Implement result set metadata fetching for the non-executed query.
-#ifdef MUTED
 TEST_F(meta_queries_test, col_attributes_column_length_prepare) {
     odbc_connect(get_basic_connection_string());
 
@@ -478,7 +476,7 @@ TEST_F(meta_queries_test, col_attributes_column_length_prepare) {
     if (!SQL_SUCCEEDED(ret))
         FAIL() << (get_odbc_error_message(SQL_HANDLE_STMT, m_statement));
 
-    EXPECT_EQ(int_val, 60);
+    EXPECT_EQ(int_val, 1000);
 
     ret = SQLExecute(m_statement);
     ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, m_statement);
@@ -488,7 +486,7 @@ TEST_F(meta_queries_test, col_attributes_column_length_prepare) {
     if (!SQL_SUCCEEDED(ret))
         FAIL() << (get_odbc_error_message(SQL_HANDLE_STMT, m_statement));
 
-    EXPECT_EQ(int_val, 60);
+    EXPECT_EQ(int_val, 1000);
 }
 
 TEST_F(meta_queries_test, col_attributes_column_presicion_prepare) {
@@ -508,7 +506,7 @@ TEST_F(meta_queries_test, col_attributes_column_presicion_prepare) {
     if (!SQL_SUCCEEDED(ret))
         FAIL() << (get_odbc_error_message(SQL_HANDLE_STMT, m_statement));
 
-    EXPECT_EQ(int_val, 60);
+    EXPECT_EQ(int_val, 1000);
 
     ret = SQLExecute(m_statement);
     ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, m_statement);
@@ -518,7 +516,7 @@ TEST_F(meta_queries_test, col_attributes_column_presicion_prepare) {
     if (!SQL_SUCCEEDED(ret))
         FAIL() << (get_odbc_error_message(SQL_HANDLE_STMT, m_statement));
 
-    EXPECT_EQ(int_val, 60);
+    EXPECT_EQ(int_val, 1000);
 }
 
 TEST_F(meta_queries_test, col_attributes_column_scale_prepare) {
@@ -546,7 +544,6 @@ TEST_F(meta_queries_test, col_attributes_column_scale_prepare) {
     if (!SQL_SUCCEEDED(ret))
         FAIL() << (get_odbc_error_message(SQL_HANDLE_STMT, m_statement));
 }
-#endif // MUTED
 
 TEST_F(meta_queries_test, get_data_with_get_type_info) {
     odbc_connect(get_basic_connection_string());
@@ -837,39 +834,29 @@ TEST_F(meta_queries_test, ddl_columns_meta_escaped) {
     ASSERT_EQ(ret, SQL_NO_DATA);
 }
 
-// TODO: IGNITE-21158 Implement result set metadata fetching for the non-executed query.
-#ifdef MUTED
 TEST_F(meta_queries_test, sqlnum_result_cols_after_sqlprepare) {
     odbc_connect(get_basic_connection_string());
 
-    SQLRETURN ret =
-        exec_query("create table TestSqlPrepare(id int primary key, test1 varchar, test2 long, test3 varchar)");
+    SQLRETURN ret = prepare_query("select 1, TRUE, 'Lorem Ipsum', 42 * 2");
     ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, m_statement);
 
-    ret = SQLFreeStmt(m_statement, SQL_CLOSE);
+    SQLSMALLINT column_count = 0;
+
+    ret = SQLNumResultCols(m_statement, &column_count);
     ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, m_statement);
 
-    ret = prepare_query("select * from PUBLIC.TestSqlPrepare");
-    ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, m_statement);
-
-    SQLSMALLINT columnCount = 0;
-
-    ret = SQLNumResultCols(m_statement, &columnCount);
-    ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, m_statement);
-
-    EXPECT_EQ(columnCount, 4);
+    EXPECT_EQ(column_count, 4);
 
     ret = SQLExecute(m_statement);
     ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, m_statement);
 
-    columnCount = 0;
+    column_count = 0;
 
-    ret = SQLNumResultCols(m_statement, &columnCount);
+    ret = SQLNumResultCols(m_statement, &column_count);
     ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, m_statement);
 
-    EXPECT_EQ(columnCount, 4);
+    EXPECT_EQ(column_count, 4);
 }
-#endif // MUTED
 
 /**
  * Check that SQLDescribeCol return valid scale and precision for columns of different type after Prepare.

--- a/modules/platforms/cpp/tests/odbc-test/meta_queries_test.cpp
+++ b/modules/platforms/cpp/tests/odbc-test/meta_queries_test.cpp
@@ -464,7 +464,7 @@ TEST_F(meta_queries_test, col_attributes_column_length_prepare) {
 
     insert_test_string();
 
-    SQLCHAR req[] = "select str from TBL_ALL_COLUMNS_SQL";
+    SQLCHAR req[] = "select \"DECIMAL\" from TBL_ALL_COLUMNS_SQL";
     SQLPrepare(m_statement, req, SQL_NTS);
 
     SQLLEN int_val;
@@ -476,7 +476,7 @@ TEST_F(meta_queries_test, col_attributes_column_length_prepare) {
     if (!SQL_SUCCEEDED(ret))
         FAIL() << (get_odbc_error_message(SQL_HANDLE_STMT, m_statement));
 
-    EXPECT_EQ(int_val, 1000);
+    EXPECT_EQ(int_val, 19);
 
     ret = SQLExecute(m_statement);
     ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, m_statement);
@@ -486,7 +486,7 @@ TEST_F(meta_queries_test, col_attributes_column_length_prepare) {
     if (!SQL_SUCCEEDED(ret))
         FAIL() << (get_odbc_error_message(SQL_HANDLE_STMT, m_statement));
 
-    EXPECT_EQ(int_val, 1000);
+    EXPECT_EQ(int_val, 19);
 }
 
 TEST_F(meta_queries_test, col_attributes_column_presicion_prepare) {
@@ -494,7 +494,7 @@ TEST_F(meta_queries_test, col_attributes_column_presicion_prepare) {
 
     insert_test_string();
 
-    SQLCHAR req[] = "select str from TBL_ALL_COLUMNS_SQL";
+    SQLCHAR req[] = "select \"DECIMAL\" from TBL_ALL_COLUMNS_SQL";
     SQLPrepare(m_statement, req, SQL_NTS);
 
     SQLLEN int_val;
@@ -506,7 +506,7 @@ TEST_F(meta_queries_test, col_attributes_column_presicion_prepare) {
     if (!SQL_SUCCEEDED(ret))
         FAIL() << (get_odbc_error_message(SQL_HANDLE_STMT, m_statement));
 
-    EXPECT_EQ(int_val, 1000);
+    EXPECT_EQ(int_val, 19);
 
     ret = SQLExecute(m_statement);
     ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, m_statement);
@@ -516,7 +516,7 @@ TEST_F(meta_queries_test, col_attributes_column_presicion_prepare) {
     if (!SQL_SUCCEEDED(ret))
         FAIL() << (get_odbc_error_message(SQL_HANDLE_STMT, m_statement));
 
-    EXPECT_EQ(int_val, 1000);
+    EXPECT_EQ(int_val, 19);
 }
 
 TEST_F(meta_queries_test, col_attributes_column_scale_prepare) {
@@ -524,7 +524,7 @@ TEST_F(meta_queries_test, col_attributes_column_scale_prepare) {
 
     insert_test_string();
 
-    SQLCHAR req[] = "select str from TBL_ALL_COLUMNS_SQL";
+    SQLCHAR req[] = "select \"DECIMAL\" from TBL_ALL_COLUMNS_SQL";
     SQLPrepare(m_statement, req, SQL_NTS);
 
     SQLLEN int_val;
@@ -536,6 +536,8 @@ TEST_F(meta_queries_test, col_attributes_column_scale_prepare) {
     if (!SQL_SUCCEEDED(ret))
         FAIL() << (get_odbc_error_message(SQL_HANDLE_STMT, m_statement));
 
+    EXPECT_EQ(int_val, 3);
+
     ret = SQLExecute(m_statement);
     ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, m_statement);
 
@@ -543,6 +545,38 @@ TEST_F(meta_queries_test, col_attributes_column_scale_prepare) {
 
     if (!SQL_SUCCEEDED(ret))
         FAIL() << (get_odbc_error_message(SQL_HANDLE_STMT, m_statement));
+
+    EXPECT_EQ(int_val, 3);
+}
+
+TEST_F(meta_queries_test, col_attributes_column_nullability_prepare) {
+    odbc_connect(get_basic_connection_string());
+
+    insert_test_string();
+
+    SQLCHAR req[] = "select \"DECIMAL\" from TBL_ALL_COLUMNS_SQL";
+    SQLPrepare(m_statement, req, SQL_NTS);
+
+    SQLLEN int_val;
+    SQLCHAR str_buf[1024];
+    SQLSMALLINT str_len;
+
+    SQLRETURN ret = SQLColAttribute(m_statement, 1, SQL_DESC_NULLABLE, str_buf, sizeof(str_buf), &str_len, &int_val);
+
+    if (!SQL_SUCCEEDED(ret))
+        FAIL() << (get_odbc_error_message(SQL_HANDLE_STMT, m_statement));
+
+    EXPECT_EQ(int_val, SQL_NULLABLE);
+
+    ret = SQLExecute(m_statement);
+    ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_STMT, m_statement);
+
+    ret = SQLColAttribute(m_statement, 1, SQL_DESC_NULLABLE, str_buf, sizeof(str_buf), &str_len, &int_val);
+
+    if (!SQL_SUCCEEDED(ret))
+        FAIL() << (get_odbc_error_message(SQL_HANDLE_STMT, m_statement));
+
+    EXPECT_EQ(int_val, SQL_NULLABLE);
 }
 
 TEST_F(meta_queries_test, get_data_with_get_type_info) {

--- a/modules/platforms/cpp/tests/odbc-test/meta_queries_test.cpp
+++ b/modules/platforms/cpp/tests/odbc-test/meta_queries_test.cpp
@@ -875,8 +875,7 @@ TEST_F(meta_queries_test, sqlnum_result_cols_after_sqlprepare) {
  * Check that SQLDescribeCol return valid scale and precision for columns of different type after Prepare.
  */
 TEST_F(meta_queries_test, sqldescribe_col_precision_and_scale_after_prepare) {
-    // TODO: IGNITE-21158 Implement result set metadata fetching for the non-executed query.
-    //    check_col_precision_and_scale(&odbc_suite::prepare_query, &check_column_meta_with_sqldescribe_col);
+    check_col_precision_and_scale(&odbc_suite::prepare_query, &check_column_meta_with_sqldescribe_col);
 }
 
 /**
@@ -890,8 +889,7 @@ TEST_F(meta_queries_test, sqldescribe_col_precision_and_scale_after_exec) {
  * Check that SQLColAttribute return valid scale and precision for columns of different type after Prepare.
  */
 TEST_F(meta_queries_test, sqlcol_attribute_precision_and_scale_after_prepare) {
-    // TODO: IGNITE-21158 Implement result set metadata fetching for the non-executed query.
-    //    check_col_precision_and_scale(&odbc_suite::prepare_query, &check_column_meta_with_sqlcol_attribute);
+    check_col_precision_and_scale(&odbc_suite::prepare_query, &check_column_meta_with_sqlcol_attribute);
 }
 
 /**

--- a/modules/platforms/cpp/tests/odbc-test/odbc_connection.h
+++ b/modules/platforms/cpp/tests/odbc-test/odbc_connection.h
@@ -97,6 +97,17 @@ public:
     }
 
     /**
+     * Prepare query.
+     *
+     * @param qry Query.
+     * @return Result.
+     */
+    SQLRETURN prepare_query(const std::string &qry) { // NOLINT(readability-make-member-function-const)
+        auto sql = to_sqlchar(qry);
+        return SQLPrepare(m_statement, sql.data(), static_cast<SQLINTEGER>(sql.size()));
+    }
+
+    /**
      * Make a certain number of retry of operation while it fails
      *
      * @param func Function.

--- a/modules/platforms/cpp/tests/test-common/basic_auth_test_suite.h
+++ b/modules/platforms/cpp/tests/test-common/basic_auth_test_suite.h
@@ -101,7 +101,7 @@ public:
         }
 
         // Wait for the server to apply the configuration change and drop the client connection.
-        std::this_thread::sleep_for(std::chrono::seconds(3));
+        std::this_thread::sleep_for(std::chrono::seconds(5));
 
         m_auth_enabled = enable;
     }


### PR DESCRIPTION
- Re-factored server side. Now a single request returns metadata for both parameter and result set meta;
- Re-factored client side - moved parameter metadata to `data_query` class, as this is the only type of query that can have this metadata;
- Implemented on client side;
- Un-commented related tests and added some new;
- Fixed Windows compilation in C++ project.