### PR TITLE
IGNITE-21651 Fix ItSslClientHandlerTest on Java 21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@
 [versions]
 assertj = "3.22.0"
 asm = "9.1"
+bouncycastle = "1.76"
 compileTesting = "0.19"
 fliptables = "1.1.0"
 fmpp = "0.9.16"
@@ -99,6 +100,9 @@ ideaext = "org.jetbrains.gradle.plugin.idea-ext:1.1.7"
 
 [libraries]
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+
+bouncycastle-bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
+bouncycastle-bcpkix-jdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle" }
 
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotations" }
 

--- a/modules/client-handler/build.gradle
+++ b/modules/client-handler/build.gradle
@@ -81,6 +81,7 @@ dependencies {
     integrationTestImplementation libs.msgpack.core
     integrationTestImplementation libs.netty.handler
     integrationTestImplementation libs.jetbrains.annotations
+    integrationTestImplementation libs.bouncycastle.bcpkix.jdk18on;
 
     testFixturesImplementation project(':ignite-core')
     testFixturesImplementation project(':ignite-placement-driver-api')

--- a/modules/network/build.gradle
+++ b/modules/network/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     testImplementation libs.bytebuddy
     testImplementation libs.compileTesting
     testImplementation libs.awaitility
+    testImplementation libs.bouncycastle.bcpkix.jdk18on;
 
     testFixturesAnnotationProcessor project(":ignite-network-annotation-processor")
     testFixturesImplementation project(':ignite-configuration')

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/raft/snapshot/incoming/IncomingSnapshotCopierTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/raft/snapshot/incoming/IncomingSnapshotCopierTest.java
@@ -106,7 +106,6 @@ import org.apache.ignite.internal.tx.storage.state.test.TestTxStateTableStorage;
 import org.apache.ignite.internal.type.NativeTypes;
 import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.TopologyService;
-import org.apache.ignite.raft.jraft.RaftMessagesFactory;
 import org.apache.ignite.raft.jraft.Status;
 import org.apache.ignite.raft.jraft.entity.RaftOutter.SnapshotMeta;
 import org.apache.ignite.raft.jraft.error.RaftError;
@@ -136,8 +135,6 @@ public class IncomingSnapshotCopierTest extends BaseIgniteAbstractTest {
     private static final HybridClock CLOCK = new HybridClockImpl();
 
     private static final TableMessagesFactory TABLE_MSG_FACTORY = new TableMessagesFactory();
-
-    private static final RaftMessagesFactory RAFT_MSG_FACTORY = new RaftMessagesFactory();
 
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 


### PR DESCRIPTION
Netty uses OpenJDK internal classes to implement TLS; doing so, it uses Reflection to invoke their methods. In Java 21, one of the needed methods (set()) does not exist anymore, so OpenJDK's classes cannot be used anymore.

This commit switches to BouncyCastle by adding it to the classpath.

https://issues.apache.org/jira/browse/IGNITE-21651