### PR TITLE
IGNITE-21654 Fix flaky client compute tests

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientCompute.java
@@ -159,7 +159,7 @@ public class ClientCompute implements IgniteCompute {
         return new ClientJobExecution<>(ch, doExecuteColocatedAsync(tableName, key, keyMapper, units, jobClassName, options, args));
     }
 
-    private CompletableFuture<PayloadInputChannel> doExecuteColocatedAsync(
+    private CompletableFuture<SubmitResult> doExecuteColocatedAsync(
             String tableName,
             Tuple key,
             List<DeploymentUnit> units,
@@ -178,7 +178,7 @@ public class ClientCompute implements IgniteCompute {
                 .thenCompose(Function.identity());
     }
 
-    private <K> CompletableFuture<PayloadInputChannel> doExecuteColocatedAsync(
+    private <K> CompletableFuture<SubmitResult> doExecuteColocatedAsync(
             String tableName,
             K key,
             Mapper<K> keyMapper,
@@ -261,7 +261,7 @@ public class ClientCompute implements IgniteCompute {
         return map;
     }
 
-    private CompletableFuture<PayloadInputChannel> executeOnNodesAsync(
+    private CompletableFuture<SubmitResult> executeOnNodesAsync(
             Set<ClusterNode> nodes,
             List<DeploymentUnit> units,
             String jobClassName,
@@ -276,10 +276,11 @@ public class ClientCompute implements IgniteCompute {
                     packNodeNames(w.out(), nodes);
                     packJob(w.out(), units, jobClassName, options, args);
                 },
-                ch -> ch,
+                ClientCompute::unpackSubmitResult,
                 node.name(),
                 null,
-                true);
+                true
+        );
     }
 
     private static ClusterNode randomNode(Set<ClusterNode> nodes) {
@@ -297,7 +298,7 @@ public class ClientCompute implements IgniteCompute {
         return iterator.next();
     }
 
-    private static <K> CompletableFuture<PayloadInputChannel> executeColocatedObjectKey(
+    private static <K> CompletableFuture<SubmitResult> executeColocatedObjectKey(
             ClientTable t,
             K key,
             Mapper<K> keyMapper,
@@ -315,7 +316,7 @@ public class ClientCompute implements IgniteCompute {
                 args);
     }
 
-    private static CompletableFuture<PayloadInputChannel> executeColocatedTupleKey(
+    private static CompletableFuture<SubmitResult> executeColocatedTupleKey(
             ClientTable t,
             Tuple key,
             List<DeploymentUnit> units,
@@ -332,7 +333,7 @@ public class ClientCompute implements IgniteCompute {
                 args);
     }
 
-    private static CompletableFuture<PayloadInputChannel> executeColocatedInternal(
+    private static CompletableFuture<SubmitResult> executeColocatedInternal(
             ClientTable t,
             BiConsumer<PayloadOutputChannel, ClientSchema> keyWriter,
             PartitionAwarenessProvider partitionAwarenessProvider,
@@ -352,7 +353,7 @@ public class ClientCompute implements IgniteCompute {
 
                     packJob(w, units, jobClassName, options, args);
                 },
-                ch -> ch,
+                ClientCompute::unpackSubmitResult,
                 partitionAwarenessProvider,
                 true);
     }
@@ -377,11 +378,11 @@ public class ClientCompute implements IgniteCompute {
         });
     }
 
-    private CompletableFuture<PayloadInputChannel> handleMissingTable(
+    private CompletableFuture<SubmitResult> handleMissingTable(
             String tableName,
-            PayloadInputChannel res,
+            SubmitResult res,
             Throwable err,
-            Supplier<CompletableFuture<PayloadInputChannel>> retry
+            Supplier<CompletableFuture<SubmitResult>> retry
     ) {
         if (err instanceof CompletionException) {
             err = err.getCause();
@@ -427,5 +428,16 @@ public class ClientCompute implements IgniteCompute {
         w.packInt(options.priority());
         w.packInt(options.maxRetries());
         w.packObjectArrayAsBinaryTuple(args);
+    }
+
+    /**
+     * Unpacks job id from channel and gets notification future. This is needed because we need to unpack message response in the payload
+     * reader because the unpacker will be closed after the response is processed.
+     *
+     * @param ch Payload channel.
+     * @return Result of the job submission.
+     */
+    private static SubmitResult unpackSubmitResult(PayloadInputChannel ch) {
+        return new SubmitResult(ch.in().unpackUuid(), ch.notificationFuture());
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientJobExecution.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/ClientJobExecution.java
@@ -48,13 +48,13 @@ class ClientJobExecution<R> implements JobExecution<R> {
     // Local status cache
     private final CompletableFuture<@Nullable JobStatus> statusFuture = new CompletableFuture<>();
 
-    ClientJobExecution(ReliableChannel ch, CompletableFuture<PayloadInputChannel> reqFuture) {
+    ClientJobExecution(ReliableChannel ch, CompletableFuture<SubmitResult> reqFuture) {
         this.ch = ch;
 
-        jobIdFuture = reqFuture.thenApply(r -> r.in().unpackUuid());
+        jobIdFuture = reqFuture.thenApply(SubmitResult::jobId);
 
         resultAsync = reqFuture
-                .thenCompose(PayloadInputChannel::notificationFuture)
+                .thenCompose(SubmitResult::notificationFuture)
                 .thenApply(r -> {
                     // Notifications require explicit input close.
                     try (r) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/compute/SubmitResult.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/compute/SubmitResult.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.client.compute;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.apache.ignite.internal.client.PayloadInputChannel;
+
+/**
+ * Result of the job submission. Contains unpacked job id and notification future.
+ */
+class SubmitResult {
+    private final UUID jobId;
+    private final CompletableFuture<PayloadInputChannel> notificationFuture;
+
+    SubmitResult(UUID jobId, CompletableFuture<PayloadInputChannel> notificationFuture) {
+        this.jobId = jobId;
+        this.notificationFuture = notificationFuture;
+    }
+
+    UUID jobId() {
+        return jobId;
+    }
+
+    CompletableFuture<PayloadInputChannel> notificationFuture() {
+        return notificationFuture;
+    }
+}


### PR DESCRIPTION
Fix `Unpacker is closed` error due to a race condition: do not postpone response deserialization.

https://issues.apache.org/jira/browse/IGNITE-21654