### PR TITLE
IGNITE-21764 Fix PersistentPageMemoryMvTableStorageTest.testIndexDestructionOnRecovery

### DIFF
--- a/modules/storage-api/src/testFixtures/java/org/apache/ignite/internal/storage/AbstractMvTableStorageTest.java
+++ b/modules/storage-api/src/testFixtures/java/org/apache/ignite/internal/storage/AbstractMvTableStorageTest.java
@@ -777,12 +777,13 @@ public abstract class AbstractMvTableStorageTest extends BaseMvStoragesTest {
         tableStorage = createMvTableStorage();
 
         mvPartitionStorage = getOrCreateMvPartition(PARTITION_ID);
-        hashIndexStorage = tableStorage.getOrCreateHashIndex(PARTITION_ID, hashIdx);
-        sortedIndexStorage = tableStorage.getOrCreateSortedIndex(PARTITION_ID, sortedIdx);
+        hashIndexStorage = (HashIndexStorage) tableStorage.getIndex(PARTITION_ID, hashIdx.id());
+        sortedIndexStorage = (SortedIndexStorage) tableStorage.getIndex(PARTITION_ID, sortedIdx.id());
 
         // Data should remain in the partition storages, but the indexes must be cleaned up.
         checkForPresenceRows(mvPartitionStorage, null, null, rows);
-        checkForMissingRows(null, hashIndexStorage, sortedIndexStorage, rows);
+        assertThat(hashIndexStorage, is(nullValue()));
+        assertThat(sortedIndexStorage, is(nullValue()));
     }
 
     private static void createTestTableAndIndexes(CatalogService catalogService) {

--- a/modules/storage-page-memory/src/main/java/org/apache/ignite/internal/storage/pagememory/index/meta/IndexMetaKey.java
+++ b/modules/storage-page-memory/src/main/java/org/apache/ignite/internal/storage/pagememory/index/meta/IndexMetaKey.java
@@ -38,4 +38,23 @@ public class IndexMetaKey {
     public int indexId() {
         return indexId;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        IndexMetaKey that = (IndexMetaKey) o;
+
+        return indexId == that.indexId;
+    }
+
+    @Override
+    public int hashCode() {
+        return indexId;
+    }
 }

--- a/modules/storage-page-memory/src/test/java/org/apache/ignite/internal/storage/pagememory/PersistentPageMemoryMvTableStorageTest.java
+++ b/modules/storage-page-memory/src/test/java/org/apache/ignite/internal/storage/pagememory/PersistentPageMemoryMvTableStorageTest.java
@@ -37,8 +37,6 @@ import org.apache.ignite.internal.testframework.WorkDirectoryExtension;
 import org.apache.ignite.internal.util.IgniteUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -93,12 +91,5 @@ public class PersistentPageMemoryMvTableStorageTest extends AbstractMvTableStora
                 engine.checkpointManager().forceCheckpoint("after-test-destroy-partition").futureFor(CheckpointState.FINISHED),
                 willCompleteSuccessfully()
         );
-    }
-
-    @Test
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-21764")
-    @Override
-    public void testIndexDestructionOnRecovery() throws Exception {
-        super.testIndexDestructionOnRecovery();
     }
 }

