### PR TITLE
IGNITE-18258 .NET: LINQ: Clean up inlineConstArgs logic

### DIFF
--- a/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/BinaryTupleBuilder.java
+++ b/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/BinaryTupleBuilder.java
@@ -315,6 +315,8 @@ public class BinaryTupleBuilder {
      * @return {@code this} for chaining.
      */
     public BinaryTupleBuilder appendDecimalNotNull(BigDecimal value, int scale) {
+        // TODO: Inefficient serialization, we should store the unscaled value and scale separately.
+        // Otherwise for big values with lots of trailing zeros we will waste a lot of space.
         putBytes(value.setScale(scale, RoundingMode.HALF_UP).unscaledValue().toByteArray());
         return proceed();
     }

--- a/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/BinaryTupleBuilder.java
+++ b/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/BinaryTupleBuilder.java
@@ -315,8 +315,7 @@ public class BinaryTupleBuilder {
      * @return {@code this} for chaining.
      */
     public BinaryTupleBuilder appendDecimalNotNull(BigDecimal value, int scale) {
-        // TODO: Inefficient serialization, we should store the unscaled value and scale separately.
-        // Otherwise for big values with lots of trailing zeros we will waste a lot of space.
+        // TODO IGNITE-21745: Inefficient serialization, many bytes wasted to store small values when scale is big.
         putBytes(value.setScale(scale, RoundingMode.HALF_UP).unscaledValue().toByteArray());
         return proceed();
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
@@ -37,6 +37,7 @@ public partial class LinqTests
                 Long = (long?)x.Val,
                 Float = (float?)x.Val / 1000,
                 Double = (double?)x.Val / 2000,
+                Decimal0 = (decimal?)x.Val / 7,
             })
             .OrderByDescending(x => x.Long);
 
@@ -47,6 +48,7 @@ public partial class LinqTests
         Assert.AreEqual(900, res[0].Long);
         Assert.AreEqual(900f / 1000, res[0].Float);
         Assert.AreEqual(900d / 2000, res[0].Double);
+        Assert.AreEqual(900m / 7, res[0].Decimal0);
 
         StringAssert.Contains(
             "select cast((_T0.VAL / ?) as tinyint) as BYTE, cast(_T0.VAL as smallint) as SHORT, cast(_T0.VAL as bigint) as LONG, " +

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
@@ -37,10 +37,13 @@ public partial class LinqTests
                 Long = (long?)x.Val,
                 Float = (float?)x.Val / 1000,
                 Double = (double?)x.Val / 2000,
-                Decimal0 = (decimal?)x.Val / 7,
+                Decimal0 = (decimal?)x.Val / 7.7m,
             })
             .OrderByDescending(x => x.Long);
 
+
+        // TODO: Specify scale when casting to decimal:
+        var x = Client.Sql.ExecuteAsync(null, "select cast(10 as decimal(4,2)) / 3").Result.SingleAsync().AsTask().Result;
         var res = query.ToList();
 
         Assert.AreEqual(90, res[0].Byte);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
@@ -17,7 +17,6 @@
 
 namespace Apache.Ignite.Tests.Linq;
 
-using System;
 using System.Linq;
 using NUnit.Framework;
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Tests.Linq;
 
 using System.Linq;
+using System.Numerics;
 using NUnit.Framework;
 
 /// <summary>
@@ -28,7 +29,6 @@ public partial class LinqTests
     [Test]
     public void TestProjectionWithCastIntoAnonymousType()
     {
-        // TODO IGNITE-18258 decimal, BigInteger.
         // ReSharper disable once RedundantCast
         var query = PocoIntView.AsQueryable()
             .Select(x => new
@@ -38,7 +38,8 @@ public partial class LinqTests
                 Long = (long?)x.Val,
                 Float = (float?)x.Val / 1000,
                 Double = (double?)x.Val / 2000,
-                Decimal0 = (decimal?)x.Val / 200m
+                Decimal0 = (decimal?)x.Val / 200m,
+                BigInt = (BigInteger?)x.Val
             })
             .OrderByDescending(x => x.Long);
 
@@ -53,6 +54,8 @@ public partial class LinqTests
         // TODO IGNITE-21743 Cast to decimal loses precision: "Expected: 4.5m But was: 5m"
         // Assert.AreEqual(900m / 200, res[0].Decimal0);
         Assert.AreEqual(5m, res[0].Decimal0);
