### PR TITLE
IGNITE-21558: Sql. Remove ExecutionContext dependency from ExpressionFactory.

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/SqlQueryProcessor.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/SqlQueryProcessor.java
@@ -66,6 +66,8 @@ import org.apache.ignite.internal.sql.engine.exec.QueryTaskExecutorImpl;
 import org.apache.ignite.internal.sql.engine.exec.SqlRowHandler;
 import org.apache.ignite.internal.sql.engine.exec.TransactionTracker;
 import org.apache.ignite.internal.sql.engine.exec.ddl.DdlCommandHandler;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactory;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactoryImpl;
 import org.apache.ignite.internal.sql.engine.exec.exp.func.TableFunctionRegistryImpl;
 import org.apache.ignite.internal.sql.engine.exec.fsm.ExecutionPhase;
 import org.apache.ignite.internal.sql.engine.exec.fsm.QueryExecutor;
@@ -314,6 +316,7 @@ public class SqlQueryProcessor implements QueryProcessor, SystemViewProvider {
         placementDriver.listen(PrimaryReplicaEvent.PRIMARY_REPLICA_EXPIRED, mappingService::onPrimaryReplicaExpired);
         // Need to be implemented after https://issues.apache.org/jira/browse/IGNITE-23519 Add an event for lease Assignments
         // placementDriver.listen(PrimaryReplicaEvent.ASSIGNMENTS_CHANGED, mappingService::onPrimaryReplicaAssignment);
+        ExpressionFactory expressionFactory = new ExpressionFactoryImpl();
 
         var executionSrvc = registerService(ExecutionServiceImpl.create(
                 clusterSrvc.topologyService(),
@@ -327,6 +330,7 @@ public class SqlQueryProcessor implements QueryProcessor, SystemViewProvider {
                 mappingService,
                 executableTableRegistry,
                 dependencyResolver,
+                expressionFactory,
                 tableFunctionRegistry,
                 clockService,
                 EXECUTION_SERVICE_SHUTDOWN_TIMEOUT

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/DynamicPartitionProvider.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/DynamicPartitionProvider.java
@@ -19,7 +19,6 @@ package org.apache.ignite.internal.sql.engine.exec;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import java.util.List;
-import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactory;
 import org.apache.ignite.internal.sql.engine.prepare.pruning.PartitionPruningColumns;
 import org.apache.ignite.internal.sql.engine.prepare.pruning.PartitionPruningPredicate;
 import org.apache.ignite.internal.sql.engine.schema.IgniteTable;
@@ -53,8 +52,6 @@ public class DynamicPartitionProvider<RowT> implements PartitionProvider<RowT> {
     /** {@inheritDoc} */
     @Override
     public List<PartitionWithConsistencyToken> getPartitions(ExecutionContext<RowT> ctx) {
-        ExpressionFactory<RowT> expressionFactory = ctx.expressionFactory();
-
-        return PartitionPruningPredicate.prunePartitions(columns, table, expressionFactory, assignments, nodeName);
+        return PartitionPruningPredicate.prunePartitions(columns, table, ctx, assignments, nodeName);
     }
 }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionContext.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionContext.java
@@ -17,7 +17,6 @@
 
 package org.apache.ignite.internal.sql.engine.exec;
 
-import static org.apache.ignite.internal.sql.engine.util.Commons.FRAMEWORK_CONFIG;
 import static org.apache.ignite.lang.ErrorGroups.Common.INTERNAL_ERR;
 
 import java.lang.reflect.Type;
@@ -42,7 +41,6 @@ import org.apache.ignite.internal.logger.Loggers;
 import org.apache.ignite.internal.sql.engine.QueryCancel;
 import org.apache.ignite.internal.sql.engine.QueryCancelledException;
 import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactory;
-import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactoryImpl;
 import org.apache.ignite.internal.sql.engine.exec.mapping.ColocationGroup;
 import org.apache.ignite.internal.sql.engine.exec.mapping.FragmentDescription;
 import org.apache.ignite.internal.sql.engine.prepare.pruning.PartitionPruningColumns;
@@ -80,7 +78,7 @@ public class ExecutionContext<RowT> implements DataContext {
 
     private final RowHandler<RowT> handler;
 
-    private final ExpressionFactory<RowT> expressionFactory;
+    private final ExpressionFactory expressionFactory;
 
     private final AtomicBoolean cancelFlag = new AtomicBoolean();
 
@@ -102,6 +100,7 @@ public class ExecutionContext<RowT> implements DataContext {
      * Constructor.
      *
      * @param executor Task executor.
+     * @param expressionFactory Expression factory.
      * @param qryId Query ID.
      * @param localNode Local node.
      * @param originatingNodeName Name of the node that initiated the query.
@@ -115,6 +114,7 @@ public class ExecutionContext<RowT> implements DataContext {
     @SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType")
     public ExecutionContext(
             QueryTaskExecutor executor,
+            ExpressionFactory expressionFactory,
             UUID qryId,
             ClusterNode localNode,
             String originatingNodeName,
@@ -129,17 +129,13 @@ public class ExecutionContext<RowT> implements DataContext {
         this.qryId = qryId;
         this.description = description;
         this.handler = handler;
+        this.expressionFactory = expressionFactory;
         this.params = params;
         this.localNode = localNode;
         this.originatingNodeName = originatingNodeName;
         this.txAttributes = txAttributes;
         this.timeZoneId = timeZoneId;
         this.cancel = cancel;
-
-        expressionFactory = new ExpressionFactoryImpl<>(
-                this,
-                FRAMEWORK_CONFIG.getParserConfig().conformance()
-        );
 
         Instant nowUtc = Instant.now();
         startTs = nowUtc.plusSeconds(this.timeZoneId.getRules().getOffset(nowUtc).getTotalSeconds()).toEpochMilli();
@@ -205,7 +201,7 @@ public class ExecutionContext<RowT> implements DataContext {
     /**
      * Get expression factory.
      */
-    public ExpressionFactory<RowT> expressionFactory() {
+    public ExpressionFactory expressionFactory() {
         return expressionFactory;
     }
 

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/exp/ExpressionFactory.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/exp/ExpressionFactory.java
@@ -30,6 +30,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.ignite.internal.sql.engine.exec.ExecutionContext;
 import org.apache.ignite.internal.sql.engine.exec.exp.agg.AccumulatorWrapper;
 import org.apache.ignite.internal.sql.engine.exec.exp.agg.AggregateType;
 import org.apache.ignite.internal.sql.engine.prepare.bounds.SearchBounds;
@@ -38,8 +39,20 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Expression factory.
  */
-public interface ExpressionFactory<RowT> {
-    Supplier<List<AccumulatorWrapper<RowT>>> accumulatorsFactory(
+public interface ExpressionFactory {
+    /**
+     * Creates a factory for the given aggregate calls.
+     *
+     * @param ctx Execution context.
+     * @param type Aggregate type.
+     * @param calls Aggregate calls.
+     * @param rowType Input row type.
+     *
+     * @return Factory.
+     *
+     * @param <RowT> Row type.
+     */
+    <RowT> Supplier<List<AccumulatorWrapper<RowT>>> accumulatorsFactory(ExecutionContext<RowT> ctx,
             AggregateType type,
             List<AggregateCall> calls,
             RelDataType rowType
@@ -48,82 +61,99 @@ public interface ExpressionFactory<RowT> {
     /**
      * Creates a comparator for given data type and collations. Mainly used for sorted exchange.
      *
+     * @param ctx Execution context.
      * @param collations Collations.
      * @return Row comparator.
      */
-    Comparator<RowT> comparator(RelCollation collations);
+    <RowT> Comparator<RowT> comparator(ExecutionContext<RowT> ctx, RelCollation collations);
 
     /**
      * Creates a comparator for different rows by given field collations. Mainly used for merge join rows comparison. Note: Both list has to
      * have the same size and matched fields collations has to have the same traits (i.e. all pairs of field collations should have the same
      * sorting and nulls ordering).
      *
+     * @param ctx Execution context.
      * @param left  Collations of left row.
      * @param right Collations of right row.
      * @param equalNulls Bitset with null comparison strategy, use in case of NOT DISTINCT FROM syntax.
      * @return Rows comparator.
      */
-    Comparator<RowT> comparator(List<RelFieldCollation> left, List<RelFieldCollation> right, ImmutableBitSet equalNulls);
+    <RowT> Comparator<RowT> comparator(
+            ExecutionContext<RowT> ctx,
+            List<RelFieldCollation> left,
+            List<RelFieldCollation> right,
+            ImmutableBitSet equalNulls
+    );
 
     /**
      * Creates a Filter predicate.
      *
+     * @param ctx Execution context.
      * @param filter  Filter expression.
      * @param rowType Input row type.
      * @return Filter predicate.
      */
-    Predicate<RowT> predicate(RexNode filter, RelDataType rowType);
+    <RowT> Predicate<RowT> predicate(ExecutionContext<RowT> ctx, RexNode filter, RelDataType rowType);
 
     /**
      * Creates a Filter predicate.
      *
+     * @param ctx Execution context.
      * @param filter Filter expression.
      * @param rowType Input row type.
      * @return Filter predicate.
      */
-    BiPredicate<RowT, RowT> biPredicate(RexNode filter, RelDataType rowType);
+    <RowT> BiPredicate<RowT, RowT> biPredicate(ExecutionContext<RowT> ctx, RexNode filter, RelDataType rowType);
 
     /**
      * Creates a Project function. Resulting function returns a row with different fields, fields order, fields types, etc.
      *
+     * @param ctx Execution context.
      * @param projects Projection expressions.
      * @param rowType  Input row type.
      * @return Project function.
      */
-    Function<RowT, RowT> project(List<RexNode> projects, RelDataType rowType);
+    <RowT> Function<RowT, RowT> project(ExecutionContext<RowT> ctx, List<RexNode> projects, RelDataType rowType);
 
     /**
      * Creates a Values relational node rows source.
      *
+     * @param ctx Execution context.
      * @param values  Values.
      * @param rowType Output row type.
      * @return Values relational node rows source.
      */
-    Iterable<RowT> values(List<RexLiteral> values, RelDataType rowType);
+    <RowT> Iterable<RowT> values(ExecutionContext<RowT> ctx, List<RexLiteral> values, RelDataType rowType);
 
     /**
      * Creates row from RexNodes.
      *
+     * @param ctx Execution context.
      * @param values Values ({@code null} values allowed in this list).
      * @return Row.
      */
-    Supplier<RowT> rowSource(List<RexNode> values);
+    <RowT> Supplier<RowT> rowSource(ExecutionContext<RowT> ctx, List<RexNode> values);
 
     /**
      * Creates iterable search bounds tuples (lower row/upper row) by search bounds expressions.
      *
+     * @param ctx Execution context.
      * @param searchBounds Search bounds.
      * @param rowType Row type.
      * @param comparator Comparator to return bounds in particular order.
      */
-    RangeIterable<RowT> ranges(
+    <RowT> RangeIterable<RowT> ranges(
+            ExecutionContext<RowT> ctx,
             List<SearchBounds> searchBounds,
             RelDataType rowType,
             @Nullable Comparator<RowT> comparator
     );
 
     /**
-     * Executes expression.
+     * Creates a function that evaluates the given scalar expression.
+     *
+     * @param ctx Execution context.
+     * @param node Expression.
      */
-    <T> Supplier<T> execute(RexNode node);
+    <T, RowT> Supplier<T> execute(ExecutionContext<RowT> ctx, RexNode node);
 }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/exp/func/TableFunctionRegistryImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/exp/func/TableFunctionRegistryImpl.java
@@ -32,12 +32,12 @@ public class TableFunctionRegistryImpl implements TableFunctionRegistry {
     @Override
     public <RowT> TableFunction<RowT> getTableFunction(ExecutionContext<RowT> ctx, RexCall rexCall) {
         if (rexCall.getOperator() == IgniteSqlOperatorTable.SYSTEM_RANGE) {
-            Supplier<Long> start = implementGetLongExpr(ctx.expressionFactory(), rexCall.operands.get(0));
-            Supplier<Long> end = implementGetLongExpr(ctx.expressionFactory(), rexCall.operands.get(1));
+            Supplier<Long> start = implementGetLongExpr(ctx, rexCall.operands.get(0));
+            Supplier<Long> end = implementGetLongExpr(ctx, rexCall.operands.get(1));
             Supplier<Long> increment;
 
             if (rexCall.operands.size() > 2) {
-                increment = implementGetLongExpr(ctx.expressionFactory(), rexCall.operands.get(2));
+                increment = implementGetLongExpr(ctx, rexCall.operands.get(2));
             } else {
                 increment = null;
             }
@@ -48,12 +48,16 @@ public class TableFunctionRegistryImpl implements TableFunctionRegistry {
         }
     }
 
-    private static <RowT> @Nullable Supplier<Long> implementGetLongExpr(ExpressionFactory<RowT> expressionFactory, RexNode expr) {
+    private static <RowT> @Nullable Supplier<Long> implementGetLongExpr(
+            ExecutionContext<RowT> ctx,
+            RexNode expr
+    ) {
         if (expr == null) {
             return null;
         }
+        ExpressionFactory expressionFactory = ctx.expressionFactory();
 
-        Supplier<Object> value = expressionFactory.execute(expr);
+        Supplier<Object> value = expressionFactory.execute(ctx, expr);
         return () -> {
             Number num = (Number) value.get();
             if (num == null) {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/KeyValueGetPlan.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/KeyValueGetPlan.java
@@ -146,11 +146,11 @@ public class KeyValueGetPlan implements ExplainablePlan, ExecutablePlan {
                     RelDataType rowType = sqlTable.getRowType(Commons.typeFactory(), requiredColumns);
 
                     Supplier<RowT> keySupplier = ctx.expressionFactory()
-                            .rowSource(keyExpressions);
+                            .rowSource(ctx, keyExpressions);
                     Predicate<RowT> filter = filterExpr == null ? null : ctx.expressionFactory()
-                            .predicate(filterExpr, rowType);
+                            .predicate(ctx, filterExpr, rowType);
                     Function<RowT, RowT> projection = projectionExpr == null ? null : ctx.expressionFactory()
-                            .project(projectionExpr, rowType);
+                            .project(ctx, projectionExpr, rowType);
 
                     RowHandler<RowT> rowHandler = ctx.rowHandler();
                     RowSchema rowSchema = TypeUtils.rowSchemaFromRelTypes(RelOptUtil.getFieldTypeList(rowType));

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/KeyValueModifyPlan.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/KeyValueModifyPlan.java
@@ -126,7 +126,7 @@ public class KeyValueModifyPlan implements ExplainablePlan, ExecutablePlan {
                     List<RexNode> expressions = modifyNode.expressions();
 
                     Supplier<RowT> rowSupplier = ctx.expressionFactory()
-                            .rowSource(expressions);
+                            .rowSource(ctx, expressions);
 
                     UpdatableTable updatableTable = execTable.updatableTable();
 

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/SelectCountPlan.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/SelectCountPlan.java
@@ -159,7 +159,7 @@ public class SelectCountPlan implements ExplainablePlan, ExecutablePlan {
                 .build();
 
         RelDataType resultType = selectCountNode.getRowType();
-        Function<RowT, RowT> projection = ctx.expressionFactory().project(expressions, getCountType);
+        Function<RowT, RowT> projection = ctx.expressionFactory().project(ctx, expressions, getCountType);
 
         RowHandler<RowT> rowHandler = ctx.rowHandler();
         BiFunction<Integer, Object, Object> internalTypeConverter = TypeUtils.resultTypeConverter(ctx, resultType);

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/Commons.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/Commons.java
@@ -175,7 +175,7 @@ public final class Commons {
             .sqlValidatorConfig(SqlValidator.Config.DEFAULT
                     .withIdentifierExpansion(true)
                     .withDefaultNullCollation(NullCollation.HIGH)
-                    .withSqlConformance(IgniteSqlConformance.INSTANCE)
+                    .withConformance(IgniteSqlConformance.INSTANCE)
                     .withTypeCoercionRules(standardCompatibleCoercionRules())
                     .withTypeCoercionFactory(IgniteTypeCoercion::new))
             // Dialects support.

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImplTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImplTest.java
@@ -100,6 +100,7 @@ import org.apache.ignite.internal.sql.engine.SqlQueryProcessor;
 import org.apache.ignite.internal.sql.engine.SqlQueryProcessor.PrefetchCallback;
 import org.apache.ignite.internal.sql.engine.exec.ExecutionServiceImplTest.TestCluster.TestNode;
 import org.apache.ignite.internal.sql.engine.exec.ddl.DdlCommandHandler;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactoryImpl;
 import org.apache.ignite.internal.sql.engine.exec.exp.func.TableFunctionRegistry;
 import org.apache.ignite.internal.sql.engine.exec.exp.func.TableFunctionRegistryImpl;
 import org.apache.ignite.internal.sql.engine.exec.mapping.MappingServiceImpl;
@@ -1134,6 +1135,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
 
         var mappingService = createMappingService(nodeName, clockService, mappingCacheFactory, nodeNames);
         var tableFunctionRegistry = new TableFunctionRegistryImpl();
+        var expressionFactory = new ExpressionFactoryImpl();
 
         var executionService = new ExecutionServiceImpl<>(
                 messageService,
@@ -1145,6 +1147,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
                 ArrayRowHandler.INSTANCE,
                 executableTableRegistry,
                 dependencyResolver,
+                expressionFactory,
                 (ctx, deps) -> node.implementor(ctx, mailboxRegistry, exchangeService, deps, tableFunctionRegistry),
                 clockService,
                 SHUTDOWN_TIMEOUT

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/RuntimeSortedIndexTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/RuntimeSortedIndexTest.java
@@ -36,6 +36,8 @@ import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.Pair;
 import org.apache.ignite.internal.network.ClusterNodeImpl;
 import org.apache.ignite.internal.sql.engine.SqlQueryProcessor;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactory;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactoryImpl;
 import org.apache.ignite.internal.sql.engine.framework.ArrayRowHandler;
 import org.apache.ignite.internal.sql.engine.type.IgniteTypeFactory;
 import org.apache.ignite.internal.sql.engine.util.Commons;
@@ -111,10 +113,13 @@ public class RuntimeSortedIndexTest extends IgniteAbstractTest {
         }
     }
 
-    private RuntimeSortedIndex<Object[]> generate(RelDataType rowType, final List<Integer> idxCols, int notUnique) {
+    private RuntimeSortedIndex<Object[]> generate(RelDataType rowType, List<Integer> idxCols, int notUnique) {
+        ExpressionFactory expressionFactory = new ExpressionFactoryImpl();
+
         RuntimeSortedIndex<Object[]> idx = new RuntimeSortedIndex<>(
                 new ExecutionContext<>(
                         null,
+                        expressionFactory,
                         randomUUID(),
                         new ClusterNodeImpl(randomUUID(), "fake-test-node", NetworkAddress.from("127.0.0.1:1111")),
                         "fake-test-node",

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/exp/ExpressionFactoryImplTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/exp/ExpressionFactoryImplTest.java
@@ -104,7 +104,9 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
     private IgniteTypeFactory typeFactory;
 
     /** Expression factory. */
-    private ExpressionFactoryImpl<Object[]> expFactory;
+    private ExpressionFactoryImpl expFactory;
+
+    private  ExecutionContext<Object[]> ctx;
 
     @BeforeEach
     public void prepare() {
@@ -113,14 +115,14 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
         FragmentDescription fragmentDescription = new FragmentDescription(1, true,
                 Long2ObjectMaps.emptyMap(), null, null, null);
 
-        ExecutionContext<Object[]> ctx = TestBuilders.executionContext()
+        ctx = TestBuilders.executionContext()
                 .queryId(randomUUID())
                 .localNode(new ClusterNodeImpl(randomUUID(), "node-1", new NetworkAddress("localhost", 1234)))
                 .fragment(fragmentDescription)
                 .executor(Mockito.mock(QueryTaskExecutor.class))
                 .build();
 
-        expFactory = new ExpressionFactoryImpl<>(ctx, SqlConformanceEnum.DEFAULT);
+        expFactory = new ExpressionFactoryImpl(SqlConformanceEnum.DEFAULT);
     }
 
     @Test
@@ -168,9 +170,9 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(0));
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(0));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.upper())));
@@ -186,9 +188,9 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(new RelFieldCollation(0, Direction.DESCENDING)));
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(new RelFieldCollation(0, Direction.DESCENDING)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.upper())));
@@ -204,10 +206,10 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(
                     new RelFieldCollation(0, Direction.DESCENDING, NullDirection.FIRST)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.upper())));
@@ -223,10 +225,10 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(
                     new RelFieldCollation(0, Direction.DESCENDING, NullDirection.LAST)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.upper())));
@@ -242,9 +244,9 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(0));
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(0));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.upper())));
@@ -260,9 +262,9 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(new RelFieldCollation(0, Direction.DESCENDING)));
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(new RelFieldCollation(0, Direction.DESCENDING)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.upper())));
@@ -278,10 +280,10 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(
                     new RelFieldCollation(0, Direction.DESCENDING, NullDirection.FIRST)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.upper())));
@@ -297,10 +299,10 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(
                     new RelFieldCollation(0, Direction.ASCENDING, NullDirection.LAST)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.upper())));
@@ -316,10 +318,10 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(
                     new RelFieldCollation(0, Direction.DESCENDING, NullDirection.FIRST)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.upper())));
@@ -353,10 +355,10 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(
                     new RelFieldCollation(0, Direction.ASCENDING)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.lowerInclude(), r.upper(), r.upperInclude())));
@@ -373,10 +375,10 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(
                     new RelFieldCollation(0, Direction.DESCENDING)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.lowerInclude(), r.upper(), r.upperInclude())));
