### PR TITLE
IGNITE-21523 Send a probe message to server when channel opens at client side

### DIFF
--- a/modules/network/src/main/java/org/apache/ignite/internal/network/NetworkMessageTypes.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/NetworkMessageTypes.java
@@ -30,6 +30,7 @@ import org.apache.ignite.internal.network.recovery.message.HandshakeFinishMessag
 import org.apache.ignite.internal.network.recovery.message.HandshakeRejectedMessage;
 import org.apache.ignite.internal.network.recovery.message.HandshakeStartMessage;
 import org.apache.ignite.internal.network.recovery.message.HandshakeStartResponseMessage;
+import org.apache.ignite.internal.network.recovery.message.ProbeMessage;
 
 /**
  * Message types for the network module.
@@ -95,4 +96,9 @@ public class NetworkMessageTypes {
      * Type for {@link ClusterNodeMessage}.
      */
     public static final short CLUSTER_NODE_MESSAGE = 11;
+
+    /**
+     * Type for {@link ProbeMessage}.
+     */
+    public static final short PROBE_MESSAGE = 12;
 }

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/netty/MessageHandler.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/netty/MessageHandler.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import java.util.function.Consumer;
 import org.apache.ignite.internal.network.NetworkMessage;
 import org.apache.ignite.internal.network.recovery.message.AcknowledgementMessage;
+import org.apache.ignite.internal.network.recovery.message.ProbeMessage;
 import org.apache.ignite.internal.network.serialization.PerSessionSerializationService;
 import org.apache.ignite.network.ClusterNode;
 
@@ -66,12 +67,16 @@ public class MessageHandler extends ChannelInboundHandlerAdapter {
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
         NetworkMessage message = (NetworkMessage) msg;
 
-        if (message instanceof AcknowledgementMessage) {
+        if (notPayloadMessage(message)) {
             return;
         }
 
         messageListener.accept(
                 new InNetworkObject(message, remoteNode, connectionIndex, serializationService.compositeDescriptorRegistry())
         );
+    }
+
+    private static boolean notPayloadMessage(NetworkMessage message) {
+        return message instanceof AcknowledgementMessage || message instanceof ProbeMessage;
     }
 }

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/recovery/RecoveryClientHandshakeManager.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/recovery/RecoveryClientHandshakeManager.java
@@ -21,12 +21,14 @@ import static java.util.Collections.emptyList;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static org.apache.ignite.internal.failure.FailureType.CRITICAL_ERROR;
+import static org.apache.ignite.internal.network.netty.NettyUtils.toCompletableFuture;
 import static org.apache.ignite.internal.network.recovery.HandshakeManagerUtils.clusterNodeToMessage;
 import static org.apache.ignite.internal.network.recovery.HandshakeManagerUtils.switchEventLoopIfNeeded;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
+import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -50,13 +52,13 @@ import org.apache.ignite.internal.network.netty.ChannelKey;
 import org.apache.ignite.internal.network.netty.HandshakeHandler;
 import org.apache.ignite.internal.network.netty.MessageHandler;
 import org.apache.ignite.internal.network.netty.NettySender;
-import org.apache.ignite.internal.network.netty.NettyUtils;
 import org.apache.ignite.internal.network.netty.PipelineUtils;
 import org.apache.ignite.internal.network.recovery.message.HandshakeFinishMessage;
 import org.apache.ignite.internal.network.recovery.message.HandshakeRejectedMessage;
 import org.apache.ignite.internal.network.recovery.message.HandshakeRejectionReason;
 import org.apache.ignite.internal.network.recovery.message.HandshakeStartMessage;
 import org.apache.ignite.internal.network.recovery.message.HandshakeStartResponseMessage;
+import org.apache.ignite.internal.network.recovery.message.ProbeMessage;
 import org.apache.ignite.network.ClusterNode;
 import org.jetbrains.annotations.TestOnly;
 
@@ -167,6 +169,30 @@ public class RecoveryClientHandshakeManager implements HandshakeManager {
         this.ctx = handlerContext;
         this.channel = handlerContext.channel();
         this.handler = (HandshakeHandler) ctx.handler();
+    }
+
+    @Override
+    public void onConnectionOpen() {
+        // Sending a probe to make sure we detect a channel that ends up in a strange state upon creation:
+        // the client sees it as a normally open channel, but the server (at least, Netty) did inot even notice that it accepted it.
+        // This happens if the client tries to connect a server that is stopping its network (and closing its server socket) just
+        // the same exact moment, but then starts its network (binding to the port again) still staying in the same OS process.
+        sendProbeToServer();
+    }
+
+    private void sendProbeToServer() {
+        ProbeMessage probe = MESSAGE_FACTORY.probeMessage().build();
+
+        toCompletableFuture(channel.writeAndFlush(new OutNetworkObject(probe, List.of(), false))).whenComplete((res, ex) -> {
+            if (ex != null) {
+                if (ex instanceof IOException) {
+                    // We don't care: the channel will be reopened.
+                    LOG.debug("Could not send a probe message via {}", ex, channel);
+                } else {
+                    LOG.info("Could not send a probe message via {}", ex, channel);
+                }
+            }
+        });
     }
 
     /** {@inheritDoc} */
