### PR TITLE
IGNITE-21554 Encapsulate raft-related code of InternalTable

### DIFF
--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeInternalTable.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeInternalTable.java
@@ -47,6 +47,7 @@ import org.apache.ignite.internal.table.InternalTable;
 import org.apache.ignite.internal.table.TableRaftService;
 import org.apache.ignite.internal.tx.InternalTransaction;
 import org.apache.ignite.internal.tx.storage.state.TxStateTableStorage;
+import org.apache.ignite.internal.util.PendingComparableValuesTracker;
 import org.apache.ignite.internal.utils.PrimaryReplica;
 import org.apache.ignite.network.ClusterNode;
 import org.jetbrains.annotations.Nullable;
@@ -479,4 +480,13 @@ public class FakeInternalTable implements InternalTable {
         }
     }
 
+    @Override
+    public @Nullable PendingComparableValuesTracker<HybridTimestamp, Void> getPartitionSafeTimeTracker(int partitionId) {
+        return null;
+    }
+
+    @Override
+    public @Nullable PendingComparableValuesTracker<Long, Void> getPartitionStorageIndexTracker(int partitionId) {
+        return null;
+    }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeInternalTable.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeInternalTable.java
@@ -36,7 +36,6 @@ import java.util.function.BiConsumer;
 import javax.naming.OperationNotSupportedException;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.apache.ignite.internal.lang.IgniteInternalException;
-import org.apache.ignite.internal.raft.service.RaftGroupService;
 import org.apache.ignite.internal.replicator.TablePartitionId;
 import org.apache.ignite.internal.schema.BinaryRow;
 import org.apache.ignite.internal.schema.BinaryRowEx;
@@ -45,9 +44,9 @@ import org.apache.ignite.internal.schema.BinaryTuplePrefix;
 import org.apache.ignite.internal.schema.ColumnsExtractor;
 import org.apache.ignite.internal.storage.engine.MvTableStorage;
 import org.apache.ignite.internal.table.InternalTable;
+import org.apache.ignite.internal.table.TableRaftService;
 import org.apache.ignite.internal.tx.InternalTransaction;
 import org.apache.ignite.internal.tx.storage.state.TxStateTableStorage;
-import org.apache.ignite.internal.util.PendingComparableValuesTracker;
 import org.apache.ignite.internal.utils.PrimaryReplica;
 import org.apache.ignite.network.ClusterNode;
 import org.jetbrains.annotations.Nullable;
@@ -446,14 +445,10 @@ public class FakeInternalTable implements InternalTable {
     }
 
     @Override
-    public ClusterNode leaderAssignment(int partition) {
+    public TableRaftService tableRaftService() {
         throw new IgniteInternalException(new OperationNotSupportedException());
     }
 
-    @Override
-    public RaftGroupService partitionRaftGroupService(int partition) {
-        return null;
-    }
 
     @Override public TxStateTableStorage txStateStorage() {
         return null;
@@ -484,13 +479,4 @@ public class FakeInternalTable implements InternalTable {
         }
     }
 
-    @Override
-    public @Nullable PendingComparableValuesTracker<HybridTimestamp, Void> getPartitionSafeTimeTracker(int partitionId) {
-        return null;
-    }
-
-    @Override
-    public @Nullable PendingComparableValuesTracker<Long, Void> getPartitionStorageIndexTracker(int partitionId) {
-        return null;
-    }
 }

