### PR TITLE
IGNITE-20491 .NET: Add configurable operation timeout

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/OperationTimeoutTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/OperationTimeoutTests.cs
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests;
+
+/// <summary>
+/// Tests <see cref="IgniteClientConfiguration.OperationTimeout"/> behavior.
+/// </summary>
+public class OperationTimeoutTests
+{
+
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/OperationTimeoutTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/OperationTimeoutTests.cs
@@ -17,10 +17,30 @@
 
 namespace Apache.Ignite.Tests;
 
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
 /// <summary>
 /// Tests <see cref="IgniteClientConfiguration.OperationTimeout"/> behavior.
 /// </summary>
 public class OperationTimeoutTests
 {
+    [Test]
+    public async Task TestOperationTimeoutThrowsException()
+    {
+        using var server = new FakeServer
+        {
+            OperationDelay = TimeSpan.FromMilliseconds(100)
+        };
 
+        var cfg = new IgniteClientConfiguration
+        {
+            OperationTimeout = TimeSpan.FromMilliseconds(30)
+        };
+
+        using var client = await server.ConnectClientAsync(cfg);
+
+        Assert.ThrowsAsync<TimeoutException>(async () => await client.Tables.GetTablesAsync());
+    }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/SocketTimeoutTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/SocketTimeoutTest.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Tests;
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -69,5 +70,24 @@ public class SocketTimeoutTest
         Assert.IsTrue(
             condition: log.Entries.Any(e => e.Message.Contains(expectedLog) && e.Exception is TimeoutException),
             message: string.Join(Environment.NewLine, log.Entries));
+    }
+
+    [Test]
+    public void TestInfiniteTimeout()
+    {
+        using var server = new FakeServer
+        {
+            HandshakeDelay = TimeSpan.FromMilliseconds(300)
+        };
+
+        var cfg = new IgniteClientConfiguration
+        {
+            SocketTimeout = Timeout.InfiniteTimeSpan
+        };
+
+        Assert.DoesNotThrowAsync(async () =>
+        {
+            using var client = await server.ConnectClientAsync(cfg);
+        });
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
@@ -83,6 +83,7 @@ namespace Apache.Ignite
 
             LoggerFactory = other.LoggerFactory;
             SocketTimeout = other.SocketTimeout;
+            OperationTimeout = other.OperationTimeout;
             Endpoints = other.Endpoints.ToList();
             RetryPolicy = other.RetryPolicy;
             HeartbeatInterval = other.HeartbeatInterval;

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
@@ -109,6 +109,14 @@ namespace Apache.Ignite
         public TimeSpan SocketTimeout { get; set; } = DefaultSocketTimeout;
 
         /// <summary>
+        /// Gets or sets the operation timeout.
+        ///
+        /// TODO: 0 or -1 for infinite.
+        /// </summary>
+        [DefaultValue(typeof(TimeSpan), "00:00:00")]
+        public TimeSpan OperationTimeout { get; set; } = TimeSpan.Zero;
+
+        /// <summary>
         /// Gets endpoints to connect to.
         /// <para />
         /// Providing addresses of multiple nodes in the cluster will improve performance:

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClientConfiguration.cs
@@ -21,6 +21,7 @@ namespace Apache.Ignite
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Linq;
+    using System.Threading;
     using Internal.Common;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Abstractions;
@@ -104,18 +105,19 @@ namespace Apache.Ignite
         /// If the server does not respond to the initial handshake message or a periodic heartbeat in the specified time,
         /// the connection is closed with a <see cref="TimeoutException"/>.
         /// <para />
-        /// -1 means infinite timeout.
+        /// Use <see cref="Timeout.InfiniteTimeSpan"/> for infinite timeout.
         /// </summary>
         [DefaultValue(typeof(TimeSpan), "00:00:30")]
         public TimeSpan SocketTimeout { get; set; } = DefaultSocketTimeout;
 
         /// <summary>
-        /// Gets or sets the operation timeout.
-        ///
-        /// TODO: 0 or -1 for infinite.
+        /// Gets or sets the operation timeout. Default is <see cref="Timeout.InfiniteTimeSpan"/> (no timeout).
+        /// <para />
+        /// The timeout applies to all operations except handshake and heartbeats.
+        /// The time is measured from the moment the request is written to the socket to the moment the response is received.
         /// </summary>
-        [DefaultValue(typeof(TimeSpan), "00:00:00")]
-        public TimeSpan OperationTimeout { get; set; } = TimeSpan.Zero;
+        [DefaultValue(typeof(TimeSpan), "-00:00:00.001")]
+        public TimeSpan OperationTimeout { get; set; } = Timeout.InfiniteTimeSpan;
 
         /// <summary>
         /// Gets endpoints to connect to.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -271,7 +271,7 @@ namespace Apache.Ignite.Internal
             PooledArrayBuffer? request = null,
             bool expectNotifications = false) =>
             DoOutInOpAsyncInternal(clientOp, request, expectNotifications)
-                .WaitAsync(_operationTimeout, _disposeTokenSource.Token);
+                .WaitAsync(_operationTimeout);
 
         /// <inheritdoc/>
         public void Dispose()

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -92,6 +92,9 @@ namespace Apache.Ignite.Internal
         /** Socket timeout for handshakes and heartbeats. */
         private readonly TimeSpan _socketTimeout;
 
+        /** Operation timeout for user-initiated requests. */
+        private readonly TimeSpan _operationTimeout;
+
         /** Logger. */
         private readonly ILogger _logger;
 
@@ -127,6 +130,7 @@ namespace Apache.Ignite.Internal
             _listener = listener;
             _logger = logger;
             _socketTimeout = configuration.SocketTimeout;
+            _operationTimeout = configuration.OperationTimeout;
 
             _heartbeatInterval = GetHeartbeatInterval(configuration.HeartbeatInterval, connectionContext.IdleTimeout, _logger);
 
@@ -262,69 +266,12 @@ namespace Apache.Ignite.Internal
         /// <param name="request">Request data.</param>
         /// <param name="expectNotifications">Whether to expect notifications as a result of the operation.</param>
         /// <returns>Response data.</returns>
-        public async Task<PooledBuffer> DoOutInOpAsync(
+        public Task<PooledBuffer> DoOutInOpAsync(
             ClientOp clientOp,
             PooledArrayBuffer? request = null,
-            bool expectNotifications = false)
-        {
-            var ex = _exception;
-
-            if (ex != null)
-            {
-                throw new IgniteClientConnectionException(
-                    ErrorGroups.Client.Connection,
-                    "Socket is closed due to an error, examine inner exception for details.",
-                    ex);
-            }
-
-            if (_disposeTokenSource.IsCancellationRequested)
-            {
-                throw new IgniteClientConnectionException(
-                    ErrorGroups.Client.Connection,
-                    "Socket is disposed.",
-                    new ObjectDisposedException(nameof(ClientSocket)));
-            }
-
-            var requestId = Interlocked.Increment(ref _requestId);
-            var taskCompletionSource = new TaskCompletionSource<PooledBuffer>();
-            _requests[requestId] = taskCompletionSource;
-
-            NotificationHandler? notificationHandler = null;
-            if (expectNotifications)
-            {
-                notificationHandler = new NotificationHandler();
-                _notificationHandlers[requestId] = notificationHandler;
-            }
-
-            Metrics.RequestsActiveIncrement();
-
-            try
-            {
-                await SendRequestAsync(request, clientOp, requestId).ConfigureAwait(false);
-                PooledBuffer resBuf = await taskCompletionSource.Task.ConfigureAwait(false);
-                resBuf.Metadata = notificationHandler;
-
-                return resBuf;
-            }
-            catch (Exception e)
-            {
-                if (_requests.TryRemove(requestId, out _))
-                {
-                    Metrics.RequestsFailed.Add(1);
-                    Metrics.RequestsActiveDecrement();
-                }
-
-                _notificationHandlers.TryRemove(requestId, out _);
-
-                if (e is OperationCanceledException or ObjectDisposedException)
-                {
-                    // Canceled task means Dispose was called.
-                    throw new IgniteClientConnectionException(ErrorGroups.Client.Connection, "Connection closed.", e);
-                }
-
-                throw;
-            }
-        }
+            bool expectNotifications = false) =>
+            DoOutInOpAsyncInternal(clientOp, request, expectNotifications)
+                .WaitAsync(_operationTimeout, _disposeTokenSource.Token);
 
         /// <inheritdoc/>
         public void Dispose()
@@ -599,6 +546,70 @@ namespace Apache.Ignite.Internal
                     sslStream.RemoteCertificate,
                     sslStream.SslProtocol)
                 : null;
