### PR TITLE
IGNITE-21989 Get topology in the JDBC URL completer directly

### DIFF
--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/core/repl/executor/ItIgnitePicocliCommandsTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/core/repl/executor/ItIgnitePicocliCommandsTest.java
@@ -389,11 +389,10 @@ public class ItIgnitePicocliCommandsTest extends CliIntegrationTest {
 
         // When stop one node
         CLUSTER.stopNode(nodeIndex);
-        var actualNodeNames = allNodeNames();
-        actualNodeNames.remove(igniteNodeName);
+        assertThat(allNodeNames(), not(hasItem(igniteNodeName)));
 
         // Then node name suggestions does not contain the stopped node
-        await().until(() -> complete(givenParsedLine), containsInAnyOrder(actualNodeNames.toArray()));
+        await().until(() -> complete(givenParsedLine), containsInAnyOrder(allNodeNames().toArray()));
 
         // When start the node again
         CLUSTER.startNode(nodeIndex);

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/JdbcUrlRegistryImpl.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/JdbcUrlRegistryImpl.java
@@ -21,16 +21,18 @@ import jakarta.inject.Singleton;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.ignite.internal.cli.call.cluster.topology.PhysicalTopologyCall;
 import org.apache.ignite.internal.cli.core.JdbcUrlFactory;
+import org.apache.ignite.internal.cli.core.call.UrlCallInput;
 import org.apache.ignite.internal.cli.core.repl.PeriodicSessionTask;
 import org.apache.ignite.internal.cli.core.repl.SessionInfo;
 import org.apache.ignite.internal.cli.core.repl.registry.JdbcUrlRegistry;
-import org.apache.ignite.internal.cli.core.repl.registry.NodeNameRegistry;
 import org.apache.ignite.internal.cli.core.rest.ApiClientFactory;
 import org.apache.ignite.internal.cli.logger.CliLoggers;
 import org.apache.ignite.internal.logger.IgniteLogger;
 import org.apache.ignite.rest.client.api.NodeManagementApi;
 import org.apache.ignite.rest.client.invoker.ApiException;
+import org.apache.ignite.rest.client.model.ClusterNode;
 import org.apache.ignite.rest.client.model.NodeInfo;
 import org.jetbrains.annotations.Nullable;
 
@@ -40,7 +42,7 @@ public class JdbcUrlRegistryImpl implements JdbcUrlRegistry, PeriodicSessionTask
 
     private static final IgniteLogger LOG = CliLoggers.forClass(JdbcUrlRegistryImpl.class);
 
-    private final NodeNameRegistry nodeNameRegistry;
+    private final PhysicalTopologyCall physicalTopologyCall;
 
     private final ApiClientFactory clientFactory;
 
@@ -49,15 +51,15 @@ public class JdbcUrlRegistryImpl implements JdbcUrlRegistry, PeriodicSessionTask
     private volatile Set<String> jdbcUrls = Set.of();
 
     /** Constructor. */
-    public JdbcUrlRegistryImpl(NodeNameRegistry nodeNameRegistry, ApiClientFactory clientFactory, JdbcUrlFactory jdbcUrlFactory) {
-        this.nodeNameRegistry = nodeNameRegistry;
+    public JdbcUrlRegistryImpl(PhysicalTopologyCall physicalTopologyCall, ApiClientFactory clientFactory, JdbcUrlFactory jdbcUrlFactory) {
+        this.physicalTopologyCall = physicalTopologyCall;
         this.clientFactory = clientFactory;
         this.jdbcUrlFactory = jdbcUrlFactory;
     }
 
     @Override
     public void update(SessionInfo sessionInfo) {
-        jdbcUrls = nodeNameRegistry.urls()
+        jdbcUrls = physicalTopologyCall.execute(new UrlCallInput(sessionInfo.nodeUrl())).body()
                 .stream()
                 .map(this::fetchJdbcUrl)
                 .filter(Objects::nonNull)
@@ -76,13 +78,16 @@ public class JdbcUrlRegistryImpl implements JdbcUrlRegistry, PeriodicSessionTask
     }
 
     @Nullable
-    private String fetchJdbcUrl(String nodeUrl) {
+    private String fetchJdbcUrl(ClusterNode node) {
         try {
-            NodeInfo nodeInfo = new NodeManagementApi(clientFactory.getClient(nodeUrl)).nodeInfo();
-            return jdbcUrlFactory.constructJdbcUrl(nodeUrl, nodeInfo.getJdbcPort());
+            String nodeUrl = NodeNameRegistryImpl.urlFromClusterNode(node.getMetadata());
+            if (nodeUrl != null) {
+                NodeInfo nodeInfo = new NodeManagementApi(clientFactory.getClient(nodeUrl)).nodeInfo();
+                return jdbcUrlFactory.constructJdbcUrl(nodeUrl, nodeInfo.getJdbcPort());
+            }
         } catch (ApiException e) {
-            LOG.warn("Couldn't fetch jdbc url of " + nodeUrl + " node: ", e);
-            return null;
+            LOG.warn("Couldn't fetch jdbc url of node {}", e, node.getName());
         }
+        return null;
     }
 }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/NodeNameRegistryImpl.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/repl/registry/impl/NodeNameRegistryImpl.java
@@ -87,7 +87,7 @@ public class NodeNameRegistryImpl implements NodeNameRegistry, PeriodicSessionTa
     }
 
     @Nullable
-    private static String urlFromClusterNode(ClusterNodeMetadata metadata) {
+    static String urlFromClusterNode(@Nullable ClusterNodeMetadata metadata) {
         if (metadata == null) {
             return null;
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-21989

Changes in the test are not really related, just the clarification that `allNodeNames` returns actual list of node names.