### PR TITLE
IGNITE-21268 .NET: Expose metric names as public constants

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -290,6 +290,7 @@ public class MetricsTests
         var instrumentNames = _listener.MetricNames;
 
         CollectionAssert.AreEquivalent(publicNames, instrumentNames);
+        CollectionAssert.AreEquivalent(publicNames, MetricNames.All);
     }
 
     private static IgniteClientConfiguration GetConfig() =>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -862,13 +862,11 @@ namespace Apache.Ignite.Internal
                 {
                     _logger.LogConnectionClosedWithErrorWarn(ex, ConnectionContext.ClusterNode.Address, ex.Message);
 
+                    Metrics.ConnectionsLost.Add(1);
+
                     if (ex.GetBaseException() is TimeoutException)
                     {
                         Metrics.ConnectionsLostTimeout.Add(1);
-                    }
-                    else
-                    {
-                        Metrics.ConnectionsLost.Add(1);
                     }
                 }
                 else

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
@@ -79,7 +79,7 @@ internal static class Metrics
     public static readonly Counter<long> HandshakesFailed = Meter.CreateCounter<long>(
         name: MetricNames.HandshakesFailed,
         unit: "handshakes",
-        description: "Total number of failed handshakes (due to version mismatch, auth failure, etc)");
+        description: "Total number of failed handshakes (due to version mismatch, auth failure, or other problems)");
 
     /// <summary>
     /// Handshakes failed due to a timeout.
@@ -128,7 +128,7 @@ internal static class Metrics
     public static readonly Counter<long> RequestsFailed = Meter.CreateCounter<long>(
         name: MetricNames.RequestsFailed,
         unit: "requests",
-        description: "Total number of failed requests (due to failure to send, or completed with error)");
+        description: "Total number of failed requests (completed with error or failed to send)");
 
     /// <summary>
     /// Bytes sent.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
@@ -21,8 +21,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
 using System.Threading;
 
-using MetricNames = Apache.Ignite.Metrics;
-
 /// <summary>
 /// Ignite.NET client metrics.
 /// </summary>
@@ -46,7 +44,7 @@ internal static class Metrics
     /// Currently active connections.
     /// </summary>
     public static readonly ObservableCounter<int> ConnectionsActive = Meter.CreateObservableCounter(
-        name: "connections-active",
+        name: MetricNames.ConnectionsActive,
         observeValue: () => Interlocked.CompareExchange(ref _connectionsActive, 0, 0),
         unit: "connections",
         description: "Currently active connections");

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
@@ -150,7 +150,7 @@ internal static class Metrics
     /// Data streamer batches sent.
     /// </summary>
     public static readonly Counter<long> StreamerBatchesSent = Meter.CreateCounter<long>(
-        name: "streamer-batches-sent",
+        name: MetricNames.StreamerBatchesSent,
         unit: "batches",
         description: "Total number of data streamer batches sent.");
 
@@ -158,7 +158,7 @@ internal static class Metrics
     /// Data streamer items sent.
     /// </summary>
     public static readonly Counter<long> StreamerItemsSent = Meter.CreateCounter<long>(
-        name: "streamer-items-sent",
+        name: MetricNames.StreamerItemsSent,
         unit: "batches",
         description: "Total number of data streamer items sent.");
 
@@ -166,7 +166,7 @@ internal static class Metrics
     /// Data streamer batches active.
     /// </summary>
     public static readonly ObservableCounter<int> StreamerBatchesActive = Meter.CreateObservableCounter(
-        name: "streamer-batches-active",
+        name: MetricNames.StreamerBatchesActive,
         observeValue: () => Interlocked.CompareExchange(ref _streamerBatchesActive, 0, 0),
         unit: "batches",
         description: "Total number of existing data streamer batches.");
@@ -175,7 +175,7 @@ internal static class Metrics
     /// Data streamer items (rows) queued.
     /// </summary>
     public static readonly ObservableCounter<int> StreamerItemsQueued = Meter.CreateObservableCounter(
-        name: "streamer-items-queued",
+        name: MetricNames.StreamerItemsQueued,
         observeValue: () => Interlocked.CompareExchange(ref _streamerItemsQueued, 0, 0),
         unit: "items",
         description: "Total number of queued data streamer items (rows).");

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
@@ -128,7 +128,7 @@ internal static class Metrics
     public static readonly Counter<long> RequestsFailed = Meter.CreateCounter<long>(
         name: MetricNames.RequestsFailed,
         unit: "requests",
-        description: "Total number of failed requests (failed to send, or completed with error)");
+        description: "Total number of failed requests (due to failure to send, or completed with error)");
 
     /// <summary>
     /// Bytes sent.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