@@ -392,10 +394,10 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(
                     new RelFieldCollation(0, Direction.ASCENDING)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.lowerInclude(), r.upper(), r.upperInclude())));
@@ -411,10 +413,10 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(
                     new RelFieldCollation(0, Direction.DESCENDING)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.lowerInclude(), r.upper(), r.upperInclude())));
@@ -430,10 +432,10 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(
                     new RelFieldCollation(0, Direction.ASCENDING)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.lowerInclude(), r.upper(), r.upperInclude())));
@@ -449,10 +451,10 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(
                     new RelFieldCollation(0, Direction.DESCENDING)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.lowerInclude(), r.upper(), r.upperInclude())));
@@ -468,10 +470,10 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(
                     new RelFieldCollation(0, Direction.ASCENDING)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.lowerInclude(), r.upper(), r.upperInclude())));
@@ -487,10 +489,10 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(
                     new RelFieldCollation(0, Direction.DESCENDING)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.lowerInclude(), r.upper(), r.upperInclude())));
@@ -523,10 +525,10 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(
                     new RelFieldCollation(0, Direction.ASCENDING)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.lowerInclude(), r.upper(), r.upperInclude())));
@@ -542,10 +544,10 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                     ))
             );
 
-            Comparator<Object[]> comparator = expFactory.comparator(RelCollations.of(
+            Comparator<Object[]> comparator = expFactory.comparator(ctx, RelCollations.of(
                     new RelFieldCollation(0, Direction.DESCENDING)));
 
-            RangeIterable<Object[]> ranges = expFactory.ranges(boundsList, rowType, comparator);
+            RangeIterable<Object[]> ranges = expFactory.ranges(ctx, boundsList, rowType, comparator);
             List<TestRange> list = new ArrayList<>();
 
             ranges.forEach(r -> list.add(new TestRange(r.lower(), r.lowerInclude(), r.upper(), r.upperInclude())));
@@ -590,7 +592,7 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
             assertNotNull(bounds);
         }
 
-        RangeIterable<Object[]> ranges = expFactory.ranges(bounds, rowType, null);
+        RangeIterable<Object[]> ranges = expFactory.ranges(ctx, bounds, rowType, null);
         // TODO: https://issues.apache.org/jira/browse/IGNITE-13568 seems length predicate bounds
         //  for sequential columns also belong to index need to be 2
         assertEquals(1, ranges.iterator().next().lower().length);
@@ -603,7 +605,7 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                 new RangeBounds(condition, val1, val2, true, true)
         );
 