+
+        private async Task<PooledBuffer> DoOutInOpAsyncInternal(
+            ClientOp clientOp,
+            PooledArrayBuffer? request = null,
+            bool expectNotifications = false)
+        {
+            var ex = _exception;
+
+            if (ex != null)
+            {
+                throw new IgniteClientConnectionException(
+                    ErrorGroups.Client.Connection,
+                    "Socket is closed due to an error, examine inner exception for details.",
+                    ex);
+            }
+
+            if (_disposeTokenSource.IsCancellationRequested)
+            {
+                throw new IgniteClientConnectionException(
+                    ErrorGroups.Client.Connection,
+                    "Socket is disposed.",
+                    new ObjectDisposedException(nameof(ClientSocket)));
+            }
+
+            var requestId = Interlocked.Increment(ref _requestId);
+            var taskCompletionSource = new TaskCompletionSource<PooledBuffer>();
+            _requests[requestId] = taskCompletionSource;
+
+            NotificationHandler? notificationHandler = null;
+            if (expectNotifications)
+            {
+                notificationHandler = new NotificationHandler();
+                _notificationHandlers[requestId] = notificationHandler;
+            }
+
+            Metrics.RequestsActiveIncrement();
+
+            try
+            {
+                await SendRequestAsync(request, clientOp, requestId).ConfigureAwait(false);
+                PooledBuffer resBuf = await taskCompletionSource.Task.ConfigureAwait(false);
+                resBuf.Metadata = notificationHandler;
+
+                return resBuf;
+            }
+            catch (Exception e)
+            {
+                if (_requests.TryRemove(requestId, out _))
+                {
+                    Metrics.RequestsFailed.Add(1);
+                    Metrics.RequestsActiveDecrement();
+                }
+
+                _notificationHandlers.TryRemove(requestId, out _);
+
+                if (e is OperationCanceledException or ObjectDisposedException)
+                {
+                    // Canceled task means Dispose was called.
+                    throw new IgniteClientConnectionException(ErrorGroups.Client.Connection, "Connection closed.", e);
+                }
+
+                throw;
+            }
+        }
 
         [SuppressMessage(
             "Microsoft.Design",


### PR DESCRIPTION
Add `IgniteClientConfiguration.OperationTimeout`:
* `Timeout.InfiniteTimeSpan` by default (no timeout)
* Only affects user-initiated operations; there are separate timeouts for connect and heartbeat.