@@ -47,7 +47,7 @@ internal static class Metrics
         name: MetricNames.ConnectionsActive,
         observeValue: () => Interlocked.CompareExchange(ref _connectionsActive, 0, 0),
         unit: "connections",
-        description: "Currently active connections");
+        description: "Total number of currently active connections");
 
     /// <summary>
     /// Total number of connections established.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
@@ -85,7 +85,7 @@ internal static class Metrics
     /// Handshakes failed due to a timeout.
     /// </summary>
     public static readonly Counter<long> HandshakesFailedTimeout = Meter.CreateCounter<long>(
-        name: "handshakes-failed-timeout",
+        name: MetricNames.HandshakesFailedTimeout,
         unit: "handshakes",
         description: "Total number of failed handshakes due to network timeout");
 
@@ -93,7 +93,7 @@ internal static class Metrics
     /// Currently active requests (request sent, waiting for response).
     /// </summary>
     public static readonly ObservableCounter<int> RequestsActive = Meter.CreateObservableCounter(
-        name: "requests-active",
+        name: MetricNames.RequestsActive,
         observeValue: () => Interlocked.CompareExchange(ref _requestsActive, 0, 0),
         unit: "requests",
         description: "Currently active requests (request sent, waiting for response)");
@@ -102,7 +102,7 @@ internal static class Metrics
     /// Requests sent.
     /// </summary>
     public static readonly Counter<long> RequestsSent = Meter.CreateCounter<long>(
-        name: "requests-sent",
+        name: MetricNames.RequestsSent,
         unit: "requests",
         description: "Total number of requests sent");
 
@@ -110,7 +110,7 @@ internal static class Metrics
     /// Requests completed (response received).
     /// </summary>
     public static readonly Counter<long> RequestsCompleted = Meter.CreateCounter<long>(
-        name: "requests-completed",
+        name: MetricNames.RequestsCompleted,
         unit: "requests",
         description: "Total number of requests completed (response received)");
 
@@ -118,7 +118,7 @@ internal static class Metrics
     /// Total number of request retries.
     /// </summary>
     public static readonly Counter<long> RequestsRetried = Meter.CreateCounter<long>(
-        name: "requests-retried",
+        name: MetricNames.RequestsRetried,
         unit: "requests",
         description: "Total number of request retries");
 
@@ -126,7 +126,7 @@ internal static class Metrics
     /// Requests failed.
     /// </summary>
     public static readonly Counter<long> RequestsFailed = Meter.CreateCounter<long>(
-        name: "requests-failed",
+        name: MetricNames.RequestsFailed,
         unit: "requests",
         description: "Total number of failed requests (failed to send, or completed with error)");
 
@@ -134,7 +134,7 @@ internal static class Metrics
     /// Bytes sent.
     /// </summary>
     public static readonly Counter<long> BytesSent = Meter.CreateCounter<long>(
-        name: "bytes-sent",
+        name: MetricNames.BytesSent,
         unit: "bytes",
         description: "Total number of bytes sent");
 
@@ -142,7 +142,7 @@ internal static class Metrics
     /// Bytes received.
     /// </summary>
     public static readonly Counter<long> BytesReceived = Meter.CreateCounter<long>(
-        name: "bytes-received",
+        name: MetricNames.BytesReceived,
         unit: "bytes",
         description: "Total number of bytes received");
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
@@ -115,12 +115,12 @@ internal static class Metrics
         description: "Total number of requests completed (response received)");
 
     /// <summary>
-    /// Total number of request retries.
+    /// Total number of retried requests.
     /// </summary>
     public static readonly Counter<long> RequestsRetried = Meter.CreateCounter<long>(
         name: MetricNames.RequestsRetried,
         unit: "requests",
-        description: "Total number of request retries");
+        description: "Total number of retried requests");
 
     /// <summary>
     /// Requests failed.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
@@ -53,7 +53,7 @@ internal static class Metrics
     /// Total number of connections established.
     /// </summary>
     public static readonly Counter<long> ConnectionsEstablished = Meter.CreateCounter<long>(
-        name: "connections-established",
+        name: MetricNames.ConnectionsEstablished,
         unit: "connections",
         description: "Total number of established connections");
 
