### PR TITLE
IGNITE-21504: Sql. PlanningCacheMetricsTest.plannerCacheStatisticsTest is flaky.

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/cache/CaffeineCacheFactory.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/cache/CaffeineCacheFactory.java
@@ -38,7 +38,7 @@ public class CaffeineCacheFactory implements CacheFactory {
     private final Executor executor;
 
     private CaffeineCacheFactory() {
-        this.executor = null;
+        this(null);
     }
 
     private CaffeineCacheFactory(@Nullable Executor executor) {
@@ -47,7 +47,7 @@ public class CaffeineCacheFactory implements CacheFactory {
 
     /** Creates a cache factory with the given executor for running auxiliary tasks. */
     @TestOnly
-    public static CacheFactory create(@Nullable Executor executor) {
+    public static CacheFactory create(Executor executor) {
         return new CaffeineCacheFactory(executor);
     }
 

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/cache/CaffeineCacheFactory.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/cache/CaffeineCacheFactory.java
@@ -20,11 +20,13 @@ package org.apache.ignite.internal.sql.engine.util.cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 /**
  * Factory that creates caches backed by {@link Caffeine} cache.
@@ -32,7 +34,21 @@ import org.jetbrains.annotations.Nullable;
 public class CaffeineCacheFactory implements CacheFactory {
     public static final CacheFactory INSTANCE = new CaffeineCacheFactory();
 
+    @Nullable
+    private final Executor executor;
+
     private CaffeineCacheFactory() {
+        this.executor = null;
+    }
+
+    private CaffeineCacheFactory(@Nullable Executor executor) {
+        this.executor = executor;
+    }
+
+    /** Creates a cache factory with the given executor for running auxiliary tasks. */
+    @TestOnly
+    public static CacheFactory create(@Nullable Executor executor) {
+        return new CaffeineCacheFactory(executor);
     }
 
     /** {@inheritDoc} */
@@ -40,6 +56,10 @@ public class CaffeineCacheFactory implements CacheFactory {
     public <K, V> Cache<K, V> create(int size, StatsCounter statCounter) {
         Caffeine<Object, Object> builder = Caffeine.newBuilder()
                 .maximumSize(size);
+
+        if (executor != null) {
+            builder.executor(executor);
+        }
 
         if (statCounter != null) {
             builder.recordStats(() -> new CaffeineStatsCounterAdapter(statCounter));

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/metrics/PlanningCacheMetricsTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/metrics/PlanningCacheMetricsTest.java
@@ -35,6 +35,7 @@ import org.apache.ignite.internal.sql.engine.sql.ParserServiceImpl;
 import org.apache.ignite.internal.sql.engine.trait.IgniteDistributions;
 import org.apache.ignite.internal.sql.engine.util.BaseQueryContext;
 import org.apache.ignite.internal.sql.engine.util.EmptyCacheFactory;
+import org.apache.ignite.internal.sql.engine.util.cache.CacheFactory;
 import org.apache.ignite.internal.sql.engine.util.cache.CaffeineCacheFactory;
 import org.apache.ignite.internal.type.NativeTypes;
 import org.junit.jupiter.api.Test;
@@ -47,8 +48,9 @@ public class PlanningCacheMetricsTest extends AbstractPlannerTest {
     @Test
     public void plannerCacheStatisticsTest() throws Exception {
         MetricManager metricManager = new MetricManager();
-        PrepareService prepareService = new PrepareServiceImpl("test", 2, CaffeineCacheFactory.INSTANCE,
-                null, 15_000L, 2, metricManager);
+        // Run clean up tasks in the current thread, so no eviction event is delayed.
+        CacheFactory cacheFactory = CaffeineCacheFactory.create(Runnable::run);
+        PrepareService prepareService = new PrepareServiceImpl("test", 2, cacheFactory, null, 15_000L, 2, metricManager);
 
         prepareService.start();
 


### PR DESCRIPTION
Fixes tests by running eviction tasks in the current thread.

https://issues.apache.org/jira/browse/IGNITE-21504

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)