### PR TITLE
IGNITE-21685 Fix client executeColocated with quoted table names

### DIFF
--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteColocatedRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteColocatedRequest.java
@@ -74,7 +74,7 @@ public class ClientComputeExecuteColocatedRequest {
 
             sendResultAndStatus(jobExecutionFut, notificationSender);
 
-            //noinspection DataFlowIssue
+            // noinspection DataFlowIssue
             return jobExecutionFut.thenCompose(JobExecution::idAsync).thenAccept(out::packUuid);
         }));
     }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteColocatedRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteColocatedRequest.java
@@ -27,11 +27,11 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.client.handler.NotificationSender;
 import org.apache.ignite.compute.DeploymentUnit;
-import org.apache.ignite.compute.IgniteCompute;
 import org.apache.ignite.compute.JobExecution;
 import org.apache.ignite.compute.JobExecutionOptions;
 import org.apache.ignite.internal.client.proto.ClientMessagePacker;
 import org.apache.ignite.internal.client.proto.ClientMessageUnpacker;
+import org.apache.ignite.internal.compute.IgniteComputeInternal;
 import org.apache.ignite.internal.network.ClusterService;
 import org.apache.ignite.table.manager.IgniteTables;
 
@@ -52,24 +52,30 @@ public class ClientComputeExecuteColocatedRequest {
     public static CompletableFuture<Void> process(
             ClientMessageUnpacker in,
             ClientMessagePacker out,
-            IgniteCompute compute,
+            IgniteComputeInternal compute,
             IgniteTables tables,
             ClusterService cluster,
             NotificationSender notificationSender) {
-        return readTableAsync(in, tables).thenCompose(table -> {
-            return readTuple(in, table, true).thenCompose(keyTuple -> {
-                List<DeploymentUnit> deploymentUnits = unpackDeploymentUnits(in);
-                String jobClassName = in.unpackString();
-                JobExecutionOptions options = JobExecutionOptions.builder().priority(in.unpackInt()).maxRetries(in.unpackInt()).build();
-                Object[] args = unpackArgs(in);
+        return readTableAsync(in, tables).thenCompose(table -> readTuple(in, table, true).thenCompose(keyTuple -> {
+            List<DeploymentUnit> deploymentUnits = unpackDeploymentUnits(in);
+            String jobClassName = in.unpackString();
+            JobExecutionOptions options = JobExecutionOptions.builder().priority(in.unpackInt()).maxRetries(in.unpackInt()).build();
+            Object[] args = unpackArgs(in);
 
-                out.packInt(table.schemaView().lastKnownSchemaVersion());
+            out.packInt(table.schemaView().lastKnownSchemaVersion());
 
-                JobExecution<Object> execution =
-                        compute.submitColocated(table.name(), keyTuple, deploymentUnits, jobClassName, options, args);
-                sendResultAndStatus(execution, notificationSender);
-                return execution.idAsync().thenAccept(out::packUuid);
-            });
-        });
+            CompletableFuture<JobExecution<Object>> jobExecutionFut = compute.submitColocatedInternal(
+                    table,
+                    keyTuple,
+                    deploymentUnits,
+                    jobClassName,
+                    options,
+                    args);
+
+            sendResultAndStatus(jobExecutionFut, notificationSender);
+
+            //noinspection DataFlowIssue
+            return jobExecutionFut.thenCompose(JobExecution::idAsync).thenAccept(out::packUuid);
+        }));
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteColocatedRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteColocatedRequest.java
@@ -72,10 +72,12 @@ public class ClientComputeExecuteColocatedRequest {
                     options,
                     args);
 
-            sendResultAndStatus(jobExecutionFut, notificationSender);
+            var jobExecution = compute.wrapJobExecutionFuture(jobExecutionFut);
+
+            sendResultAndStatus(jobExecution, notificationSender);
 
             // noinspection DataFlowIssue
-            return jobExecutionFut.thenCompose(JobExecution::idAsync).thenAccept(out::packUuid);
+            return jobExecution.idAsync().thenAccept(out::packUuid);
         }));
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteRequest.java
@@ -66,7 +66,7 @@ public class ClientComputeExecuteRequest {
         JobExecution<Object> execution = compute.executeAsyncWithFailover(candidates, deploymentUnits, jobClassName, options, args);
         sendResultAndStatus(execution, notificationSender);
 
-        //noinspection DataFlowIssue
+        // noinspection DataFlowIssue
         return execution.idAsync().thenAccept(out::packUuid);
     }
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteRequest.java
@@ -105,10 +105,6 @@ public class ClientComputeExecuteRequest {
                         }, err)));
     }
 
