### PR TITLE
IGNITE-21360 Fix ClientComputeTest

### DIFF
--- a/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
@@ -73,7 +73,6 @@ public class ClientComputeTest extends BaseIgniteAbstractTest {
     void tearDown() throws Exception {
         IgniteUtils.closeAll(server1, server2, server3);
         FakeCompute.future = null;
-        FakeCompute.status = null;
     }
 
     @Test


### PR DESCRIPTION
`JobStatus` static field in the `FakeCompute` is accessed concurrently from several executions, we need to mimic what the implementation is doing by storing statuses in the map.

https://issues.apache.org/jira/browse/IGNITE-21360