### PR TITLE
IGNITE-21963: flaky KvMarshallerTest#basicTypes

### DIFF
--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
@@ -62,7 +62,8 @@ public final class MarshallerUtil {
                 return sizeInBytes((BigInteger) val);
 
             case DECIMAL:
-                return sizeInBytes((BigDecimal) val);
+                int unscaledSize = sizeInBytes((BigDecimal) val);
+                return 2 + unscaledSize;
 
             default:
                 throw new InvalidTypeException("Unsupported variable-length type: " + type);

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
@@ -62,8 +62,7 @@ public final class MarshallerUtil {
                 return sizeInBytes((BigInteger) val);
 
             case DECIMAL:
-                int unscaledSize = sizeInBytes((BigDecimal) val);
-                return Short.BYTES + unscaledSize;
+                return sizeInBytes((BigDecimal) val);
 
             default:
                 throw new InvalidTypeException("Unsupported variable-length type: " + type);
@@ -130,7 +129,7 @@ public final class MarshallerUtil {
      * Calculates byte size for BigDecimal value.
      */
     public static int sizeInBytes(BigDecimal val) {
-        return sizeInBytes(val.unscaledValue());
+        return sizeInBytes(val.unscaledValue()) + Short.BYTES;
     }
 
     /**

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
@@ -63,7 +63,7 @@ public final class MarshallerUtil {
 
             case DECIMAL:
                 int unscaledSize = sizeInBytes((BigDecimal) val);
-                return 2 + unscaledSize;
+                return Short.BYTES + unscaledSize;
 
             default:
                 throw new InvalidTypeException("Unsupported variable-length type: " + type);

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
@@ -129,7 +129,7 @@ public final class MarshallerUtil {
      * Calculates byte size for BigDecimal value.
      */
     public static int sizeInBytes(BigDecimal val) {
-        return sizeInBytes(val.unscaledValue()) + Short.BYTES;
+        return sizeInBytes(val.unscaledValue()) + Short.BYTES /* Size of scale */;
     }
 
     /**

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/ObjectStatistics.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/ObjectStatistics.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Object statistic.
  */
-public class ObjectStatistics {
+class ObjectStatistics {
     /** Cached zero statistics. */
     private static final ObjectStatistics ZERO_STATISTICS = new ObjectStatistics(-1);
 

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/ObjectStatistics.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/ObjectStatistics.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Object statistic.
  */
-class ObjectStatistics {
+public class ObjectStatistics {
     /** Cached zero statistics. */
     private static final ObjectStatistics ZERO_STATISTICS = new ObjectStatistics(-1);
 

--- a/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/KvMarshallerTest.java
+++ b/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/KvMarshallerTest.java
@@ -716,6 +716,7 @@ public class KvMarshallerTest {
     public void testVariableLengthBigDecimalAndBytes() throws MarshallerException {
         List<Map.Entry<Integer, Integer>> args = new ArrayList<>();
         args.add(Map.entry(6, 251));
+
         for (int i = 0; i < 100; i++) {
             args.add(Map.entry(rnd.nextInt(8) + 1, rnd.nextInt(512) + 1));
         }

--- a/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/KvMarshallerTest.java
+++ b/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/KvMarshallerTest.java
@@ -715,6 +715,8 @@ public class KvMarshallerTest {
     @Test
     public void testVariableLengthBigDecimalAndBytes() throws MarshallerException {
         List<Map.Entry<Integer, Integer>> args = new ArrayList<>();
+        // Breaks marshalling if big decimal size does not include 2 additional bytes
+        // used by length
         args.add(Map.entry(6, 251));
 
         for (int i = 0; i < 100; i++) {

--- a/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtilTest.java
+++ b/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtilTest.java
@@ -21,6 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.stream.Stream;
 import org.apache.ignite.internal.binarytuple.BinaryTupleCommon;
 import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
@@ -31,7 +34,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
- * Tests for {@link {@link MarshallerUtil}.
+ * Tests for {@link MarshallerUtil}.
  */
 public class MarshallerUtilTest extends BaseIgniteAbstractTest {
 
@@ -55,14 +58,9 @@ public class MarshallerUtilTest extends BaseIgniteAbstractTest {
                 Arguments.of("", NativeTypes.STRING, 1),
                 Arguments.of("1", NativeTypes.STRING, 1),
                 Arguments.of("abc", NativeTypes.STRING, 3),
-                // noinspection AvoidEscapedUnicodeCharacters
-                Arguments.of("\u0700", NativeTypes.STRING, 2),
-                // noinspection AvoidEscapedUnicodeCharacters
-                Arguments.of("\u2600", NativeTypes.STRING, 3),
-                // noinspection AvoidEscapedUnicodeCharacters
-                Arguments.of("\uD800", NativeTypes.STRING, 4),
-                // noinspection AvoidEscapedUnicodeCharacters
-                Arguments.of("a\u0700\u2600\uD800", NativeTypes.STRING, 10),
+                Arguments.of(new String(new byte[]{-36, -128}, StandardCharsets.UTF_8), NativeTypes.STRING, 2),
+                Arguments.of(new String(new byte[]{-30, -104, -128}, StandardCharsets.UTF_8), NativeTypes.STRING, 3),
+                Arguments.of(new String(new byte[]{97, -36, -128, -30, -104, -128}, StandardCharsets.UTF_8), NativeTypes.STRING, 6),
                 // number
                 Arguments.of(BigInteger.ONE, NativeTypes.numberOf(12), 1),
                 Arguments.of(BigInteger.valueOf(123456789), NativeTypes.numberOf(12), 4),

--- a/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtilTest.java
+++ b/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtilTest.java
@@ -1,0 +1,47 @@
+package org.apache.ignite.internal.schema.marshaller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.stream.Stream;
+import org.apache.ignite.internal.binarytuple.BinaryTupleCommon;
+import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
+import org.apache.ignite.internal.type.NativeType;
+import org.apache.ignite.internal.type.NativeTypes;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class MarshallerUtilTest extends BaseIgniteAbstractTest {
+
+    @ParameterizedTest
+    @MethodSource("getValueSizes")
+    public void testGetValueSize(Object val, NativeType nativeType, int expectedSize) {
+        int valueSize = MarshallerUtil.getValueSize(val, nativeType);
+        assertEquals(expectedSize, valueSize);
+    }
+
+    private static Stream<Arguments> getValueSizes() {
+        return Stream.of(
+                // bytes
+                Arguments.of(new byte[0], NativeTypes.BYTES, 1),
+                Arguments.of(new byte[1], NativeTypes.BYTES, 1),
+                Arguments.of(new byte[]{BinaryTupleCommon.VARLEN_EMPTY_BYTE}, NativeTypes.BYTES, 2),
+                Arguments.of(new byte[]{BinaryTupleCommon.VARLEN_EMPTY_BYTE, 1}, NativeTypes.BYTES, 3),
+                // pojo
+                Arguments.of(new Object(), NativeTypes.BYTES, 0),
+                // string
+                Arguments.of("", NativeTypes.STRING, 1),
+                Arguments.of("1", NativeTypes.STRING, 1),
+                Arguments.of("abc", NativeTypes.STRING, 3),
+                Arguments.of("\u2600", NativeTypes.STRING, 3),
+                // number
+                Arguments.of(BigInteger.ONE, NativeTypes.numberOf(12), 1),
+                Arguments.of(BigInteger.valueOf(123456789), NativeTypes.numberOf(12), 4),
+                // decimal
+                Arguments.of(BigDecimal.ONE, NativeTypes.decimalOf(12, 1), 3),
+                Arguments.of(BigDecimal.valueOf(123456789), NativeTypes.decimalOf(12, 3), 6)
+        );
+    }
+}

--- a/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtilTest.java
+++ b/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtilTest.java
@@ -55,7 +55,14 @@ public class MarshallerUtilTest extends BaseIgniteAbstractTest {
                 Arguments.of("", NativeTypes.STRING, 1),
                 Arguments.of("1", NativeTypes.STRING, 1),
                 Arguments.of("abc", NativeTypes.STRING, 3),
+                // noinspection AvoidEscapedUnicodeCharacters
+                Arguments.of("\u0700", NativeTypes.STRING, 2),
+                // noinspection AvoidEscapedUnicodeCharacters
                 Arguments.of("\u2600", NativeTypes.STRING, 3),
+                // noinspection AvoidEscapedUnicodeCharacters
+                Arguments.of("\uD800", NativeTypes.STRING, 4),
+                // noinspection AvoidEscapedUnicodeCharacters
+                Arguments.of("a\u0700\u2600\uD800", NativeTypes.STRING, 10),
                 // number
                 Arguments.of(BigInteger.ONE, NativeTypes.numberOf(12), 1),
                 Arguments.of(BigInteger.valueOf(123456789), NativeTypes.numberOf(12), 4),

--- a/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtilTest.java
+++ b/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtilTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.ignite.internal.schema.marshaller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,6 +30,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+/**
+ * Tests for {@link {@link MarshallerUtil}.
+ */
 public class MarshallerUtilTest extends BaseIgniteAbstractTest {
 
     @ParameterizedTest

--- a/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtilTest.java
+++ b/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtilTest.java
@@ -21,9 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.stream.Stream;
 import org.apache.ignite.internal.binarytuple.BinaryTupleCommon;
 import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;


### PR DESCRIPTION
Fixes tuple size estimation for `BigDecimal` type used by KvMarshallers, https://github.com/apache/ignite-3/pull/3493 didn't update `MarshallerUtil::getValueSize` to include additional 2 bytes for `BigDecimal` type that PR introduced.

https://issues.apache.org/jira/browse/IGNITE-21963

---
Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)