-    static void sendResultAndStatus(CompletableFuture<JobExecution<Object>> executionFut, NotificationSender notificationSender) {
-        executionFut.thenCompose(execution -> sendResultAndStatus(execution, notificationSender));
-    }
-
     /**
      * Unpacks args.
      *

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/compute/ClientComputeExecuteRequest.java
@@ -94,13 +94,13 @@ public class ClientComputeExecuteRequest {
         return nodes;
     }
 
-    static void sendResultAndStatus(JobExecution<Object> execution, NotificationSender notificationSender) {
-        execution.resultAsync().whenComplete((val, err) ->
+    static void sendResultAndStatus(CompletableFuture<JobExecution<Object>> executionFut, NotificationSender notificationSender) {
+        executionFut.thenCompose(execution -> execution.resultAsync().whenComplete((val, err) ->
                 execution.statusAsync().whenComplete((status, errStatus) ->
                         notificationSender.sendNotification(w -> {
                             w.packObjectAsBinaryTuple(val);
                             packJobStatus(w, status);
-                        }, err)));
+                        }, err))));
     }
 
     /**

--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeCompute.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeCompute.java
@@ -42,6 +42,7 @@ import org.apache.ignite.compute.JobExecutionOptions;
 import org.apache.ignite.compute.JobState;
 import org.apache.ignite.compute.JobStatus;
 import org.apache.ignite.internal.compute.IgniteComputeInternal;
+import org.apache.ignite.internal.table.TableViewInternal;
 import org.apache.ignite.internal.util.ExceptionUtils;
 import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.table.Tuple;
@@ -102,6 +103,13 @@ public class FakeCompute implements IgniteComputeInternal {
         }
 
         return jobExecution(future != null ? future : completedFuture((R) nodeName));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <R> CompletableFuture<JobExecution<R>> submitColocatedInternal(TableViewInternal table, Tuple key, List<DeploymentUnit> units,
+            String jobClassName, JobExecutionOptions options, Object[] args) {
+        return completedFuture(jobExecution(future != null ? future : completedFuture((R) nodeName)));
     }
 
     /** {@inheritDoc} */

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeImpl.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeImpl.java
@@ -236,8 +236,9 @@ public class IgniteComputeImpl implements IgniteComputeInternal {
         );
     }
 
+    /** {@inheritDoc} */
     @Override
