### PR TITLE
IGNITE-20573 Java client: Add configurable operation timeout

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
@@ -20,6 +20,7 @@ package org.apache.ignite.client;
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_CONNECT_TIMEOUT;
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_HEARTBEAT_INTERVAL;
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_HEARTBEAT_TIMEOUT;
+import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_OPERATION_TIMEOUT;
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_RECONNECT_INTERVAL;
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_RECONNECT_THROTTLING_PERIOD;
 import static org.apache.ignite.client.IgniteClientConfiguration.DFLT_RECONNECT_THROTTLING_RETRIES;
@@ -109,6 +110,9 @@ public interface IgniteClient extends Ignite {
 
         /** Authenticator. */
         private @Nullable IgniteClientAuthenticator authenticator;
+
+        /** Operation timeout. */
+        private long operationTimeout = DFLT_OPERATION_TIMEOUT;
 
         /**
          * Sets the addresses of Ignite server nodes within a cluster. An address can be an IP address or a hostname, with or without port.
@@ -334,6 +338,24 @@ public interface IgniteClient extends Ignite {
         }
 
         /**
+         * Sets the operation timeout, in milliseconds. Default is {@code 0} (no timeout).
+         *
+         * @param operationTimeout Operation timeout, in milliseconds.
+         * @return This instance.
+         * @throws IllegalArgumentException When value is less than zero.
+         */
+        public Builder operationTimeout(long operationTimeout) {
+            if (operationTimeout < 0) {
+                throw new IllegalArgumentException("Operation timeout [" + operationTimeout + "] "
+                        + "must be a non-negative integer value.");
+            }
+
+            this.operationTimeout = operationTimeout;
+
+            return this;
+        }
+
+        /**
          * Builds the client.
          *
          * @return Ignite client.
@@ -362,7 +384,8 @@ public interface IgniteClient extends Ignite {
                     loggerFactory,
                     sslConfiguration,
                     metricsEnabled,
-                    authenticator);
+                    authenticator,
+                    operationTimeout);
 
             return TcpIgniteClient.startAsync(cfg);
         }

--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConfiguration.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConfiguration.java
@@ -48,6 +48,9 @@ public interface IgniteClientConfiguration {
     /** Default reconnect interval, in milliseconds. */
     long DFLT_RECONNECT_INTERVAL = 30_000L;
 
+    /** Default operation timeout, in milliseconds. */
+    int DFLT_OPERATION_TIMEOUT = 0;
+
     /**
      * Gets the address finder.
      *
@@ -182,4 +185,11 @@ public interface IgniteClientConfiguration {
      * @return Authenticator.
      */
     @Nullable IgniteClientAuthenticator authenticator();
+
+    /**
+     * Gets the operation timeout, in milliseconds. Default is {@code 0} (no timeout).
+     *
+     * @return Operation timeout, in milliseconds.
+     */
+    long operationTimeout();
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/IgniteClientConfigurationImpl.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/IgniteClientConfigurationImpl.java
@@ -68,6 +68,8 @@ public final class IgniteClientConfigurationImpl implements IgniteClientConfigur
 
     private final @Nullable  IgniteClientAuthenticator authenticator;
 
+    private final long operationTimeout;
+
     /**
      * Constructor.
      *
@@ -100,7 +102,8 @@ public final class IgniteClientConfigurationImpl implements IgniteClientConfigur
             @Nullable LoggerFactory loggerFactory,
             @Nullable SslConfiguration sslConfiguration,
             boolean metricsEnabled,
-            @Nullable IgniteClientAuthenticator authenticator) {
+            @Nullable IgniteClientAuthenticator authenticator,
+            long operationTimeout) {
         this.addressFinder = addressFinder;
 
         //noinspection AssignmentOrReturnOfFieldWithMutableType (cloned in Builder).
@@ -118,6 +121,7 @@ public final class IgniteClientConfigurationImpl implements IgniteClientConfigur
         this.sslConfiguration = sslConfiguration;
         this.metricsEnabled = metricsEnabled;
         this.authenticator = authenticator;
+        this.operationTimeout = operationTimeout;
     }
 
     /** {@inheritDoc} */
@@ -202,5 +206,10 @@ public final class IgniteClientConfigurationImpl implements IgniteClientConfigur
     @Override
     public IgniteClientAuthenticator authenticator() {
         return authenticator;
+    }
+
+    @Override
+    public long operationTimeout() {
+        return operationTimeout;
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -278,6 +278,8 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
 
             ClientRequestFuture<T> fut = send(opCode, id, payloadWriter, payloadReader, notificationFut);
 
+            // Client-facing future will fail with a timeout, but internal ClientRequestFuture will stay in the map - otherwise
+            // we'll fail with "protocol breakdown" error when a late response arrives from the server.
             return operationTimeout <= 0
                     ? fut
                     : fut.orTimeout(operationTimeout, TimeUnit.MILLISECONDS);

--- a/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -101,6 +101,26 @@ public class ConnectionTest extends AbstractClientTest {
         }
     }
 
+    @SuppressWarnings("ThrowableNotThrown")
+    @Test
+    public void testNoResponseFromServerWithinOperationTimeoutThrowsException() throws Exception {
+        Function<Integer, Integer> responseDelay = x -> x > 2 ? 500 : 0;
+
+        try (var srv = new TestServer(300, new FakeIgnite(), x -> false, responseDelay, null, UUID.randomUUID(), null, null)) {
+            Builder builder = IgniteClient.builder()
+                    .addresses("127.0.0.1:" + srv.port())
+                    .retryPolicy(new RetryLimitPolicy().retryLimit(1))
+                    .operationTimeout(50);
+
+            try (IgniteClient client = builder.build()) {
+                client.tables().tables();
+
+                // Second request fails according to responseDelay function.
+                assertThrowsWithCause(() -> client.tables().tables(), TimeoutException.class);
+            }
+        }
+    }
+
     private static void testConnection(String... addrs) throws Exception {
         IgniteClient c = AbstractClientTest.startClient(addrs);
 

--- a/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -104,13 +104,13 @@ public class ConnectionTest extends AbstractClientTest {
     @SuppressWarnings("ThrowableNotThrown")
     @Test
     public void testNoResponseFromServerWithinOperationTimeoutThrowsException() throws Exception {
-        Function<Integer, Integer> responseDelay = x -> x > 2 ? 500 : 0;
+        Function<Integer, Integer> responseDelay = x -> x > 2 ? 100 : 0;
 
         try (var srv = new TestServer(300, new FakeIgnite(), x -> false, responseDelay, null, UUID.randomUUID(), null, null)) {
             Builder builder = IgniteClient.builder()
                     .addresses("127.0.0.1:" + srv.port())
                     .retryPolicy(new RetryLimitPolicy().retryLimit(1))
-                    .operationTimeout(50);
+                    .operationTimeout(30);
 
             try (IgniteClient client = builder.build()) {
                 client.tables().tables();

--- a/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
@@ -229,7 +229,7 @@ public class RetryPolicyTest extends BaseIgniteAbstractTest {
     @Test
     public void testRetryReadPolicyAllOperationsSupported() {
         var plc = new RetryReadPolicy();
-        var cfg = new IgniteClientConfigurationImpl(null, null, 0, 0, 0, 0, null, 0, 0, null, null, null, false, null);
+        var cfg = new IgniteClientConfigurationImpl(null, null, 0, 0, 0, 0, null, 0, 0, null, null, null, false, null, 0);
 
         for (var op : ClientOperationType.values()) {
             var ctx = new RetryPolicyContextImpl(cfg, op, 0, null);


### PR DESCRIPTION
Add `IgniteClientConfiguration.operationTimeout`:
* 0 by default (no timeout)
* Only affects user-initiated operations; there are separate timeouts for connect and heartbeat.