-        ranges = expFactory.ranges(boundsList, rowType, null);
+        ranges = expFactory.ranges(ctx, boundsList, rowType, null);
         assertEquals(1, ranges.iterator().next().lower().length);
         assertEquals(1, ranges.iterator().next().upper().length);
     }
@@ -624,7 +626,7 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                 .add("c2", bigIntType)
                 .build();
 
-        Function<Object[], Object[]> project = expFactory.project(List.of(val1, val2), rowType);
+        Function<Object[], Object[]> project = expFactory.project(ctx, List.of(val1, val2), rowType);
         Object[] result = project.apply(new Object[]{null, null});
 
         assertArrayEquals(new Object[]{1, 2L}, result);
@@ -643,7 +645,7 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
         RexInputRef ref = rexBuilder.makeInputRef(rowType, 0);
         RexNode filter = rexBuilder.makeCall(SqlStdOperatorTable.IS_NULL, List.of(ref));
 
-        Predicate<Object[]> predicate = expFactory.predicate(filter, rowType);
+        Predicate<Object[]> predicate = expFactory.predicate(ctx, filter, rowType);
         assertFalse(predicate.test(new Object[]{1}));
     }
 
@@ -662,7 +664,7 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
         RexInputRef ref2 = rexBuilder.makeInputRef(rowType, 1);
         RexNode filter = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, List.of(ref1, ref2));
 
