### PR TITLE
IGNITE-21602 Fix direct buffers allocation on Java 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ ext {
             "--add-opens=java.base/java.util=ALL-UNNAMED",
             "--add-opens=java.base/java.time=ALL-UNNAMED",
             "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED",
+            "--add-opens=java.base/jdk.internal.access=ALL-UNNAMED",
             "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
             "--add-opens=java.base/sun.security.x509=ALL-UNNAMED",
             "-Dio.netty.tryReflectionSetAccessible=true",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,7 +82,7 @@ jna = "5.13.0"
 #Tools
 pmdTool = "6.55.0"
 checkstyleTool = "10.3.3"
-jacocoTool = "0.8.8"
+jacocoTool = "0.8.11"
 
 [plugins]
 openapiGenerator = "org.openapi.generator:5.4.0"

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/BrokenPointerWrapping.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/BrokenPointerWrapping.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.util;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Always fails with an exception.
+ */
+class BrokenPointerWrapping implements PointerWrapping {
+    @Override
+    public ByteBuffer wrapPointer(long ptr, int len) {
+        throw new RuntimeException(
+                "All alternatives for a new DirectByteBuffer() creation failed: " + FeatureChecker.JAVA_VER_SPECIFIC_WARN);
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/FeatureChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/FeatureChecker.java
@@ -22,13 +22,15 @@ package org.apache.ignite.internal.util;
  */
 public class FeatureChecker {
     /** Required options to run on Java 9, 10, 11. */
-    public static final String JAVA_9_10_11_OPTIONS = "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED\n"
+    public static final String JAVA_9_10_11_OPTIONS = ""
+            + "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED\n"
+            + "--add-exports=java.base/jdk.internal.access=ALL-UNNAMED\n"
             + "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED\n"
             + "--add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED\n"
             + "--add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED\n"
             + "--add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED\n"
             + "--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED\n"
-            + "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+            + "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED\n"
             + "--illegal-access=permit";
 
     /** Java version specific warning to be added in case access failed. */

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/GridUnsafe.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/GridUnsafe.java
@@ -2149,7 +2149,7 @@ public abstract class GridUnsafe {
             try {
                 ByteBuffer buf = (ByteBuffer) newDirectBufMh.invokeExact(javaNioAccessObj, ptr, len, NULL_OBJ);
 
-                assert buf.isDirect();
+                assert buf.isDirect() : "ptr=" + ptr + ", len=" + len;
 
                 buf.order(NATIVE_BYTE_ORDER);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/JavaNioPointerWrapping.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/JavaNioPointerWrapping.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.util;
+
+import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
+
+/**
+ * Uses the JavaNioAccess object to wraps a pointer to unmanaged memory into a direct byte buffer.
+ */
+class JavaNioPointerWrapping implements PointerWrapping {
+    /** Null object. */
+    private static final Object NULL_OBJ = null;
+
+    private final MethodHandle newDirectBufMh;
+    private final Object javaNioAccessObj;
+
+    JavaNioPointerWrapping(MethodHandle newDirectBufMh, Object javaNioAccessObj) {
+        this.newDirectBufMh = newDirectBufMh;
+        this.javaNioAccessObj = javaNioAccessObj;
+    }
+
+    @Override
+    public ByteBuffer wrapPointer(long ptr, int len) {
+        try {
+            ByteBuffer buf = (ByteBuffer) newDirectBufMh.invokeExact(javaNioAccessObj, ptr, len, NULL_OBJ);
+
+            assert buf.isDirect() : "ptr=" + ptr + ", len=" + len;
+
+            buf.order(GridUnsafe.NATIVE_BYTE_ORDER);
+
+            return buf;
+        } catch (Throwable e) {
+            throw new RuntimeException("JavaNioAccess#newDirectByteBuffer() method is unavailable."
+                    + FeatureChecker.JAVA_VER_SPECIFIC_WARN, e);
+        }
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/PointerWrapping.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/PointerWrapping.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.util;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Wraps a pointer to unmanaged memory into a direct byte buffer.
+ */
+@SuppressWarnings("InterfaceMayBeAnnotatedFunctional")
+interface PointerWrapping {
+    /**
+     * Wraps a pointer to unmanaged memory into a direct byte buffer.
+     *
+     * @param ptr Pointer to wrap.
+     * @param len Memory location length.
+     * @return Byte buffer wrapping the given memory.
+     */
+    ByteBuffer wrapPointer(long ptr, int len);
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/WrapWithIntDirectBufferConstructor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/WrapWithIntDirectBufferConstructor.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.util;
+
+import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
+
+/**
+ * Uses constructor of the direct byte buffer with 'length' parameter of type {@code int} to wrap a pointer to unmanaged memory into a
+ * direct byte buffer.
+ */
+class WrapWithIntDirectBufferConstructor implements PointerWrapping {
+    private final MethodHandle constructor;
+
+    WrapWithIntDirectBufferConstructor(MethodHandle constructor) {
+        this.constructor = constructor;
+    }
+
+    @Override
+    public ByteBuffer wrapPointer(long ptr, int len) {
+        return GridUnsafe.wrapPointerDirectBufferConstructor(ptr, len, constructor);
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/WrapWithLongDirectBufferConstructor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/WrapWithLongDirectBufferConstructor.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.util;
+
+import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
+
+/**
+ * Uses constructor of the direct byte buffer with 'length' parameter of type {@code long} to wrap a pointer to unmanaged memory into a
+ * direct byte buffer.
+ */
+class WrapWithLongDirectBufferConstructor implements PointerWrapping {
+    private final MethodHandle constructor;
+
+    WrapWithLongDirectBufferConstructor(MethodHandle constructor) {
+        this.constructor = constructor;
+    }
+
+    @Override
+    public ByteBuffer wrapPointer(long ptr, int len) {
+        return GridUnsafe.wrapPointerDirectBufferConstructor(ptr, (long) len, constructor);
+    }
+}

--- a/packaging/common/bootstrap-functions.sh
+++ b/packaging/common/bootstrap-functions.sh
@@ -28,6 +28,7 @@ ADD_OPENS_JAVA_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED \
     --add-opens java.base/java.math=ALL-UNNAMED \
     --add-opens java.base/java.util=ALL-UNNAMED \
     --add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+    --add-opens java.base/jdk.internal.access=ALL-UNNAMED \
     --add-opens java.base/sun.nio.ch=ALL-UNNAMED "
 
 # used by rpm, deb, zip and docker distributions

--- a/packaging/db/build.gradle
+++ b/packaging/db/build.gradle
@@ -292,6 +292,7 @@ setupBuilder {
                            "--add-opens=java.base/java.math=ALL-UNNAMED",
                            "--add-opens=java.base/java.util=ALL-UNNAMED",
                            "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED",
+                           "--add-opens=java.base/jdk.internal.access=ALL-UNNAMED",
                            "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
                            "-Dio.netty.tryReflectionSetAccessible=true",
                            "-Djava.util.logging.config.file=etc\\ignite.java.util.logging.properties",


### PR DESCRIPTION
* DirectByteBuffer constructor signature has changed, length is now long, not int
* MethodHandle-based mechanism used on Java 11 was broken as a wrong package was used (jdk.internal.misc instead of jdk.internal.access)

https://issues.apache.org/jira/browse/IGNITE-21602