@@ -61,7 +61,7 @@ internal static class Metrics
     /// Total number of connections lost.
     /// </summary>
     public static readonly Counter<long> ConnectionsLost = Meter.CreateCounter<long>(
-        name: "connections-lost",
+        name: MetricNames.ConnectionsLost,
         unit: "connections",
         description: "Total number of lost connections");
 
@@ -69,7 +69,7 @@ internal static class Metrics
     /// Total number of connections lost due to timeout.
     /// </summary>
     public static readonly Counter<long> ConnectionsLostTimeout = Meter.CreateCounter<long>(
-        name: "connections-lost-timeout",
+        name: MetricNames.ConnectionsLostTimeout,
         unit: "connections",
         description: "Total number of lost connections due to network timeout");
 
@@ -77,7 +77,7 @@ internal static class Metrics
     /// Handshakes failed.
     /// </summary>
     public static readonly Counter<long> HandshakesFailed = Meter.CreateCounter<long>(
-        name: "handshakes-failed",
+        name: MetricNames.HandshakesFailed,
         unit: "handshakes",
         description: "Total number of failed handshakes (due to version mismatch, auth failure, etc)");
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
@@ -21,6 +21,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
 using System.Threading;
 
+using MetricNames = Apache.Ignite.Metrics;
+
 /// <summary>
 /// Ignite.NET client metrics.
 /// </summary>
@@ -30,7 +32,7 @@ using System.Threading;
     Justification = "Meter should be private and comes before metrics.")]
 internal static class Metrics
 {
-    private static readonly Meter Meter = new(name: "Apache.Ignite", version: "3.0.0");
+    private static readonly Meter Meter = new(name: MetricNames.MeterName, version: MetricNames.MeterVersion);
 
     private static int _connectionsActive;
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
@@ -96,7 +96,7 @@ internal static class Metrics
         name: MetricNames.RequestsActive,
         observeValue: () => Interlocked.CompareExchange(ref _requestsActive, 0, 0),
         unit: "requests",
-        description: "Currently active requests (request sent, waiting for response)");
+        description: "Currently active requests (requests being sent to the socket or waiting for response)");
 
     /// <summary>
     /// Requests sent.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Metrics.cs
@@ -87,7 +87,7 @@ internal static class Metrics
     public static readonly Counter<long> HandshakesFailedTimeout = Meter.CreateCounter<long>(
         name: MetricNames.HandshakesFailedTimeout,
         unit: "handshakes",
-        description: "Total number of failed handshakes due to network timeout");
+        description: "Total number of failed handshakes due to a network timeout");
 
     /// <summary>
     /// Currently active requests (request sent, waiting for response).

--- a/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
@@ -19,8 +19,35 @@ namespace Apache.Ignite;
 
 /// <summary>
 /// Ignite.NET client metrics.
+/// <para />
+/// CLI usage example:
+/// <code>
+/// dotnet-counters monitor --counters Apache.Ignite,System.Runtime --process-id PID
+/// </code>
+/// See https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-counters for more details.
+/// <para />
+/// Code usage example:
+/// <code>
+/// var meterListener = new MeterListener();
 ///
