### PR TITLE
IGNITE-21765 Fix streamer partition awareness

### DIFF
--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientPrimaryReplicaTracker.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientPrimaryReplicaTracker.java
@@ -384,7 +384,7 @@ public class ClientPrimaryReplicaTracker {
 
         private final long timestamp;
 
-        public PrimaryReplicasResult(int partitions) {
+        PrimaryReplicasResult(int partitions) {
             this.partitions = partitions;
             this.nodeNames = null;
             this.timestamp = 0;

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientPrimaryReplicaTracker.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientPrimaryReplicaTracker.java
@@ -166,7 +166,7 @@ public class ClientPrimaryReplicaTracker {
         }
 
         // Request primary for all partitions.
-        CompletableFuture<Void> partitionsFut = partitionsAsync(tableId, timestamp).thenCompose(partitions -> {
+        CompletableFuture<Integer> partitionsFut = partitionsAsync(tableId, timestamp).thenCompose(partitions -> {
             CompletableFuture<?>[] futures = new CompletableFuture<?>[partitions];
 
             for (int partition = 0; partition < partitions; partition++) {
@@ -179,13 +179,13 @@ public class ClientPrimaryReplicaTracker {
                 });
             }
 
-            return CompletableFuture.allOf(futures);
+            return CompletableFuture.allOf(futures).thenApply(v -> partitions);
         });
 
         // Wait for all futures, check condition again.
         // Give up (return null) if we don't have replicas with specified maxStartTime - the client will retry later.
         long maxStartTime0 = maxStartTime;
-        return partitionsFut.handle((v, err) -> {
+        return partitionsFut.handle((partitions, err) -> {
             if (err != null) {
                 var cause = ExceptionUtils.unwrapCause(err);
 
@@ -196,7 +196,13 @@ public class ClientPrimaryReplicaTracker {
                 assert false : "Unexpected error: " + err;
             }
 
-            return primaryReplicasNoWait(tableId, maxStartTime0, timestamp, true);
+            PrimaryReplicasResult res = primaryReplicasNoWait(tableId, maxStartTime0, timestamp, true);
+            if (res != null) {
+                return res;
+            }
+
+            // Return partition count to the client so that batching can be initialized.
+            return new PrimaryReplicasResult(partitions);
         });
     }
 
@@ -371,21 +377,35 @@ public class ClientPrimaryReplicaTracker {
      * Primary replicas per partition with timestamp.
      */
     public static class PrimaryReplicasResult {
+        private final int partitions;
+
+        @Nullable
         private final List<String> nodeNames;
 
         private final long timestamp;
 
+        public PrimaryReplicasResult(int partitions) {
+            this.partitions = partitions;
+            this.nodeNames = null;
+            this.timestamp = 0;
+        }
+
         PrimaryReplicasResult(List<String> nodeNames, long timestamp) {
+            this.partitions = nodeNames.size();
             this.nodeNames = nodeNames;
             this.timestamp = timestamp;
         }
 
-        public List<String> nodeNames() {
+        public @Nullable List<String> nodeNames() {
             return nodeNames;
         }
 
         public long timestamp() {
             return timestamp;
+        }
+
+        public int partitions() {
+            return partitions;
         }
     }
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTablePartitionPrimaryReplicasGetRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/table/ClientTablePartitionPrimaryReplicasGetRequest.java
@@ -32,8 +32,8 @@ public class ClientTablePartitionPrimaryReplicasGetRequest {
     /**
      * Processes the request.
      *
-     * @param in      Unpacker.
-     * @param out     Packer.
+     * @param in Unpacker.
+     * @param out Packer.
      * @param tracker Replica tracker.
      * @return Future.
      * @throws IgniteException When schema registry is no initialized.
@@ -47,15 +47,19 @@ public class ClientTablePartitionPrimaryReplicasGetRequest {
         long timestamp = in.unpackLong();
 
         return tracker.primaryReplicasAsync(tableId, timestamp).thenAccept(primaryReplicas -> {
-            if (primaryReplicas == null) {
-                out.packInt(0);
-            } else {
-                out.packInt(primaryReplicas.nodeNames().size());
-                out.packLong(primaryReplicas.timestamp());
+            assert primaryReplicas != null : "Primary replicas == null";
 
-                for (String nodeName : primaryReplicas.nodeNames()) {
-                    out.packString(nodeName);
-                }
+            if (primaryReplicas.nodeNames() == null) {
+                // Special case: assignment is not yet available, but we return the partition count.
+                out.packInt(primaryReplicas.partitions());
+                out.packInt(0);
+            }
+
+            out.packInt(primaryReplicas.nodeNames().size());
+            out.packLong(primaryReplicas.timestamp());
+
+            for (String nodeName : primaryReplicas.nodeNames()) {
+                out.packString(nodeName);
             }
         });
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -236,6 +236,7 @@ namespace Apache.Ignite.Tests
                         using var arrayBufferWriter = new PooledArrayBuffer();
                         var writer = new MsgPackWriter(arrayBufferWriter);
                         writer.Write(PartitionAssignment.Length);
+                        writer.Write(true); // Assignment available.
                         writer.Write(DateTime.UtcNow.Ticks); // Timestamp
 
                         foreach (var nodeId in PartitionAssignment)

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
@@ -67,7 +67,7 @@ internal static class DataStreamer
         Func<PooledArrayBuffer, int, string, IRetryPolicy, Task> sender,
         RecordSerializer<T> writer,
         Func<int?, Task<Schema>> schemaProvider, // Not a ValueTask because Tasks are cached.
-        Func<ValueTask<string?[]?>> partitionAssignmentProvider,
+        Func<ValueTask<string?[]>> partitionAssignmentProvider,
         DataStreamerOptions options,
         CancellationToken cancellationToken)
     {
@@ -187,9 +187,7 @@ internal static class DataStreamer
 
             // ReSharper disable once AccessToModifiedClosure (reviewed)
             var partitionAssignment0 = partitionAssignment;
-            var partition = partitionAssignment0 == null
-                ? string.Empty // Default connection.
-                : partitionAssignment0[Math.Abs(tupleBuilder.GetHash() % partitionAssignment0.Length)] ?? string.Empty;
+            var partition = partitionAssignment0[Math.Abs(tupleBuilder.GetHash() % partitionAssignment0.Length)] ?? string.Empty;
 
             var batch = GetOrCreateBatch(partition);
 

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItKvKeyColumnPositionTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItKvKeyColumnPositionTest.java
@@ -67,22 +67,16 @@ public class ItKvKeyColumnPositionTest extends BaseSqlIntegrationTest {
     private KeyValueView<String, IntBoolDate> serverSimpleValKey;
 
     // client
-    // TODO https://issues.apache.org/jira/browse/IGNITE-21768
-    @SuppressWarnings("unused")
     private KeyValueView<IntString, BoolInt> clientValKey;
 
-    @SuppressWarnings("unused")
     private KeyValueView<IntString, BoolInt> clientKeyVal;
 
-    @SuppressWarnings("unused")
     private KeyValueView<IntString, BoolInt> clientValKeyFlipped;
 
-    @SuppressWarnings("unused")
     private KeyValueView<IntString, BoolInt> clientKeyValFlipped;
 
     private KeyValueView<String, IntBoolDate> clientSimpleKeyVal;
 
-    @SuppressWarnings("unused")
     private KeyValueView<String, IntBoolDate> clientSimpleValKey;
 
     private IgniteClient client;
@@ -111,7 +105,6 @@ public class ItKvKeyColumnPositionTest extends BaseSqlIntegrationTest {
         serverSimpleValKey = serverTables.table("simple_val_key").keyValueView(Mapper.of(String.class), Mapper.of(IntBoolDate.class));
 
         // CLIENT
-
         String addressString = "127.0.0.1:" + igniteImpl.clientAddress().port();
 
         client = IgniteClient.builder().addresses(addressString).build();
@@ -137,28 +130,24 @@ public class ItKvKeyColumnPositionTest extends BaseSqlIntegrationTest {
     }
 
     private List<Arguments> complexKeyKvs() {
-        // TODO https://issues.apache.org/jira/browse/IGNITE-21768
-        // Arguments.of(Named.named("client key_val_key", clientKeyVal)),
-        // Arguments.of(Named.named("client key_val_key_flipped", clientKeyValFlipped)),
-        // Arguments.of(Named.named("client val_key_val_key", clientValKey)),
-        // Arguments.of(Named.named("client val_key_val_key", clientValKeyFlipped))
-
         return List.of(
                 Arguments.of(Named.named("server key_val_key", serverKeyVal)),
                 Arguments.of(Named.named("server key_val_key_flipped", serverKeyValFlipped)),
                 Arguments.of(Named.named("server val_key_val_key", serverValKey)),
-                Arguments.of(Named.named("server val_key_val_key_flipped", serverValKeyFlipped))
+                Arguments.of(Named.named("server val_key_val_key_flipped", serverValKeyFlipped)),
+                Arguments.of(Named.named("client key_val_key", clientKeyVal)),
+                Arguments.of(Named.named("client key_val_key_flipped", clientKeyValFlipped)),
+                Arguments.of(Named.named("client val_key_val_key", clientValKey)),
+                Arguments.of(Named.named("client val_key_val_key", clientValKeyFlipped))
         );
     }
 
     private List<Arguments> simpleKeyKvs() {
-        // TODO https://issues.apache.org/jira/browse/IGNITE-21768
-        // Arguments.of(Named.named("client simple val key", clientSimpleValKey))
-
         return List.of(
                 Arguments.of(Named.named("server simple key val", serverSimpleKeyVal)),
                 Arguments.of(Named.named("server simple val key", serverSimpleValKey)),
-                Arguments.of(Named.named("client simple key val", clientSimpleKeyVal))
+                Arguments.of(Named.named("client simple key val", clientSimpleKeyVal)),
+                Arguments.of(Named.named("client simple val key", clientSimpleValKey))
         );
     }
 
@@ -203,11 +192,9 @@ public class ItKvKeyColumnPositionTest extends BaseSqlIntegrationTest {
     }
 
     private List<Arguments> nullableKvsSimple() {
-        // TODO https://issues.apache.org/jira/browse/IGNITE-21768
-        // Arguments.of(Named.named("client", clientSimpleKeyVal))
-
         return List.of(
-                Arguments.of(Named.named("server", serverSimpleValKey))
+                Arguments.of(Named.named("server", serverSimpleValKey)),
+                Arguments.of(Named.named("client", clientSimpleKeyVal))
         );
     }
 


### PR DESCRIPTION
Always return partition count from `ClientTablePartitionPrimaryReplicasGetRequest`, even when assignment is not available, so that per-partition batches can be initialized.

Before that we could end up with 0 partitions in `DataStreamer`, resulting in broken awareness.

Also: Fix TODOs for closed IGNITE-21768