### PR TITLE
IGNITE-22055 Shut destruction executor down before closing volatile regions

### DIFF
--- a/modules/storage-page-memory/src/main/java/org/apache/ignite/internal/storage/pagememory/VolatilePageMemoryStorageEngine.java
+++ b/modules/storage-page-memory/src/main/java/org/apache/ignite/internal/storage/pagememory/VolatilePageMemoryStorageEngine.java
@@ -130,7 +130,7 @@ public class VolatilePageMemoryStorageEngine implements StorageEngine {
                             : (AutoCloseable) () -> shutdownAndAwaitTermination(destructionExecutor, 30, TimeUnit.SECONDS)
             );
 
-            closeAll(Stream.concat(closeRegions, shutdownExecutor));
+            closeAll(Stream.concat(shutdownExecutor, closeRegions));
         } catch (Exception e) {
             throw new StorageException("Error when stopping components", e);
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22055