### PR TITLE
IGNITE-20745 Improve performance of ClientTableCommon.readTableAsync

### DIFF
--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgniteTables.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeIgniteTables.java
@@ -39,6 +39,7 @@ import org.apache.ignite.internal.tx.impl.HeapLockManager;
 import org.apache.ignite.internal.type.NativeTypes;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.table.Table;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Fake tables.
@@ -160,6 +161,11 @@ public class FakeIgniteTables implements IgniteTablesInternal {
     @Override
     public CompletableFuture<TableViewInternal> tableViewAsync(String name) {
         return completedFuture(tableView(name));
+    }
+
+    @Override
+    public @Nullable TableViewInternal cachedTable(int tableId) {
+        return table(tableId);
     }
 
     private TableViewInternal getNewTable(String name, int id) {

--- a/modules/index/src/main/java/org/apache/ignite/internal/index/IndexManager.java
+++ b/modules/index/src/main/java/org/apache/ignite/internal/index/IndexManager.java
@@ -436,7 +436,7 @@ public class IndexManager implements IgniteComponent {
     }
 
     private TableViewInternal getTableViewStrict(int tableId) {
-        TableViewInternal table = tableManager.getTable(tableId);
+        TableViewInternal table = tableManager.cachedTable(tableId);
 
         assert table != null : tableId;
 

--- a/modules/index/src/test/java/org/apache/ignite/internal/index/IndexManagerTest.java
+++ b/modules/index/src/test/java/org/apache/ignite/internal/index/IndexManagerTest.java
@@ -135,7 +135,7 @@ public class IndexManagerTest extends BaseIgniteAbstractTest {
 
         when(mockTableManager.tableAsync(anyLong(), anyInt())).thenAnswer(inv -> completedFuture(mockTable(inv.getArgument(1))));
 
-        when(mockTableManager.getTable(anyInt())).thenAnswer(inv -> mockTable(inv.getArgument(0)));
+        when(mockTableManager.cachedTable(anyInt())).thenAnswer(inv -> mockTable(inv.getArgument(0)));
 
         when(mockTableManager.localPartitionSetAsync(anyLong(), anyInt())).thenReturn(completedFuture(PartitionSet.EMPTY_SET));
 

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Program.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Program.cs
@@ -22,5 +22,6 @@ using Table;
 
 internal static class Program
 {
-    private static void Main() => BenchmarkRunner.Run<DataStreamerBenchmark>();
+    // IMPORTANT: Disable Netty leak detector when using a real Ignite server for benchmarks.
+    private static void Main() => BenchmarkRunner.Run<TupleGetBenchmarks>();
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TupleGetBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TupleGetBenchmarks.cs
@@ -24,9 +24,9 @@ namespace Apache.Ignite.Benchmarks.Table
 
     /// <summary>
     /// Results on i9-12900H, .NET SDK 6.0.419, Ubuntu 22.04:
-    /// | Method |     Mean |     Error |    StdDev |
-    /// |------- |---------:|----------:|----------:|
-    /// |    Get | 122.5 us | 2.45 us   | 5.72 us   |.
+    /// | Method |     Mean |   Error |  StdDev |
+    /// |------- |---------:|--------:|--------:|
+    /// |    Get | 113.8 us | 1.74 us | 1.45 us |.
     /// </summary>
     [SimpleJob]
     public class TupleGetBenchmarks

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TupleGetBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/TupleGetBenchmarks.cs
@@ -23,12 +23,12 @@ namespace Apache.Ignite.Benchmarks.Table
     using Tests;
 
     /// <summary>
-    /// Results on i9-12900H, .NET SDK 6.0.405, Ubuntu 22.04:
+    /// Results on i9-12900H, .NET SDK 6.0.419, Ubuntu 22.04:
     /// | Method |     Mean |     Error |    StdDev |
     /// |------- |---------:|----------:|----------:|
-    /// |    Get | 4.788 ms | 0.3198 ms | 0.0830 ms |.
+    /// |    Get | 122.5 us | 2.45 us   | 5.72 us   |.
     /// </summary>
-    [SimpleJob(launchCount: 1, warmupCount: 5, targetCount: 5, invocationCount: 10)]
+    [SimpleJob]
     public class TupleGetBenchmarks
     {
         private JavaServer? _javaServer;

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/schemasync/ItSchemaSyncAndReplicationTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/schemasync/ItSchemaSyncAndReplicationTest.java
@@ -150,7 +150,7 @@ class ItSchemaSyncAndReplicationTest extends ClusterPerTestIntegrationTest {
 
     private static MvPartitionStorage solePartitionStorage(IgniteImpl node) {
         // We use this api because there is no waiting for schemas to sync.
-        TableViewInternal table = ((TableManager) node.tables()).getTable(TABLE_NAME);
+        TableViewInternal table = ((TableManager) node.tables()).cachedTable(TABLE_NAME);
 
         assertNotNull(table);
 

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/IgniteTablesInternal.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/IgniteTablesInternal.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.internal.lang.NodeStoppingException;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.table.manager.IgniteTables;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Internal tables facade provides low-level methods for table operations.
@@ -73,4 +74,11 @@ public interface IgniteTablesInternal extends IgniteTables {
      *                         </ul>
      */
     CompletableFuture<TableViewInternal> tableViewAsync(String name);
+
+    /**
+     * Returns a cached table instance if it exists, {@code null} otherwise. Can return a table that is being stopped.
+     *
+     * @param tableId Table id.
+     */
+    @Nullable TableViewInternal cachedTable(int tableId);
 }

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
@@ -2339,21 +2339,22 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
     }
 
     /**
-     * Returns a table instance if it exists, {@code null} otherwise.
+     * Returns a cached table instance if it exists, {@code null} otherwise. Can return a table that is being stopped.
      *
      * @param tableId Table id.
      */
-    public @Nullable TableViewInternal getTable(int tableId) {
+    @Override
+    public @Nullable TableViewInternal cachedTable(int tableId) {
         return startedTables.get(tableId);
     }
 
     /**
-     * Returns a table instance if it exists, {@code null} otherwise.
+     * Returns a cached table instance if it exists, {@code null} otherwise. Can return a table that is being stopped.
      *
      * @param name Table name.
      */
     @TestOnly
-    public @Nullable TableViewInternal getTable(String name) {
+    public @Nullable TableViewInternal cachedTable(String name) {
         return findTableImplByName(startedTables.values(), name);
     }
 

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/TableManagerTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/TableManagerTest.java
@@ -380,8 +380,8 @@ public class TableManagerTest extends IgniteAbstractTest {
 
         // TODO IGNITE-20680 ensure old table is available
         // assertNotNull(tableManager.getTable(oldTableId));
-        assertNotNull(tableManager.getTable(table.tableId()));
-        assertNotSame(tableManager.getTable(oldTableId), tableManager.getTable(table.tableId()));
+        assertNotNull(tableManager.cachedTable(table.tableId()));
+        assertNotSame(tableManager.cachedTable(oldTableId), tableManager.cachedTable(table.tableId()));
     }
 
     /**


### PR DESCRIPTION
* `ClientTableCommon.readTableAsync` is called on every table operation (get, put, etc), so performance is critical
* It calls `TableManager.tableAsync(int tableId)`, which performs complex async logic
* To speed this up, check cached tables in `TableManager.startedTables`, which will return a table immediately in most cases
  * The table can be stopped, but that is not a problem:
    * New table with the same id can't be started
    * Any operation will throw an exception

Benchmarked from .NET thin client (`TupleGetBenchmarks`), ~8% improvement:

```
| Method |     Mean |   Error |  StdDev |
|------- |---------:|--------:|--------:|
|    Get | 123.6 us | 2.46 us | 5.66 us | (before)
|    Get | 113.8 us | 1.74 us | 1.45 us | (after)
```

https://issues.apache.org/jira/browse/IGNITE-20745