### PR TITLE
IGNITE-22022: Sql. Json object with nested object creation fails

### DIFF
--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlOperatorsTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlOperatorsTest.java
@@ -335,21 +335,20 @@ public class ItSqlOperatorsTest extends BaseSqlIntegrationTest {
         assertExpression("'{\"a\":1}' IS NOT JSON OBJECT").returns(false).check();
         assertExpression("'[1, 2]' IS NOT JSON ARRAY").returns(false).check();
         assertExpression("'1' IS NOT JSON SCALAR").returns(false).check();
-        
     }
-    
+
     @Test
     public void testFormatJson() {
         // TODO https://issues.apache.org/jira/browse/IGNITE-20163 Convert these tests to ones that do not expect errors
         //  this issue is resolved
         String error = "Expression is not supported: FORMAT JSON";
-        
+
         assertThrowsSqlException(SqlException.class, Sql.STMT_VALIDATION_ERR, error, 
                 () -> sql("SELECT '{\"a\":1}' FORMAT JSON"));
-        
+
         assertThrowsSqlException(SqlException.class, Sql.STMT_VALIDATION_ERR, error, 
                 () -> sql("SELECT JSON_VALUE('{\"a\":1}' FORMAT JSON, '$.a')"));
-        
+
         assertThrowsSqlException(SqlException.class, Sql.STMT_VALIDATION_ERR, error,
                 () -> sql("SELECT c FORMAT JSON FROM (VALUES ('{\"a\":1}')) t(c)"));
     }
@@ -365,7 +364,7 @@ public class ItSqlOperatorsTest extends BaseSqlIntegrationTest {
                 .returns("[1]")
                 .check();
     }