-/// TODO: brief description of the usage.
+/// meterListener.InstrumentPublished = (instrument, listener) =>
+/// {
+///     if (instrument.Meter.Name == MetricNames.MeterName)
+///     {
+///         listener.EnableMeasurementEvents(instrument);
+///         Console.WriteLine($"Instrument enabled: {instrument.Name}");
+///     }
+/// };
+///
+/// meterListener.SetMeasurementEventCallback&lt;long&gt;((instrument, measurement, tags, state) =>
+///     Console.WriteLine($"{instrument.Name}: {measurement}"));
+///
+/// meterListener.SetMeasurementEventCallback&lt;int&gt;((instrument, measurement, tags, state) =>
+///     Console.WriteLine($"{instrument.Name}: {measurement}"));
+///
+/// meterListener.Start();
+/// </code>
+/// See https://learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics for more details.
 /// </summary>
 public static class MetricNames
 {

--- a/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
@@ -58,4 +58,44 @@ public static class MetricNames
     /// Total number of failed handshakes (due to version mismatch, auth failure, or other problems).
     /// </summary>
     public const string HandshakesFailed = "handshakes-failed";
+
+    /// <summary>
+    /// Total number of failed handshakes due to network timeout.
+    /// </summary>
+    public const string HandshakesFailedTimeout = "handshakes-failed-timeout";
+
+    /// <summary>
+    /// Currently active requests (being sent to the socket or waiting for response).
+    /// </summary>
+    public const string RequestsActive = "requests-active";
+
+    /// <summary>
+    /// Total number of requests sent.
+    /// </summary>
+    public const string RequestsSent = "requests-sent";
+
+    /// <summary>
+    /// Total number of requests completed (response received).
+    /// </summary>
+    public const string RequestsCompleted = "requests-completed";
+
+    /// <summary>
+    /// Total number of request retries.
+    /// </summary>
+    public const string RequestsRetried = "requests-retried";
+
+    /// <summary>
+    /// Total number of failed requests (failed to send, or completed with error).
+    /// </summary>
+    public const string RequestsFailed = "requests-failed";
+
+    /// <summary>
+    /// Total number of bytes sent.
+    /// </summary>
+    public const string BytesSent = "bytes-sent";
+
+    /// <summary>
+    /// Total number of bytes received.
+    /// </summary>
+    public const string BytesReceived = "bytes-received";
 }

--- a/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
@@ -64,7 +64,7 @@ public static class MetricNames
     public const string MeterVersion = "3.0.0";
 
     /// <summary>
-    /// Currently active connections.
+    /// Total number of currently active connections.
     /// </summary>
     public const string ConnectionsActive = "connections-active";
 

--- a/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
@@ -98,4 +98,24 @@ public static class MetricNames
     /// Total number of bytes received.
     /// </summary>
     public const string BytesReceived = "bytes-received";
+
+    /// <summary>
+    /// Total number of data streamer batches sent.
+    /// </summary>
+    public const string StreamerBatchesSent = "streamer-batches-sent";
+
+    /// <summary>
+    /// Total number of data streamer items sent.
+    /// </summary>
+    public const string StreamerItemsSent = "streamer-items-sent";
+
+    /// <summary>
+    /// Total number of active (in-memory) data streamer batches.
+    /// </summary>
+    public const string StreamerBatchesActive = "streamer-batches-active";
+
+    /// <summary>
+    /// Total number of queued data streamer items (rows).
+    /// </summary>
+    public const string StreamerItemsQueued = "streamer-items-queued";
 }

--- a/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
@@ -94,7 +94,7 @@ public static class MetricNames
     public const string HandshakesFailedTimeout = "handshakes-failed-timeout";
 
     /// <summary>
-    /// Currently active requests (being sent to the socket or waiting for response).
+    /// Currently active requests (requests being sent to the socket or waiting for response).
     /// </summary>
     public const string RequestsActive = "requests-active";
 

--- a/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
@@ -26,7 +26,7 @@ using System.Collections.Generic;
 /// <code>
 /// dotnet-counters monitor --counters Apache.Ignite,System.Runtime --process-id PID
 /// </code>
-/// See https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-counters for more details.
+/// See https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-counters for details.
 /// <para />
 /// Code usage example:
 /// <code>
@@ -49,7 +49,7 @@ using System.Collections.Generic;
 ///
 /// meterListener.Start();
 /// </code>
