### PR TITLE
IGNITE-21613 Make CheckpointManagerTest run on Java 21

### DIFF
--- a/modules/page-memory/src/test/java/org/apache/ignite/internal/pagememory/persistence/checkpoint/CheckpointManagerTest.java
+++ b/modules/page-memory/src/test/java/org/apache/ignite/internal/pagememory/persistence/checkpoint/CheckpointManagerTest.java
@@ -216,7 +216,7 @@ public class CheckpointManagerTest extends BaseIgniteAbstractTest {
 
         when(checkpointManager.lastCheckpointProgress()).thenReturn(checkpointProgress);
 
-        ByteBuffer pageBuf = mock(ByteBuffer.class);
+        ByteBuffer pageBuf = spy(ByteBuffer.wrap(new byte[deltaFilePageStoreIo.pageSize()]));
 
         checkpointManager.writePageToDeltaFilePageStore(pageMemory, dirtyPageId, pageBuf, true);
 


### PR DESCRIPTION
The test mocks ByteBuffer class, this does not work on Java 21. Switching to spy() does work.

https://issues.apache.org/jira/browse/IGNITE-21613