### PR TITLE
[IGNITE-21404] Do not wrap SqlException into RuntimeException for PlannerHelper.optimize.

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PlannerHelper.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PlannerHelper.java
@@ -160,7 +160,7 @@ public final class PlannerHelper {
             if (ex instanceof CannotPlanException) {
                 throw ex;
             } else if (ex.getClass() == RuntimeException.class && ex.getCause() instanceof SqlException) {
-                SqlException sqlEx = (SqlException)ex.getCause();
+                SqlException sqlEx = (SqlException) ex.getCause();
                 throw new SqlException(sqlEx.traceId(), sqlEx.code(), sqlEx.getMessage(), ex);
             } else {
                 throw new SqlException(Common.INTERNAL_ERR, "Unable to optimize plan due to internal error", ex);

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PlannerHelper.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PlannerHelper.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.apache.calcite.plan.RelOptPlanner.CannotPlanException;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollations;
@@ -44,6 +45,8 @@ import org.apache.ignite.internal.sql.engine.rel.IgniteConvention;
 import org.apache.ignite.internal.sql.engine.rel.IgniteProject;
 import org.apache.ignite.internal.sql.engine.rel.IgniteRel;
 import org.apache.ignite.internal.sql.engine.trait.IgniteDistributions;
+import org.apache.ignite.lang.ErrorGroups.Common;
+import org.apache.ignite.sql.SqlException;
 
 /**
  * Utility class that encapsulates the query optimization pipeline.
@@ -154,7 +157,11 @@ public final class PlannerHelper {
                 LOG.debug(planner.dump());
             }
 
-            throw ex;
+            if (ex instanceof CannotPlanException) {
+                throw ex;
+            } else {
+                throw new SqlException(Common.INTERNAL_ERR, "Unable to optimize plan due to internal error", ex);
+            }
         }
     }
 

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PlannerHelper.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PlannerHelper.java
@@ -21,6 +21,7 @@ import static org.apache.ignite.internal.sql.engine.hint.IgniteHint.DISABLE_RULE
 import static org.apache.ignite.internal.sql.engine.hint.IgniteHint.ENFORCE_JOIN_ORDER;
 import static org.apache.ignite.internal.sql.engine.util.Commons.shortRuleName;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -159,6 +160,9 @@ public final class PlannerHelper {
 
             if (ex instanceof CannotPlanException) {
                 throw ex;
+            } else if (ex.getClass() == RuntimeException.class && ex.getCause() instanceof SqlException) {
+                SqlException sqlEx = (SqlException)ex.getCause();
+                throw new SqlException(sqlEx.traceId(), sqlEx.code(), sqlEx.getMessage(), ex);
             } else {
                 throw new SqlException(Common.INTERNAL_ERR, "Unable to optimize plan due to internal error", ex);
             }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PlannerHelper.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PlannerHelper.java
@@ -21,7 +21,6 @@ import static org.apache.ignite.internal.sql.engine.hint.IgniteHint.DISABLE_RULE
 import static org.apache.ignite.internal.sql.engine.hint.IgniteHint.ENFORCE_JOIN_ORDER;
 import static org.apache.ignite.internal.sql.engine.util.Commons.shortRuleName;
 
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;


### PR DESCRIPTION
Wrappinternal errors during optimization in SqlExceptions.

With in code an that throws an exception in LogicalTableScanConverterRule.

Prior to fix:

> java.lang.RuntimeException: Error while applying rule LogicalTableScanConverterRule(in:NONE,out:IGNITE), args [rel#22:LogicalTableScan.NONE.any.[](table=[PUBLIC, TEST_TBL],filters=>=($t1, 10),projects=[$t0],requiredColumns={0, 1})]

After this patch:
> org.apache.ignite.sql.SqlException: IGN-CMN-65535 TraceId:041f8c94-9e3a-4569-ba9a-60de7753ef32 Unable to optimize plan due to internal error


https://issues.apache.org/jira/browse/IGNITE-21404

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)