+
+        Assert.AreEqual(new BigInteger(900m), res[0].BigInt);
 
         StringAssert.Contains(
             "select cast((_T0.VAL / ?) as tinyint) as BYTE, " +

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
@@ -39,15 +39,15 @@ public partial class LinqTests
                 Long = (long?)x.Val,
                 Float = (float?)x.Val / 1000,
                 Double = (double?)x.Val / 2000,
-                Decimal0 = (decimal?)x.Val / 36m,
+                Decimal0 = (decimal?)x.Val / 36,
             })
             .OrderByDescending(x => x.Long);
 
         // TODO: This works, but in LINQ we get scale > 32000, why?
-        var x = Client.Sql.ExecuteAsync(null, "select cast(_T0.VAL as decimal(20,10)) / 33 from PUBLIC.TBL_INT32 as _T0")
-            .Result.SingleAsync().AsTask().Result;
-        Console.WriteLine(x);
-
+        // Because of the division we lose precision/scale from the cast.
+        // var x = Client.Sql.ExecuteAsync(null, "select cast(_T0.VAL as decimal(20,10)) / 33 from PUBLIC.TBL_INT32 as _T0")
+        //     .Result.SingleAsync().AsTask().Result;
+        // Console.WriteLine(x);
         var res = query.ToList();
 
         Assert.AreEqual(90, res[0].Byte);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
@@ -17,8 +17,8 @@
 
 namespace Apache.Ignite.Tests.Linq;
 
+using System;
 using System.Linq;
-using System.Numerics;
 using NUnit.Framework;
 
 /// <summary>
@@ -29,6 +29,7 @@ public partial class LinqTests
     [Test]
     public void TestProjectionWithCastIntoAnonymousType()
     {
+        // BigInteger is not suppoerted by the SQL engine.
         // ReSharper disable once RedundantCast
         var query = PocoIntView.AsQueryable()
             .Select(x => new
@@ -38,8 +39,7 @@ public partial class LinqTests
                 Long = (long?)x.Val,
                 Float = (float?)x.Val / 1000,
                 Double = (double?)x.Val / 2000,
-                Decimal0 = (decimal?)x.Val / 200m,
-                BigInt = (BigInteger?)x.Val
+                Decimal0 = (decimal?)x.Val / 200m
             })
             .OrderByDescending(x => x.Long);
 
@@ -54,8 +54,6 @@ public partial class LinqTests
         // TODO IGNITE-21743 Cast to decimal loses precision: "Expected: 4.5m But was: 5m"
         // Assert.AreEqual(900m / 200, res[0].Decimal0);
         Assert.AreEqual(5m, res[0].Decimal0);
-
-        Assert.AreEqual(new BigInteger(900m), res[0].BigInt);
 
         StringAssert.Contains(
             "select cast((_T0.VAL / ?) as tinyint) as BYTE, " +

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Functions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Functions.cs
@@ -83,7 +83,7 @@ public partial class LinqTests
         TestOpDouble(x => Math.Exp(x.Key), 8103.0839275753842d, "select Exp(_T0.KEY) from");
         TestOpDouble(x => Math.Log(x.Key), 2.1972245773362196d, "select Ln(_T0.KEY) from");
         TestOpDouble(x => Math.Log10(x.Key), 0.95424250943932487d, "select Log10(_T0.KEY) from");
-        TestOpDouble(x => Math.Pow(x.Key, 2), 81, "select Power(_T0.KEY, 2) from");
+        TestOpDouble(x => Math.Pow(x.Key, 2), 81, "select Power(_T0.KEY, ?) from");
         TestOpDouble(x => Math.Round(x.Key / 5), 2, "select Round((_T0.KEY / ?)) from");
         TestOpDouble(x => Math.Sign(x.Key - 10), -1, "select Sign((_T0.KEY - ?)) from");
         TestOpDouble(x => Math.Sqrt(x.Key), 3.0d, "select Sqrt(_T0.KEY) from");
@@ -101,7 +101,7 @@ public partial class LinqTests
         TestOpString(x => x.Val!.ToLower(), "v-9", "select lower(_T0.VAL) from");
 
         TestOpString(x => x.Val!.Substring(1), "-9", "select substring(_T0.VAL, ? + 1) from");
-        TestOpString(x => x.Val!.Substring(0, 2), "v-", "select substring(_T0.VAL, 0 + 1, 2) from");
+        TestOpString(x => x.Val!.Substring(0, 2), "v-", "select substring(_T0.VAL, ? + 1, ?) from");
 
         TestOpString(x => x.Val!.Trim(), "v-9", "select trim(_T0.VAL) from");
         TestOpString(x => x.Val!.TrimStart(), "v-9", "select ltrim(_T0.VAL) from");

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -479,6 +479,11 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
                 // Special case for string concatenation.
                 ResultBuilder.Append(" as varchar)");
             }