-        BiPredicate<Object[], Object[]> predicate = expFactory.biPredicate(filter, rowType);
+        BiPredicate<Object[], Object[]> predicate = expFactory.biPredicate(ctx, filter, rowType);
         assertFalse(predicate.test(new Object[]{0, 1}, new Object[]{1, 0}));
         assertTrue(predicate.test(new Object[]{0, 0}, new Object[]{0, 0}));
     }
@@ -686,7 +688,7 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                 .build();
 
         List<List<Object>> actual = new ArrayList<>();
-        expFactory.values(List.of(val10, val11, val20, val21), rowType).forEach(v -> actual.add(Arrays.asList(v)));
+        expFactory.values(ctx, List.of(val10, val11, val20, val21), rowType).forEach(v -> actual.add(Arrays.asList(v)));
 
         assertEquals(List.of(List.of(1, 2L), List.of(3, 4L)), actual);
     }
@@ -704,13 +706,13 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
                 .build();
 
         List<List<Object>> actual = new ArrayList<>();
-        expFactory.values(List.of(), rowType).forEach(v -> actual.add(Arrays.asList(v)));
+        expFactory.values(ctx, List.of(), rowType).forEach(v -> actual.add(Arrays.asList(v)));
 
         assertEquals(List.of(), actual);
     }
 
     /**
-     * Checks the execution of the {@link ExpressionFactory#rowSource(List)} method.
+     * Checks the execution of the {@link ExpressionFactory#rowSource(ExecutionContext, List)} method.
      * <ul>
      * <li>If the input list contains only constant expressions (literals), then row assembly must be performed without compiling the
      * expressions.</li>
@@ -732,9 +734,9 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
         RexNode expr2 = SqlTestUtils.generateLiteralOrValueExpr(literalsOnly ? ColumnType.INT32 : ColumnType.UUID, val2);
         assertEquals(literalsOnly, expr2 instanceof RexLiteral);
 
-        ExpressionFactoryImpl<Object[]> expFactorySpy = Mockito.spy(expFactory);
+        ExpressionFactoryImpl expFactorySpy = Mockito.spy(expFactory);
 
-        Object[] actual = expFactorySpy.rowSource(List.of(expr1, expr2)).get();
+        Object[] actual = expFactorySpy.rowSource(ctx, List.of(expr1, expr2)).get();
 
         Object expected;
 
@@ -757,7 +759,7 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
         IgniteTypeFactory tf = Commons.typeFactory();
 
         RelDataType varcharType = tf.createSqlType(SqlTypeName.VARCHAR);
-        Object actual = expFactory.execute(rexBuilder.makeLiteral("42", varcharType)).get();
+        Object actual = expFactory.execute(ctx, rexBuilder.makeLiteral("42", varcharType)).get();
 
         assertEquals("42", actual);
     }
@@ -768,19 +770,19 @@ public class ExpressionFactoryImplTest extends BaseIgniteAbstractTest {
         RelDataType rowType = new Builder(typeFactory).add("c1", dataType).build();
 
         if (!err) {
-            Object[] rowValues = expFactory.rowSource(List.of(lit)).get();
+            Object[] rowValues = expFactory.rowSource(ctx, List.of(lit)).get();
             assertArrayEquals(new Object[]{expected}, rowValues, "rowSource");
 
-            Object[] litValues = expFactory.values(List.of(lit), rowType).iterator().next();
+            Object[] litValues = expFactory.values(ctx, List.of(lit), rowType).iterator().next();
             assertArrayEquals(new Object[]{expected}, litValues, "values");
         } else {
             String errorMessage = "out of range";
 
-            Supplier<Object[]> rowExpr = expFactory.rowSource(List.of(lit));
+            Supplier<Object[]> rowExpr = expFactory.rowSource(ctx, List.of(lit));
             assertThrowsSqlException(Sql.RUNTIME_ERR, errorMessage, rowExpr::get);
 
             assertThrowsSqlException(Sql.RUNTIME_ERR, errorMessage, () -> {
-                expFactory.values(List.of(lit), rowType).iterator().next();
+                expFactory.values(ctx, List.of(lit), rowType).iterator().next();
             });
         }
     }

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/AbstractExecutionTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/AbstractExecutionTest.java
@@ -52,6 +52,8 @@ import org.apache.ignite.internal.sql.engine.exec.QueryTaskExecutorImpl;
 import org.apache.ignite.internal.sql.engine.exec.RowHandler;
 import org.apache.ignite.internal.sql.engine.exec.RowHandler.RowBuilder;
 import org.apache.ignite.internal.sql.engine.exec.TxAttributes;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactory;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactoryImpl;
 import org.apache.ignite.internal.sql.engine.exec.mapping.FragmentDescription;
 import org.apache.ignite.internal.sql.engine.framework.ArrayRowHandler;
 import org.apache.ignite.internal.sql.engine.framework.NoOpTransaction;
@@ -69,6 +71,8 @@ import org.junit.jupiter.api.BeforeEach;
  */
 public abstract class AbstractExecutionTest<T> extends IgniteAbstractTest {
     public static final Object[][] EMPTY = new Object[0][];
+
+    private final ExpressionFactory expressionFactory = new ExpressionFactoryImpl();
 
     private QueryTaskExecutorImpl taskExecutor;
 
@@ -118,6 +122,7 @@ public abstract class AbstractExecutionTest<T> extends IgniteAbstractTest {
 
         return new ExecutionContext<>(
                 taskExecutor,
+                expressionFactory,
                 randomUUID(),
                 new ClusterNodeImpl(randomUUID(), "fake-test-node", NetworkAddress.from("127.0.0.1:1111")),
                 "fake-test-node",

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/AbstractJoinExecutionTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/AbstractJoinExecutionTest.java
@@ -41,6 +41,7 @@ import org.apache.calcite.util.ImmutableIntList;
 import org.apache.ignite.internal.sql.engine.exec.ExecutionContext;
 import org.apache.ignite.internal.sql.engine.exec.RowHandler;
 import org.apache.ignite.internal.sql.engine.exec.TestDownstream;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactory;
 import org.apache.ignite.internal.sql.engine.framework.ArrayRowHandler;
 import org.apache.ignite.internal.sql.engine.type.IgniteTypeFactory;
 import org.apache.ignite.internal.sql.engine.util.TypeUtils;
@@ -432,16 +433,17 @@ public abstract class AbstractJoinExecutionTest extends AbstractExecutionTest<Ob
 
         ProjectNode<Object[]> project;
         SortNode<Object[]> sortNode;
+        ExpressionFactory expressionFactory = ctx.expressionFactory();
         if (setOf(SEMI, ANTI).contains(joinType)) {
             project = new ProjectNode<>(ctx, r -> new Object[]{r[0], r[1]});
             RelCollation collation = RelCollations.of(ImmutableIntList.of(0, 1));
-            Comparator<Object[]> cmp = ctx.expressionFactory().comparator(collation);
+            Comparator<Object[]> cmp = expressionFactory.comparator(ctx, collation);
 
             sortNode = new SortNode<>(ctx, cmp);
         } else {
             project = new ProjectNode<>(ctx, r -> new Object[]{r[0], r[1], r[4]});
             RelCollation collation = RelCollations.of(ImmutableIntList.of(0, 1, 4));
-            Comparator<Object[]> cmp = ctx.expressionFactory().comparator(collation);
+            Comparator<Object[]> cmp = expressionFactory.comparator(ctx, collation);
 
             sortNode = new SortNode<>(ctx, cmp);
         }

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/AbstractSetOpExecutionTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/AbstractSetOpExecutionTest.java
@@ -37,6 +37,7 @@ import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.util.ImmutableIntList;
 import org.apache.ignite.internal.sql.engine.exec.ExecutionContext;
 import org.apache.ignite.internal.sql.engine.exec.RowHandler;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactory;
 import org.apache.ignite.internal.sql.engine.exec.exp.agg.AggregateType;
 import org.apache.ignite.internal.sql.engine.framework.ArrayRowHandler;
 import org.junit.jupiter.api.Test;
@@ -144,7 +145,8 @@ public abstract class AbstractSetOpExecutionTest extends AbstractExecutionTest<O
         }
 
         RelCollation collation = RelCollations.of(ImmutableIntList.of(IntStream.range(0, COLUMN_NUN).toArray()));
-        Comparator<Object[]> cmp = ctx.expressionFactory().comparator(collation);
+        ExpressionFactory expressionFactory = ctx.expressionFactory();
+        Comparator<Object[]> cmp = expressionFactory.comparator(ctx, collation);
 
         // Create sort node on the top to check sorted results.
         SortNode<Object[]> sortNode = new SortNode<>(ctx, cmp);

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/BaseAggregateTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/BaseAggregateTest.java
@@ -807,7 +807,7 @@ public abstract class BaseAggregateTest extends AbstractExecutionTest<Object[]> 
             AggregateType type,
             RelDataType rowType
     ) {
-        return ctx.expressionFactory().accumulatorsFactory(type, asList(call), rowType);
+        return ctx.expressionFactory().accumulatorsFactory(ctx, type, asList(call), rowType);
     }
 
     enum TestAggregateType {

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/HashAggregateExecutionTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/HashAggregateExecutionTest.java
@@ -35,6 +35,7 @@ import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.mapping.Mapping;
 import org.apache.ignite.internal.sql.engine.exec.ExecutionContext;
 import org.apache.ignite.internal.sql.engine.exec.RowHandler;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactory;
 import org.apache.ignite.internal.sql.engine.rel.agg.MapReduceAggregates;
 import org.apache.ignite.internal.sql.engine.rel.agg.MapReduceAggregates.MapReduceAgg;
 import org.apache.ignite.internal.sql.engine.util.Commons;
@@ -70,7 +71,7 @@ public class HashAggregateExecutionTest extends BaseAggregateTest {
         if (group) {
             RelCollation collation = createOutCollation(grpSets);
 
-            Comparator<Object[]> cmp = ctx.expressionFactory().comparator(collation);
+            Comparator<Object[]> cmp = ctx.expressionFactory().comparator(ctx, collation);
 
             // Create sort node on the top to check sorted results
             SortNode<Object[]> sort = new SortNode<>(ctx, cmp);
@@ -145,8 +146,8 @@ public class HashAggregateExecutionTest extends BaseAggregateTest {
         aggRdc.register(aggMap);
 
         RelCollation collation = createOutCollation(grpSets);
-
-        Comparator<Object[]> cmp = ctx.expressionFactory().comparator(collation);
+        ExpressionFactory expressionFactory = ctx.expressionFactory();
+        Comparator<Object[]> cmp = expressionFactory.comparator(ctx, collation);
 
         if (group) {
             // Create sort node on the top to check sorted results

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/HashAggregateSingleGroupExecutionTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/HashAggregateSingleGroupExecutionTest.java
@@ -409,7 +409,7 @@ public class HashAggregateSingleGroupExecutionTest extends AbstractExecutionTest
             AggregateType type,
             RelDataType rowType
     ) {
-        return ctx.expressionFactory().accumulatorsFactory(type, asList(call), rowType);
+        return ctx.expressionFactory().accumulatorsFactory(ctx, type, asList(call), rowType);
     }
 
     private HashAggregateNode<Object[]> newHashAggNode(ExecutionContext<Object[]> ctx,

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/MergeJoinExecutionTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/MergeJoinExecutionTest.java
@@ -43,6 +43,7 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.ignite.internal.sql.engine.SqlQueryProcessor;
 import org.apache.ignite.internal.sql.engine.exec.ExecutionContext;
 import org.apache.ignite.internal.sql.engine.exec.RowHandler;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactory;
 import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactoryImpl;
 import org.apache.ignite.internal.sql.engine.framework.ArrayRowHandler;
 import org.apache.ignite.internal.sql.engine.type.IgniteTypeFactory;
@@ -483,12 +484,13 @@ public class MergeJoinExecutionTest extends AbstractExecutionTest<Object[]> {
 
         RelDataType rightType = TypeUtils.createRowType(tf, TypeUtils.native2relationalTypes(tf, NativeTypes.INT32, NativeTypes.STRING));
         ScanNode<Object[]> rightNode = new ScanNode<>(ctx, Arrays.asList(right));
+        ExpressionFactory expressionFactory = new ExpressionFactoryImpl();
 
         ExecutionContext<Object[]> ectx =
-                new ExecutionContext<>(null, null, null, null, null,
+                new ExecutionContext<>(null, expressionFactory, null, null, null, null,
                         ArrayRowHandler.INSTANCE, null, null, SqlQueryProcessor.DEFAULT_TIME_ZONE_ID, null);
 
-        ExpressionFactoryImpl<Object[]> expFactory = new ExpressionFactoryImpl<>(ectx, SqlConformanceEnum.DEFAULT);
+        ExpressionFactoryImpl expFactory = new ExpressionFactoryImpl();
 
         RelFieldCollation colLeft = new RelFieldCollation(2, Direction.ASCENDING, NullDirection.FIRST);
         RelFieldCollation colRight = new RelFieldCollation(0, Direction.ASCENDING, NullDirection.FIRST);
@@ -499,7 +501,7 @@ public class MergeJoinExecutionTest extends AbstractExecutionTest<Object[]> {
             nullComparison.set(0, left[0].length);
         }
 
-        Comparator<Object[]> comp = expFactory.comparator(List.of(colLeft), List.of(colRight), nullComparison.build());
+        Comparator<Object[]> comp = expFactory.comparator(ectx, List.of(colLeft), List.of(colRight), nullComparison.build());
 
         MergeJoinNode<Object[]> join = MergeJoinNode.create(ctx, leftType, rightType, joinType, comp);
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/SortAggregateExecutionTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/SortAggregateExecutionTest.java
@@ -35,6 +35,7 @@ import org.apache.calcite.util.ImmutableIntList;
 import org.apache.calcite.util.mapping.Mapping;
 import org.apache.ignite.internal.sql.engine.exec.ExecutionContext;
 import org.apache.ignite.internal.sql.engine.exec.RowHandler;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactory;
 import org.apache.ignite.internal.sql.engine.rel.agg.MapReduceAggregates;
 import org.apache.ignite.internal.sql.engine.rel.agg.MapReduceAggregates.MapReduceAgg;
 import org.apache.ignite.internal.sql.engine.util.Commons;
@@ -60,8 +61,9 @@ public class SortAggregateExecutionTest extends BaseAggregateTest {
         ImmutableBitSet grpSet = first(grpSets);
 
         RelCollation collation = RelCollations.of(ImmutableIntList.copyOf(grpSet.asList()));
+        ExpressionFactory expressionFactory = ctx.expressionFactory();
 
-        Comparator<Object[]> cmp = ctx.expressionFactory().comparator(collation);
+        Comparator<Object[]> cmp = expressionFactory.comparator(ctx, collation);
 
         if (grpSet.isEmpty() && cmp == null) {
             cmp = (k1, k2) -> 0;
@@ -107,7 +109,8 @@ public class SortAggregateExecutionTest extends BaseAggregateTest {
 
         RelCollation collation = RelCollations.of(ImmutableIntList.copyOf(grpSet.asList()));
 
-        Comparator<Object[]> cmp = ctx.expressionFactory().comparator(collation);
+        ExpressionFactory expressionFactory = ctx.expressionFactory();
+        Comparator<Object[]> cmp = expressionFactory.comparator(ctx, collation);
 
         if (grpSet.isEmpty() && cmp == null) {
             cmp = (k1, k2) -> 0;
@@ -140,7 +143,7 @@ public class SortAggregateExecutionTest extends BaseAggregateTest {
 
         RelCollation rdcCollation = RelCollations.of(reduceGrpFields);
 
-        Comparator<Object[]> rdcCmp = ctx.expressionFactory().comparator(rdcCollation);
+        Comparator<Object[]> rdcCmp = expressionFactory.comparator(ctx, rdcCollation);
 
         if (grpSet.isEmpty() && rdcCmp == null) {
             rdcCmp = (k1, k2) -> 0;

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/TestBuilders.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/TestBuilders.java
@@ -100,6 +100,8 @@ import org.apache.ignite.internal.sql.engine.exec.ScannableTable;
 import org.apache.ignite.internal.sql.engine.exec.TxAttributes;
 import org.apache.ignite.internal.sql.engine.exec.UpdatableTable;
 import org.apache.ignite.internal.sql.engine.exec.ddl.DdlCommandHandler;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactory;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactoryImpl;
 import org.apache.ignite.internal.sql.engine.exec.exp.RangeCondition;
 import org.apache.ignite.internal.sql.engine.exec.mapping.ExecutionDistributionProvider;
 import org.apache.ignite.internal.sql.engine.exec.mapping.FragmentDescription;
@@ -531,6 +533,7 @@ public class TestBuilders {
         private ClusterNode node = null;
         private Object[] dynamicParams = ArrayUtils.OBJECT_EMPTY_ARRAY;
         private QueryCancel queryCancel = null;
+        private ExpressionFactory expressionFactory = new ExpressionFactoryImpl();
 
         /** {@inheritDoc} */
         @Override
@@ -583,6 +586,7 @@ public class TestBuilders {
         public ExecutionContext<Object[]> build() {
             return new ExecutionContext<>(
                     Objects.requireNonNull(executor, "executor"),
+                    expressionFactory,
                     queryId,
                     Objects.requireNonNull(node, "node"),
                     node.name(),

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/TestNode.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/TestNode.java
@@ -60,6 +60,8 @@ import org.apache.ignite.internal.sql.engine.exec.QueryTaskExecutor;
 import org.apache.ignite.internal.sql.engine.exec.QueryTaskExecutorImpl;
 import org.apache.ignite.internal.sql.engine.exec.RowHandler;
 import org.apache.ignite.internal.sql.engine.exec.ddl.DdlCommandHandler;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactory;
+import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactoryImpl;
 import org.apache.ignite.internal.sql.engine.exec.exp.func.TableFunctionRegistryImpl;
 import org.apache.ignite.internal.sql.engine.exec.mapping.MappingService;
 import org.apache.ignite.internal.sql.engine.message.MessageService;
@@ -149,6 +151,7 @@ public class TestNode implements LifecycleAware {
         );
 
         TableFunctionRegistryImpl tableFunctionRegistry = new TableFunctionRegistryImpl();
+        ExpressionFactory expressionFactory = new ExpressionFactoryImpl();
 
         executionService = registerService(ExecutionServiceImpl.create(
                 topologyService,
@@ -162,6 +165,7 @@ public class TestNode implements LifecycleAware {
                 mappingService,
                 tableRegistry,
                 dependencyResolver,
+                expressionFactory,
                 tableFunctionRegistry,
                 clockService,
                 5_000

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/prepare/pruning/PartitionPruningPredicateSelfTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/prepare/pruning/PartitionPruningPredicateSelfTest.java
@@ -38,7 +38,6 @@ import org.apache.ignite.internal.sql.engine.exec.ExecutionContext;
 import org.apache.ignite.internal.sql.engine.exec.NodeWithConsistencyToken;
 import org.apache.ignite.internal.sql.engine.exec.PartitionWithConsistencyToken;
 import org.apache.ignite.internal.sql.engine.exec.QueryTaskExecutor;
-import org.apache.ignite.internal.sql.engine.exec.exp.ExpressionFactory;
 import org.apache.ignite.internal.sql.engine.exec.mapping.ColocationGroup;
 import org.apache.ignite.internal.sql.engine.framework.TestBuilders;
 import org.apache.ignite.internal.sql.engine.schema.IgniteTable;
@@ -208,10 +207,13 @@ public class PartitionPruningPredicateSelfTest extends BaseIgniteAbstractTest {
                     .executor(Mockito.mock(QueryTaskExecutor.class))
                     .dynamicParameters(dynamicParameters)
                     .build();
-            ExpressionFactory<Object[]> expressionFactory = ctx.expressionFactory();
 
             List<PartitionWithConsistencyToken> result = PartitionPruningPredicate.prunePartitions(
-                    pruningColumns, table, expressionFactory, assignments, nodeName
+                    pruningColumns,
+                    table,
+                    ctx,
+                    assignments,
+                    nodeName
             );
             dynamicActual.put(nodeName, result);
         }


### PR DESCRIPTION
- Modifies `ExpressionFactory` to take `ExecutionContext` as an argument of expression-building methods instead of accepting during construction.
- Makes expression cache non-static.

https://issues.apache.org/jira/browse/IGNITE-21558

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)