-    public  <R> CompletableFuture<JobExecution<R>> submitColocatedInternal(
+    public <R> CompletableFuture<JobExecution<R>> submitColocatedInternal(
             TableViewInternal table,
             Tuple key,
             List<DeploymentUnit> units,

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeImpl.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeImpl.java
@@ -238,23 +238,6 @@ public class IgniteComputeImpl implements IgniteComputeInternal {
 
     /** {@inheritDoc} */
     @Override
-    public <R> CompletableFuture<JobExecution<R>> submitColocatedInternal(
-            TableViewInternal table,
-            Tuple key,
-            List<DeploymentUnit> units,
-            String jobClassName,
-            JobExecutionOptions options,
-            Object[] args) {
-        return primaryReplicaForPartitionByTupleKey(table, key)
-                .thenApply(primaryNode -> executeOnOneNodeWithFailover(
-                        primaryNode,
-                        new NextColocatedWorkerSelector<>(placementDriver, topologyService, clock, table, key),
-                        units, jobClassName, options, args
-                ));
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public <K, R> JobExecution<R> submitColocated(
             String tableName,
             K key,
@@ -316,6 +299,23 @@ public class IgniteComputeImpl implements IgniteComputeInternal {
         } catch (CompletionException e) {
             throw ExceptionUtils.sneakyThrow(mapToPublicException(unwrapCause(e)));
         }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <R> CompletableFuture<JobExecution<R>> submitColocatedInternal(
+            TableViewInternal table,
+            Tuple key,
+            List<DeploymentUnit> units,
+            String jobClassName,
+            JobExecutionOptions options,
+            Object[] args) {
+        return primaryReplicaForPartitionByTupleKey(table, key)
+                .thenApply(primaryNode -> executeOnOneNodeWithFailover(
+                        primaryNode,
+                        new NextColocatedWorkerSelector<>(placementDriver, topologyService, clock, table, key),
+                        units, jobClassName, options, args
+                ));
     }
 
     private CompletableFuture<TableViewInternal> requiredTable(String tableName) {

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeInternal.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeInternal.java
@@ -79,6 +79,17 @@ public interface IgniteComputeInternal extends IgniteCompute {
             Object[] args);
 
     /**
+     * Wraps the given future into a job execution object.
+     *
+     * @param fut Future to wrap.
+     * @return Job execution object.
+     * @param <R> Job result type.
+     */
+    default <R> JobExecution<R> wrapJobExecutionFuture(CompletableFuture<JobExecution<R>> fut) {
+        return new JobExecutionFutureWrapper<>(fut);
+    }
+
+    /**
      * Retrieves the current status of all jobs on all nodes in the cluster.
      *
      * @return The collection of job statuses.

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeInternal.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeInternal.java
@@ -82,8 +82,8 @@ public interface IgniteComputeInternal extends IgniteCompute {
      * Wraps the given future into a job execution object.
      *
      * @param fut Future to wrap.
-     * @return Job execution object.
      * @param <R> Job result type.
+     * @return Job execution object.
      */
     default <R> JobExecution<R> wrapJobExecutionFuture(CompletableFuture<JobExecution<R>> fut) {
         return new JobExecutionFutureWrapper<>(fut);

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeInternal.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeInternal.java
@@ -28,7 +28,9 @@ import org.apache.ignite.compute.IgniteCompute;
 import org.apache.ignite.compute.JobExecution;
 import org.apache.ignite.compute.JobExecutionOptions;
 import org.apache.ignite.compute.JobStatus;
+import org.apache.ignite.internal.table.TableViewInternal;
 import org.apache.ignite.network.ClusterNode;
+import org.apache.ignite.table.Tuple;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -54,6 +56,27 @@ public interface IgniteComputeInternal extends IgniteCompute {
             JobExecutionOptions options,
             Object... args
     );
+
+    /**
+     * Submits a job of the given class for the execution on the node where the given key is located. The node is a leader of the
+     * corresponding RAFT group.
+     *
+     * @param table Table whose key is used to determine the node to execute the job on.
+     * @param key Key that identifies the node to execute the job on.
+     * @param units Deployment units. Can be empty.
+     * @param jobClassName Name of the job class to execute.
+     * @param options job execution options (priority, max retries).
+     * @param args Arguments of the job.
+     * @param <R> Job result type.
+     * @return Job execution object.
+     */
+    <R> CompletableFuture<JobExecution<R>> submitColocatedInternal(
+            TableViewInternal table,
+            Tuple key,
+            List<DeploymentUnit> units,
+            String jobClassName,
+            JobExecutionOptions options,
+            Object[] args);
 
     /**
      * Retrieves the current status of all jobs on all nodes in the cluster.

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -643,6 +643,15 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
         testEchoArg(BigInteger.TEN);
     }
 
+    @Test
+    void testExecuteColocatedEscapedTableName() {
+        var session = client().sql().sessionBuilder().build();
+        session.execute(null, "CREATE TABLE \"TBL ABC\" (key INT PRIMARY KEY, val INT)");
+
+        var tableName = "TBL ABC";
+        client().compute().executeColocated(tableName, Tuple.create().set("key", 1), List.of(), NodeNameJob.class.getName());
+    }
+
     private void testEchoArg(Object arg) {
         Object res = client().compute().execute(Set.of(node(0)), List.of(), EchoJob.class.getName(), arg, arg.toString());
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -648,7 +648,7 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
         var session = client().sql().sessionBuilder().build();
         session.execute(null, "CREATE TABLE \"TBL ABC\" (key INT PRIMARY KEY, val INT)");
 
-        var tableName = "TBL ABC";
+        var tableName = "\"TBL ABC\"";
         client().compute().executeColocated(tableName, Tuple.create().set("key", 1), List.of(), NodeNameJob.class.getName());
     }
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -645,10 +645,10 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
 
     @Test
     void testExecuteColocatedEscapedTableName() {
-        var session = client().sql().sessionBuilder().build();
-        session.execute(null, "CREATE TABLE \"TBL ABC\" (key INT PRIMARY KEY, val INT)");
-
         var tableName = "\"TBL ABC\"";
+        var session = client().sql().sessionBuilder().build();
+        session.execute(null, "CREATE TABLE " + tableName + " (key INT PRIMARY KEY, val INT)");
+
         client().compute().executeColocated(tableName, Tuple.create().set("key", 1), List.of(), NodeNameJob.class.getName());
     }
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -649,7 +649,14 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
         var session = client().sql().sessionBuilder().build();
         session.execute(null, "CREATE TABLE " + tableName + " (key INT PRIMARY KEY, val INT)");
 
-        client().compute().executeColocated(tableName, Tuple.create().set("key", 1), List.of(), NodeNameJob.class.getName());
+        Mapper<TestPojo> mapper = Mapper.of(TestPojo.class);
+        TestPojo pojoKey = new TestPojo(1);
+        Tuple tupleKey = Tuple.create().set("key", pojoKey.key);
+
+        var tupleRes = client().compute().executeColocated(tableName, tupleKey, List.of(), NodeNameJob.class.getName());
+        var pojoRes = client().compute().executeColocated(tableName, pojoKey, mapper, List.of(), NodeNameJob.class.getName());
+
+        assertEquals(tupleRes, pojoRes);
     }
 
     private void testEchoArg(Object arg) {


### PR DESCRIPTION
**Problem**: `ClientComputeExecuteColocatedRequest` retrieves the table by id, then passes the (unquoted) name to `submitColocated`, which fails.

**Fix**: we already get the table by id, no need to use the name. Extract `IgniteComputeInternal.submitColocatedInternal` method and pass the table directly.