@@ -400,7 +426,7 @@ public class RecoveryClientHandshakeManager implements HandshakeManager {
 
         ChannelFuture sendFuture = ctx.channel().writeAndFlush(new OutNetworkObject(response, emptyList(), false));
 
-        NettyUtils.toCompletableFuture(sendFuture).whenComplete((unused, throwable) -> {
+        toCompletableFuture(sendFuture).whenComplete((unused, throwable) -> {
             if (throwable != null) {
                 localHandshakeCompleteFuture.completeExceptionally(
                         new HandshakeException("Failed to send handshake response: " + throwable.getMessage(), throwable)

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/recovery/RecoveryClientHandshakeManager.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/recovery/RecoveryClientHandshakeManager.java
@@ -174,7 +174,7 @@ public class RecoveryClientHandshakeManager implements HandshakeManager {
     @Override
     public void onConnectionOpen() {
         // Sending a probe to make sure we detect a channel that ends up in a strange state upon creation:
-        // the client sees it as a normally open channel, but the server (at least, Netty) did inot even notice that it accepted it.
+        // the client sees it as a normally open channel, but the server (at least, Netty) did not even notice that it accepted it.
         // This happens if the client tries to connect a server that is stopping its network (and closing its server socket) just
         // the same exact moment, but then starts its network (binding to the port again) still staying in the same OS process.
         sendProbeToServer();

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/recovery/RecoveryServerHandshakeManager.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/recovery/RecoveryServerHandshakeManager.java
@@ -55,6 +55,7 @@ import org.apache.ignite.internal.network.recovery.message.HandshakeRejectedMess
 import org.apache.ignite.internal.network.recovery.message.HandshakeRejectionReason;
 import org.apache.ignite.internal.network.recovery.message.HandshakeStartMessage;
 import org.apache.ignite.internal.network.recovery.message.HandshakeStartResponseMessage;
+import org.apache.ignite.internal.network.recovery.message.ProbeMessage;
 import org.apache.ignite.network.ClusterNode;
 
 /**
@@ -181,6 +182,11 @@ public class RecoveryServerHandshakeManager implements HandshakeManager {
     /** {@inheritDoc} */
     @Override
     public void onMessage(NetworkMessage message) {
+        if (message instanceof ProbeMessage) {
+            // No action required, just ignore it.
+            return;
+        }
+
         if (message instanceof HandshakeRejectedMessage) {
             onHandshakeRejectedMessage((HandshakeRejectedMessage) message);
 

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/recovery/message/ProbeMessage.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/recovery/message/ProbeMessage.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.network.recovery.message;
+
+import static org.apache.ignite.internal.network.NetworkMessageTypes.PROBE_MESSAGE;
+
+import org.apache.ignite.internal.network.annotations.Transferable;
+
+/**
+ * Sent to make sure the established channel is still alive.
+ */
+@Transferable(PROBE_MESSAGE)
+public interface ProbeMessage extends InternalMessage {
+    /**
+     * A dummy field to overcome inability to send 'empty' messages.
+     * TODO: remove when IGNITE-21667 is fixed.
+     */
+    byte dummy();
+}

--- a/modules/network/src/test/java/org/apache/ignite/internal/network/netty/RecoveryHandshakeTest.java
+++ b/modules/network/src/test/java/org/apache/ignite/internal/network/netty/RecoveryHandshakeTest.java
@@ -104,6 +104,7 @@ public class RecoveryHandshakeTest extends BaseIgniteAbstractTest {
 
         assertTrue(serverSideChannel.isActive());
 
+        exchangeClientToServer(serverSideChannel, clientSideChannel);
         exchangeServerToClient(serverSideChannel, clientSideChannel);
         exchangeClientToServer(serverSideChannel, clientSideChannel);
         exchangeServerToClient(serverSideChannel, clientSideChannel);
@@ -154,6 +155,7 @@ public class RecoveryHandshakeTest extends BaseIgniteAbstractTest {
 
         assertTrue(serverSideChannel.isActive());
 
+        exchangeClientToServer(serverSideChannel, clientSideChannel);
         exchangeServerToClient(serverSideChannel, clientSideChannel);
         exchangeClientToServer(serverSideChannel, clientSideChannel);
         exchangeServerToClient(serverSideChannel, clientSideChannel);
@@ -214,6 +216,7 @@ public class RecoveryHandshakeTest extends BaseIgniteAbstractTest {
 
         assertTrue(serverSideChannel.isActive());
 
+        exchangeClientToServer(serverSideChannel, clientSideChannel);
         exchangeServerToClient(serverSideChannel, clientSideChannel);
         exchangeClientToServer(serverSideChannel, clientSideChannel);
         exchangeServerToClient(serverSideChannel, clientSideChannel);
@@ -270,6 +273,9 @@ public class RecoveryHandshakeTest extends BaseIgniteAbstractTest {
         // Channel 2.
         setupChannel(channel2Src, chm2, noMessageListener);
         setupChannel(channel2Dst, shm1, noMessageListener);
+
+        exchangeClientToServer(channel2Dst, channel2Src);
+        exchangeClientToServer(channel1Dst, channel1Src);
 
         exchangeServerToClient(channel2Dst, channel2Src);
         exchangeServerToClient(channel1Dst, channel1Src);
@@ -332,10 +338,12 @@ public class RecoveryHandshakeTest extends BaseIgniteAbstractTest {
         setupChannel(channel2Dst, shm1, noMessageListener);
 
         // Channel 2's handshake acquires both locks.
+        exchangeClientToServer(channel2Dst, channel2Src);
         exchangeServerToClient(channel2Dst, channel2Src);
         exchangeClientToServer(channel2Dst, channel2Src);
 
         // Now Channel 1's handshake cannot acquire even first lock.
+        exchangeClientToServer(channel1Dst, channel1Src);
         exchangeServerToClient(channel1Dst, channel1Src);
 
         // 2 -> 1 is alive, while 1 -> 2 closes because it is late.
@@ -401,6 +409,7 @@ public class RecoveryHandshakeTest extends BaseIgniteAbstractTest {
         setupChannel(serverSideChannel, serverHandshakeManager, serverDidntReceiveAck ?  noMessageListener : listener1);
 
         // Normal handshake
+        exchangeClientToServer(serverSideChannel, clientSideChannel);
         exchangeServerToClient(serverSideChannel, clientSideChannel);
         exchangeClientToServer(serverSideChannel, clientSideChannel);
         exchangeServerToClient(serverSideChannel, clientSideChannel);
@@ -446,6 +455,7 @@ public class RecoveryHandshakeTest extends BaseIgniteAbstractTest {
         setupChannel(serverSideChannel, serverHandshakeManager, serverDidntReceiveAck ? noMessageListener : listener2);
 
         // Handshake
+        exchangeClientToServer(serverSideChannel, clientSideChannel);
         exchangeServerToClient(serverSideChannel, clientSideChannel);
         exchangeClientToServer(serverSideChannel, clientSideChannel);
         exchangeServerToClient(serverSideChannel, clientSideChannel);
@@ -495,6 +505,7 @@ public class RecoveryHandshakeTest extends BaseIgniteAbstractTest {
 
         assertTrue(serverSideChannel.isActive());
 
+        exchangeClientToServer(serverSideChannel, clientSideChannel);
         exchangeServerToClient(serverSideChannel, clientSideChannel);
         exchangeClientToServer(serverSideChannel, clientSideChannel);
         exchangeServerToClient(serverSideChannel, clientSideChannel);
@@ -534,6 +545,7 @@ public class RecoveryHandshakeTest extends BaseIgniteAbstractTest {
 
         assertTrue(serverSideChannel.isActive());
 
+        exchangeClientToServer(serverSideChannel, clientSideChannel);
         exchangeServerToClient(serverSideChannel, clientSideChannel);
         exchangeClientToServer(serverSideChannel, clientSideChannel);
 

--- a/modules/raft/src/integrationTest/java/org/apache/ignite/raft/jraft/core/ItNodeTest.java
+++ b/modules/raft/src/integrationTest/java/org/apache/ignite/raft/jraft/core/ItNodeTest.java
@@ -76,6 +76,7 @@ import org.apache.ignite.internal.logger.IgniteLogger;
 import org.apache.ignite.internal.logger.Loggers;
 import org.apache.ignite.internal.network.ClusterService;
 import org.apache.ignite.internal.network.StaticNodeFinder;
+import org.apache.ignite.internal.network.utils.ClusterServiceTestUtils;
 import org.apache.ignite.internal.raft.JraftGroupEventsListener;
 import org.apache.ignite.internal.raft.storage.impl.DefaultLogStorageFactory;
 import org.apache.ignite.internal.raft.storage.impl.IgniteJraftServiceFactory;
@@ -126,7 +127,6 @@ import org.apache.ignite.raft.jraft.util.ExecutorServiceHelper;
 import org.apache.ignite.raft.jraft.util.ExponentialBackoffTimeoutStrategy;
 import org.apache.ignite.raft.jraft.util.Utils;
 import org.apache.ignite.raft.jraft.util.concurrent.FixedThreadsExecutorGroup;
-import org.apache.ignite.internal.network.utils.ClusterServiceTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -1770,7 +1770,6 @@ public class ItNodeTest extends BaseIgniteAbstractTest {
     }
 
     @Test
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-21457")
     public void testSetPeer2() throws Exception {
         List<TestPeer> peers = TestUtils.generatePeers(testInfo, 3);
 

--- a/modules/replicator/src/main/java/org/apache/ignite/internal/replicator/ReplicaManager.java
+++ b/modules/replicator/src/main/java/org/apache/ignite/internal/replicator/ReplicaManager.java
@@ -234,8 +234,6 @@ public class ReplicaManager extends AbstractEventProducer<LocalReplicaEvent, Loc
             return;
         }
 
-        String senderConsistentId = sender.name();
-
         assert correlationId != null;
 
         ReplicaRequest request = (ReplicaRequest) message;
@@ -244,9 +242,9 @@ public class ReplicaManager extends AbstractEventProducer<LocalReplicaEvent, Loc
         // and writes.
         // But if this is a local call (in the same Ignite instance), we might still be in a thread that does not have those permissions.
         if (currentThreadCannotDoStorageReadsAndWrites()) {
-            requestsExecutor.execute(() -> handleReplicaRequest(request, senderConsistentId, correlationId));
+            requestsExecutor.execute(() -> handleReplicaRequest(request, sender, correlationId));
         } else {
-            handleReplicaRequest(request, senderConsistentId, correlationId);
+            handleReplicaRequest(request, sender, correlationId);
         }
     }
 
@@ -260,7 +258,7 @@ public class ReplicaManager extends AbstractEventProducer<LocalReplicaEvent, Loc
         }
     }
 
-    private void handleReplicaRequest(ReplicaRequest request, String senderConsistentId, @Nullable Long correlationId) {
+    private void handleReplicaRequest(ReplicaRequest request, ClusterNode sender, @Nullable Long correlationId) {
         if (!busyLock.enterBusy()) {
             if (LOG.isInfoEnabled()) {
                 LOG.info("Failed to process replica request (the node is stopping) [request={}].", request);
@@ -268,6 +266,8 @@ public class ReplicaManager extends AbstractEventProducer<LocalReplicaEvent, Loc
 
             return;
         }
+
+        String senderConsistentId = sender.name();
 
         try {
             // Notify the sender that the Replica is created and ready to process requests.
@@ -318,11 +318,6 @@ public class ReplicaManager extends AbstractEventProducer<LocalReplicaEvent, Loc
 
             // replicaFut is always completed here.
             Replica replica = replicaFut.join();
-
-            // TODO IGNITE-20296 Id of the node should come along with the message itself.
-            ClusterNode sender = clusterNetSvc.topologyService().getByConsistentId(senderConsistentId);
-
-            assert sender != null : "The sender is undefined (should be fixed by https://issues.apache.org/jira/browse/IGNITE-20296 )";
 
             String senderId = sender.id();
 

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/raft/snapshot/incoming/IncomingSnapshotCopierTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/raft/snapshot/incoming/IncomingSnapshotCopierTest.java
@@ -106,7 +106,6 @@ import org.apache.ignite.internal.tx.storage.state.test.TestTxStateTableStorage;
 import org.apache.ignite.internal.type.NativeTypes;
 import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.TopologyService;
-import org.apache.ignite.raft.jraft.RaftMessagesFactory;
 import org.apache.ignite.raft.jraft.Status;
 import org.apache.ignite.raft.jraft.entity.RaftOutter.SnapshotMeta;
 import org.apache.ignite.raft.jraft.error.RaftError;
@@ -136,8 +135,6 @@ public class IncomingSnapshotCopierTest extends BaseIgniteAbstractTest {
     private static final HybridClock CLOCK = new HybridClockImpl();
 
     private static final TableMessagesFactory TABLE_MSG_FACTORY = new TableMessagesFactory();
-
-    private static final RaftMessagesFactory RAFT_MSG_FACTORY = new RaftMessagesFactory();
 
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 


### PR DESCRIPTION
If a channel gets opened right at the moment the server closes its server socket (but the server process still lives), the channel might look as open and alive to the client, but the server will never see it, so the handshake will not start.

Sending a probe message from the client makes sure that the client detects such a broken channel and is able to react.

https://issues.apache.org/jira/browse/IGNITE-21523