-/// See https://learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics for more details.
+/// See https://learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics for details.
 /// </summary>
 public static class MetricNames
 {

--- a/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
@@ -22,7 +22,7 @@ namespace Apache.Ignite;
 ///
 /// TODO: brief description of the usage.
 /// </summary>
-public static class Metrics
+public static class MetricNames
 {
     /// <summary>
     /// Meter name.
@@ -33,4 +33,19 @@ public static class Metrics
     /// Meter version.
     /// </summary>
     public const string MeterVersion = "3.0.0";
+
+    /// <summary>
+    /// Currently active connections metric name.
+    /// </summary>
+    public const string ConnectionsActive = "connections-active";
+
+    /// <summary>
+    /// Total number of connections established during the lifetime of the process.
+    /// </summary>
+    public const string ConnectionsEstablished = "connections-established";
+
+    /// <summary>
+    /// Total number of connections lost during the lifetime of the process.
+    /// </summary>
+    public const string ConnectionsLost = "connections-lost";
 }

--- a/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
@@ -109,7 +109,7 @@ public static class MetricNames
     public const string RequestsCompleted = "requests-completed";
 
     /// <summary>
-    /// Total number of request retries.
+    /// Total number of retried requests.
     /// </summary>
     public const string RequestsRetried = "requests-retried";
 

--- a/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
@@ -114,7 +114,7 @@ public static class MetricNames
     public const string RequestsRetried = "requests-retried";
 
     /// <summary>
-    /// Total number of failed requests (due to failure to send, or completed with error).
+    /// Total number of failed requests (completed with error or failed to send).
     /// </summary>
     public const string RequestsFailed = "requests-failed";
 

--- a/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
@@ -17,6 +17,8 @@
 
 namespace Apache.Ignite;
 
+using System.Collections.Generic;
+
 /// <summary>
 /// Ignite.NET client metrics.
 /// <para />
@@ -145,4 +147,28 @@ public static class MetricNames
     /// Total number of queued data streamer items (rows).
     /// </summary>
     public const string StreamerItemsQueued = "streamer-items-queued";
+
+    /// <summary>
+    /// All metric names.
+    /// </summary>
+    public static readonly IReadOnlyCollection<string> All = new[]
+    {
+        ConnectionsActive,
+        ConnectionsEstablished,
+        ConnectionsLost,
+        ConnectionsLostTimeout,
+        HandshakesFailed,
+        HandshakesFailedTimeout,
+        RequestsActive,
+        RequestsSent,
+        RequestsCompleted,
+        RequestsRetried,
+        RequestsFailed,
+        BytesSent,
+        BytesReceived,
+        StreamerBatchesSent,
+        StreamerItemsSent,
+        StreamerBatchesActive,
+        StreamerItemsQueued
+    };
 }

--- a/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
@@ -89,7 +89,7 @@ public static class MetricNames
     public const string HandshakesFailed = "handshakes-failed";
 
     /// <summary>
-    /// Total number of failed handshakes due to network timeout.
+    /// Total number of failed handshakes due to a network timeout.
     /// </summary>
     public const string HandshakesFailedTimeout = "handshakes-failed-timeout";
 

--- a/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
@@ -35,17 +35,27 @@ public static class MetricNames
     public const string MeterVersion = "3.0.0";
 
     /// <summary>
-    /// Currently active connections metric name.
+    /// Currently active connections.
     /// </summary>
     public const string ConnectionsActive = "connections-active";
 
     /// <summary>
-    /// Total number of connections established during the lifetime of the process.
+    /// Total number of connections established (unlike <see cref="ConnectionsActive"/>, this metric only goes up).
     /// </summary>
     public const string ConnectionsEstablished = "connections-established";
 
     /// <summary>
-    /// Total number of connections lost during the lifetime of the process.
+    /// Total number of connections lost.
     /// </summary>
     public const string ConnectionsLost = "connections-lost";
+
+    /// <summary>
+    /// Total number of connections lost due to a timeout.
+    /// </summary>
+    public const string ConnectionsLostTimeout = "connections-lost-timeout";
+
+    /// <summary>
+    /// Total number of failed handshakes (due to version mismatch, auth failure, or other problems).
+    /// </summary>
+    public const string HandshakesFailed = "handshakes-failed";
 }

--- a/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/MetricNames.cs
@@ -114,7 +114,7 @@ public static class MetricNames
     public const string RequestsRetried = "requests-retried";
 
     /// <summary>
-    /// Total number of failed requests (failed to send, or completed with error).
+    /// Total number of failed requests (due to failure to send, or completed with error).
     /// </summary>
     public const string RequestsFailed = "requests-failed";
 

--- a/modules/platforms/dotnet/Apache.Ignite/Metrics.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Metrics.cs
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite;
+
+/// <summary>
+/// Ignite.NET client metrics.
+///
+/// TODO: brief description of the usage.
+/// </summary>
+public static class Metrics
+{
+    /// <summary>
+    /// Meter name.
+    /// </summary>
+    public const string MeterName = "Apache.Ignite";
+
+    /// <summary>
+    /// Meter version.
+    /// </summary>
+    public const string MeterVersion = "3.0.0";
+}


### PR DESCRIPTION
Add public `MetricNames` class with a name for every metric and usage examples in XMLdoc.

Previously, as a user, you had to look at internal class source code to get a list of available metrics; now it is a part of the public API.