--- a/modules/index/src/integrationTest/java/org/apache/ignite/internal/index/ItBuildIndexTest.java
+++ b/modules/index/src/integrationTest/java/org/apache/ignite/internal/index/ItBuildIndexTest.java
@@ -223,7 +223,7 @@ public class ItBuildIndexTest extends BaseSqlIntegrationTest {
         TableViewInternal table = getTableView(node, TABLE_NAME);
         assertNotNull(table);
 
-        return table.internalTable().partitionRaftGroupService(partitionId);
+        return table.internalTable().tableRaftService().partitionRaftGroupService(partitionId);
     }
 
     /**
@@ -337,7 +337,7 @@ public class ItBuildIndexTest extends BaseSqlIntegrationTest {
                 );
 
                 for (int partitionId = 0; partitionId < internalTable.partitions(); partitionId++) {
-                    RaftGroupService raftGroupService = internalTable.partitionRaftGroupService(partitionId);
+                    RaftGroupService raftGroupService = internalTable.tableRaftService().partitionRaftGroupService(partitionId);
 
                     List<Peer> allPeers = raftGroupService.peers();
 

--- a/modules/placement-driver/src/integrationTest/java/org/apache/ignite/internal/placementdriver/ItPrimaryReplicaChoiceTest.java
+++ b/modules/placement-driver/src/integrationTest/java/org/apache/ignite/internal/placementdriver/ItPrimaryReplicaChoiceTest.java
@@ -366,9 +366,9 @@ public class ItPrimaryReplicaChoiceTest extends ClusterPerTestIntegrationTest {
      * @throws InterruptedException If fail.
      */
     private static void waitingForLeaderCache(TableViewInternal tbl, String primary) throws InterruptedException {
-        RaftGroupService raftSrvc = tbl.internalTable().partitionRaftGroupService(0);
+        RaftGroupService raftSrvc = tbl.internalTable().tableRaftService().partitionRaftGroupService(0);
 
-        assertTrue(IgniteTestUtils.waitForCondition(() -> {
+        assertTrue(waitForCondition(() -> {
             raftSrvc.refreshLeader();
 
             Peer leader = raftSrvc.leader();

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItIgniteInMemoryNodeRestartTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItIgniteInMemoryNodeRestartTest.java
@@ -169,7 +169,7 @@ public class ItIgniteInMemoryNodeRestartTest extends BaseIgniteRestartTest {
         TableViewInternal table = (TableViewInternal) ignite.tables().table(TABLE_NAME);
 
         // Find the leader of the table's partition group.
-        RaftGroupService raftGroupService = table.internalTable().partitionRaftGroupService(0);
+        RaftGroupService raftGroupService = table.internalTable().tableRaftService().partitionRaftGroupService(0);
         LeaderWithTerm leaderWithTerm = raftGroupService.refreshAndGetLeaderWithTerm().join();
         String leaderId = leaderWithTerm.leader().consistentId();
 
@@ -213,7 +213,7 @@ public class ItIgniteInMemoryNodeRestartTest extends BaseIgniteRestartTest {
     }
 
     private static boolean solePartitionAssignmentsContain(String restartingNodeConsistentId, InternalTableImpl internalTable) {
-        Map<Integer, List<String>> assignments = internalTable.peersAndLearners();
+        Map<Integer, List<String>> assignments = internalTable.tableRaftService().peersAndLearners();
 
         List<String> partitionAssignments = assignments.get(0);
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItRaftCommandLeftInLogUntilRestartTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItRaftCommandLeftInLogUntilRestartTest.java
@@ -171,7 +171,7 @@ public class ItRaftCommandLeftInLogUntilRestartTest extends ClusterPerClassInteg
 
         TableViewInternal table = (TableViewInternal) createTable(DEFAULT_TABLE_NAME, 2, 1);
 
-        ClusterNode leader = table.internalTable().leaderAssignment(0);
+        ClusterNode leader = table.internalTable().tableRaftService().leaderAssignment(0);
 
         boolean isNode0Leader = node0.id().equals(leader.id());
 
@@ -190,7 +190,7 @@ public class ItRaftCommandLeftInLogUntilRestartTest extends ClusterPerClassInteg
 
             assertTrue(IgniteTestUtils.waitForCondition(() -> appliedIndexNode0.get() == appliedIndexNode1.get(), 10_000));
 
-            RaftGroupService raftGroupService = table.internalTable().partitionRaftGroupService(0);
+            RaftGroupService raftGroupService = table.internalTable().tableRaftService().partitionRaftGroupService(0);
 
             raftGroupService.peers().forEach(peer -> assertThat(raftGroupService.snapshot(peer), willCompleteSuccessfully()));
 
@@ -340,7 +340,7 @@ public class ItRaftCommandLeftInLogUntilRestartTest extends ClusterPerClassInteg
     private void transferLeadershipToLocalNode(IgniteImpl ignite) {
         TableViewInternal table = (TableViewInternal) ignite.tables().table(DEFAULT_TABLE_NAME);
 
-        RaftGroupService raftGroupService = table.internalTable().partitionRaftGroupService(0);
+        RaftGroupService raftGroupService = table.internalTable().tableRaftService().partitionRaftGroupService(0);
 
         List<Peer> peers = raftGroupService.peers();
         assertNotNull(peers);

--- a/modules/runner/src/testFixtures/java/org/apache/ignite/internal/table/NodeUtils.java
+++ b/modules/runner/src/testFixtures/java/org/apache/ignite/internal/table/NodeUtils.java
@@ -77,7 +77,7 @@ public class NodeUtils {
 
         // Change leader for the replication group.
 
-        RaftGroupService raftSrvc = tbl.internalTable().partitionRaftGroupService(0);
+        RaftGroupService raftSrvc = tbl.internalTable().tableRaftService().partitionRaftGroupService(0);
 
         raftSrvc.refreshLeader();
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/TableScanNodeExecutionTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/TableScanNodeExecutionTest.java
@@ -66,6 +66,7 @@ import org.apache.ignite.internal.sql.engine.util.Commons;
 import org.apache.ignite.internal.sql.engine.util.TypeUtils;
 import org.apache.ignite.internal.storage.engine.MvTableStorage;
 import org.apache.ignite.internal.table.distributed.storage.InternalTableImpl;
+import org.apache.ignite.internal.table.distributed.storage.TableRaftServiceImpl;
 import org.apache.ignite.internal.tx.HybridTimestampTracker;
 import org.apache.ignite.internal.tx.TxManager;
 import org.apache.ignite.internal.tx.configuration.TransactionConfiguration;
@@ -215,7 +216,6 @@ public class TableScanNodeExecutionTest extends AbstractExecutionTest<Object[]> 
             super(
                     "test",
                     1,
-                    Int2ObjectMaps.singleton(0, mock(RaftGroupService.class)),
                     PART_CNT,
                     new SingleClusterNodeResolver(mock(ClusterNode.class)),
                     txManager,
@@ -224,7 +224,13 @@ public class TableScanNodeExecutionTest extends AbstractExecutionTest<Object[]> 
                     replicaSvc,
                     mock(HybridClock.class),
                     timestampTracker,
-                    mock(PlacementDriver.class)
+                    mock(PlacementDriver.class),
+                    new TableRaftServiceImpl(
+                            "test",
+                            PART_CNT,
+                            Int2ObjectMaps.singleton(0, mock(RaftGroupService.class)),
+                            new SingleClusterNodeResolver(mock(ClusterNode.class))
+                    )
             );
             this.dataAmount = dataAmount;
 

--- a/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItInternalTableReadWriteScanTest.java
+++ b/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItInternalTableReadWriteScanTest.java
@@ -76,11 +76,11 @@ public class ItInternalTableReadWriteScanTest extends ItAbstractInternalTableSca
         InternalTransaction tx = internalTbl.txManager().begin(HYBRID_TIMESTAMP_TRACKER);
 
         TablePartitionId tblPartId = new TablePartitionId(internalTbl.tableId(), ((TablePartitionId) internalTbl.groupId()).partitionId());
-        RaftGroupService raftSvc = internalTbl.partitionRaftGroupService(tblPartId.partitionId());
+        RaftGroupService raftSvc = internalTbl.tableRaftService().partitionRaftGroupService(tblPartId.partitionId());
         long term = IgniteTestUtils.await(raftSvc.refreshAndGetLeaderWithTerm()).term();
 
         tx.assignCommitPartition(tblPartId);
-        tx.enlist(tblPartId, new IgniteBiTuple<>(internalTbl.leaderAssignment(tblPartId.partitionId()), term));
+        tx.enlist(tblPartId, new IgniteBiTuple<>(internalTbl.tableRaftService().leaderAssignment(tblPartId.partitionId()), term));
 
         return tx;
     }

--- a/modules/table/src/integrationTest/java/org/apache/ignite/internal/rebalance/ItRebalanceDistributedTest.java
+++ b/modules/table/src/integrationTest/java/org/apache/ignite/internal/rebalance/ItRebalanceDistributedTest.java
@@ -162,6 +162,7 @@ import org.apache.ignite.internal.storage.pagememory.VolatilePageMemoryDataStora
 import org.apache.ignite.internal.storage.pagememory.configuration.schema.PersistentPageMemoryStorageEngineConfiguration;
 import org.apache.ignite.internal.storage.pagememory.configuration.schema.VolatilePageMemoryStorageEngineConfiguration;
 import org.apache.ignite.internal.table.InternalTable;
+import org.apache.ignite.internal.table.TableRaftService;
 import org.apache.ignite.internal.table.TableTestUtils;
 import org.apache.ignite.internal.table.TableViewInternal;
 import org.apache.ignite.internal.table.distributed.TableManager;
@@ -388,7 +389,7 @@ public class ItRebalanceDistributedTest extends BaseIgniteAbstractTest {
 
         Node newNode = nodes.stream().filter(n -> !partitionNodesConsistentIds.contains(n.name)).findFirst().orElseThrow();
 
-        Node leaderNode = findNodeByConsistentId(table.leaderAssignment(0).name());
+        Node leaderNode = findNodeByConsistentId(table.tableRaftService().leaderAssignment(0).name());
 
         String nonLeaderNodeConsistentId = partitionNodesConsistentIds.stream()
                 .filter(n -> !n.equals(leaderNode.name))
@@ -421,8 +422,10 @@ public class ItRebalanceDistributedTest extends BaseIgniteAbstractTest {
 
         assertTrue(countDownLatch.await(10, SECONDS));
 
+        TableRaftService tableRaftService = nonLeaderTable.internalTable().tableRaftService();
+
         assertThat(
-                nonLeaderTable.internalTable().partitionRaftGroupService(0).transferLeadership(new Peer(nonLeaderNodeConsistentId)),
+                tableRaftService.partitionRaftGroupService(0).transferLeadership(new Peer(nonLeaderNodeConsistentId)),
                 willCompleteSuccessfully()
         );
 
@@ -651,6 +654,7 @@ public class ItRebalanceDistributedTest extends BaseIgniteAbstractTest {
                                 .latestTables()
                                 .get(getTableId(node, TABLE_NAME))
                                 .internalTable()
+                                .tableRaftService()
                                 .partitionRaftGroupService(0)
                                 .peers()
                                 .equals(List.of(new Peer(newNodeNameForAssignment)))),
@@ -706,6 +710,7 @@ public class ItRebalanceDistributedTest extends BaseIgniteAbstractTest {
                                 .latestTables()
                                 .get(getTableId(node, TABLE_NAME))
                                 .internalTable()
+                                .tableRaftService()
                                 .partitionRaftGroupService(0)
                                 .peers()
                                 .stream()
@@ -786,6 +791,7 @@ public class ItRebalanceDistributedTest extends BaseIgniteAbstractTest {
                                         .latestTables()
                                         .get(getTableId(n, TABLE_NAME))
                                         .internalTable()
+                                        .tableRaftService()
                                         .partitionRaftGroupService(partNum) != null
                         );
                     } catch (IgniteInternalException e) {

--- a/modules/table/src/integrationTest/java/org/apache/ignite/internal/table/ItColocationTest.java
+++ b/modules/table/src/integrationTest/java/org/apache/ignite/internal/table/ItColocationTest.java
@@ -89,6 +89,7 @@ import org.apache.ignite.internal.table.distributed.replication.request.ReadWrit
 import org.apache.ignite.internal.table.distributed.replication.request.ReadWriteSingleRowReplicaRequest;
 import org.apache.ignite.internal.table.distributed.schema.ConstantSchemaVersions;
 import org.apache.ignite.internal.table.distributed.storage.InternalTableImpl;
+import org.apache.ignite.internal.table.distributed.storage.TableRaftServiceImpl;
 import org.apache.ignite.internal.table.impl.DummyInternalTableImpl;
 import org.apache.ignite.internal.table.impl.DummySchemaManagerImpl;
 import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
@@ -269,7 +270,6 @@ public class ItColocationTest extends BaseIgniteAbstractTest {
         intTable = new InternalTableImpl(
                 "PUBLIC.TEST",
                 tblId,
-                partRafts,
                 PARTS,
                 new SingleClusterNodeResolver(clusterNode),
                 txManager,
@@ -278,7 +278,8 @@ public class ItColocationTest extends BaseIgniteAbstractTest {
                 replicaService,
                 new HybridClockImpl(),
                 observableTimestampTracker,
-                new TestPlacementDriver(clusterNode)
+                new TestPlacementDriver(clusterNode),
+                new TableRaftServiceImpl("PUBLIC.TEST", PARTS, partRafts, new SingleClusterNodeResolver(clusterNode))
         );
     }
 

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/InternalTable.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/InternalTable.java
@@ -25,8 +25,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow.Publisher;
 import org.apache.ignite.internal.close.ManuallyCloseable;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
-import org.apache.ignite.internal.lang.IgniteInternalException;
-import org.apache.ignite.internal.raft.service.RaftGroupService;
 import org.apache.ignite.internal.replicator.TablePartitionId;
 import org.apache.ignite.internal.schema.BinaryRow;
 import org.apache.ignite.internal.schema.BinaryRowEx;
@@ -36,7 +34,6 @@ import org.apache.ignite.internal.storage.engine.MvTableStorage;
 import org.apache.ignite.internal.tx.InternalTransaction;
 import org.apache.ignite.internal.tx.LockException;
 import org.apache.ignite.internal.tx.storage.state.TxStateTableStorage;
-import org.apache.ignite.internal.util.PendingComparableValuesTracker;
 import org.apache.ignite.internal.utils.PrimaryReplica;
 import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.tx.TransactionException;
@@ -440,29 +437,18 @@ public interface InternalTable extends ManuallyCloseable {
     int partitions();
 
     /**
-     * Returns cluster node that is the leader of the corresponding partition group or throws an exception if
-     * it cannot be found.
-     *
-     * @param partition partition number
-     * @return leader node of the partition group corresponding to the partition
-     */
-    ClusterNode leaderAssignment(int partition);
-
-    /**
-     * Returns raft group client for corresponding partition.
-     *
-     * @param partition partition number
-     * @return raft group client for corresponding partition
-     * @throws IgniteInternalException if partition can't be found.
-     */
-    RaftGroupService partitionRaftGroupService(int partition);
-
-    /**
      * Storage of transaction states for this table.
      *
      * @return Transaction states' storage.
      */
     TxStateTableStorage txStateStorage();
+
+    /**
+     * Raft service for this table.
+     *
+     * @return Table raft service.
+     */
+    TableRaftService tableRaftService();
 
     //TODO: IGNITE-14488. Add invoke() methods.
 
@@ -471,18 +457,4 @@ public interface InternalTable extends ManuallyCloseable {
      */
     @Override
     void close();
-
-    /**
-     * Returns the partition safe time tracker, {@code null} means not added.
-     *
-     * @param partitionId Partition ID.
-     */
-    @Nullable PendingComparableValuesTracker<HybridTimestamp, Void> getPartitionSafeTimeTracker(int partitionId);
-
-    /**
-     * Returns the partition storage index tracker, {@code null} means not added.
-     *
-     * @param partitionId Partition ID.
-     */
-    @Nullable PendingComparableValuesTracker<Long, Void> getPartitionStorageIndexTracker(int partitionId);
 }

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/InternalTable.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/InternalTable.java
@@ -34,6 +34,7 @@ import org.apache.ignite.internal.storage.engine.MvTableStorage;
 import org.apache.ignite.internal.tx.InternalTransaction;
 import org.apache.ignite.internal.tx.LockException;
 import org.apache.ignite.internal.tx.storage.state.TxStateTableStorage;
+import org.apache.ignite.internal.util.PendingComparableValuesTracker;
 import org.apache.ignite.internal.utils.PrimaryReplica;
 import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.tx.TransactionException;
@@ -457,4 +458,18 @@ public interface InternalTable extends ManuallyCloseable {
      */
     @Override
     void close();
+
+    /**
+     * Returns the partition safe time tracker, {@code null} means not added.
+     *
+     * @param partitionId Partition ID.
+     */
+    @Nullable PendingComparableValuesTracker<HybridTimestamp, Void> getPartitionSafeTimeTracker(int partitionId);
+
+    /**
+     * Returns the partition storage index tracker, {@code null} means not added.
+     *
+     * @param partitionId Partition ID.
+     */
+    @Nullable PendingComparableValuesTracker<Long, Void> getPartitionStorageIndexTracker(int partitionId);
 }

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/TableImpl.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/TableImpl.java
@@ -217,7 +217,7 @@ public class TableImpl implements TableViewInternal {
 
     @Override
     public ClusterNode leaderAssignment(int partition) {
-        return tbl.leaderAssignment(partition);
+        return tbl.tableRaftService().leaderAssignment(partition);
     }
 
     /** Returns a supplier of index storage wrapper factories for given partition. */

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/TableRaftService.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/TableRaftService.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.table;
+
+import org.apache.ignite.internal.close.ManuallyCloseable;
+import org.apache.ignite.internal.hlc.HybridTimestamp;
+import org.apache.ignite.internal.lang.IgniteInternalException;
+import org.apache.ignite.internal.raft.service.RaftGroupService;
+import org.apache.ignite.internal.util.PendingComparableValuesTracker;
+import org.apache.ignite.network.ClusterNode;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Internal facade that provides methods for table's raft operations.
+ */
+public interface TableRaftService extends ManuallyCloseable {
+
+    /**
+     * Returns cluster node that is the leader of the corresponding partition group or throws an exception if it cannot be found.
+     *
+     * @param partition partition number
+     * @return leader node of the partition group corresponding to the partition
+     */
+    ClusterNode leaderAssignment(int partition);
+
+    /**
+     * Returns raft group client for corresponding partition.
+     *
+     * @param partition partition number
+     * @return raft group client for corresponding partition
+     * @throws IgniteInternalException if partition can't be found.
+     */
+    RaftGroupService partitionRaftGroupService(int partition);
+
+    /**
+     * Closes the service.
+     */
+    @Override
+    void close();
+
+    /**
+     * Returns the partition safe time tracker, {@code null} means not added.
+     *
+     * @param partitionId Partition ID.
+     */
+    @Nullable PendingComparableValuesTracker<HybridTimestamp, Void> getPartitionSafeTimeTracker(int partitionId);
+
+    /**
+     * Returns the partition storage index tracker, {@code null} means not added.
+     *
+     * @param partitionId Partition ID.
+     */
+    @Nullable PendingComparableValuesTracker<Long, Void> getPartitionStorageIndexTracker(int partitionId);
+}

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/TableRaftService.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/TableRaftService.java
@@ -18,12 +18,9 @@
 package org.apache.ignite.internal.table;
 
 import org.apache.ignite.internal.close.ManuallyCloseable;
-import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.apache.ignite.internal.lang.IgniteInternalException;
 import org.apache.ignite.internal.raft.service.RaftGroupService;
-import org.apache.ignite.internal.util.PendingComparableValuesTracker;
 import org.apache.ignite.network.ClusterNode;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Internal facade that provides methods for table's raft operations.
@@ -52,18 +49,4 @@ public interface TableRaftService extends ManuallyCloseable {
      */
     @Override
     void close();
-
-    /**
-     * Returns the partition safe time tracker, {@code null} means not added.
-     *
-     * @param partitionId Partition ID.
-     */
-    @Nullable PendingComparableValuesTracker<HybridTimestamp, Void> getPartitionSafeTimeTracker(int partitionId);
-
-    /**
-     * Returns the partition storage index tracker, {@code null} means not added.
-     *
-     * @param partitionId Partition ID.
-     */
-    @Nullable PendingComparableValuesTracker<Long, Void> getPartitionStorageIndexTracker(int partitionId);
 }

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
@@ -840,7 +840,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
         boolean shouldStartRaftListeners = localMemberAssignment != null && !((Loza) raftMgr).isStarted(raftNodeId);
 
         if (shouldStartRaftListeners) {
-            ((InternalTableImpl) internalTbl).tableRaftService().updatePartitionTrackers(partId, safeTimeTracker, storageIndexTracker);
+            ((InternalTableImpl) internalTbl).updatePartitionTrackers(partId, safeTimeTracker, storageIndexTracker);
 
             mvGc.addStorage(replicaGrpId, partitionUpdateHandlers.gcUpdateHandler);
         }
@@ -2298,9 +2298,9 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
     }
 
     private static void closePartitionTrackers(InternalTable internalTable, int partitionId) {
-        closeTracker(internalTable.tableRaftService().getPartitionSafeTimeTracker(partitionId));
+        closeTracker(internalTable.getPartitionSafeTimeTracker(partitionId));
 
-        closeTracker(internalTable.tableRaftService().getPartitionStorageIndexTracker(partitionId));
+        closeTracker(internalTable.getPartitionStorageIndexTracker(partitionId));
     }
 
     private static void closeTracker(@Nullable PendingComparableValuesTracker<?, Void> tracker) {

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
@@ -172,6 +172,7 @@ import org.apache.ignite.internal.table.distributed.schema.SchemaVersionsImpl;
 import org.apache.ignite.internal.table.distributed.schema.ThreadLocalPartitionCommandsMarshaller;
 import org.apache.ignite.internal.table.distributed.storage.InternalTableImpl;
 import org.apache.ignite.internal.table.distributed.storage.PartitionStorages;
+import org.apache.ignite.internal.table.distributed.storage.TableRaftServiceImpl;
 import org.apache.ignite.internal.table.distributed.wrappers.ExecutorInclinedPlacementDriver;
 import org.apache.ignite.internal.thread.IgniteThreadFactory;
 import org.apache.ignite.internal.thread.NamedThreadFactory;
@@ -839,7 +840,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
         boolean shouldStartRaftListeners = localMemberAssignment != null && !((Loza) raftMgr).isStarted(raftNodeId);
 
         if (shouldStartRaftListeners) {
-            ((InternalTableImpl) internalTbl).updatePartitionTrackers(partId, safeTimeTracker, storageIndexTracker);
+            ((InternalTableImpl) internalTbl).tableRaftService().updatePartitionTrackers(partId, safeTimeTracker, storageIndexTracker);
 
             mvGc.addStorage(replicaGrpId, partitionUpdateHandlers.gcUpdateHandler);
         }
@@ -898,7 +899,8 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
                     }
                 }), ioExecutor)
                 .thenAcceptAsync(updatedRaftGroupService -> inBusyLock(busyLock, () -> {
-                    ((InternalTableImpl) internalTbl).updateInternalTableRaftGroupService(partId, updatedRaftGroupService);
+                    ((InternalTableImpl) internalTbl).tableRaftService()
+                            .updateInternalTableRaftGroupService(partId, updatedRaftGroupService);
 
                     boolean startedRaftNode = startGroupFut.join();
                     if (localMemberAssignment == null || !startedRaftNode || replicaMgr.isReplicaStarted(replicaGrpId)) {
@@ -1235,10 +1237,16 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
 
         int partitions = zoneDescriptor.partitions();
 
+        TableRaftServiceImpl tableRaftService = new TableRaftServiceImpl(
+                tableName,
+                partitions,
+                new Int2ObjectOpenHashMap<>(partitions),
+                clusterService.topologyService()
+        );
+
         InternalTableImpl internalTable = new InternalTableImpl(
                 tableName,
                 tableId,
-                new Int2ObjectOpenHashMap<>(partitions),
                 partitions,
                 clusterService.topologyService(),
                 txManager,
@@ -1247,7 +1255,8 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
                 replicaSvc,
                 clock,
                 observableTimestampTracker,
-                placementDriver
+                placementDriver,
+                tableRaftService
         );
 
         var table = new TableImpl(internalTable, lockMgr, schemaVersions, marshallers, sql.get());
@@ -1863,6 +1872,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
 
         return localServicesStartFuture.thenRunAsync(
                 () -> tbl.internalTable()
+                        .tableRaftService()
                         .partitionRaftGroupService(replicaGrpId.partitionId())
                         .updateConfiguration(configurationFromAssignments(union(pendingAssignments, stableAssignments))),
                 ioExecutor
@@ -1877,7 +1887,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
     ) {
         int partId = replicaGrpId.partitionId();
 
-        RaftGroupService partGrpSvc = table.internalTable().partitionRaftGroupService(partId);
+        RaftGroupService partGrpSvc = table.internalTable().tableRaftService().partitionRaftGroupService(partId);
 
         return partGrpSvc.refreshAndGetLeaderWithTerm()
                 .exceptionally(throwable -> {
@@ -2038,7 +2048,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
     }
 
     private PartitionMover createPartitionMover(InternalTable internalTable, int partId) {
-        return new PartitionMover(busyLock, () -> internalTable.partitionRaftGroupService(partId));
+        return new PartitionMover(busyLock, () -> internalTable.tableRaftService().partitionRaftGroupService(partId));
     }
 
     private static PeersAndLearners configurationFromAssignments(Collection<Assignment> assignments) {
@@ -2181,6 +2191,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
         // Update raft client peers and learners according to the actual assignments.
         return tablesById(revision).thenAccept(t -> {
             t.get(tablePartitionId.tableId()).internalTable()
+                    .tableRaftService()
                     .partitionRaftGroupService(tablePartitionId.partitionId())
                     .updateConfiguration(configurationFromAssignments(stableAssignments));
         });
@@ -2287,9 +2298,9 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
     }
 
     private static void closePartitionTrackers(InternalTable internalTable, int partitionId) {
-        closeTracker(internalTable.getPartitionSafeTimeTracker(partitionId));
+        closeTracker(internalTable.tableRaftService().getPartitionSafeTimeTracker(partitionId));
 
-        closeTracker(internalTable.getPartitionStorageIndexTracker(partitionId));
+        closeTracker(internalTable.tableRaftService().getPartitionStorageIndexTracker(partitionId));
     }
 
     private static void closeTracker(@Nullable PendingComparableValuesTracker<?, Void> tracker) {

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/storage/TableRaftServiceImpl.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/storage/TableRaftServiceImpl.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.table.distributed.storage;
+
+import static it.unimi.dsi.fastutil.ints.Int2ObjectMaps.emptyMap;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap.Entry;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.ignite.internal.hlc.HybridTimestamp;
+import org.apache.ignite.internal.lang.IgniteInternalException;
+import org.apache.ignite.internal.raft.Peer;
+import org.apache.ignite.internal.raft.service.RaftGroupService;
+import org.apache.ignite.internal.table.TableRaftService;
+import org.apache.ignite.internal.util.PendingComparableValuesTracker;
+import org.apache.ignite.network.ClusterNode;
+import org.apache.ignite.network.ClusterNodeResolver;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
+
+/**
+ * Table's raft client storage.
+ */
+public class TableRaftServiceImpl implements TableRaftService {
+
+    /** Mutex for the partition maps update. */
+    private final Object updatePartitionMapsMux = new Object();
+
+    /** Map update guarded by {@link #updatePartitionMapsMux}. */
+    private volatile Int2ObjectMap<RaftGroupService> raftGroupServiceByPartitionId;
+
+    /** Map update guarded by {@link #updatePartitionMapsMux}. */
+    private volatile Int2ObjectMap<PendingComparableValuesTracker<HybridTimestamp, Void>> safeTimeTrackerByPartitionId = emptyMap();
+
+    /** Map update guarded by {@link #updatePartitionMapsMux}. */
+    private volatile Int2ObjectMap<PendingComparableValuesTracker<Long, Void>> storageIndexTrackerByPartitionId = emptyMap();
+
+    /** Resolver that resolves a node consistent ID to cluster node. */
+    private final ClusterNodeResolver clusterNodeResolver;
+
+    /** Partitions. */
+    private final int partitions;
+
+    /** Table name. */
+    private volatile String tableName;
+
+    /**
+     * Constructor.
+     *
+     * @param tableName Table name.
+     * @param partitions Partitions.
+     * @param partMap Map partition id to raft group.
+     * @param clusterNodeResolver Cluster node resolver.
+     */
+    public TableRaftServiceImpl(
+            String tableName,
+            int partitions,
+            Int2ObjectMap<RaftGroupService> partMap,
+            ClusterNodeResolver clusterNodeResolver
+    ) {
+        this.tableName = tableName;
+        this.partitions = partitions;
+        this.raftGroupServiceByPartitionId = partMap;
+        this.clusterNodeResolver = clusterNodeResolver;
+    }
+
+    @Override
+    public ClusterNode leaderAssignment(int partition) {
+        awaitLeaderInitialization();
+
+        RaftGroupService raftGroupService = raftGroupServiceByPartitionId.get(partition);
+        if (raftGroupService == null) {
+            throw new IgniteInternalException("No such partition " + partition + " in table " + tableName);
+        }
+
+        return clusterNodeResolver.getByConsistentId(raftGroupService.leader().consistentId());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public RaftGroupService partitionRaftGroupService(int partition) {
+        RaftGroupService raftGroupService = raftGroupServiceByPartitionId.get(partition);
+        if (raftGroupService == null) {
+            throw new IgniteInternalException("No such partition " + partition + " in table " + tableName);
+        }
+
+        return raftGroupService;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void close() {
+        for (RaftGroupService srv : raftGroupServiceByPartitionId.values()) {
+            srv.shutdown();
+        }
+    }
+
+    @Override
+    public @Nullable PendingComparableValuesTracker<HybridTimestamp, Void> getPartitionSafeTimeTracker(int partitionId) {
+        return safeTimeTrackerByPartitionId.get(partitionId);
+    }
+
+    @Override
+    public @Nullable PendingComparableValuesTracker<Long, Void> getPartitionStorageIndexTracker(int partitionId) {
+        return storageIndexTrackerByPartitionId.get(partitionId);
+    }
+
+    public void name(String newName) {
+        this.tableName = newName;
+    }
+
+    /**
+     * Updates internal table raft group service for given partition.
+     *
+     * @param p Partition.
+     * @param raftGrpSvc Raft group service.
+     */
+    public void updateInternalTableRaftGroupService(int p, RaftGroupService raftGrpSvc) {
+        RaftGroupService oldSrvc;
+
+        synchronized (updatePartitionMapsMux) {
+            Int2ObjectMap<RaftGroupService> newPartitionMap = new Int2ObjectOpenHashMap<>(partitions);
+
+            newPartitionMap.putAll(raftGroupServiceByPartitionId);
+
+            oldSrvc = newPartitionMap.put(p, raftGrpSvc);
+
+            raftGroupServiceByPartitionId = newPartitionMap;
+        }
+
+        if (oldSrvc != null) {
+            oldSrvc.shutdown();
+        }
+    }
+
+    /**
+     * Updates the partition trackers, if there were previous ones, it closes them.
+     *
+     * @param partitionId Partition ID.
+     * @param newSafeTimeTracker New partition safe time tracker.
+     * @param newStorageIndexTracker New partition storage index tracker.
+     */
+    public void updatePartitionTrackers(
+            int partitionId,
+            PendingComparableValuesTracker<HybridTimestamp, Void> newSafeTimeTracker,
+            PendingComparableValuesTracker<Long, Void> newStorageIndexTracker
+    ) {
+        PendingComparableValuesTracker<HybridTimestamp, Void> previousSafeTimeTracker;
+        PendingComparableValuesTracker<Long, Void> previousStorageIndexTracker;
+
+        synchronized (updatePartitionMapsMux) {
+            Int2ObjectMap<PendingComparableValuesTracker<HybridTimestamp, Void>> newSafeTimeTrackerMap =
+                    new Int2ObjectOpenHashMap<>(partitions);
+            Int2ObjectMap<PendingComparableValuesTracker<Long, Void>> newStorageIndexTrackerMap = new Int2ObjectOpenHashMap<>(partitions);
+
+            newSafeTimeTrackerMap.putAll(safeTimeTrackerByPartitionId);
+            newStorageIndexTrackerMap.putAll(storageIndexTrackerByPartitionId);
+
+            previousSafeTimeTracker = newSafeTimeTrackerMap.put(partitionId, newSafeTimeTracker);
+            previousStorageIndexTracker = newStorageIndexTrackerMap.put(partitionId, newStorageIndexTracker);
+
+            safeTimeTrackerByPartitionId = newSafeTimeTrackerMap;
+            storageIndexTrackerByPartitionId = newStorageIndexTrackerMap;
+        }
+
+        if (previousSafeTimeTracker != null) {
+            previousSafeTimeTracker.close();
+        }
+
+        if (previousStorageIndexTracker != null) {
+            previousStorageIndexTracker.close();
+        }
+    }
+
+    /**
+     * Returns map of partition -> list of peers and learners of that partition.
+     */
+    @TestOnly
+    public Map<Integer, List<String>> peersAndLearners() {
+        awaitLeaderInitialization();
+
+        return raftGroupServiceByPartitionId.int2ObjectEntrySet().stream()
+                .collect(Collectors.toMap(Entry::getIntKey, e -> {
+                    RaftGroupService service = e.getValue();
+                    return Stream.of(service.peers(), service.learners())
+                            .filter(Objects::nonNull)
+                            .flatMap(Collection::stream)
+                            .map(Peer::consistentId)
+                            .collect(Collectors.toList());
+                }));
+    }
+
+    private void awaitLeaderInitialization() {
+        List<CompletableFuture<Void>> futs = new ArrayList<>();
+
+        for (RaftGroupService raftSvc : raftGroupServiceByPartitionId.values()) {
+            if (raftSvc.leader() == null) {
+                futs.add(raftSvc.refreshLeader());
+            }
+        }
+
+        CompletableFuture.allOf(futs.toArray(CompletableFuture[]::new)).join();
+    }
+}

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/storage/InternalTableImplTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/storage/InternalTableImplTest.java
@@ -74,17 +74,17 @@ public class InternalTableImplTest extends BaseIgniteAbstractTest {
         );
 
         // Let's check the empty table.
-        assertNull(internalTable.tableRaftService().getPartitionSafeTimeTracker(0));
-        assertNull(internalTable.tableRaftService().getPartitionStorageIndexTracker(0));
+        assertNull(internalTable.getPartitionSafeTimeTracker(0));
+        assertNull(internalTable.getPartitionStorageIndexTracker(0));
 
         // Let's check the first insert.
         PendingComparableValuesTracker<HybridTimestamp, Void> safeTime0 = mock(PendingComparableValuesTracker.class);
         PendingComparableValuesTracker<Long, Void> storageIndex0 = mock(PendingComparableValuesTracker.class);
 
-        internalTable.tableRaftService().updatePartitionTrackers(0, safeTime0, storageIndex0);
+        internalTable.updatePartitionTrackers(0, safeTime0, storageIndex0);
 
-        assertSame(safeTime0, internalTable.tableRaftService().getPartitionSafeTimeTracker(0));
-        assertSame(storageIndex0, internalTable.tableRaftService().getPartitionStorageIndexTracker(0));
+        assertSame(safeTime0, internalTable.getPartitionSafeTimeTracker(0));
+        assertSame(storageIndex0, internalTable.getPartitionStorageIndexTracker(0));
 
         verify(safeTime0, never()).close();
         verify(storageIndex0, never()).close();
@@ -93,10 +93,10 @@ public class InternalTableImplTest extends BaseIgniteAbstractTest {
         PendingComparableValuesTracker<HybridTimestamp, Void> safeTime1 = mock(PendingComparableValuesTracker.class);
         PendingComparableValuesTracker<Long, Void> storageIndex1 = mock(PendingComparableValuesTracker.class);
 
-        internalTable.tableRaftService().updatePartitionTrackers(0, safeTime1, storageIndex1);
+        internalTable.updatePartitionTrackers(0, safeTime1, storageIndex1);
 
-        assertSame(safeTime1, internalTable.tableRaftService().getPartitionSafeTimeTracker(0));
-        assertSame(storageIndex1, internalTable.tableRaftService().getPartitionStorageIndexTracker(0));
+        assertSame(safeTime1, internalTable.getPartitionSafeTimeTracker(0));
+        assertSame(storageIndex1, internalTable.getPartitionStorageIndexTracker(0));
 
         verify(safeTime0).close();
         verify(storageIndex0).close();

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/storage/InternalTableImplTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/storage/InternalTableImplTest.java
@@ -61,7 +61,6 @@ public class InternalTableImplTest extends BaseIgniteAbstractTest {
         InternalTableImpl internalTable = new InternalTableImpl(
                 "test",
                 1,
-                Int2ObjectMaps.emptyMap(),
                 1,
                 new SingleClusterNodeResolver(mock(ClusterNode.class)),
                 mock(TxManager.class),
@@ -70,21 +69,22 @@ public class InternalTableImplTest extends BaseIgniteAbstractTest {
                 mock(ReplicaService.class),
                 mock(HybridClock.class),
                 new HybridTimestampTracker(),
-                mock(PlacementDriver.class)
+                mock(PlacementDriver.class),
+                new TableRaftServiceImpl("test", 1, Int2ObjectMaps.emptyMap(), new SingleClusterNodeResolver(mock(ClusterNode.class)))
         );
 
         // Let's check the empty table.
-        assertNull(internalTable.getPartitionSafeTimeTracker(0));
-        assertNull(internalTable.getPartitionStorageIndexTracker(0));
+        assertNull(internalTable.tableRaftService().getPartitionSafeTimeTracker(0));
+        assertNull(internalTable.tableRaftService().getPartitionStorageIndexTracker(0));
 
         // Let's check the first insert.
         PendingComparableValuesTracker<HybridTimestamp, Void> safeTime0 = mock(PendingComparableValuesTracker.class);
         PendingComparableValuesTracker<Long, Void> storageIndex0 = mock(PendingComparableValuesTracker.class);
 
-        internalTable.updatePartitionTrackers(0, safeTime0, storageIndex0);
+        internalTable.tableRaftService().updatePartitionTrackers(0, safeTime0, storageIndex0);
 
-        assertSame(safeTime0, internalTable.getPartitionSafeTimeTracker(0));
-        assertSame(storageIndex0, internalTable.getPartitionStorageIndexTracker(0));
+        assertSame(safeTime0, internalTable.tableRaftService().getPartitionSafeTimeTracker(0));
+        assertSame(storageIndex0, internalTable.tableRaftService().getPartitionStorageIndexTracker(0));
 
         verify(safeTime0, never()).close();
         verify(storageIndex0, never()).close();
@@ -93,10 +93,10 @@ public class InternalTableImplTest extends BaseIgniteAbstractTest {
         PendingComparableValuesTracker<HybridTimestamp, Void> safeTime1 = mock(PendingComparableValuesTracker.class);
         PendingComparableValuesTracker<Long, Void> storageIndex1 = mock(PendingComparableValuesTracker.class);
 
-        internalTable.updatePartitionTrackers(0, safeTime1, storageIndex1);
+        internalTable.tableRaftService().updatePartitionTrackers(0, safeTime1, storageIndex1);
 
-        assertSame(safeTime1, internalTable.getPartitionSafeTimeTracker(0));
-        assertSame(storageIndex1, internalTable.getPartitionStorageIndexTracker(0));
+        assertSame(safeTime1, internalTable.tableRaftService().getPartitionSafeTimeTracker(0));
+        assertSame(storageIndex1, internalTable.tableRaftService().getPartitionStorageIndexTracker(0));
 
         verify(safeTime0).close();
         verify(storageIndex0).close();
@@ -107,7 +107,6 @@ public class InternalTableImplTest extends BaseIgniteAbstractTest {
         InternalTableImpl internalTable = new InternalTableImpl(
                 "test",
                 1,
-                Int2ObjectMaps.emptyMap(),
                 3,
                 new SingleClusterNodeResolver(mock(ClusterNode.class)),
                 mock(TxManager.class),
@@ -116,7 +115,8 @@ public class InternalTableImplTest extends BaseIgniteAbstractTest {
                 mock(ReplicaService.class),
                 mock(HybridClock.class),
                 new HybridTimestampTracker(),
-                mock(PlacementDriver.class)
+                mock(PlacementDriver.class),
+                new TableRaftServiceImpl("test", 3, Int2ObjectMaps.emptyMap(), new SingleClusterNodeResolver(mock(ClusterNode.class)))
         );
 
         List<BinaryRowEx> originalRows = List.of(

--- a/modules/table/src/testFixtures/java/org/apache/ignite/distributed/ItTxTestCluster.java
+++ b/modules/table/src/testFixtures/java/org/apache/ignite/distributed/ItTxTestCluster.java
@@ -120,6 +120,7 @@ import org.apache.ignite.internal.table.distributed.schema.SchemaSyncService;
 import org.apache.ignite.internal.table.distributed.schema.ThreadLocalPartitionCommandsMarshaller;
 import org.apache.ignite.internal.table.distributed.schema.ValidationSchemasSource;
 import org.apache.ignite.internal.table.distributed.storage.InternalTableImpl;
+import org.apache.ignite.internal.table.distributed.storage.TableRaftServiceImpl;
 import org.apache.ignite.internal.table.impl.DummyInternalTableImpl;
 import org.apache.ignite.internal.table.impl.DummySchemaManagerImpl;
 import org.apache.ignite.internal.table.impl.DummyValidationSchemasSource;
@@ -659,7 +660,6 @@ public class ItTxTestCluster {
                 new InternalTableImpl(
                         tableName,
                         tableId,
-                        clients,
                         1,
                         nodeResolver,
                         clientTxManager,
@@ -668,7 +668,8 @@ public class ItTxTestCluster {
                         startClient ? clientReplicaSvc : replicaServices.get(localNodeName),
                         startClient ? clientClock : clocks.get(localNodeName),
                         timestampTracker,
-                        placementDriver
+                        placementDriver,
+                        new TableRaftServiceImpl(tableName, 1, clients, nodeResolver)
                 ),
                 new DummySchemaManagerImpl(schemaDescriptor),
                 clientTxManager.lockManager(),

--- a/modules/table/src/testFixtures/java/org/apache/ignite/internal/table/TxAbstractTest.java
+++ b/modules/table/src/testFixtures/java/org/apache/ignite/internal/table/TxAbstractTest.java
@@ -1539,7 +1539,7 @@ public abstract class TxAbstractTest extends IgniteAbstractTest {
      */
     private CompletableFuture<List<Tuple>> scan(InternalTable internalTable, @Nullable InternalTransaction internalTx) {
         Flow.Publisher<BinaryRow> pub = internalTx != null && internalTx.isReadOnly()
-                ? internalTable.scan(0, internalTx.id(), internalTx.readTimestamp(), internalTable.leaderAssignment(0))
+                ? internalTable.scan(0, internalTx.id(), internalTx.readTimestamp(), internalTable.tableRaftService().leaderAssignment(0))
                 : internalTable.scan(0, internalTx);
 
         List<Tuple> rows = new ArrayList<>();

--- a/modules/table/src/testFixtures/java/org/apache/ignite/internal/table/impl/DummyInternalTableImpl.java
+++ b/modules/table/src/testFixtures/java/org/apache/ignite/internal/table/impl/DummyInternalTableImpl.java
@@ -89,6 +89,7 @@ import org.apache.ignite.internal.table.distributed.replicator.PartitionReplicaL
 import org.apache.ignite.internal.table.distributed.replicator.TransactionStateResolver;
 import org.apache.ignite.internal.table.distributed.schema.AlwaysSyncedSchemaSyncService;
 import org.apache.ignite.internal.table.distributed.storage.InternalTableImpl;
+import org.apache.ignite.internal.table.distributed.storage.TableRaftServiceImpl;
 import org.apache.ignite.internal.tx.HybridTimestampTracker;
 import org.apache.ignite.internal.tx.InternalTransaction;
 import org.apache.ignite.internal.tx.TxManager;
@@ -248,7 +249,6 @@ public class DummyInternalTableImpl extends InternalTableImpl {
         super(
                 "test",
                 nextTableId.getAndIncrement(),
-                Int2ObjectMaps.singleton(PART_ID, mock(RaftGroupService.class)),
                 1,
                 new SingleClusterNodeResolver(LOCAL_NODE),
                 txManager,
@@ -257,10 +257,16 @@ public class DummyInternalTableImpl extends InternalTableImpl {
                 replicaSvc,
                 CLOCK,
                 tracker,
-                placementDriver
+                placementDriver,
+                new TableRaftServiceImpl(
+                        "test",
+                        1,
+                        Int2ObjectMaps.singleton(PART_ID, mock(RaftGroupService.class)),
+                        new SingleClusterNodeResolver(LOCAL_NODE)
+                )
         );
         this.storageUpdateConfiguration = storageUpdateConfiguration;
-        RaftGroupService svc = raftGroupServiceByPartitionId.get(PART_ID);
+        RaftGroupService svc = tableRaftService().partitionRaftGroupService(PART_ID);
 
         groupId = crossTableUsage ? new TablePartitionId(tableId(), PART_ID) : crossTableGroupId;
 
@@ -384,7 +390,7 @@ public class DummyInternalTableImpl extends InternalTableImpl {
 
         replicaListener = new PartitionReplicaListener(
                 mvPartStorage,
-                raftGroupServiceByPartitionId.get(PART_ID),
+                tableRaftService().partitionRaftGroupService(PART_ID),
                 this.txManager,
                 this.txManager.lockManager(),
                 Runnable::run,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-21554

- Moved raft-related methods to a separate entity - TableRaftService
- InternalTableImpl now uses the consistent way of building a replication group id
