### PR TITLE
IGNITE-21655 .NET: Fix async method naming in Compute API

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/BasicAuthenticatorTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/BasicAuthenticatorTests.cs
@@ -99,7 +99,7 @@ public class BasicAuthenticatorTests : IgniteTestsBase
 
         try
         {
-            await client.Compute.Submit<object>(nodes, Array.Empty<DeploymentUnit>(), EnableAuthnJob, enable ? 1 : 0);
+            await client.Compute.SubmitAsync<object>(nodes, Array.Empty<DeploymentUnit>(), EnableAuthnJob, enable ? 1 : 0);
         }
         catch (IgniteClientConnectionException)
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeClusterAwarenessTests.cs
@@ -45,10 +45,10 @@ namespace Apache.Ignite.Tests.Compute
             using var client = await IgniteClient.StartAsync(clientCfg);
             client.WaitForConnections(3);
 
-            IJobExecution<string> exec2 = await client.Compute.Submit<string>(
+            IJobExecution<string> exec2 = await client.Compute.SubmitAsync<string>(
                 new[] { server2.Node }, Array.Empty<DeploymentUnit>(), jobClassName: string.Empty);
 
-            IJobExecution<string> exec3 = await client.Compute.Submit<string>(
+            IJobExecution<string> exec3 = await client.Compute.SubmitAsync<string>(
                 new[] { server3.Node }, Array.Empty<DeploymentUnit>(), jobClassName: string.Empty);
 
             Assert.AreEqual("s2", await exec2.GetResultAsync());
@@ -69,10 +69,10 @@ namespace Apache.Ignite.Tests.Compute
 
             using var client = await server1.ConnectClientAsync();
 
-            IJobExecution<string> exec2 = await client.Compute.Submit<string>(
+            IJobExecution<string> exec2 = await client.Compute.SubmitAsync<string>(
                 new[] { server2.Node }, Array.Empty<DeploymentUnit>(), jobClassName: string.Empty);
 
-            IJobExecution<string> exec3 = await client.Compute.Submit<string>(
+            IJobExecution<string> exec3 = await client.Compute.SubmitAsync<string>(
                 new[] { server3.Node }, Array.Empty<DeploymentUnit>(), jobClassName: string.Empty);
 
             Assert.AreEqual("s1", await exec2.GetResultAsync());
@@ -106,7 +106,7 @@ namespace Apache.Ignite.Tests.Compute
             {
                 var node = i % 2 == 0 ? server1.Node : server2.Node;
 
-                IJobExecution<string> jobExecution = await client.Compute.Submit<string>(
+                IJobExecution<string> jobExecution = await client.Compute.SubmitAsync<string>(
                     new[] { node }, Array.Empty<DeploymentUnit>(), jobClassName: string.Empty);
 
                 string res = await jobExecution.GetResultAsync();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTestExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTestExtensions.cs
@@ -28,24 +28,24 @@ using Network;
 /// </summary>
 public static class ComputeTestExtensions
 {
-    public static async Task<IJobExecution<T>> Submit<T>(
+    public static async Task<IJobExecution<T>> SubmitAsync<T>(
         this ICompute compute,
         IEnumerable<IClusterNode> nodes,
         IEnumerable<DeploymentUnit> units,
         string jobClassName,
         params object?[]? args) =>
-        await compute.Submit<T>(nodes, units, jobClassName, JobExecutionOptions.Default, args);
+        await compute.SubmitAsync<T>(nodes, units, jobClassName, JobExecutionOptions.Default, args);
 
-    public static async Task<IJobExecution<T>> SubmitColocated<T>(
+    public static async Task<IJobExecution<T>> SubmitColocatedAsync<T>(
         this ICompute compute,
         string tableName,
         IIgniteTuple key,
         IEnumerable<DeploymentUnit> units,
         string jobClassName,
         params object?[]? args) =>
-        await compute.SubmitColocated<T>(tableName, key, units, jobClassName, JobExecutionOptions.Default, args);
+        await compute.SubmitColocatedAsync<T>(tableName, key, units, jobClassName, JobExecutionOptions.Default, args);
 
-    public static async Task<IJobExecution<T>> SubmitColocated<T, TKey>(
+    public static async Task<IJobExecution<T>> SubmitColocatedAsync<T, TKey>(
         this ICompute compute,
         string tableName,
         TKey key,
@@ -53,7 +53,7 @@ public static class ComputeTestExtensions
         string jobClassName,
         params object?[]? args)
         where TKey : notnull =>
-        await compute.SubmitColocated<T, TKey>(tableName, key, units, jobClassName, JobExecutionOptions.Default, args);
+        await compute.SubmitColocatedAsync<T, TKey>(tableName, key, units, jobClassName, JobExecutionOptions.Default, args);
 
     public static IDictionary<IClusterNode, Task<IJobExecution<T>>> SubmitBroadcast<T>(
         this ICompute compute,

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -84,8 +84,8 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestExecuteOnSpecificNode()
         {
-            var res1 = await Client.Compute.Submit<string>(await GetNodeAsync(0), Units, NodeNameJob, "-", 11);
-            var res2 = await Client.Compute.Submit<string>(await GetNodeAsync(1), Units, NodeNameJob, ":", 22);
+            var res1 = await Client.Compute.SubmitAsync<string>(await GetNodeAsync(0), Units, NodeNameJob, "-", 11);
+            var res2 = await Client.Compute.SubmitAsync<string>(await GetNodeAsync(1), Units, NodeNameJob, ":", 22);
 
             Assert.AreEqual(PlatformTestNodeRunner + "-_11", await res1.GetResultAsync());
             Assert.AreEqual(PlatformTestNodeRunner + "_2:_22", await res2.GetResultAsync());
@@ -94,7 +94,7 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestExecuteOnRandomNode()
         {
-            var jobExecution = await Client.Compute.Submit<string>(await Client.GetClusterNodesAsync(), Units, NodeNameJob);
+            var jobExecution = await Client.Compute.SubmitAsync<string>(await Client.GetClusterNodesAsync(), Units, NodeNameJob);
             var res = await jobExecution.GetResultAsync();
 
             var expectedNodeNames = Enumerable.Range(1, 4)
@@ -107,7 +107,7 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestExecuteResultTypeMismatchThrowsInvalidCastException()
         {
-            var jobExecution = await Client.Compute.Submit<Guid>(await Client.GetClusterNodesAsync(), Units, NodeNameJob);
+            var jobExecution = await Client.Compute.SubmitAsync<Guid>(await Client.GetClusterNodesAsync(), Units, NodeNameJob);
             Assert.ThrowsAsync<InvalidCastException>(async () => await jobExecution.GetResultAsync());
         }
 
@@ -157,7 +157,7 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestExecuteWithArgs()
         {
-            var res = await Client.Compute.Submit<string>(
+            var res = await Client.Compute.SubmitAsync<string>(
                 await Client.GetClusterNodesAsync(),
                 Units,
                 ConcatJob,
@@ -173,7 +173,7 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestExecuteWithNullArgs()
         {
-            var res = await Client.Compute.Submit<string>(await Client.GetClusterNodesAsync(), Units, ConcatJob, args: null);
+            var res = await Client.Compute.SubmitAsync<string>(await Client.GetClusterNodesAsync(), Units, ConcatJob, args: null);
 
             Assert.IsNull(await res.GetResultAsync());
         }
@@ -181,7 +181,7 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestJobErrorPropagatesToClientWithClassAndMessage()
         {
-            var jobExecution = await Client.Compute.Submit<string>(await Client.GetClusterNodesAsync(), Units, ErrorJob, "unused");
+            var jobExecution = await Client.Compute.SubmitAsync<string>(await Client.GetClusterNodesAsync(), Units, ErrorJob, "unused");
             var ex = Assert.ThrowsAsync<IgniteException>(async () => await jobExecution.GetResultAsync());
 
             StringAssert.Contains("Custom job error", ex!.Message);
@@ -202,7 +202,7 @@ namespace Apache.Ignite.Tests.Compute
             var unknownNode = new ClusterNode("x", "y", new IPEndPoint(IPAddress.Loopback, 0));
 
             var ex = Assert.ThrowsAsync<NodeNotFoundException>(async () =>
-                await Client.Compute.Submit<string>(new[] { unknownNode }, Units, EchoJob, "unused"));
+                await Client.Compute.SubmitAsync<string>(new[] { unknownNode }, Units, EchoJob, "unused"));
 
             StringAssert.Contains("None of the specified nodes are present in the cluster: [y]", ex!.Message);
             Assert.AreEqual(ErrorGroups.Compute.NodeNotFound, ex.Code);
@@ -265,7 +265,7 @@ namespace Apache.Ignite.Tests.Compute
             {
                 var nodes = await Client.GetClusterNodesAsync();
                 var str = expectedStr ?? val.ToString()!.Replace("E+", "E");
-                IJobExecution<object> resExec = await Client.Compute.Submit<object>(nodes, Units, EchoJob, val, str);
+                IJobExecution<object> resExec = await Client.Compute.SubmitAsync<object>(nodes, Units, EchoJob, val, str);
                 object res = await resExec.GetResultAsync();
 
                 Assert.AreEqual(val, res);
@@ -290,15 +290,15 @@ namespace Apache.Ignite.Tests.Compute
             client.WaitForConnections(proxies.Count);
 
             var keyTuple = new IgniteTuple { [KeyCol] = key };
-            var resNodeName = await client.Compute.SubmitColocated<string>(TableName, keyTuple, Units, NodeNameJob);
+            var resNodeName = await client.Compute.SubmitColocatedAsync<string>(TableName, keyTuple, Units, NodeNameJob);
             var requestTargetNodeName = GetRequestTargetNodeName(proxies, ClientOp.ComputeExecuteColocated);
 
             var keyPoco = new Poco { Key = key };
-            var resNodeName2 = await client.Compute.SubmitColocated<string, Poco>(TableName, keyPoco, Units.Reverse(), NodeNameJob);
+            var resNodeName2 = await client.Compute.SubmitColocatedAsync<string, Poco>(TableName, keyPoco, Units.Reverse(), NodeNameJob);
             var requestTargetNodeName2 = GetRequestTargetNodeName(proxies, ClientOp.ComputeExecuteColocated);
 
             var keyPocoStruct = new PocoStruct(key, null);
-            var resNodeName3 = await client.Compute.SubmitColocated<string, PocoStruct>(TableName, keyPocoStruct, Units, NodeNameJob);
+            var resNodeName3 = await client.Compute.SubmitColocatedAsync<string, PocoStruct>(TableName, keyPocoStruct, Units, NodeNameJob);
             var requestTargetNodeName3 = GetRequestTargetNodeName(proxies, ClientOp.ComputeExecuteColocated);
 
             var nodeName = nodeIdx == 1 ? string.Empty : "_" + nodeIdx;
@@ -321,7 +321,7 @@ namespace Apache.Ignite.Tests.Compute
         public void TestExecuteColocatedThrowsWhenTableDoesNotExist()
         {
             var ex = Assert.ThrowsAsync<IgniteClientException>(async () =>
-                await Client.Compute.SubmitColocated<string>("unknownTable", new IgniteTuple(), Units, EchoJob));
+                await Client.Compute.SubmitColocatedAsync<string>("unknownTable", new IgniteTuple(), Units, EchoJob));
 
             Assert.AreEqual("Table 'unknownTable' does not exist.", ex!.Message);
         }
@@ -330,7 +330,7 @@ namespace Apache.Ignite.Tests.Compute
         public void TestExecuteColocatedThrowsWhenKeyColumnIsMissing()
         {
             var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
-                await Client.Compute.SubmitColocated<string>(TableName, new IgniteTuple { ["VAL"] = "1" }, Units, EchoJob));
+                await Client.Compute.SubmitColocatedAsync<string>(TableName, new IgniteTuple { ["VAL"] = "1" }, Units, EchoJob));
 
             Assert.AreEqual(
                 "Can't map 'IgniteTuple { VAL = 1 }' to columns 'Int64 KEY, String VAL'. Matching fields not found.",
@@ -342,21 +342,21 @@ namespace Apache.Ignite.Tests.Compute
         {
             // Create table and use it in ExecuteColocated.
             var nodes = await GetNodeAsync(0);
-            var tableNameExec = await Client.Compute.Submit<string>(nodes, Units, CreateTableJob, "drop_me");
+            var tableNameExec = await Client.Compute.SubmitAsync<string>(nodes, Units, CreateTableJob, "drop_me");
             var tableName = await tableNameExec.GetResultAsync();
 
             try
             {
                 var keyTuple = new IgniteTuple { [KeyCol] = 1L };
-                var resNodeNameExec = await Client.Compute.SubmitColocated<string>(tableName, keyTuple, Units, NodeNameJob);
+                var resNodeNameExec = await Client.Compute.SubmitColocatedAsync<string>(tableName, keyTuple, Units, NodeNameJob);
                 var resNodeName = await resNodeNameExec.GetResultAsync();
 
                 // Drop table and create a new one with a different ID, then execute a computation again.
                 // This should update the cached table and complete the computation successfully.
-                var dropExec = await Client.Compute.Submit<string>(nodes, Units, DropTableJob, tableName);
+                var dropExec = await Client.Compute.SubmitAsync<string>(nodes, Units, DropTableJob, tableName);
                 await dropExec.GetResultAsync();
 
-                var createExec = await Client.Compute.Submit<string>(nodes, Units, CreateTableJob, tableName);
+                var createExec = await Client.Compute.SubmitAsync<string>(nodes, Units, CreateTableJob, tableName);
                 await createExec.GetResultAsync();
 
                 if (forceLoadAssignment)
@@ -365,21 +365,21 @@ namespace Apache.Ignite.Tests.Compute
                     table.SetFieldValue("_partitionAssignment", null);
                 }
 
-                var resNodeName2Exec = await Client.Compute.SubmitColocated<string>(tableName, keyTuple, Units, NodeNameJob);
+                var resNodeName2Exec = await Client.Compute.SubmitColocatedAsync<string>(tableName, keyTuple, Units, NodeNameJob);
                 var resNodeName2 = await resNodeName2Exec.GetResultAsync();
 
                 Assert.AreEqual(resNodeName, resNodeName2);
             }
             finally
             {
-                await (await Client.Compute.Submit<string>(nodes, Units, DropTableJob, tableName)).GetResultAsync();
+                await (await Client.Compute.SubmitAsync<string>(nodes, Units, DropTableJob, tableName)).GetResultAsync();
             }
         }
 
         [Test]
         public async Task TestExceptionInJobWithSendServerExceptionStackTraceToClientPropagatesToClientWithStackTrace()
         {
-            var jobExecution = await Client.Compute.Submit<object>(await GetNodeAsync(1), Units, ExceptionJob, "foo-bar");
+            var jobExecution = await Client.Compute.SubmitAsync<object>(await GetNodeAsync(1), Units, ExceptionJob, "foo-bar");
             var ex = Assert.ThrowsAsync<ComputeException>(async () => await jobExecution.GetResultAsync());
 
             Assert.AreEqual("Job execution failed: java.lang.RuntimeException: Test exception: foo-bar", ex!.Message);
@@ -395,7 +395,7 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestCheckedExceptionInJobPropagatesToClient()
         {
-            var jobExecution = await Client.Compute.Submit<object>(await GetNodeAsync(1), Units, CheckedExceptionJob, "foo-bar");
+            var jobExecution = await Client.Compute.SubmitAsync<object>(await GetNodeAsync(1), Units, CheckedExceptionJob, "foo-bar");
             var ex = Assert.ThrowsAsync<IgniteException>(async () => await jobExecution.GetResultAsync());
 
             Assert.AreEqual("TestCheckedEx: foo-bar", ex!.Message);
@@ -416,16 +416,16 @@ namespace Apache.Ignite.Tests.Compute
             using var server = new FakeServer();
             using var client = await server.ConnectClientAsync();
 
-            var res = await client.Compute.Submit<string>(await GetNodeAsync(1), units, FakeServer.GetDetailsJob);
+            var res = await client.Compute.SubmitAsync<string>(await GetNodeAsync(1), units, FakeServer.GetDetailsJob);
             StringAssert.Contains("Units = unit-latest|latest, unit1|1.0.0", await res.GetResultAsync());
 
             // Lazy enumerable.
-            var res2 = await client.Compute.Submit<string>(await GetNodeAsync(1), units.Reverse(), FakeServer.GetDetailsJob);
+            var res2 = await client.Compute.SubmitAsync<string>(await GetNodeAsync(1), units.Reverse(), FakeServer.GetDetailsJob);
             StringAssert.Contains("Units = unit1|1.0.0, unit-latest|latest", await res2.GetResultAsync());
 
             // Colocated.
             var keyTuple = new IgniteTuple { ["ID"] = 1 };
-            var res3 = await client.Compute.SubmitColocated<string>(
+            var res3 = await client.Compute.SubmitColocatedAsync<string>(
                 FakeServer.ExistingTableName, keyTuple, units, FakeServer.GetDetailsJob);
 
             StringAssert.Contains("Units = unit-latest|latest, unit1|1.0.0", await res3.GetResultAsync());
@@ -437,7 +437,7 @@ namespace Apache.Ignite.Tests.Compute
             var deploymentUnits = new DeploymentUnit[] { new("unit-latest") };
 
             var ex = Assert.ThrowsAsync<IgniteException>(
-                async () => await Client.Compute.Submit<string>(await GetNodeAsync(1), deploymentUnits, NodeNameJob));
+                async () => await Client.Compute.SubmitAsync<string>(await GetNodeAsync(1), deploymentUnits, NodeNameJob));
 
             StringAssert.Contains("Deployment unit unit-latest:latest doesn't exist", ex!.Message);
         }
@@ -449,7 +449,7 @@ namespace Apache.Ignite.Tests.Compute
             var deploymentUnits = new DeploymentUnit[] { new("unit-latest") };
 
             var ex = Assert.ThrowsAsync<IgniteException>(
-                async () => await Client.Compute.SubmitColocated<string>(TableName, keyTuple, deploymentUnits, NodeNameJob));
+                async () => await Client.Compute.SubmitColocatedAsync<string>(TableName, keyTuple, deploymentUnits, NodeNameJob));
 
             StringAssert.Contains("Deployment unit unit-latest:latest doesn't exist", ex!.Message);
         }
@@ -460,7 +460,7 @@ namespace Apache.Ignite.Tests.Compute
             var deploymentUnits = new DeploymentUnit[] { new(null!) };
 
             var ex = Assert.ThrowsAsync<ArgumentNullException>(
-                async () => await Client.Compute.Submit<string>(await GetNodeAsync(1), deploymentUnits, NodeNameJob));
+                async () => await Client.Compute.SubmitAsync<string>(await GetNodeAsync(1), deploymentUnits, NodeNameJob));
 
             Assert.AreEqual("Value cannot be null. (Parameter 'unit.Name')", ex!.Message);
         }
@@ -471,7 +471,7 @@ namespace Apache.Ignite.Tests.Compute
             var deploymentUnits = new DeploymentUnit[] { new(string.Empty) };
 
             var ex = Assert.ThrowsAsync<ArgumentException>(
-                async () => await Client.Compute.Submit<string>(await GetNodeAsync(1), deploymentUnits, NodeNameJob));
+                async () => await Client.Compute.SubmitAsync<string>(await GetNodeAsync(1), deploymentUnits, NodeNameJob));
 
             Assert.AreEqual("The value cannot be an empty string. (Parameter 'unit.Name')", ex!.Message);
         }
@@ -482,7 +482,7 @@ namespace Apache.Ignite.Tests.Compute
             var deploymentUnits = new DeploymentUnit[] { new("u", null!) };
 
             var ex = Assert.ThrowsAsync<ArgumentNullException>(
-                async () => await Client.Compute.Submit<string>(await GetNodeAsync(1), deploymentUnits, NodeNameJob));
+                async () => await Client.Compute.SubmitAsync<string>(await GetNodeAsync(1), deploymentUnits, NodeNameJob));
 
             Assert.AreEqual("Value cannot be null. (Parameter 'unit.Version')", ex!.Message);
         }
@@ -493,7 +493,7 @@ namespace Apache.Ignite.Tests.Compute
             var deploymentUnits = new DeploymentUnit[] { new("u", string.Empty) };
 
             var ex = Assert.ThrowsAsync<ArgumentException>(
-                async () => await Client.Compute.Submit<string>(await GetNodeAsync(1), deploymentUnits, NodeNameJob));
+                async () => await Client.Compute.SubmitAsync<string>(await GetNodeAsync(1), deploymentUnits, NodeNameJob));
 
             Assert.AreEqual("The value cannot be an empty string. (Parameter 'unit.Version')", ex!.Message);
         }
@@ -506,7 +506,7 @@ namespace Apache.Ignite.Tests.Compute
             using var client = await IgniteClient.StartAsync(GetConfig());
 
             const int sleepMs = 3000;
-            var jobExecution = await client.Compute.Submit<string>(await GetNodeAsync(1), Units, SleepJob, sleepMs);
+            var jobExecution = await client.Compute.SubmitAsync<string>(await GetNodeAsync(1), Units, SleepJob, sleepMs);
             var jobTask = jobExecution.GetResultAsync();
 
             // Wait a bit and close the connection.
@@ -523,7 +523,7 @@ namespace Apache.Ignite.Tests.Compute
             const int sleepMs = 3000;
             var beforeStart = SystemClock.Instance.GetCurrentInstant();
 
-            var jobExecution = await Client.Compute.Submit<string>(await GetNodeAsync(1), Units, SleepJob, sleepMs);
+            var jobExecution = await Client.Compute.SubmitAsync<string>(await GetNodeAsync(1), Units, SleepJob, sleepMs);
 
             await AssertJobStatus(jobExecution, JobState.Executing, beforeStart);
         }
@@ -534,7 +534,7 @@ namespace Apache.Ignite.Tests.Compute
             const int sleepMs = 1;
             var beforeStart = SystemClock.Instance.GetCurrentInstant();
 
-            var jobExecution = await Client.Compute.Submit<string>(await GetNodeAsync(1), Units, SleepJob, sleepMs);
+            var jobExecution = await Client.Compute.SubmitAsync<string>(await GetNodeAsync(1), Units, SleepJob, sleepMs);
             await jobExecution.GetResultAsync();
 
             await AssertJobStatus(jobExecution, JobState.Completed, beforeStart);
@@ -545,7 +545,7 @@ namespace Apache.Ignite.Tests.Compute
         {
             var beforeStart = SystemClock.Instance.GetCurrentInstant();
 
-            var jobExecution = await Client.Compute.Submit<string>(await GetNodeAsync(1), Units, ErrorJob, "unused");
+            var jobExecution = await Client.Compute.SubmitAsync<string>(await GetNodeAsync(1), Units, ErrorJob, "unused");
             Assert.CatchAsync(async () => await jobExecution.GetResultAsync());
 
             await AssertJobStatus(jobExecution, JobState.Failed, beforeStart);
@@ -568,7 +568,7 @@ namespace Apache.Ignite.Tests.Compute
             const int sleepMs = 5000;
             var beforeStart = SystemClock.Instance.GetCurrentInstant();
 
-            var jobExecution = await Client.Compute.Submit<string>(await GetNodeAsync(1), Units, SleepJob, sleepMs);
+            var jobExecution = await Client.Compute.SubmitAsync<string>(await GetNodeAsync(1), Units, SleepJob, sleepMs);
             await jobExecution.CancelAsync();
 
             await AssertJobStatus(jobExecution, JobState.Canceled, beforeStart);
@@ -577,7 +577,7 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestChangePriority()
         {
-            var jobExecution = await Client.Compute.Submit<string>(
+            var jobExecution = await Client.Compute.SubmitAsync<string>(
                 await GetNodeAsync(1),
                 Units,
                 SleepJob,
@@ -599,16 +599,16 @@ namespace Apache.Ignite.Tests.Compute
             using var server = new FakeServer();
             using var client = await server.ConnectClientAsync();
 
-            var defaultRes = await client.Compute.Submit<string>(
+            var defaultRes = await client.Compute.SubmitAsync<string>(
                 await GetNodeAsync(1), units, FakeServer.GetDetailsJob, JobExecutionOptions.Default);
             StringAssert.Contains("priority = 0, maxRetries = 0", await defaultRes.GetResultAsync());
 
-            var res = await client.Compute.Submit<string>(await GetNodeAsync(1), units, FakeServer.GetDetailsJob, options);
+            var res = await client.Compute.SubmitAsync<string>(await GetNodeAsync(1), units, FakeServer.GetDetailsJob, options);
             StringAssert.Contains("priority = 999, maxRetries = 66", await res.GetResultAsync());
 
             // Colocated.
             var keyTuple = new IgniteTuple { ["ID"] = 1 };
-            var colocatedRes = await client.Compute.SubmitColocated<string>(
+            var colocatedRes = await client.Compute.SubmitColocatedAsync<string>(
                 FakeServer.ExistingTableName, keyTuple, units, FakeServer.GetDetailsJob, options);
 
             StringAssert.Contains("priority = 999, maxRetries = 66", await colocatedRes.GetResultAsync());

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessRealClusterTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessRealClusterTests.cs
@@ -50,7 +50,7 @@ public class PartitionAwarenessRealClusterTests : IgniteTestsBase
         {
             var keyTuple = new IgniteTuple { ["KEY"] = key };
 
-            var primaryNodeNameExec = await client.Compute.SubmitColocated<string>(
+            var primaryNodeNameExec = await client.Compute.SubmitColocatedAsync<string>(
                 TableName,
                 keyTuple,
                 Array.Empty<DeploymentUnit>(),

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessTests.cs
@@ -304,10 +304,10 @@ public class PartitionAwarenessTests
         var key = new IgniteTuple { ["ID"] = keyId };
 
         // Warm up.
-        await client.Compute.SubmitColocated<object?>(FakeServer.ExistingTableName, key, Array.Empty<DeploymentUnit>(), "job");
+        await client.Compute.SubmitColocatedAsync<object?>(FakeServer.ExistingTableName, key, Array.Empty<DeploymentUnit>(), "job");
 
         await AssertOpOnNode(
-            () => client.Compute.SubmitColocated<object?>(FakeServer.ExistingTableName, key, Array.Empty<DeploymentUnit>(), "job"),
+            () => client.Compute.SubmitColocatedAsync<object?>(FakeServer.ExistingTableName, key, Array.Empty<DeploymentUnit>(), "job"),
             ClientOp.ComputeExecuteColocated,
             expectedNode);
     }
@@ -321,11 +321,11 @@ public class PartitionAwarenessTests
         var key = new SimpleKey(keyId);
 
         // Warm up.
-        await client.Compute.SubmitColocated<object?, SimpleKey>(
+        await client.Compute.SubmitColocatedAsync<object?, SimpleKey>(
             FakeServer.ExistingTableName, key, Array.Empty<DeploymentUnit>(), "job");
 
         await AssertOpOnNode(
-            () => client.Compute.SubmitColocated<object?, SimpleKey>(
+            () => client.Compute.SubmitColocatedAsync<object?, SimpleKey>(
                 FakeServer.ExistingTableName, key, Array.Empty<DeploymentUnit>(), "job"),
             ClientOp.ComputeExecuteColocated,
             expectedNode);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/ColocationHashTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/ColocationHashTests.cs
@@ -195,7 +195,7 @@ public class ColocationHashTests : IgniteTestsBase
             using var writer = ProtoCommon.GetMessageWriter();
             var clientColocationHash = ser.Write(writer, null, schema, key);
 
-            var serverColocationHashExec = await Client.Compute.Submit<int>(
+            var serverColocationHashExec = await Client.Compute.SubmitAsync<int>(
                 clusterNodes,
                 Array.Empty<DeploymentUnit>(),
                 TableRowColocationHashJob,
@@ -338,7 +338,7 @@ public class ColocationHashTests : IgniteTestsBase
     {
         var nodes = await Client.GetClusterNodesAsync();
 
-        IJobExecution<int> jobExecution = await Client.Compute.Submit<int>(
+        IJobExecution<int> jobExecution = await Client.Compute.SubmitAsync<int>(
             nodes,
             Array.Empty<DeploymentUnit>(),
             ColocationHashJob,

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -95,7 +95,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
                     break;
 
                 case TestMode.Compute:
-                    await Client.Compute.SubmitColocated<string>(
+                    await Client.Compute.SubmitColocatedAsync<string>(
                         table.Name, rec2, Array.Empty<DeploymentUnit>(), ComputeTests.NodeNameJob);
                     break;
 
@@ -152,7 +152,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
 
             case TestMode.Compute:
                 // ExecuteColocated requires key part only.
-                await Client.Compute.SubmitColocated<string>(
+                await Client.Compute.SubmitColocatedAsync<string>(
                     table.Name, rec, Array.Empty<DeploymentUnit>(), ComputeTests.NodeNameJob);
                 break;
 
@@ -292,7 +292,7 @@ public class SchemaSynchronizationTest : IgniteTestsBase
                 break;
 
             case TestMode.Compute:
-                var jobExecution = await Client.Compute.SubmitColocated<string, Poco>(
+                var jobExecution = await Client.Compute.SubmitColocatedAsync<string, Poco>(
                     table.Name, new Poco(1, "foo"), Array.Empty<DeploymentUnit>(), ComputeTests.NodeNameJob);
 
                 await jobExecution.GetResultAsync();

--- a/modules/platforms/dotnet/Apache.Ignite/ClientOperationType.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/ClientOperationType.cs
@@ -117,7 +117,7 @@ namespace Apache.Ignite
         TupleContainsKey,
 
         /// <summary>
-        /// Compute (<see cref="ICompute.Submit{T}"/>, <see cref="ICompute.SubmitBroadcast{T}"/>).
+        /// Compute (<see cref="ICompute.SubmitAsync{T}"/>, <see cref="ICompute.SubmitBroadcast{T}"/>).
         /// </summary>
         ComputeExecute,
 

--- a/modules/platforms/dotnet/Apache.Ignite/Compute/ICompute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Compute/ICompute.cs
@@ -37,7 +37,7 @@ public interface ICompute
     /// <param name="args">Job arguments.</param>
     /// <typeparam name="T">Job result type.</typeparam>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    Task<IJobExecution<T>> Submit<T>(
+    Task<IJobExecution<T>> SubmitAsync<T>(
         IEnumerable<IClusterNode> nodes,
         IEnumerable<DeploymentUnit> units,
         string jobClassName,
@@ -55,7 +55,7 @@ public interface ICompute
     /// <param name="args">Job arguments.</param>
     /// <typeparam name="T">Job result type.</typeparam>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    Task<IJobExecution<T>> SubmitColocated<T>(
+    Task<IJobExecution<T>> SubmitColocatedAsync<T>(
         string tableName,
         IIgniteTuple key,
         IEnumerable<DeploymentUnit> units,
@@ -75,7 +75,7 @@ public interface ICompute
     /// <typeparam name="T">Job result type.</typeparam>
     /// <typeparam name="TKey">Key type.</typeparam>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    Task<IJobExecution<T>> SubmitColocated<T, TKey>(
+    Task<IJobExecution<T>> SubmitColocatedAsync<T, TKey>(
         string tableName,
         TKey key,
         IEnumerable<DeploymentUnit> units,

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -60,7 +60,7 @@ namespace Apache.Ignite.Internal.Compute
         }
 
         /// <inheritdoc/>
-        public async Task<IJobExecution<T>> Submit<T>(
+        public async Task<IJobExecution<T>> SubmitAsync<T>(
             IEnumerable<IClusterNode> nodes,
             IEnumerable<DeploymentUnit> units,
             string jobClassName,
@@ -77,7 +77,7 @@ namespace Apache.Ignite.Internal.Compute
         }
 
         /// <inheritdoc/>
-        public async Task<IJobExecution<T>> SubmitColocated<T>(
+        public async Task<IJobExecution<T>> SubmitColocatedAsync<T>(
             string tableName,
             IIgniteTuple key,
             IEnumerable<DeploymentUnit> units,
@@ -95,7 +95,7 @@ namespace Apache.Ignite.Internal.Compute
                 .ConfigureAwait(false);
 
         /// <inheritdoc/>
-        public async Task<IJobExecution<T>> SubmitColocated<T, TKey>(
+        public async Task<IJobExecution<T>> SubmitColocatedAsync<T, TKey>(
             string tableName,
             TKey key,
             IEnumerable<DeploymentUnit> units,


### PR DESCRIPTION
Async methods (returning `Task<>`) must have async suffix.