### PR TITLE
IGNITE-21396: NPE SqlQueryProcessor during concurrent SELECT and DROP  TABLE.

### DIFF
--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItCreateTableDdlTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItCreateTableDdlTest.java
@@ -21,6 +21,7 @@ import static org.apache.ignite.internal.catalog.commands.CatalogUtils.SYSTEM_SC
 import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
 import static org.apache.ignite.internal.sql.engine.util.SqlTestUtils.assertThrowsSqlException;
 import static org.apache.ignite.internal.table.TableTestUtils.getTableStrict;
+import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willCompleteSuccessfully;
 import static org.apache.ignite.lang.ErrorGroups.Sql.STMT_VALIDATION_ERR;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -30,6 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.ignite.internal.app.IgniteImpl;
@@ -44,6 +47,7 @@ import org.apache.ignite.internal.type.NativeType;
 import org.apache.ignite.internal.type.NativeTypeSpec;
 import org.apache.ignite.lang.ErrorGroups.Sql;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -335,5 +339,25 @@ public class ItCreateTableDdlTest extends BaseSqlIntegrationTest {
 
     private static Stream<Arguments> reservedSchemaNames() {
         return SYSTEM_SCHEMAS.stream().map(Arguments::of);
+    }
+
+    @Disabled("https://issues.apache.org/jira/browse/IGNITE-20680")
+    @Test
+    public void concurrentDrop() {
+        sql("CREATE TABLE test (key INT PRIMARY KEY)");
+
+        var stopFlag = new AtomicBoolean();
+
+        CompletableFuture<Void> selectFuture = CompletableFuture.runAsync(() -> {
+            while (!stopFlag.get()) {
+                sql("SELECT COUNT(*) FROM test");
+            }
+        });
+
+        sql("DROP TABLE test");
+
+        stopFlag.set(true);
+
+        assertThat(selectFuture, willCompleteSuccessfully());
     }
 }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/SqlQueryProcessor.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/SqlQueryProcessor.java
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
@@ -54,10 +53,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.tools.Frameworks;
-import org.apache.ignite.internal.catalog.Catalog;
 import org.apache.ignite.internal.catalog.CatalogManager;
-import org.apache.ignite.internal.catalog.descriptors.CatalogTableDescriptor;
-import org.apache.ignite.internal.catalog.descriptors.CatalogZoneDescriptor;
 import org.apache.ignite.internal.cluster.management.topology.api.LogicalTopologyService;
 import org.apache.ignite.internal.hlc.HybridClock;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
