### PR TITLE
Enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2
+


### PR DESCRIPTION
Enable Dependabot version updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
* Run once per weekday
* 2 open PRs at most