### PR TITLE
IGNITE-21722 Fix NPE in correlated nested loop join

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/rel/CorrelatedNestedLoopJoinNode.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/rel/CorrelatedNestedLoopJoinNode.java
@@ -406,11 +406,11 @@ public class CorrelatedNestedLoopJoinNode<RowT> extends AbstractNode<RowT> {
             }
 
             if (joinType == JoinRelType.LEFT && !nullOrEmpty(leftInBuf)) {
+                int notMatchedIdx = leftMatched.nextClearBit(0);
+
                 state = State.IN_LOOP;
 
                 try {
-                    int notMatchedIdx = leftMatched.nextClearBit(0);
-
                     while (requested > 0 && notMatchedIdx < leftInBuf.size()) {
                         requested--;
 
@@ -420,12 +420,12 @@ public class CorrelatedNestedLoopJoinNode<RowT> extends AbstractNode<RowT> {
 
                         notMatchedIdx = leftMatched.nextClearBit(notMatchedIdx + 1);
                     }
-
-                    if (requested == 0 && notMatchedIdx < leftInBuf.size()) {
-                        return; // Some rows required to be pushed, wait for request.
-                    }
                 } finally {
                     state = State.IDLE;
+                }
+
+                if (requested == 0 && notMatchedIdx < leftInBuf.size()) {
+                    return; // Some rows required to be pushed, wait for request.
                 }
             }
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/ExecutionTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/ExecutionTest.java
@@ -496,8 +496,11 @@ public class ExecutionTest extends AbstractExecutionTest<Object[]> {
 
         join.register(Arrays.asList(left, right));
 
+        FilterNode<Object[]> filter = new FilterNode<>(ctx, r -> true);
+        filter.register(join);
+
         RootNode<Object[]> root = new RootNode<>(ctx);
-        root.register(join);
+        root.register(filter);
 
         int cnt = 0;
         while (root.hasNext()) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-21722

The problem occurs because for the left join we have not protected the loop that pushes the rows to downstream.

The following sequence occurs (**in case of disabled assertions**):

1. `CorrelatedNestedLoopJoinNode` pushes last row to downstream (FilterNode). See `joinType == JoinRelType.LEFT` branch in `join()` method.
2. `FilterNode` receives last requested row and tries to request next batch from the upstream (CorrelatedNestedLoopJoinNode).
3. `CorrelatedNestedLoopJoinNode` is in IDLE state (which is incorrect), so it submits `join()` to the execution queue.
4. `CorrelatedNestedLoopJoinNode` resets `rightInBuf`, changes state to FILLING_LEFT and requests rows from `leftsource()`.
5. Previously submitted `join()` starts executing and crashes with `NullPointerException`, because `rightInBuf` is null.