@@ -310,7 +306,7 @@ public class SqlQueryProcessor implements QueryProcessor {
         var executionTargetProvider = new ExecutionTargetProvider() {
             @Override
             public CompletableFuture<ExecutionTarget> forTable(ExecutionTargetFactory factory, IgniteTable table) {
-                return primaryReplicas(table.id())
+                return primaryReplicas(table)
                         .thenApply(replicas -> factory.partitioned(replicas));
             }
 
@@ -370,16 +366,8 @@ public class SqlQueryProcessor implements QueryProcessor {
 
     // need to be refactored after TODO: https://issues.apache.org/jira/browse/IGNITE-20925
     /** Get primary replicas. */
-    private CompletableFuture<List<NodeWithConsistencyToken>> primaryReplicas(int tableId) {
-        int catalogVersion = catalogManager.latestCatalogVersion();
-
-        Catalog catalog = catalogManager.catalog(catalogVersion);
-
-        CatalogTableDescriptor tblDesc = Objects.requireNonNull(catalog.table(tableId), "table");
-
-        CatalogZoneDescriptor zoneDesc = Objects.requireNonNull(catalog.zone(tblDesc.zoneId()), "zone");
-
-        int partitions = zoneDesc.partitions();
+    private CompletableFuture<List<NodeWithConsistencyToken>> primaryReplicas(IgniteTable table) {
+        int partitions = table.partitions();
 
         List<CompletableFuture<NodeWithConsistencyToken>> result = new ArrayList<>(partitions);
 
@@ -388,7 +376,7 @@ public class SqlQueryProcessor implements QueryProcessor {
         // no need to wait all partitions after pruning was implemented.
         for (int partId = 0; partId < partitions; ++partId) {
             int partitionId = partId;
-            ReplicationGroupId partGroupId = new TablePartitionId(tableId, partitionId);
+            ReplicationGroupId partGroupId = new TablePartitionId(table.id(), partitionId);
 
             CompletableFuture<ReplicaMeta> f = placementDriver.awaitPrimaryReplica(
                     partGroupId,

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutableTableRegistryImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutableTableRegistryImpl.java
@@ -78,6 +78,9 @@ public class ExecutableTableRegistryImpl implements ExecutableTableRegistry {
                     TableDescriptor tableDescriptor = sqlTable.descriptor();
 
                     SchemaRegistry schemaRegistry = schemaManager.schemaRegistry(sqlTable.id());
+                    // TODO Can be removed after https://issues.apache.org/jira/browse/IGNITE-20680
+                    assert schemaRegistry != null : "SchemaRegistry does not exist: " + sqlTable.id();
+
                     SchemaDescriptor schemaDescriptor = schemaRegistry.schema(sqlTable.version());
                     TableRowConverterFactory converterFactory = requiredColumns -> new TableRowConverterImpl(
                             schemaRegistry, schemaDescriptor, requiredColumns

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/IgniteTable.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/IgniteTable.java
@@ -30,4 +30,11 @@ public interface IgniteTable extends IgniteDataSource {
      * @return Indexes for the current table.
      */
     Map<String, IgniteIndex> indexes();
+
+    /**
+     * Returns the number of partitions for this table.
+     *
+     * @return Number of partitions.
+     */
+    int partitions();
 }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/IgniteTableImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/IgniteTableImpl.java
@@ -34,18 +34,27 @@ public class IgniteTableImpl extends AbstractIgniteDataSource implements IgniteT
 
     private final Map<String, IgniteIndex> indexMap;
 
+    private final int partitions;
+
     /** Constructor. */
     public IgniteTableImpl(String name, int id, int version, TableDescriptor desc,
-            Statistic statistic, Map<String, IgniteIndex> indexMap) {
+            Statistic statistic, Map<String, IgniteIndex> indexMap, int partitions) {
 
         super(name, id, version, desc, statistic);
         this.indexMap = indexMap;
+        this.partitions = partitions;
     }
 
     /** {@inheritDoc} */
     @Override
     public Map<String, IgniteIndex> indexes() {
         return indexMap;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int partitions() {
+        return partitions;
     }
 
     /** {@inheritDoc} */

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/ExecutableTableRegistrySelfTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/ExecutableTableRegistrySelfTest.java
@@ -147,7 +147,7 @@ public class ExecutableTableRegistrySelfTest extends BaseIgniteAbstractTest {
             when(schemaRegistry.schema(tableVersion)).thenReturn(schemaDescriptor);
 
             IgniteTable sqlTable = new IgniteTableImpl(
-                    table.name(), tableId, tableVersion, descriptor, new TestStatistic(1_000.0), Map.of()
+                    table.name(), tableId, tableVersion, descriptor, new TestStatistic(1_000.0), Map.of(), 1
             );
 
             when(sqlSchemaManager.table(schemaVersion, tableId)).thenReturn(sqlTable);

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/TestTable.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/TestTable.java
@@ -61,7 +61,7 @@ public class TestTable extends IgniteTableImpl {
             Map<String, DataProvider<?>> dataProviders
     ) {
         super(name, tableId, 1, descriptor, new TestStatistic(rowCnt),
-                indexList.stream().collect(Collectors.toUnmodifiableMap(IgniteIndex::name, Function.identity())));
+                indexList.stream().collect(Collectors.toUnmodifiableMap(IgniteIndex::name, Function.identity())), 1);
 
         this.dataProviders = dataProviders;
     }

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/prepare/TypeCoercionTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/prepare/TypeCoercionTest.java
@@ -651,6 +651,11 @@ public class TypeCoercionTest extends AbstractPlannerTest {
         }
 
         @Override
+        public int partitions() {
+            return 1;
+        }
+
+        @Override
         public String name() {
             return name;
         }

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/schema/SqlSchemaManagerImplTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/schema/SqlSchemaManagerImplTest.java
@@ -48,12 +48,14 @@ import org.apache.calcite.schema.Table;
 import org.apache.ignite.internal.catalog.CatalogCommand;
 import org.apache.ignite.internal.catalog.CatalogManager;
 import org.apache.ignite.internal.catalog.CatalogTestUtils;
+import org.apache.ignite.internal.catalog.commands.CatalogUtils;
 import org.apache.ignite.internal.catalog.commands.ColumnParams;
 import org.apache.ignite.internal.catalog.commands.CreateHashIndexCommand;
 import org.apache.ignite.internal.catalog.commands.CreateSortedIndexCommand;
 import org.apache.ignite.internal.catalog.commands.CreateSystemViewCommand;
 import org.apache.ignite.internal.catalog.commands.CreateTableCommand;
 import org.apache.ignite.internal.catalog.commands.CreateTableCommandBuilder;
+import org.apache.ignite.internal.catalog.commands.CreateZoneCommand;
 import org.apache.ignite.internal.catalog.commands.DefaultValue;
 import org.apache.ignite.internal.catalog.commands.MakeIndexAvailableCommand;
 import org.apache.ignite.internal.catalog.commands.StartBuildingIndexCommand;
@@ -64,6 +66,7 @@ import org.apache.ignite.internal.catalog.descriptors.CatalogSystemViewDescripto
 import org.apache.ignite.internal.catalog.descriptors.CatalogSystemViewDescriptor.SystemViewType;
 import org.apache.ignite.internal.catalog.descriptors.CatalogTableColumnDescriptor;
 import org.apache.ignite.internal.catalog.descriptors.CatalogTableDescriptor;
+import org.apache.ignite.internal.catalog.descriptors.CatalogZoneDescriptor;
 import org.apache.ignite.internal.hlc.HybridClockImpl;
 import org.apache.ignite.internal.lang.IgniteInternalException;
 import org.apache.ignite.internal.schema.DefaultValueGenerator;
@@ -174,8 +177,59 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
         assertThat(schema.getName(), equalTo(schemaDescriptor.name()));
 
         for (CatalogTableDescriptor tableDescriptor : schemaDescriptor.tables()) {
-            assertThat(schema.getTable(tableDescriptor.name()), notNullValue());
+            int zoneId = tableDescriptor.zoneId();
+            CatalogZoneDescriptor zoneDescriptor = catalogManager.zone(zoneId, versionAfter);
+            assertNotNull(zoneDescriptor, "Zone does not exist: " + zoneId);
+
+            Table table = schema.getTable(tableDescriptor.name());
+            assertThat(table, notNullValue());
+
+            IgniteTable igniteTable = assertInstanceOf(IgniteTable.class, table);
+
+            assertEquals(zoneDescriptor.partitions(), igniteTable.partitions(),
+                    "Number of partitions is not correct: " + tableDescriptor.name());
+
+            assertEquals(CatalogUtils.DEFAULT_PARTITION_COUNT, igniteTable.partitions(),
+                    "Number of partitions is not correct: " + tableDescriptor.name());
         }
+    }
+
+    /** Create a table with a zone. */
+    @Test
+    public void testTableWithZone() {
+        int partitions = 10;
+
+        await(catalogManager.execute(CreateZoneCommand.builder()
+                .partitions(partitions)
+                .zoneName("ABC")
+                .build())
+        );
+
+        await(catalogManager.execute(CreateTableCommand.builder()
+                .schemaName(PUBLIC_SCHEMA_NAME)
+                .tableName("T")
+                .columns(List.of(
+                        ColumnParams.builder().name("ID").type(ColumnType.INT32).nullable(false).build(),
+                        ColumnParams.builder().name("VAL").type(ColumnType.INT32).build()
+                ))
+                .primaryKeyColumns(List.of("ID"))
+                .zone("ABC")
+                .build()));
+
+        int version = catalogManager.latestCatalogVersion();
+
+        SchemaPlus rootSchema = sqlSchemaManager.schema(version);
+        assertNotNull(rootSchema);
+
+        SchemaPlus schemaPlus = rootSchema.getSubSchema(PUBLIC_SCHEMA_NAME);
+        assertNotNull(schemaPlus);
+
+        IgniteSchema schema = unwrapSchema(schemaPlus);
+        Table table = schema.getTable("T");
+        assertNotNull(table);
+
+        IgniteTable igniteTable = assertInstanceOf(IgniteTable.class, table);
+        assertEquals(partitions, igniteTable.partitions());
     }
 
     /**


### PR DESCRIPTION
- Updates `IgniteTable` to store the number of partitions.
- Updates `SqlQueryProcessor` to use the number of partitions stored in `IgniteTable`.

https://issues.apache.org/jira/browse/IGNITE-21396

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)