### PR TITLE
IGNITE-22025 .NET: Remove Console.WriteLine leftovers

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ProjectFilesTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ProjectFilesTests.cs
@@ -87,6 +87,29 @@ namespace Apache.Ignite.Tests
         }
 
         [Test]
+        public void TestNoConsoleOutputInCoreProject()
+        {
+            foreach (var file in GetCsFiles())
+            {
+                if (file.Contains(".Tests", StringComparison.Ordinal) ||
+                    file.Contains(".Benchmarks", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                foreach (var line in File.ReadAllLines(file))
+                {
+                    if (line.Trim().StartsWith("//", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    StringAssert.DoesNotContain("Console.Write", line, $"Console output in '{file}'");
+                }
+            }
+        }
+
+        [Test]
         public void TestTodosHaveTickets()
         {
             var exceptions = new List<Exception>();

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
@@ -276,8 +276,6 @@ internal static class DataStreamer
         {
             Debug.Assert(items.Length > 0, "items.Length > 0");
 
-            Console.WriteLine("Sending batch: " + items.Take(count).StringJoin());
-
             if (batchSchemaOutdated)
             {
                 // Schema update was detected while the batch was being filled.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
@@ -22,7 +22,6 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;


### PR DESCRIPTION
* Remove `Console.WriteLine` leftovers from `DataStreamer`
* Add a test to prevent console output in the core project