+            else if ((Nullable.GetUnderlyingType(expression.Type) ?? expression.Type) == typeof(decimal))
+            {
+                // TODO IGNITE-21743 Cast to decimal loses precision: we should specify precision and scale here.
+                ResultBuilder.Append(" as decimal)");
+            }
             else
             {
                 ResultBuilder

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -483,7 +483,7 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
             {
                 // Use max precision and scale when performing cast to achieve expected behavior.
                 // Otherwise, zero scale leads to rounding.
-                ResultBuilder.Append(" as decimal(8, 4))");
+                ResultBuilder.Append(" as decimal(20, 10))");
             }
             else
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -479,6 +479,12 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
                 // Special case for string concatenation.
                 ResultBuilder.Append(" as varchar)");
             }
+            else if ((Nullable.GetUnderlyingType(expression.Type) ?? expression.Type) == typeof(decimal))
+            {
+                // Use max precision and scale when performing cast to achieve expected behavior.
+                // Otherwise, zero scale leads to rounding.
+                ResultBuilder.Append(" as decimal(8, 4))");
+            }
             else
             {
                 ResultBuilder

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -479,12 +479,6 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
                 // Special case for string concatenation.
                 ResultBuilder.Append(" as varchar)");
             }
-            else if ((Nullable.GetUnderlyingType(expression.Type) ?? expression.Type) == typeof(decimal))
-            {
-                // Use max precision and scale when performing cast to achieve expected behavior.
-                // Otherwise, zero scale leads to rounding.
-                ResultBuilder.Append(" as decimal(20, 10))");
-            }
             else
             {
                 ResultBuilder

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/MethodVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/MethodVisitor.cs
@@ -278,19 +278,7 @@ internal static class MethodVisitor
                 visitor.ResultBuilder.Append(", ");
             }
 
-            if (inlineConstArgs &&
-                arg is ConstantExpression constExpr &&
-                constExpr.Type.IsPrimitive &&
-                constExpr.Type != typeof(char))
-            {
-                // TODO IGNITE-18258 Remove this logic, we should be able to pass args as SQL params for all functions.
-                // We only allow inline for numeric types. Other types can lead to SQL injections.
-                visitor.ResultBuilder.Append(constExpr.Value);
-            }
-            else
-            {
-                visitor.Visit(arg);
-            }
+            visitor.Visit(arg);
 
             AppendAdjustment(visitor, adjust, i + 1);
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/MethodVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/MethodVisitor.cs
@@ -78,7 +78,7 @@ internal static class MethodVisitor
                 GetStringMethod(nameof(string.IndexOf), new[] {typeof(string)}, VisitPositionFunc),
                 GetStringMethod(nameof(string.IndexOf), new[] {typeof(string), typeof(int)}, VisitPositionFunc),
                 GetStringMethod(nameof(string.Substring), new[] {typeof(int)}, GetFunc("substring", 0, 1)),
-                GetStringMethod(nameof(string.Substring), new[] {typeof(int), typeof(int)}, GetFunc("substring", inlineConstArgs: true, 0, 1)),
+                GetStringMethod(nameof(string.Substring), new[] {typeof(int), typeof(int)}, GetFunc("substring", 0, 1)),
                 GetStringMethod(nameof(string.Trim), "trim"),
                 GetStringMethod(nameof(string.TrimStart), "ltrim"),
                 GetStringMethod(nameof(string.TrimEnd), "rtrim"),
@@ -97,7 +97,7 @@ internal static class MethodVisitor
                 GetRegexMethod(nameof(Regex.IsMatch), "regexp_like", typeof(string), typeof(string)),
                 GetRegexMethod(nameof(Regex.IsMatch), "regexp_like", typeof(string), typeof(string), typeof(RegexOptions)),
 
