### PR TITLE
IGNITE-22097 JobContext is not closed when job execution fails

### DIFF
--- a/modules/compute/src/integrationTest/java/org/apache/ignite/internal/compute/ItComputeTestStandalone.java
+++ b/modules/compute/src/integrationTest/java/org/apache/ignite/internal/compute/ItComputeTestStandalone.java
@@ -38,6 +38,7 @@ import org.apache.ignite.compute.DeploymentUnit;
 import org.apache.ignite.compute.version.Version;
 import org.apache.ignite.internal.app.IgniteImpl;
 import org.apache.ignite.internal.deployunit.NodesToDeploy;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -47,14 +48,19 @@ import org.junit.jupiter.api.Test;
  */
 @SuppressWarnings("resource")
 class ItComputeTestStandalone extends ItComputeBaseTest {
-
     private final DeploymentUnit unit = new DeploymentUnit("jobs", Version.parseVersion("1.0.0"));
+
     private final List<DeploymentUnit> units = List.of(unit);
 
     @BeforeEach
-    void setUp() throws IOException {
+    void deploy() throws IOException {
+        deployJar(node(0), unit.name(), unit.version(), "ignite-integration-test-jobs-1.0-SNAPSHOT.jar");
+    }
+
+    @AfterEach
+    void undeploy() {
         IgniteImpl entryNode = node(0);
-        // TODO https://issues.apache.org/jira/browse/IGNITE-19757
+
         try {
             entryNode.deployment().undeployAsync(unit.name(), unit.version()).join();
         } catch (Exception ignored) {
@@ -64,7 +70,6 @@ class ItComputeTestStandalone extends ItComputeBaseTest {
                 () -> entryNode.deployment().clusterStatusAsync(unit.name(), unit.version()),
                 willBe(nullValue())
         );
-        deployJar(entryNode, unit.name(), unit.version(), "ignite-integration-test-jobs-1.0-SNAPSHOT.jar");
     }
 
     @Override

--- a/modules/compute/src/jobs/java/org/apache/ignite/internal/compute/NonComputeJob.java
+++ b/modules/compute/src/jobs/java/org/apache/ignite/internal/compute/NonComputeJob.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.compute;
+
+import org.apache.ignite.compute.JobExecutionContext;
+
+/** A class which doesn't implement {@link org.apache.ignite.compute.ComputeJob}. */
+public class NonComputeJob {
+    public String execute(JobExecutionContext context, Object... args) {
+        return "";
+    }
+}

--- a/modules/compute/src/jobs/java/org/apache/ignite/internal/compute/NonEmptyConstructorJob.java
+++ b/modules/compute/src/jobs/java/org/apache/ignite/internal/compute/NonEmptyConstructorJob.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.compute;
+
+import org.apache.ignite.compute.ComputeJob;
+import org.apache.ignite.compute.JobExecutionContext;
+
+/** A compute job without default constructor. */
+public class NonEmptyConstructorJob implements ComputeJob<String> {
+    private NonEmptyConstructorJob(String s) {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String execute(JobExecutionContext context, Object... args) {
+        return "";
+    }
+}

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/ComputeComponentImpl.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/ComputeComponentImpl.java
@@ -252,11 +252,12 @@ public class ComputeComponentImpl implements ComputeComponent {
     }
 
     private <R> JobExecutionInternal<R> exec(JobContext context, ExecutionOptions options, String jobClassName, Object[] args) {
-        return executor.executeJob(
-                options,
-                ComputeUtils.jobClass(context.classLoader(), jobClassName),
-                args
-        );
+        try {
+            return executor.executeJob(options, ComputeUtils.jobClass(context.classLoader(), jobClassName), args);
+        } catch (RuntimeException e) {
+            context.close();
+            throw e;
+        }
     }
 
     @TestOnly


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22097

Moving tests to base class revealed that the job context is not closed when job instantiation fails.