### PR TITLE
IGNITE-21424 Only respond when correlationId is not null in ItScaleCubeNetworkMessagingTest.reconnectsAfterConnectionDrop

### DIFF
--- a/modules/network/src/integrationTest/java/org/apache/ignite/network/scalecube/ItScaleCubeNetworkMessagingTest.java
+++ b/modules/network/src/integrationTest/java/org/apache/ignite/network/scalecube/ItScaleCubeNetworkMessagingTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.ignite.network.scalecube;
 
-import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toUnmodifiableList;
@@ -591,11 +590,9 @@ class ItScaleCubeNetworkMessagingTest {
         receiver.messagingService().addMessageHandler(
                 TestMessageTypes.class,
                 (message, senderConsistentId, correlationId) -> {
-                    receiver.messagingService().respond(
-                            sender.topologyService().localMember(),
-                            message,
-                            requireNonNull(correlationId)
-                    );
+                    if (correlationId != null) {
+                        receiver.messagingService().respond(sender.topologyService().localMember(), message, correlationId);
+                    }
                 }
         );
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-21424

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)