-    
+
     @Test
     public void testJsonObject() throws IOException  {
         List<List<Object>> rows = sql(

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlOperatorsTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlOperatorsTest.java
@@ -17,15 +17,23 @@
 
 package org.apache.ignite.internal.sql.engine;
 
+import static org.apache.ignite.internal.sql.engine.util.SqlTestUtils.assertThrowsSqlException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Period;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.ignite.internal.sql.BaseSqlIntegrationTest;
 import org.apache.ignite.internal.sql.engine.sql.fun.IgniteSqlOperatorTable;
 import org.apache.ignite.internal.sql.engine.util.QueryChecker;
+import org.apache.ignite.lang.ErrorGroups.Sql;
+import org.apache.ignite.sql.SqlException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -305,7 +313,6 @@ public class ItSqlOperatorsTest extends BaseSqlIntegrationTest {
         assertExpression("JSON_VALUE('{\"a\":1}', '$.a' RETURNING INTEGER)").returns(1).check();
         assertExpression("JSON_VALUE('{\"a\":true}', '$.a' RETURNING BOOLEAN)").returns(true).check();
         assertExpression("JSON_VALUE('{\"a\":1.1}', '$.a' RETURNING DOUBLE)").returns(1.1d).check();
-        assertExpression("JSON_VALUE('{\"a\":1}' FORMAT JSON, '$.a')").returns("1").check();
 
         assertExpression("JSON_QUERY('{\"a\":{\"b\":1}}', '$.a')").returns("{\"b\":1}").check();
         assertExpression("JSON_TYPE('{\"a\":1}')").returns("OBJECT").check();
@@ -328,9 +335,23 @@ public class ItSqlOperatorsTest extends BaseSqlIntegrationTest {
         assertExpression("'{\"a\":1}' IS NOT JSON OBJECT").returns(false).check();
         assertExpression("'[1, 2]' IS NOT JSON ARRAY").returns(false).check();
         assertExpression("'1' IS NOT JSON SCALAR").returns(false).check();
-
-        // TODO https://issues.apache.org/jira/browse/IGNITE-20163
-        // assertExpression("'{\"a\":1}' FORMAT JSON").check();
+        
+    }
+    
+    @Test
+    public void testFormatJson() {
+        // TODO https://issues.apache.org/jira/browse/IGNITE-20163 Convert these tests to ones that do not expect errors
+        //  this issue is resolved
+        String error = "Expression is not supported: FORMAT JSON";
+        
+        assertThrowsSqlException(SqlException.class, Sql.STMT_VALIDATION_ERR, error, 
+                () -> sql("SELECT '{\"a\":1}' FORMAT JSON"));
+        
+        assertThrowsSqlException(SqlException.class, Sql.STMT_VALIDATION_ERR, error, 
+                () -> sql("SELECT JSON_VALUE('{\"a\":1}' FORMAT JSON, '$.a')"));
+        
+        assertThrowsSqlException(SqlException.class, Sql.STMT_VALIDATION_ERR, error,
+                () -> sql("SELECT c FORMAT JSON FROM (VALUES ('{\"a\":1}')) t(c)"));
     }
 
     @Test
@@ -343,6 +364,19 @@ public class ItSqlOperatorsTest extends BaseSqlIntegrationTest {
         assertQuery("SELECT JSON_ARRAYAGG(val) FROM t")
                 .returns("[1]")
                 .check();
+    }
+    
+    @Test
+    public void testJsonObject() throws IOException  {
+        List<List<Object>> rows = sql(
+                "select json_object('name': 'Alex', 'address': json_object('city': 'City 17', 'street': 'Elm', 'house': 42))"
+        );
+        assertEquals(1, rows.size(), rows.toString());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        Map<String, ?> json = (Map<String, ?>) mapper.readValue((String) rows.get(0).get(0), HashMap.class);
+        assertEquals(Map.of("name", "Alex", "address", Map.of("city", "City 17", "street", "Elm", "house", 42)), json);
     }
 
     @Test

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/sqllogic/ItSqlLogicTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/sqllogic/ItSqlLogicTest.java
@@ -139,7 +139,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Tag(value = "sqllogic")
 @ExtendWith(SystemPropertiesExtension.class)
 @WithSystemProperty(key = "IMPLICIT_PK_ENABLED", value = "true")
-@SqlLogicTestEnvironment(scriptsRoot = "src/integrationTest/sql", regex = "test_json")
+@SqlLogicTestEnvironment(scriptsRoot = "src/integrationTest/sql")
 public class ItSqlLogicTest extends IgniteIntegrationTest {
     private static final String SQL_LOGIC_TEST_INCLUDE_SLOW = "SQL_LOGIC_TEST_INCLUDE_SLOW";
 

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/sqllogic/ItSqlLogicTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/sqllogic/ItSqlLogicTest.java
@@ -139,7 +139,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Tag(value = "sqllogic")
 @ExtendWith(SystemPropertiesExtension.class)
 @WithSystemProperty(key = "IMPLICIT_PK_ENABLED", value = "true")
-@SqlLogicTestEnvironment(scriptsRoot = "src/integrationTest/sql")
+@SqlLogicTestEnvironment(scriptsRoot = "src/integrationTest/sql", regex = "test_json")
 public class ItSqlLogicTest extends IgniteIntegrationTest {
     private static final String SQL_LOGIC_TEST_INCLUDE_SLOW = "SQL_LOGIC_TEST_INCLUDE_SLOW";
 

--- a/modules/sql-engine/src/integrationTest/sql/function/json/test_json.test
+++ b/modules/sql-engine/src/integrationTest/sql/function/json/test_json.test
@@ -45,9 +45,19 @@ select json_array(name, age) from t
 ["Alex",32]
 ["Maria",27]
 
-skipif ignite3
-# IGNITE-22022 Json object with nested object creation fails
 query T
-select json_object('name': 'Alex', 'address': json_object('city': 'City 17', 'street': 'xxx'))
+select json_object('address': json_object('city': 'City 17'))
 ----
-{"name":"Alex","address":{"city":"City 17","street":"xxx"}}
+{"address":{"city":"City 17"}}
+
+skipif ignite3
+# https://issues.apache.org/jira/browse/IGNITE-22032 date during json construction is returned in caclite's internal form (number of days)
+query T
+select json_object('date': '2010-01-01'::DATE)
+----
+{"date":"2010-01-01"}
+
+query T
+select json_object('date': '2010-01-01'::DATE::VARCHAR)
+----
+{"date":"2010-01-01"}

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/externalize/RelJson.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/externalize/RelJson.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.sql.engine.externalize;
 
+import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
 import static org.apache.ignite.internal.sql.engine.util.Commons.FRAMEWORK_CONFIG;
 import static org.apache.ignite.internal.sql.engine.util.Commons.rexBuilder;
 import static org.apache.ignite.internal.util.ArrayUtils.asList;
@@ -926,7 +927,9 @@ class RelJson {
         if (cls != null) {
             return AvaticaUtils.instantiatePlugin(SqlOperator.class, cls);
         }
-        return null;
+
+        String message = format("Unknown or unexpected operator: name: {}, kind: {}, syntax: {}", name, sqlKind, sqlSyntax);
+        throw new IllegalStateException(message);
     }
 
     <T> List<T> list() {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/IgniteSqlValidator.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/IgniteSqlValidator.java
@@ -70,6 +70,7 @@ import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlUpdate;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.dialect.CalciteSqlDialect;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeName.Limit;
@@ -551,8 +552,12 @@ public class IgniteSqlValidator extends SqlValidatorImpl {
         RelDataType dataType = super.deriveType(scope, expr);
 
         SqlKind sqlKind = expr.getKind();
-        // See the comments below.
-        if (!SqlKind.BINARY_COMPARISON.contains(sqlKind)) {
+
+        // TODO https://issues.apache.org/jira/browse/IGNITE-20163 Remove this exception after this issue is fixed
+        if (sqlKind == SqlKind.JSON_VALUE_EXPRESSION) {
+            String name = SqlStdOperatorTable.JSON_VALUE_EXPRESSION.getName();
+            throw newValidationError(expr, IgniteResource.INSTANCE.unsupportedExpression(name));
+        } else if (!SqlKind.BINARY_COMPARISON.contains(sqlKind)) {
             return dataType;
         }
 

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/fun/IgniteSqlOperatorTable.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/fun/IgniteSqlOperatorTable.java
@@ -448,6 +448,7 @@ public class IgniteSqlOperatorTable extends ReflectiveSqlOperatorTable {
         register(SqlLibraryOperators.EXISTS_NODE);
 
         // JSON Operators
+        register(SqlStdOperatorTable.JSON_TYPE_OPERATOR);
         register(SqlStdOperatorTable.JSON_VALUE_EXPRESSION);
         register(SqlStdOperatorTable.JSON_VALUE);
         register(SqlStdOperatorTable.JSON_QUERY);

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/IgniteResource.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/IgniteResource.java
@@ -75,6 +75,9 @@ public interface IgniteResource {
     @Resources.BaseMessage("Incorrect type of a dynamic parameter. Expected <{0}> but got <{1}>")
     Resources.ExInst<SqlValidatorException> incorrectDynamicParameterType(String expected, String actual);
 
+    @Resources.BaseMessage("Expression is not supported: {0}")
+    Resources.ExInst<SqlValidatorException> unsupportedExpression(String exprType);
+
     /** Constructs a signature string to use in error messages. */
     static String makeSignature(SqlCallBinding binding, RelDataType... operandTypes) {
         return makeSignature(binding, Arrays.asList(operandTypes));


### PR DESCRIPTION
Adds JSON_TYPE operator to operator table. This operator is used to wrap nested json objects.

Additionally, I've disabled `FORMAT JSON` expression because it doesn't work.

https://issues.apache.org/jira/browse/IGNITE-22022

---
Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)