### PR TITLE
IGNITE-20242 Retry outdated schema error

### DIFF
--- a/modules/platforms/cpp/ignite/client/detail/cluster_connection.h
+++ b/modules/platforms/cpp/ignite/client/detail/cluster_connection.h
@@ -95,38 +95,13 @@ public:
     /**
      * Perform request raw.
      *
-     * @tparam T Result type.
      * @param op Operation code.
      * @param tx Transaction.
      * @param wr Request writer function.
      * @param handler Request handler.
-     * @return Channel used for the request.
      */
-    template<typename T>
     void perform_request_handler(protocol::client_operation op, transaction_impl *tx,
-        const std::function<void(protocol::writer &)> &wr, const std::shared_ptr<response_handler> &handler) {
-        if (tx) {
-            auto channel = tx->get_connection();
-            if (!channel)
-                throw ignite_error("Transaction was not started properly");
-
-            auto res = channel->perform_request(op, wr, handler);
-            if (!res)
-                throw ignite_error("Connection associated with the transaction is closed");
-
-            return;
-        }
-
-        while (true) {
-            auto channel = get_random_channel();
-            if (!channel)
-                throw ignite_error("No nodes connected");
-
-            auto res = channel->perform_request(op, wr, handler);
-            if (res)
-                return;
-        }
-    }
+        const std::function<void(protocol::writer &)> &wr, const std::shared_ptr<response_handler> &handler);
 
     /**
      * Perform request raw.
@@ -135,16 +110,26 @@ public:
      * @param op Operation code.
      * @param tx Transaction.
      * @param wr Request writer function.
-     * @param rd response reader function.
      * @param callback Callback to call on result.
-     * @return Channel used for the request.
+     */
+    void perform_request_raw(protocol::client_operation op, transaction_impl *tx,
+        const std::function<void(protocol::writer &)> &wr, ignite_callback<bytes_view> callback);
+
+    /**
+     * Perform request raw.
+     *
+     * @tparam T Result type.
+     * @param op Operation code.
+     * @param tx Transaction.
+     * @param wr Request writer function.
+     * @param callback Callback to call on result.
      */
     template<typename T>