-                GetMethod(typeof(DateTime), "ToString", new[] {typeof(string)}, (e, v) => VisitFunc(e, v, "formatdatetime", ", 'en', 'UTC'", false)),
+                GetMethod(typeof(DateTime), "ToString", new[] {typeof(string)}, (e, v) => VisitFunc(e, v, "formatdatetime", ", 'en', 'UTC'")),
 
                 GetMathMethod(nameof(Math.Abs), typeof(int)),
                 GetMathMethod(nameof(Math.Abs), typeof(long)),
@@ -120,10 +120,10 @@ internal static class MethodVisitor
                 GetMathMethod(nameof(Math.Exp), typeof(double)),
                 GetMathMethod(nameof(Math.Floor), typeof(double)),
                 GetMathMethod(nameof(Math.Floor), typeof(decimal)),
-                GetMathMethod(nameof(Math.Log), "Ln", inlineCostArgs: false, typeof(double)),
+                GetMathMethod(nameof(Math.Log), "Ln", typeof(double)),
                 GetMathMethod(nameof(Math.Log10), typeof(double)),
                 GetMathMethod(nameof(Math.Log2), typeof(double)),
-                GetMathMethod(nameof(Math.Pow), "Power", inlineCostArgs: true, typeof(double), typeof(double)),
+                GetMathMethod(nameof(Math.Pow), "Power", typeof(double), typeof(double)),
                 GetMathMethod(nameof(Math.Round), typeof(double)),
                 GetMathMethod(nameof(Math.Round), typeof(double), typeof(int)),
                 GetMathMethod(nameof(Math.Round), typeof(decimal)),
@@ -241,13 +241,7 @@ internal static class MethodVisitor
     /// Gets the function.
     /// </summary>
     private static VisitMethodDelegate GetFunc(string func, params int[] adjust) =>
-        (e, v) => VisitFunc(e, v, func, null, false, adjust);
-
-    /// <summary>
-    /// Gets the function.
-    /// </summary>
-    private static VisitMethodDelegate GetFunc(string func, bool inlineConstArgs, params int[] adjust) =>
-        (e, v) => VisitFunc(e, v, func, null, inlineConstArgs, adjust);
+        (e, v) => VisitFunc(e, v, func, null, adjust);
 
     /// <summary>
     /// Visits the instance function.
@@ -257,7 +251,6 @@ internal static class MethodVisitor
         IgniteQueryExpressionVisitor visitor,
         string func,
         string? suffix,
-        bool inlineConstArgs,
         params int[] adjust)
     {
         visitor.ResultBuilder.Append(func).Append('(');
@@ -468,12 +461,11 @@ internal static class MethodVisitor
         Type type,
         string name,
         Type[]? argTypes = null,
-        VisitMethodDelegate? del = null,
-        bool inlineConstArgs = false)
+        VisitMethodDelegate? del = null)
     {
         var method = argTypes == null ? type.GetMethod(name) : type.GetMethod(name, argTypes);
 
-        return new KeyValuePair<MethodInfo?, VisitMethodDelegate>(method!, del ?? GetFunc(name, inlineConstArgs));
+        return new KeyValuePair<MethodInfo?, VisitMethodDelegate>(method!, del ?? GetFunc(name));
     }
 
     /// <summary>
@@ -535,13 +527,12 @@ internal static class MethodVisitor
     private static KeyValuePair<MethodInfo?, VisitMethodDelegate> GetMathMethod(
         string name,
         string sqlName,
-        bool inlineCostArgs,
         params Type[] argTypes) =>
-        GetMethod(typeof(Math), name, argTypes, GetFunc(sqlName, inlineCostArgs), inlineCostArgs);
+        GetMethod(typeof(Math), name, argTypes, GetFunc(sqlName));
 
     /// <summary>
     /// Gets the math method.
     /// </summary>
     private static KeyValuePair<MethodInfo?, VisitMethodDelegate> GetMathMethod(string name, params Type[] argTypes) =>
-        GetMathMethod(name, name, false, argTypes);
+        GetMathMethod(name, name, argTypes);
 }


### PR DESCRIPTION
`inlineConstArgs` workaround is no longer needed - SQL engine has been fixed. Remove the extra logic and TODOs, update tests, create and mention tickets for unrelated decimal issues.

https://issues.apache.org/jira/browse/IGNITE-18258