--- a/modules/storage-page-memory/src/test/java/org/apache/ignite/internal/storage/pagememory/mv/PageMemoryIndexesTest.java
+++ b/modules/storage-page-memory/src/test/java/org/apache/ignite/internal/storage/pagememory/mv/PageMemoryIndexesTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.storage.pagememory.mv;
+
+import static org.apache.ignite.internal.util.CompletableFutures.nullCompletedFuture;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.ForkJoinPool;
+import org.apache.ignite.internal.lang.IgniteInternalCheckedException;
+import org.apache.ignite.internal.pagememory.util.GradualTaskExecutor;
+import org.apache.ignite.internal.storage.MvPartitionStorage.Locker;
+import org.apache.ignite.internal.storage.index.StorageHashIndexDescriptor;
+import org.apache.ignite.internal.storage.index.StorageSortedIndexDescriptor;
+import org.apache.ignite.internal.storage.pagememory.index.hash.PageMemoryHashIndexStorage;
+import org.apache.ignite.internal.storage.pagememory.index.meta.IndexMeta;
+import org.apache.ignite.internal.storage.pagememory.index.meta.IndexMeta.IndexType;
+import org.apache.ignite.internal.storage.pagememory.index.meta.IndexMetaKey;
+import org.apache.ignite.internal.storage.pagememory.index.meta.IndexMetaTree;
+import org.apache.ignite.internal.storage.pagememory.index.sorted.PageMemorySortedIndexStorage;
+import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
+import org.apache.ignite.internal.util.Cursor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Contains tests for {@link PageMemoryIndexes}. */
+@ExtendWith(MockitoExtension.class)
+class PageMemoryIndexesTest extends BaseIgniteAbstractTest {
+    private final GradualTaskExecutor taskExecutor = new GradualTaskExecutor(ForkJoinPool.commonPool());
+
+    private PageMemoryIndexes indexes;
+
+    @BeforeEach
+    void setUp(@Mock Locker locker) {
+        indexes = new PageMemoryIndexes(taskExecutor, closure -> closure.execute(locker));
+    }
+
+    @AfterEach
+    void tearDown() {
+        taskExecutor.close();
+    }
+
+    @Test
+    void testIndexesDestroyedOnRecovery(
+            @Mock StorageSortedIndexDescriptor sortedIndexDescriptor,
+            @Mock PageMemorySortedIndexStorage sortedIndexStorage,
+            @Mock StorageHashIndexDescriptor hashIndexDescriptor,
+            @Mock PageMemoryHashIndexStorage hashIndexStorage,
+            @Mock IndexMetaTree indexMetaTree,
+            @Mock(answer = Answers.RETURNS_DEEP_STUBS) IndexStorageFactory indexStorageFactory
+    ) throws IgniteInternalCheckedException {
+        int sortedIndexId = 0;
+
+        when(sortedIndexDescriptor.id()).thenReturn(sortedIndexId);
+        when(sortedIndexStorage.transitionToDestroyedState()).thenReturn(true);
+        when(sortedIndexStorage.startDestructionOn(taskExecutor)).thenReturn(nullCompletedFuture());
+        when(indexStorageFactory.restoreSortedIndexStorageForDestroy(any())).thenReturn(sortedIndexStorage);
+
+        int hashIndexId = 1;
+
+        when(hashIndexDescriptor.id()).thenReturn(hashIndexId);
+        when(hashIndexStorage.transitionToDestroyedState()).thenReturn(true);
+        when(hashIndexStorage.startDestructionOn(taskExecutor)).thenReturn(nullCompletedFuture());
+        when(indexStorageFactory.restoreHashIndexStorageForDestroy(any())).thenReturn(hashIndexStorage);
+
+        when(indexMetaTree.find(null, null))
+                .thenReturn(Cursor.fromIterable(List.of(
+                        new IndexMeta(sortedIndexId, IndexType.SORTED, 0, null),
+                        new IndexMeta(hashIndexId, IndexType.HASH, 0, null)
+                )));
+
+        indexes.getOrCreateSortedIndex(sortedIndexDescriptor, indexStorageFactory);
+        indexes.getOrCreateHashIndex(hashIndexDescriptor, indexStorageFactory);
+
+        indexes.performRecovery(indexMetaTree, indexStorageFactory, indexId -> null);
+
+        verify(sortedIndexStorage).startDestructionOn(any());
+        verify(hashIndexStorage).startDestructionOn(any());
+
+        verify(indexMetaTree, timeout(1_000)).removex(new IndexMetaKey(sortedIndexId));
+        verify(indexMetaTree, timeout(1_000)).removex(new IndexMetaKey(hashIndexId));
+    }
+}


### PR DESCRIPTION
Storage does not expect that an index with the same ID will be created concurrently with being dropped.

https://issues.apache.org/jira/browse/IGNITE-21764

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)