-    void perform_request_raw(protocol::client_operation op, transaction_impl *tx,
+    void perform_request_bytes(protocol::client_operation op, transaction_impl *tx,
         const std::function<void(protocol::writer &)> &wr,
         std::function<T(std::shared_ptr<node_connection>, bytes_view)> rd, ignite_callback<T> callback) {
         auto handler = std::make_shared<response_handler_bytes<T>>(std::move(rd), std::move(callback));
-        perform_request_handler<T>(op, tx, wr, std::move(handler));
+        perform_request_handler(op, tx, wr, std::move(handler));
     }
 
     /**
@@ -156,14 +141,13 @@ public:
      * @param wr Request writer function.
      * @param rd response reader function.
      * @param callback Callback to call on result.
-     * @return Channel used for the request.
      */
     template<typename T>
     void perform_request(protocol::client_operation op, transaction_impl *tx,
         const std::function<void(protocol::writer &)> &wr, std::function<T(protocol::reader &)> rd,
         ignite_callback<T> callback) {
         auto handler = std::make_shared<response_handler_reader<T>>(std::move(rd), std::move(callback));
-        perform_request_handler<T>(op, tx, wr, std::move(handler));
+        perform_request_handler(op, tx, wr, std::move(handler));
     }
 
     /**
@@ -174,13 +158,12 @@ public:
      * @param wr Request writer function.
      * @param rd response reader function.
      * @param callback Callback to call on result.
-     * @return Channel used for the request.
      */
     template<typename T>
     void perform_request(protocol::client_operation op, const std::function<void(protocol::writer &)> &wr,
         std::function<T(protocol::reader &)> rd, ignite_callback<T> callback) {
         auto handler = std::make_shared<response_handler_reader<T>>(std::move(rd), std::move(callback));
-        perform_request_handler<T>(op, nullptr, wr, std::move(handler));
+        perform_request_handler(op, nullptr, wr, std::move(handler));
     }
 
     /**
@@ -192,7 +175,6 @@ public:
      * @param response_reader Response reader function.
      * @param notification_reader Notification reader function.
      * @param callback Callback to call on result.
-     * @return Channel used for the request.
      */
     template<typename T>
     void perform_request_single_notification(protocol::client_operation op,
@@ -201,7 +183,7 @@ public:
         auto handler = std::make_shared<response_handler_notification<T>>(
             std::move(response_reader), std::move(notification_reader), std::move(callback));
 
-        perform_request_handler<T>(op, nullptr, wr, std::move(handler));
+        perform_request_handler(op, nullptr, wr, std::move(handler));
     }
 
     /**
@@ -212,13 +194,12 @@ public:
      * @param wr Request writer function.
      * @param rd response reader function.
      * @param callback Callback to call on result.
-     * @return Channel used for the request.
      */
     template<typename T>
     void perform_request(protocol::client_operation op, const std::function<void(protocol::writer &)> &wr,
         std::function<T(protocol::reader &, std::shared_ptr<node_connection>)> rd, ignite_callback<T> callback) {
         auto handler = std::make_shared<response_handler_reader_connection<T>>(std::move(rd), std::move(callback));
-        perform_request_handler<T>(op, nullptr, wr, std::move(handler));
+        perform_request_handler(op, nullptr, wr, std::move(handler));
     }
 
     /**
@@ -228,7 +209,6 @@ public:
      * @param op Operation code.
      * @param rd response reader function.
      * @param callback Callback to call on result.
-     * @return Channel used for the request.
      */
     template<typename T>
     void perform_request_rd(
@@ -244,7 +224,6 @@ public:
      * @param op Operation code.
      * @param rd response reader function.
      * @param callback Callback to call on result.
-     * @return Channel used for the request.
      */
     template<typename T>
     void perform_request_rd(protocol::client_operation op,
@@ -260,7 +239,6 @@ public:
      * @param op Operation code.
      * @param wr Request writer function.
      * @param callback Callback to call on result.
-     * @return Channel used for the request.
      */
     template<typename T>
     void perform_request_wr(
@@ -277,7 +255,6 @@ public:
      * @param tx Transaction.
      * @param wr Request writer function.
      * @param callback Callback to call on result.
-     * @return Channel used for the request.
      */
     template<typename T>
     void perform_request_wr(protocol::client_operation op, transaction_impl *tx,

--- a/modules/platforms/cpp/ignite/client/detail/compute/compute_impl.cpp
+++ b/modules/platforms/cpp/ignite/client/detail/compute/compute_impl.cpp
@@ -132,7 +132,7 @@ void compute_impl::execute_colocated_async(const std::string &table_name, const 
         }
 
         auto table = table_impl::from_facade(*table_opt);
-        table->template with_latest_schema_async<std::optional<primitive>>(
+        table->template with_proper_schema_async<std::optional<primitive>>(
             callback, [table, key, units, job, args, conn](const schema &sch, auto callback) mutable {
                 auto writer_func = [&key, &units, &sch, &table, &job, &args](protocol::writer &writer) {
                     writer.write(table->get_id());

--- a/modules/platforms/cpp/ignite/client/detail/sql/sql_impl.cpp
+++ b/modules/platforms/cpp/ignite/client/detail/sql/sql_impl.cpp
@@ -102,7 +102,7 @@ void sql_impl::execute_async(transaction *tx, const sql_statement &statement, st
         return result_set{std::make_shared<result_set_impl>(std::move(channel), msg)};
     };
 
-    m_connection->perform_request_raw<result_set>(
+    m_connection->perform_request_bytes<result_set>(
         protocol::client_operation::SQL_EXEC, tx0.get(), writer_func, std::move(reader_func), std::move(callback));
 }
 

--- a/modules/platforms/cpp/ignite/client/detail/table/table_impl.cpp
+++ b/modules/platforms/cpp/ignite/client/detail/table/table_impl.cpp
@@ -255,7 +255,7 @@ void table_impl::load_schema_async(std::optional<std::int32_t> version,
 void table_impl::get_async(
     transaction *tx, const ignite_tuple &key, ignite_callback<std::optional<ignite_tuple>> callback) {
 
-    with_latest_schema_async<std::optional<ignite_tuple>>(std::move(callback),
+    with_proper_schema_async<std::optional<ignite_tuple>>(std::move(callback),
         [self = shared_from_this(), key = std::make_shared<ignite_tuple>(key), tx0 = to_impl(tx)](
             const schema &sch, auto callback) mutable {
             auto writer_func = [self, key, &sch, &tx0](protocol::writer &writer) {
@@ -275,7 +275,7 @@ void table_impl::get_async(
 
 void table_impl::contains_async(transaction *tx, const ignite_tuple &key, ignite_callback<bool> callback) {
 
-    with_latest_schema_async<bool>(std::move(callback),
+    with_proper_schema_async<bool>(std::move(callback),
         [self = shared_from_this(), key = std::make_shared<ignite_tuple>(key), tx0 = to_impl(tx)](
             const schema &sch, auto callback) mutable {
             auto writer_func = [self, key, &sch, &tx0](protocol::writer &writer) {
@@ -298,7 +298,7 @@ void table_impl::get_all_async(transaction *tx, std::vector<ignite_tuple> keys,
     ignite_callback<std::vector<std::optional<ignite_tuple>>> callback) {
 
     auto shared_keys = std::make_shared<std::vector<ignite_tuple>>(std::move(keys));
-    with_latest_schema_async<std::vector<std::optional<ignite_tuple>>>(std::move(callback),
+    with_proper_schema_async<std::vector<std::optional<ignite_tuple>>>(std::move(callback),
         [self = shared_from_this(), keys = shared_keys, tx0 = to_impl(tx)](const schema &sch, auto callback) mutable {
             auto writer_func = [self, keys, &sch, &tx0](protocol::writer &writer) {
                 write_table_operation_header(writer, self->m_id, tx0.get(), sch);
@@ -316,7 +316,7 @@ void table_impl::get_all_async(transaction *tx, std::vector<ignite_tuple> keys,
 }
 
 void table_impl::upsert_async(transaction *tx, const ignite_tuple &record, ignite_callback<void> callback) {
-    with_latest_schema_async<void>(std::move(callback),
+    with_proper_schema_async<void>(std::move(callback),
         [self = shared_from_this(), record = ignite_tuple(record), tx0 = to_impl(tx)](
             const schema &sch, auto callback) mutable {
             auto writer_func = [self, &record, &sch, &tx0](protocol::writer &writer) {
@@ -331,7 +331,7 @@ void table_impl::upsert_async(transaction *tx, const ignite_tuple &record, ignit
 
 void table_impl::upsert_all_async(transaction *tx, std::vector<ignite_tuple> records, ignite_callback<void> callback) {
     auto shared_records = std::make_shared<std::vector<ignite_tuple>>(std::move(records));
-    with_latest_schema_async<void>(std::move(callback),
+    with_proper_schema_async<void>(std::move(callback),
         [self = shared_from_this(), records = shared_records, tx0 = to_impl(tx)](
             const schema &sch, auto callback) mutable {
             auto writer_func = [self, records, &sch, &tx0](protocol::writer &writer) {
@@ -347,7 +347,7 @@ void table_impl::upsert_all_async(transaction *tx, std::vector<ignite_tuple> rec
 void table_impl::get_and_upsert_async(
     transaction *tx, const ignite_tuple &record, ignite_callback<std::optional<ignite_tuple>> callback) {
 
-    with_latest_schema_async<std::optional<ignite_tuple>>(std::move(callback),
+    with_proper_schema_async<std::optional<ignite_tuple>>(std::move(callback),
         [self = shared_from_this(), record = std::make_shared<ignite_tuple>(record), tx0 = to_impl(tx)](
             const schema &sch, auto callback) {
             auto writer_func = [self, record, &sch, &tx0](protocol::writer &writer) {
@@ -366,7 +366,7 @@ void table_impl::get_and_upsert_async(
 }
 
 void table_impl::insert_async(transaction *tx, const ignite_tuple &record, ignite_callback<bool> callback) {
-    with_latest_schema_async<bool>(std::move(callback),
+    with_proper_schema_async<bool>(std::move(callback),
         [self = shared_from_this(), record = ignite_tuple(record), tx0 = to_impl(tx)](
             const schema &sch, auto callback) mutable {
             auto writer_func = [self, &record, &sch, &tx0](protocol::writer &writer) {
@@ -389,7 +389,7 @@ void table_impl::insert_all_async(
     transaction *tx, std::vector<ignite_tuple> records, ignite_callback<std::vector<ignite_tuple>> callback) {
 
     auto shared_records = std::make_shared<std::vector<ignite_tuple>>(std::move(records));
-    with_latest_schema_async<std::vector<ignite_tuple>>(std::move(callback),
+    with_proper_schema_async<std::vector<ignite_tuple>>(std::move(callback),
         [self = shared_from_this(), records = shared_records, tx0 = to_impl(tx)](
             const schema &sch, auto callback) mutable {
             auto writer_func = [self, records, &sch, &tx0](protocol::writer &writer) {
@@ -408,7 +408,7 @@ void table_impl::insert_all_async(
 }
 
 void table_impl::replace_async(transaction *tx, const ignite_tuple &record, ignite_callback<bool> callback) {
-    with_latest_schema_async<bool>(std::move(callback),
+    with_proper_schema_async<bool>(std::move(callback),
         [self = shared_from_this(), record = ignite_tuple(record), tx0 = to_impl(tx)](
             const schema &sch, auto callback) mutable {
             auto writer_func = [self, &record, &sch, &tx0](protocol::writer &writer) {
@@ -429,7 +429,7 @@ void table_impl::replace_async(transaction *tx, const ignite_tuple &record, igni
 
 void table_impl::replace_async(
     transaction *tx, const ignite_tuple &record, const ignite_tuple &new_record, ignite_callback<bool> callback) {
-    with_latest_schema_async<bool>(std::move(callback),
+    with_proper_schema_async<bool>(std::move(callback),
         [self = shared_from_this(), record = ignite_tuple(record), new_record = ignite_tuple(new_record),
             tx0 = to_impl(tx)](const schema &sch, auto callback) mutable {
             auto writer_func = [self, &record, &new_record, &sch, &tx0](protocol::writer &writer) {
@@ -452,7 +452,7 @@ void table_impl::replace_async(
 void table_impl::get_and_replace_async(
     transaction *tx, const ignite_tuple &record, ignite_callback<std::optional<ignite_tuple>> callback) {
 
-    with_latest_schema_async<std::optional<ignite_tuple>>(std::move(callback),
+    with_proper_schema_async<std::optional<ignite_tuple>>(std::move(callback),
         [self = shared_from_this(), record = std::make_shared<ignite_tuple>(record), tx0 = to_impl(tx)](
             const schema &sch, auto callback) mutable {
             auto writer_func = [self, record, &sch, &tx0](protocol::writer &writer) {
@@ -471,7 +471,7 @@ void table_impl::get_and_replace_async(
 }
 
 void table_impl::remove_async(transaction *tx, const ignite_tuple &key, ignite_callback<bool> callback) {
-    with_latest_schema_async<bool>(std::move(callback),
+    with_proper_schema_async<bool>(std::move(callback),
         [self = shared_from_this(), record = ignite_tuple(key), tx0 = to_impl(tx)](
             const schema &sch, auto callback) mutable {
             auto writer_func = [self, &record, &sch, &tx0](protocol::writer &writer) {
@@ -491,7 +491,7 @@ void table_impl::remove_async(transaction *tx, const ignite_tuple &key, ignite_c
 }
 
 void table_impl::remove_exact_async(transaction *tx, const ignite_tuple &record, ignite_callback<bool> callback) {
-    with_latest_schema_async<bool>(std::move(callback),
+    with_proper_schema_async<bool>(std::move(callback),
         [self = shared_from_this(), record = ignite_tuple(record), tx0 = to_impl(tx)](
             const schema &sch, auto callback) mutable {
             auto writer_func = [self, &record, &sch, &tx0](protocol::writer &writer) {
@@ -513,7 +513,7 @@ void table_impl::remove_exact_async(transaction *tx, const ignite_tuple &record,
 void table_impl::get_and_remove_async(
     transaction *tx, const ignite_tuple &key, ignite_callback<std::optional<ignite_tuple>> callback) {
 
-    with_latest_schema_async<std::optional<ignite_tuple>>(std::move(callback),
+    with_proper_schema_async<std::optional<ignite_tuple>>(std::move(callback),
         [self = shared_from_this(), record = std::make_shared<ignite_tuple>(key), tx0 = to_impl(tx)](
             const schema &sch, auto callback) mutable {
             auto writer_func = [self, record, &sch, &tx0](protocol::writer &writer) {
@@ -534,7 +534,7 @@ void table_impl::get_and_remove_async(
 void table_impl::remove_all_async(
     transaction *tx, std::vector<ignite_tuple> keys, ignite_callback<std::vector<ignite_tuple>> callback) {
 
-    with_latest_schema_async<std::vector<ignite_tuple>>(std::move(callback),
+    with_proper_schema_async<std::vector<ignite_tuple>>(std::move(callback),
         [self = shared_from_this(), keys = std::move(keys), tx0 = to_impl(tx)](const schema &sch, auto callback) {
             auto writer_func = [self, &keys, &sch, &tx0](protocol::writer &writer) {
                 write_table_operation_header(writer, self->m_id, tx0.get(), sch);
@@ -554,7 +554,7 @@ void table_impl::remove_all_async(
 void table_impl::remove_all_exact_async(
     transaction *tx, std::vector<ignite_tuple> records, ignite_callback<std::vector<ignite_tuple>> callback) {
 
-    with_latest_schema_async<std::vector<ignite_tuple>>(std::move(callback),
+    with_proper_schema_async<std::vector<ignite_tuple>>(std::move(callback),
         [self = shared_from_this(), records = std::move(records), tx0 = to_impl(tx)](const schema &sch, auto callback) {
             auto writer_func = [self, &records, &sch, &tx0](protocol::writer &writer) {
                 write_table_operation_header(writer, self->m_id, tx0.get(), sch);

--- a/modules/platforms/cpp/ignite/client/detail/table/table_impl.cpp
+++ b/modules/platforms/cpp/ignite/client/detail/table/table_impl.cpp
@@ -190,9 +190,8 @@ void table_impl::load_latest_schema_async(ignite_callback<std::shared_ptr<schema
  * @return Handler function.
  */
 template<typename T>
-std::function<void(ignite_result<bytes_view>)> make_schema_handler_function(
-    std::shared_ptr<table_impl> self, ignite_callback<T> uc,
-    std::function<void(protocol::reader&, const schema &, ignite_callback<T>)> &&func) {
+std::function<void(ignite_result<bytes_view>)> make_schema_handler_function(std::shared_ptr<table_impl> self,
+    ignite_callback<T> uc, std::function<void(protocol::reader &, const schema &, ignite_callback<T>)> &&func) {
     return [self = std::move(self), uc = std::move(uc), rf = std::move(func)](ignite_result<bytes_view> res) mutable {
         if (res.has_error()) {
             uc(std::move(res).error());
@@ -212,15 +211,15 @@ std::function<void(ignite_result<bytes_view>)> make_schema_handler_function(
         std::vector<std::byte> msg_copy(msg);
 
         self->with_schema_async<T>(schema_ver, std::move(uc),
-            [msg = std::move(msg_copy), rf = std::move(rf)] (const schema &sch, auto uc) mutable {
-            protocol::reader reader(msg);
-            rf(reader, sch, std::move(uc));
-        });
+            [msg = std::move(msg_copy), rf = std::move(rf)](const schema &sch, auto uc) mutable {
+                protocol::reader reader(msg);
+                rf(reader, sch, std::move(uc));
+            });
     };
 }
 
-void table_impl::load_schema_async(std::optional<std::int32_t> version,
-    ignite_callback<std::shared_ptr<schema>> callback) {
+void table_impl::load_schema_async(
+    std::optional<std::int32_t> version, ignite_callback<std::shared_ptr<schema>> callback) {
     auto writer_func = [&](protocol::writer &writer) {
         writer.write(m_id);
 
@@ -263,13 +262,13 @@ void table_impl::get_async(
                 write_tuple(writer, sch, *key, true);
             };
 
-            auto handle_func = make_schema_handler_function<std::optional<ignite_tuple>>(self, std::move(callback),
-                [](protocol::reader &reader, const schema &sch, auto callback) mutable {
-                callback(read_tuple_opt(reader, &sch));
-            });
+            auto handle_func = make_schema_handler_function<std::optional<ignite_tuple>>(
+                self, std::move(callback), [](protocol::reader &reader, const schema &sch, auto callback) mutable {
+                    callback(read_tuple_opt(reader, &sch));
+                });
 
-            self->m_connection->perform_request_raw(protocol::client_operation::TUPLE_GET,
-                tx0.get(), writer_func, std::move(handle_func));
+            self->m_connection->perform_request_raw(
+                protocol::client_operation::TUPLE_GET, tx0.get(), writer_func, std::move(handle_func));
         });
 }
 
@@ -305,13 +304,13 @@ void table_impl::get_all_async(transaction *tx, std::vector<ignite_tuple> keys,
                 write_tuples(writer, sch, *keys, true);
             };
 
-            auto handle_func = make_schema_handler_function<std::vector<std::optional<ignite_tuple>>>(self,
-                std::move(callback), [](protocol::reader &reader, const schema &sch, auto callback) mutable {
-                callback(read_tuples_opt(reader, &sch, false));
-            });
+            auto handle_func = make_schema_handler_function<std::vector<std::optional<ignite_tuple>>>(
+                self, std::move(callback), [](protocol::reader &reader, const schema &sch, auto callback) mutable {
+                    callback(read_tuples_opt(reader, &sch, false));
+                });
 
-            self->m_connection->perform_request_raw(protocol::client_operation::TUPLE_GET_ALL,
-                tx0.get(), writer_func, std::move(handle_func));
+            self->m_connection->perform_request_raw(
+                protocol::client_operation::TUPLE_GET_ALL, tx0.get(), writer_func, std::move(handle_func));
         });
 }
 
@@ -355,13 +354,13 @@ void table_impl::get_and_upsert_async(
                 write_tuple(writer, sch, *record, false);
             };
 
-            auto handle_func = make_schema_handler_function<std::optional<ignite_tuple>>(self, std::move(callback),
-                [](protocol::reader &reader, const schema &sch, auto callback) mutable {
-                callback(read_tuple_opt(reader, &sch));
-            });
+            auto handle_func = make_schema_handler_function<std::optional<ignite_tuple>>(
+                self, std::move(callback), [](protocol::reader &reader, const schema &sch, auto callback) mutable {
+                    callback(read_tuple_opt(reader, &sch));
+                });
 
-            self->m_connection->perform_request_raw(protocol::client_operation::TUPLE_GET_AND_UPSERT,
-                tx0.get(), writer_func, std::move(handle_func));
+            self->m_connection->perform_request_raw(
+                protocol::client_operation::TUPLE_GET_AND_UPSERT, tx0.get(), writer_func, std::move(handle_func));
         });
 }
 
@@ -397,13 +396,13 @@ void table_impl::insert_all_async(
                 write_tuples(writer, sch, *records, false);
             };
 
-            auto handle_func = make_schema_handler_function<std::vector<ignite_tuple>>(self, std::move(callback),
-                [](protocol::reader &reader, const schema &sch, auto callback) mutable {
-                callback(read_tuples(reader, &sch, false));
-            });
+            auto handle_func = make_schema_handler_function<std::vector<ignite_tuple>>(
+                self, std::move(callback), [](protocol::reader &reader, const schema &sch, auto callback) mutable {
+                    callback(read_tuples(reader, &sch, false));
+                });
 
-            self->m_connection->perform_request_raw(protocol::client_operation::TUPLE_INSERT_ALL,
-                tx0.get(), writer_func, std::move(handle_func));
+            self->m_connection->perform_request_raw(
+                protocol::client_operation::TUPLE_INSERT_ALL, tx0.get(), writer_func, std::move(handle_func));
         });
 }
 
@@ -460,13 +459,13 @@ void table_impl::get_and_replace_async(
                 write_tuple(writer, sch, *record, false);
             };
 
-            auto handle_func = make_schema_handler_function<std::optional<ignite_tuple>>(self, std::move(callback),
-                [](protocol::reader &reader, const schema &sch, auto callback) mutable {
-                callback(read_tuple_opt(reader, &sch));
-            });
+            auto handle_func = make_schema_handler_function<std::optional<ignite_tuple>>(
+                self, std::move(callback), [](protocol::reader &reader, const schema &sch, auto callback) mutable {
+                    callback(read_tuple_opt(reader, &sch));
+                });
 
-            self->m_connection->perform_request_raw(protocol::client_operation::TUPLE_GET_AND_REPLACE,
-                tx0.get(), writer_func, std::move(handle_func));
+            self->m_connection->perform_request_raw(
+                protocol::client_operation::TUPLE_GET_AND_REPLACE, tx0.get(), writer_func, std::move(handle_func));
         });
 }
 
@@ -521,10 +520,10 @@ void table_impl::get_and_remove_async(
                 write_tuple(writer, sch, *record, true);
             };
 
-            auto handle_func = make_schema_handler_function<std::optional<ignite_tuple>>(self, std::move(callback),
-                [](protocol::reader &reader, const schema &sch, auto callback) mutable {
-                callback(read_tuple_opt(reader, &sch));
-            });
+            auto handle_func = make_schema_handler_function<std::optional<ignite_tuple>>(
+                self, std::move(callback), [](protocol::reader &reader, const schema &sch, auto callback) mutable {
+                    callback(read_tuple_opt(reader, &sch));
+                });
 
             self->m_connection->perform_request_raw(
                 protocol::client_operation::TUPLE_GET_AND_DELETE, tx0.get(), writer_func, std::move(handle_func));
@@ -541,13 +540,13 @@ void table_impl::remove_all_async(
                 write_tuples(writer, sch, keys, true);
             };
 
-            auto handle_func = make_schema_handler_function<std::vector<ignite_tuple>>(self, std::move(callback),
-                [](protocol::reader &reader, const schema &sch, auto callback) mutable {
-                callback(read_tuples(reader, &sch, true));
-            });
+            auto handle_func = make_schema_handler_function<std::vector<ignite_tuple>>(
+                self, std::move(callback), [](protocol::reader &reader, const schema &sch, auto callback) mutable {
+                    callback(read_tuples(reader, &sch, true));
+                });
 
-            self->m_connection->perform_request_raw(protocol::client_operation::TUPLE_DELETE_ALL,
-                tx0.get(), writer_func, std::move(handle_func));
+            self->m_connection->perform_request_raw(
+                protocol::client_operation::TUPLE_DELETE_ALL, tx0.get(), writer_func, std::move(handle_func));
         });
 }
 
@@ -561,10 +560,10 @@ void table_impl::remove_all_exact_async(
                 write_tuples(writer, sch, records, false);
             };
 
-            auto handle_func = make_schema_handler_function<std::vector<ignite_tuple>>(self, std::move(callback),
-                [](protocol::reader &reader, const schema &sch, auto callback) mutable {
-                callback(read_tuples(reader, &sch, false));
-            });
+            auto handle_func = make_schema_handler_function<std::vector<ignite_tuple>>(
+                self, std::move(callback), [](protocol::reader &reader, const schema &sch, auto callback) mutable {
+                    callback(read_tuples(reader, &sch, false));
+                });
 
             self->m_connection->perform_request_raw(
                 protocol::client_operation::TUPLE_DELETE_ALL_EXACT, tx0.get(), writer_func, std::move(handle_func));

--- a/modules/platforms/cpp/ignite/client/detail/table/table_impl.h
+++ b/modules/platforms/cpp/ignite/client/detail/table/table_impl.h
@@ -122,7 +122,8 @@ public:
 
             auto schema = res.value();
             if (!schema) {
-                handler(ignite_error{"Can not get a schema of version " + std::to_string(version) + " for the table " + m_name});
+                handler(ignite_error{
+                    "Can not get a schema of version " + std::to_string(version) + " for the table " + m_name});
                 return;
             }
 
@@ -138,9 +139,9 @@ public:
      * @param handler Callback to call on error during retrieval of the latest schema.
      */
     template<typename T>
-    void with_proper_schema_async(ignite_callback<T> user_callback,
-        std::function<void(const schema &, ignite_callback<T>)> callback) {
-        auto fail_over = [uc = std::move(user_callback), this, callback] (ignite_result<T> &&res) mutable {
+    void with_proper_schema_async(
+        ignite_callback<T> user_callback, std::function<void(const schema &, ignite_callback<T>)> callback) {
+        auto fail_over = [uc = std::move(user_callback), this, callback](ignite_result<T> &&res) mutable {
             if (res.has_error() && res.error().get_schema_version().has_value()) {
                 auto ver = *res.error().get_schema_version();
                 with_schema_async<T>(ver, std::move(uc), callback);

--- a/modules/platforms/cpp/ignite/client/detail/table/table_impl.h
+++ b/modules/platforms/cpp/ignite/client/detail/table/table_impl.h
@@ -339,6 +339,21 @@ public:
      */
     [[nodiscard]] std::int32_t get_id() const { return m_id; }
 
+    /**
+     * Get schema by version.
+     *
+     * @param version Schema version.
+     */
+    std::shared_ptr<schema> get_schema(std::int32_t version) {
+        std::lock_guard<std::mutex> lock(m_schemas_mutex);
+
+        auto it = m_schemas.find(version);
+        if (it == m_schemas.end())
+            return {};
+
+        return it->second;
+    }
+
 private:
     /**
      * Load schema from server asynchronously.
@@ -359,21 +374,6 @@ private:
             m_latest_schema_version = val->version;
 
         m_schemas[val->version] = val;
-    }
-
-    /**
-     * Get schema by version.
-     *
-     * @param version Schema version.
-     */
-    std::shared_ptr<schema> get_schema(std::int32_t version) {
-        std::lock_guard<std::mutex> lock(m_schemas_mutex);
-
-        auto it = m_schemas.find(version);
-        if (it == m_schemas.end())
-            return {};
-
-        return it->second;
     }
 
     /**

--- a/modules/platforms/cpp/ignite/common/ignite_error.h
+++ b/modules/platforms/cpp/ignite/common/ignite_error.h
@@ -21,8 +21,8 @@
 
 #include <cstdint>
 #include <exception>
-#include <string>
 #include <optional>
+#include <string>
 
 namespace ignite {
 

--- a/modules/platforms/cpp/ignite/common/ignite_error.h
+++ b/modules/platforms/cpp/ignite/common/ignite_error.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <exception>
 #include <string>
+#include <optional>
 
 namespace ignite {
 
@@ -59,6 +60,18 @@ public:
     explicit ignite_error(error::code code, std::string message) noexcept
         : m_status_code(code)
         , m_message(std::move(message)) {} // NOLINT(bugprone-throw-keyword-missing)
+
+    /**
+     * Constructor.
+     *
+     * @param statusCode Status code.
+     * @param message Message.
+     * @param ver Version.
+     */
+    explicit ignite_error(error::code code, std::string message, std::optional<std::int32_t> ver) noexcept
+        : m_status_code(code)
+        , m_message(std::move(message)) // NOLINT(bugprone-throw-keyword-missing)
+        , m_version(ver) {}
 
     /**
      * Constructor.
@@ -104,6 +117,14 @@ public:
      */
     [[nodiscard]] std::int32_t get_flags() const noexcept { return m_flags; }
 
+    /**
+     * Get expected schema version.
+     * Internal method.
+     *
+     * @return Expected schema version.
+     */
+    [[nodiscard]] std::optional<std::int32_t> get_schema_version() const noexcept { return m_version; }
+
 private:
     /** Status code. */
     error::code m_status_code{error::code::GENERIC};
@@ -116,6 +137,9 @@ private:
 
     /** Flags. */
     std::int32_t m_flags{0};
+
+    /** Schema version. */
+    std::optional<std::int32_t> m_version{};
 };
 
 } // namespace ignite

--- a/modules/platforms/cpp/ignite/protocol/utils.cpp
+++ b/modules/platforms/cpp/ignite/protocol/utils.cpp
@@ -35,9 +35,8 @@ namespace ignite::protocol {
  * Keys are defined here.
  */
 namespace error_extensions {
-    const std::string EXPECTED_SCHEMA_VERSION{"expected-schema-ver"};
+const std::string EXPECTED_SCHEMA_VERSION{"expected-schema-ver"};
 }
-
 
 /**
  * Check if int value fits in @c T.

--- a/modules/platforms/cpp/ignite/protocol/utils.cpp
+++ b/modules/platforms/cpp/ignite/protocol/utils.cpp
@@ -31,6 +31,15 @@
 namespace ignite::protocol {
 
 /**
+ * Error data extensions. When the server returns an error response, it may contain additional data in a map.
+ * Keys are defined here.
+ */
+namespace error_extensions {
+    const std::string EXPECTED_SCHEMA_VERSION{"expected-schema-ver"};
+}
+
+
+/**
  * Check if int value fits in @c T.
  *
  * @tparam T Int type to fit value to.
@@ -223,7 +232,21 @@ ignite_error read_error(reader &reader) {
         err_msg_builder << ": " << *message;
     err_msg_builder << " (" << code << ", " << trace_id << ")";
 
-    return ignite_error{error::code(code), err_msg_builder.str()};
+    std::optional<std::int32_t> ver{};
+    if (!reader.try_read_nil()) {
+        // Reading extensions
+        auto num = reader.read_int32();
+        for (std::int32_t i = 0; i < num; ++i) {
+            auto key = reader.read_string();
+            if (key == error_extensions::EXPECTED_SCHEMA_VERSION) {
+                ver = reader.read_int32();
+            } else {
+                reader.skip();
+            }
+        }
+    }
+
+    return ignite_error{error::code(code), err_msg_builder.str(), ver};
 }
 
 void claim_primitive_with_type(binary_tuple_builder &builder, const primitive &value) {

--- a/modules/platforms/cpp/tests/client-test/schema_synchronization_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/schema_synchronization_test.cpp
@@ -82,6 +82,16 @@ TEST_F(schema_synchronization_test, upsert_add_column_upsert) {
     tuple_view.upsert(nullptr, val2);
 }
 
+TEST_F(schema_synchronization_test, upsert_add_column_upsert_old) {
+    auto val1 = ignite_tuple{{"ID", std::int32_t(1)}, {"VAL1", std::int32_t(2)}};
+    tuple_view.upsert(nullptr, val1);
+
+    m_client.get_sql().execute(nullptr, {"ALTER TABLE SCHEMA_SYN_TEST ADD COLUMN VAL2 INT"}, {});
+
+    auto val2 = ignite_tuple{{"ID", std::int32_t(2)}, {"VAL1", std::int32_t(3)}};
+    tuple_view.upsert(nullptr, val2);
+}
+
 TEST_F(schema_synchronization_test, upsert_add_column_upsert_all) {
     auto val1 = ignite_tuple{{"ID", std::int32_t(1)}, {"VAL1", std::int32_t(2)}};
     tuple_view.upsert(nullptr, val1);

--- a/modules/platforms/cpp/tests/client-test/schema_synchronization_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/schema_synchronization_test.cpp
@@ -54,7 +54,7 @@ protected:
     record_view<ignite_tuple> tuple_view;
 };
 
-TEST_F(schema_synchronization_test, upsert_alter_upsert_record_view) {
+TEST_F(schema_synchronization_test, upsert_unmapped_columns) {
     auto val1 = ignite_tuple{{"ID", std::int32_t(1)}, {"VAL1", std::int32_t(2)}};
     tuple_view.upsert(nullptr, val1);
 
@@ -70,8 +70,33 @@ TEST_F(schema_synchronization_test, upsert_alter_upsert_record_view) {
             }
         },
         ignite_error);
+}
+
+TEST_F(schema_synchronization_test, upsert_add_column_upsert) {
+    auto val1 = ignite_tuple{{"ID", std::int32_t(1)}, {"VAL1", std::int32_t(2)}};
+    tuple_view.upsert(nullptr, val1);
 
     m_client.get_sql().execute(nullptr, {"ALTER TABLE SCHEMA_SYN_TEST ADD COLUMN VAL2 INT"}, {});
 
+    auto val2 = ignite_tuple{{"ID", std::int32_t(2)}, {"VAL1", std::int32_t(3)}, {"VAL2", std::int32_t(4)}};
     tuple_view.upsert(nullptr, val2);
+}
+
+TEST_F(schema_synchronization_test, upsert_add_column_upsert_all) {
+    auto val1 = ignite_tuple{{"ID", std::int32_t(1)}, {"VAL1", std::int32_t(2)}};
+    tuple_view.upsert(nullptr, val1);
+
+    m_client.get_sql().execute(nullptr, {"ALTER TABLE SCHEMA_SYN_TEST ADD COLUMN VAL2 INT"}, {});
+
+    auto val2 = ignite_tuple{{"ID", std::int32_t(2)}, {"VAL1", std::int32_t(3)}, {"VAL2", std::int32_t(4)}};
+    tuple_view.upsert_all(nullptr, {val2, val2, val2});
+}
+
+TEST_F(schema_synchronization_test, upsert_add_column_get) {
+    auto val1 = ignite_tuple{{"ID", std::int32_t(1)}, {"VAL1", std::int32_t(2)}};
+    tuple_view.upsert(nullptr, val1);
+
+    m_client.get_sql().execute(nullptr, {"ALTER TABLE SCHEMA_SYN_TEST ADD COLUMN VAL2 INT"}, {});
+
+    auto val2 = tuple_view.get(nullptr, {{"ID", std::int32_t(1)}});
 }

--- a/modules/platforms/cpp/tests/client-test/schema_synchronization_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/schema_synchronization_test.cpp
@@ -92,6 +92,16 @@ TEST_F(schema_synchronization_test, upsert_add_column_upsert_old) {
     tuple_view.upsert(nullptr, val2);
 }
 
+TEST_F(schema_synchronization_test, upsert_add_column_compute) {
+    std::pair key{"ID", std::int32_t(1)};
+    auto val1 = ignite_tuple{key, {"VAL1", std::int32_t(2)}};
+    tuple_view.upsert(nullptr, val1);
+
+    m_client.get_sql().execute(nullptr, {"ALTER TABLE SCHEMA_SYN_TEST ADD COLUMN VAL2 INT"}, {});
+
+    m_client.get_compute().execute_colocated("SCHEMA_SYN_TEST", {key}, {}, NODE_NAME_JOB, {});
+}
+
 TEST_F(schema_synchronization_test, upsert_add_column_upsert_all) {
     auto val1 = ignite_tuple{{"ID", std::int32_t(1)}, {"VAL1", std::int32_t(2)}};
     tuple_view.upsert(nullptr, val1);
@@ -109,4 +119,13 @@ TEST_F(schema_synchronization_test, upsert_add_column_get) {
     m_client.get_sql().execute(nullptr, {"ALTER TABLE SCHEMA_SYN_TEST ADD COLUMN VAL2 INT"}, {});
 
     auto val2 = tuple_view.get(nullptr, {{"ID", std::int32_t(1)}});
+}
+
+TEST_F(schema_synchronization_test, upsert_add_column_get_all) {
+    auto val1 = ignite_tuple{{"ID", std::int32_t(1)}, {"VAL1", std::int32_t(2)}};
+    tuple_view.upsert(nullptr, val1);
+
+    m_client.get_sql().execute(nullptr, {"ALTER TABLE SCHEMA_SYN_TEST ADD COLUMN VAL2 INT"}, {});
+
+    auto val2 = tuple_view.get_all(nullptr, {{{"ID", std::int32_t(1)}}, {{"ID", std::int32_t(2)}}});
 }


### PR DESCRIPTION
- Added tests;
- Found an issue in the current implementation - there was a crash if server returns a tuple with the unknown schema version;
- Re-factored `table_impl` to allow performing multiple subsequent async calls;
- Read and store known error extensions data from server;
- Retry operation with specified schema on error.