### PR TITLE
IGNITE-21645 Fix tests extending AbstractPlannerTest on Java 21

### DIFF
--- a/modules/core/src/testFixtures/java/org/apache/ignite/internal/testframework/IgniteTestUtils.java
+++ b/modules/core/src/testFixtures/java/org/apache/ignite/internal/testframework/IgniteTestUtils.java
@@ -29,8 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -81,17 +79,6 @@ public final class IgniteTestUtils {
     private static final IgniteLogger LOG = Loggers.forClass(IgniteTestUtils.class);
 
     private static final int TIMEOUT_SEC = 30;
-
-    private static final VarHandle MODIFIERS;
-
-    static {
-        try {
-            MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(Field.class, MethodHandles.lookup());
-            MODIFIERS = lookup.findVarHandle(Field.class, "modifiers", int.class);
-        } catch (IllegalAccessException | NoSuchFieldException ex) {
-            throw new ExceptionInInitializerError(ex);
-        }
-    }
 
     /**
      * Set object field value via reflection.
@@ -163,10 +150,6 @@ public final class IgniteTestUtils {
              */
             if (isFinal && isStatic) {
                 throw new IgniteInternalException("Modification of static final field through reflection.");
-            }
-
-            if (isFinal) {
-                MODIFIERS.set(field, field.getModifiers() & ~Modifier.FINAL);
             }
 
             field.set(obj, val);


### PR DESCRIPTION
The tests change a final field value. In such a situation, the corresponding IgniteTestUtils method changes the corresponding Field's modifiers to remove the final flag from them. The modifiers are changed through a MethodHandle, and on highest Java versions, a MethodHandle of a final Field now throws an UnsupportedOperationException.

It turns out, this modification of the modifiers is actually not needed on any of the currently LTS Java versions (11, 17, 21), so we just remove this in this commit.

https://issues.apache.org/jira/browse/IGNITE-21645