### PR TITLE
IGNITE-21393 .NET: Fix TestDataStreamerMetricsWithCancellation flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -255,7 +255,7 @@ public class MetricsTests
         cts.Cancel();
         Assert.CatchAsync<OperationCanceledException>(async () => await task);
 
-        AssertMetricGreaterOrEqual("streamer-batches-sent", 2);
+        AssertMetricGreaterOrEqual("streamer-batches-sent", 1);
         AssertMetric("streamer-batches-active", 0);
         AssertMetric("streamer-items-queued", 0);
 


### PR DESCRIPTION
Relax the condition: there is no guarantee that another batch will be sent before we cancel the streamer.