### PR TITLE
IGNITE-21578 Check whether old txn state fields are null before update

### DIFF
--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/TxManagerImpl.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/TxManagerImpl.java
@@ -457,19 +457,19 @@ public class TxManagerImpl implements TxManager, NetworkMessageHandler {
 
     @Override
     public void finishFull(HybridTimestampTracker timestampTracker, UUID txId, boolean commit) {
-        TxState finalState;
 
         finishedTxs.incrementAndGet();
 
         if (commit) {
             timestampTracker.update(clock.now());
-
-            finalState = COMMITTED;
-        } else {
-            finalState = ABORTED;
         }
 
-        updateTxMeta(txId, old -> new TxStateMeta(finalState, old.txCoordinatorId(), old.commitPartitionId(), old.commitTimestamp()));
+        updateTxMeta(txId, old -> new TxStateMeta(
+                commit ? COMMITTED : ABORTED,
+                old == null ? null : old.txCoordinatorId(),
+                old == null ? null : old.commitPartitionId(),
+                old == null ? null : old.commitTimestamp()
+        ));
 
         decrementRwTxCount(txId);
     }

--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/TxManagerImpl.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/TxManagerImpl.java
@@ -100,7 +100,6 @@ import org.apache.ignite.internal.tx.TransactionMeta;
 import org.apache.ignite.internal.tx.TransactionResult;
 import org.apache.ignite.internal.tx.TxManager;
 import org.apache.ignite.internal.tx.TxPriority;
-import org.apache.ignite.internal.tx.TxState;
 import org.apache.ignite.internal.tx.TxStateMeta;
 import org.apache.ignite.internal.tx.TxStateMetaFinishing;
 import org.apache.ignite.internal.tx.configuration.TransactionConfiguration;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-21578

It's possible that on tx coordinator (including full transaction case) there won't be neither txCoordinatorId nor commitPartitionId nor commitTimestamp if txCoordinator is not collocated with replication group. Thus, it's required to check whether oldMeta retrieved from volatile txn storage is null.
