### PR TITLE
IGNITE-20475 .NET: EF Core provider [POC]

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore.Tests/.editorconfig
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore.Tests/.editorconfig
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# All files
+[*]
+
+# Code analysis
+dotnet_diagnostic.SA0001.severity = none # Enable xmldoc file generation
+dotnet_diagnostic.SA1600.severity = none # Elements should be documented
+dotnet_diagnostic.SA1601.severity = none # Partial classes should be documented
+dotnet_diagnostic.SA1602.severity = none # Enums should be documented
+dotnet_diagnostic.CA1001.severity = none # Types that own disposable fields should be disposable
+dotnet_diagnostic.CA1063.severity = none # Implement IDisposable correctly
+dotnet_diagnostic.CA1816.severity = none # Dispose must call SuppressFinalize
+dotnet_diagnostic.CA2000.severity = none # Call Dispose
+dotnet_diagnostic.CA2007.severity = none # Call ConfigureAwait (not needed in tests)
+dotnet_diagnostic.CA1031.severity = none # DoNotCatchGeneralExceptionTypes
+dotnet_diagnostic.CA1801.severity = none # UnusedParameters
+dotnet_diagnostic.CA1062.severity = none # Validate parameters.
+dotnet_diagnostic.CA1308.severity = none # Normalize to upper case
+dotnet_diagnostic.CA1014.severity = none # Mark assemblies with CLSCompliant
+dotnet_diagnostic.CA1002.severity = none # Do not expose generic lists
+dotnet_diagnostic.CA1051.severity = none # Do not declare visible instance fields
+dotnet_diagnostic.CA1720.severity = none # Identifier contains type name
+dotnet_diagnostic.CA1307.severity = none # Specify StringComparison for clarity
+dotnet_diagnostic.CA2201.severity = none # Do not raise reserved exception types
+dotnet_diagnostic.CA1508.severity = none # Avoid dead conditional code
+dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
+dotnet_diagnostic.CA1819.severity = none # Properties should not return arrays
+dotnet_diagnostic.CA1812.severity = none # Avoid uninstantiated internal classes
+dotnet_diagnostic.CA5394.severity = none # Use secure random
+
+dotnet_diagnostic.NUnit2005.severity = none # Consider using the constraint model
+dotnet_diagnostic.NUnit2006.severity = none # Consider using the constraint model
+dotnet_diagnostic.NUnit2015.severity = none # Consider using the constraint model
+dotnet_diagnostic.NUnit2031.severity = none # Consider using the constraint model
+
+# ReSharper (refer to https://www.jetbrains.com/help/resharper/Reference__Code_Inspections_CSHARP.html)
+resharper_using_statement_resource_initialization_highlighting = none # Do not use object initializer for 'using' variable

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore.Tests/Apache.Ignite.EntityFrameworkCore.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore.Tests/Apache.Ignite.EntityFrameworkCore.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
+        <PackageReference Include="NUnit" Version="3.14.0"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>
+        <PackageReference Include="System.Linq.Async" Version="6.0.1"/>
+        <PackageReference Include="NUnit.Analyzers" Version="3.6.1"/>
+
+        <PackageReference Include="Microsoft.EntityFrameworkCore" PrivateAssets="none" Version="8.0.4" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Apache.Ignite.EntityFrameworkCore\Apache.Ignite.EntityFrameworkCore.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore.Tests/Author.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore.Tests/Author.cs
@@ -1,0 +1,21 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Apache.Ignite.EntityFrameworkCore.Tests;
+
+public sealed record Author(Guid Id, string FirstName, string LastName)
+{
+    public List<Book> Books { get; set; } = null!;
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore.Tests/BasicTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore.Tests/BasicTest.cs
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.EntityFrameworkCore.Tests;
+
+using Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using NUnit.Framework;
+
+public class BasicTest
+{
+    [SetUp]
+    public async Task SetUp()
+    {
+        using var client = await IgniteClient.StartAsync(new(GetIgniteEndpoint()));
+
+        var tables = await client.Tables.GetTablesAsync();
+
+        foreach (var table in tables)
+        {
+            await client.Sql.ExecuteAsync(null, $"DROP TABLE \"{table.Name}\"");
+        }
+    }
+
+    [Test]
+    public async Task TestIgniteEfCore()
+    {
+        await using var ctx = CreateDbContext();
+
+        await ctx.Database.EnsureCreatedAsync();
+
+        var book = new Book(Guid.NewGuid(), "Nineteen Eighty-Four", 1984, Guid.NewGuid())
+        {
+            Author = new Author(Guid.NewGuid(), "George", "Orwell")
+        };
+        ctx.Books.Add(book);
+        await ctx.SaveChangesAsync();
+        ctx.ChangeTracker.Clear();
+
+        var query = ctx.Books
+            .AsNoTracking()
+            .Include(x => x.Author)
+            .Where(b => b.Year > 1900);
+
+        var books = await query.ToListAsync();
+
+        Assert.AreEqual(1, books.Count);
+        Assert.AreEqual(book.Name, books[0].Name);
+        Assert.AreEqual(book.Author.FirstName, books[0].Author.FirstName);
+        Assert.AreEqual(book.Author.LastName, books[0].Author.LastName);
+        Assert.AreEqual(book.Year, books[0].Year);
+        Assert.AreEqual(book.Id, books[0].Id);
+
+        var expectedSql =
+            """
+            SELECT "b"."Id", "b"."AuthorId", "b"."Name", "b"."Year", "a"."Id", "a"."FirstName", "a"."LastName"
+            FROM "Books" AS "b"
+            INNER JOIN "Authors" AS "a" ON "b"."AuthorId" = "a"."Id"
+            WHERE "b"."Year" > 1900
+            """;
+
+        var queryString = query.ToQueryString();
+        Assert.AreEqual(expectedSql, queryString);
+    }
+
+    private static TestDbContext CreateDbContext()
+    {
+        var contextOptionsBuilder = new DbContextOptionsBuilder<TestDbContext>(
+            new DbContextOptions<TestDbContext>(new Dictionary<Type, IDbContextOptionsExtension>()));
+
+        contextOptionsBuilder.UseIgnite(GetIgniteEndpoint());
+
+        return new TestDbContext(contextOptionsBuilder.Options);
+    }
+
+    private static string GetIgniteEndpoint() => "localhost:10942";
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore.Tests/Book.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore.Tests/Book.cs
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.EntityFrameworkCore.Tests;
+
+public sealed record Book(Guid Id, string Name, int Year, Guid AuthorId)
+{
+    public Author Author { get; set; } = null!;
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore.Tests/TestDbContext.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore.Tests/TestDbContext.cs
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.EntityFrameworkCore.Tests;
+
+using Microsoft.EntityFrameworkCore;
+
+public class TestDbContext : DbContext
+{
+    public TestDbContext(DbContextOptions<TestDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<Book> Books { get; set; } = null!;
+
+    public DbSet<Author> Authors { get; set; } = null!;
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/.editorconfig
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/.editorconfig
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# All files
+[*]
+
+# Code analysis
+dotnet_diagnostic.SA0001.severity = none # Enable xmldoc file generation
+dotnet_diagnostic.SA1600.severity = none # Elements should be documented
+dotnet_diagnostic.SA1601.severity = none # Partial classes should be documented
+dotnet_diagnostic.SA1602.severity = none # Enums should be documented
+dotnet_diagnostic.CA1001.severity = none # Types that own disposable fields should be disposable
+dotnet_diagnostic.CA1063.severity = none # Implement IDisposable correctly
+dotnet_diagnostic.CA1816.severity = none # Dispose must call SuppressFinalize
+dotnet_diagnostic.CA2000.severity = none # Call Dispose
+dotnet_diagnostic.CA2007.severity = none # Call ConfigureAwait (not needed in tests)
+dotnet_diagnostic.CA1031.severity = none # DoNotCatchGeneralExceptionTypes
+dotnet_diagnostic.CA1801.severity = none # UnusedParameters
+dotnet_diagnostic.CA1062.severity = none # Validate parameters.
+dotnet_diagnostic.CA1308.severity = none # Normalize to upper case
+dotnet_diagnostic.CA1014.severity = none # Mark assemblies with CLSCompliant
+dotnet_diagnostic.CA1002.severity = none # Do not expose generic lists
+dotnet_diagnostic.CA1051.severity = none # Do not declare visible instance fields
+dotnet_diagnostic.CA1720.severity = none # Identifier contains type name
+dotnet_diagnostic.CA1307.severity = none # Specify StringComparison for clarity
+dotnet_diagnostic.CA2201.severity = none # Do not raise reserved exception types
+dotnet_diagnostic.CA1508.severity = none # Avoid dead conditional code
+dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
+dotnet_diagnostic.CA1819.severity = none # Properties should not return arrays
+dotnet_diagnostic.CA1812.severity = none # Avoid uninstantiated internal classes
+dotnet_diagnostic.CA5394.severity = none # Use secure random
+
+dotnet_diagnostic.NUnit2005.severity = none # Consider using the constraint model
+dotnet_diagnostic.NUnit2006.severity = none # Consider using the constraint model
+dotnet_diagnostic.NUnit2015.severity = none # Consider using the constraint model
+dotnet_diagnostic.NUnit2031.severity = none # Consider using the constraint model
+
+# ReSharper (refer to https://www.jetbrains.com/help/resharper/Reference__Code_Inspections_CSHARP.html)
+resharper_using_statement_resource_initialization_highlighting = none # Do not use object initializer for 'using' variable

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Apache.Ignite.EntityFrameworkCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Apache.Ignite.EntityFrameworkCore.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <IsPackable>true</IsPackable>
+        <LangVersion>latest</LangVersion>
+
+        <PackageValidationBaselineVersion />
+        <GenerateCompatibilitySuppressionFile>false</GenerateCompatibilitySuppressionFile>
+        
+        <!-- TODO: Remove this -->
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+        <AnalysisMode>None</AnalysisMode>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" PrivateAssets="none" Version="8.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" PrivateAssets="none" Version="8.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" PrivateAssets="none" Version="8.0.4" />
+        <PackageReference Include="Microsoft.Extensions.DependencyModel" PrivateAssets="none" Version="8.0.0" />
+
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="all" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Extensions\Internal\" />
+      <Folder Include="Properties\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Apache.Ignite\Apache.Ignite.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Apache.Ignite.EntityFrameworkCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Apache.Ignite.EntityFrameworkCore.csproj
@@ -9,6 +9,10 @@
 
         <PackageValidationBaselineVersion />
         <GenerateCompatibilitySuppressionFile>false</GenerateCompatibilitySuppressionFile>
+
+        <!-- TODO: Remove this -->
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+        <AnalysisMode>None</AnalysisMode>
     </PropertyGroup>
 
     <ItemGroup>

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Apache.Ignite.EntityFrameworkCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Apache.Ignite.EntityFrameworkCore.csproj
@@ -9,11 +9,6 @@
 
         <PackageValidationBaselineVersion />
         <GenerateCompatibilitySuppressionFile>false</GenerateCompatibilitySuppressionFile>
-        
-        <!-- TODO: Remove this -->
-        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-        <AnalysisMode>None</AnalysisMode>
-        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Common/Check.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Common/Check.cs
@@ -1,0 +1,18 @@
+namespace Apache.Ignite.EntityFrameworkCore.Common;
+
+using System;
+using JetBrains.Annotations;
+
+public class Check
+{
+    // TODO: Replace with IgniteArgumentCheck via InternalsVisibleTo.
+    public static T NotNull<T>([NoEnumeration] T? value, [InvokerParameterName] string parameterName)
+    {
+        if (value is null)
+        {
+            throw new ArgumentNullException(parameterName);
+        }
+
+        return value;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Common/Check.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Common/Check.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Common;
 
 using System;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Common/DictionaryExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Common/DictionaryExtensions.cs
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Apache.Ignite.EntityFrameworkCore.Common;
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+[DebuggerStepThrough]
+internal static class DictionaryExtensions
+{
+    public static TValue GetOrAddNew<TKey, TValue>(
+        this IDictionary<TKey, TValue> source,
+        TKey key)
+        where TValue : new()
+    {
+        if (!source.TryGetValue(key, out var value))
+        {
+            value = new TValue();
+            source.Add(key, value);
+        }
+
+        return value;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Common/IgniteStrings.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Common/IgniteStrings.cs
@@ -1,0 +1,10 @@
+namespace Apache.Ignite.EntityFrameworkCore.Common;
+
+public static class IgniteStrings
+{
+    public const string SequencesNotSupported = "Ignite does not support sequences.";
+    public const string ApplyNotSupported = "Ignite does not support APPLY.";
+    public const string MigrationScriptGenerationNotSupported = "Ignite does not support migration script generation.";
+
+    public static string InvalidMigrationOperation(string shortDisplayName) => "Migration operation is invalid: " + shortDisplayName;
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Common/IgniteStrings.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Common/IgniteStrings.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Common;
 
 public static class IgniteStrings

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Common/TypeExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Common/TypeExtensions.cs
@@ -1,0 +1,24 @@
+namespace Apache.Ignite.EntityFrameworkCore.Common;
+
+using System;
+
+internal static class TypeExtensions
+{
+    public static Type UnwrapNullableType(this Type type)
+        => Nullable.GetUnderlyingType(type) ?? type;
+
+    public static bool IsInteger(this Type type)
+    {
+        type = type.UnwrapNullableType();
+
+        return type == typeof(int)
+            || type == typeof(long)
+            || type == typeof(short)
+            || type == typeof(byte)
+            || type == typeof(uint)
+            || type == typeof(ulong)
+            || type == typeof(ushort)
+            || type == typeof(sbyte)
+            || type == typeof(char);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Common/TypeExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Common/TypeExtensions.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Common;
 
 using System;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteCommand.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteCommand.cs
@@ -1,0 +1,107 @@
+namespace Apache.Ignite.EntityFrameworkCore.DataCommon;
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Ignite.Sql;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+public class IgniteCommand : DbCommand
+{
+    private IgniteParameterCollection? _parameters = null;
+
+    public override void Cancel()
+    {
+        // No-op.
+    }
+
+    public override int ExecuteNonQuery()
+    {
+        return ExecuteNonQueryAsync(CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+    {
+        if (CommandSource == CommandSource.SaveChanges)
+        {
+            // Ignite-specific: SaveChangesDataReader is used to return the number of rows affected.
+            var rowsAffected = await ExecuteNonQueryAsync(cancellationToken);
+
+            return new IgniteSaveChangesDataReader(rowsAffected);
+        }
+
+        var args = _parameters?.ToObjectArray() ?? Array.Empty<object>();
+
+        // TODO: Remove debug output.
+        Console.WriteLine($"IgniteCommand.ExecuteDbDataReaderAsync [statement={CommandText}, parameters={string.Join(", ", args)}]");
+
+        // TODO: Propagate transaction somehow.
+        return await Sql.ExecuteReaderAsync(
+            null,
+            CommandText,
+            args);
+    }
+
+    public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+    {
+        var args = _parameters?.ToObjectArray() ?? Array.Empty<object>();
+
+        // TODO: Remove debug output.
+        Console.WriteLine($"IgniteCommand.ExecuteNonQueryAsync [statement={CommandText}, parameters={string.Join(", ", args)}]");
+
+        // TODO: Propagate transaction somehow.
+        await using IResultSet<object> resultSet = await Sql.ExecuteAsync<object>(
+            transaction: null,
+            CommandText,
+            args);
+
+        Debug.Assert(!resultSet.HasRowSet, "!resultSet.HasRowSet");
+
+        return (int)resultSet.AffectedRows;
+    }
+
+    public override Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override object ExecuteScalar() => ExecuteScalarAsync().GetAwaiter().GetResult();
+
+    public override void Prepare()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string CommandText { get; set; }
+
+    public override int CommandTimeout { get; set; }
+
+    public override CommandType CommandType { get; set; }
+
+    public override UpdateRowSource UpdatedRowSource { get; set; }
+
+    protected override DbConnection DbConnection { get; set; }
+
+    protected override DbParameterCollection DbParameterCollection =>
+        _parameters ??= new IgniteParameterCollection();
+
+    protected override DbTransaction DbTransaction { get; set; }
+
+    public override bool DesignTimeVisible { get; set; }
+
+    public CommandSource CommandSource { get; set; }
+
+    protected override DbParameter CreateDbParameter() => new IgniteParameter();
+
+    protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+    {
+        throw new NotImplementedException();
+    }
+
+    private IIgniteClient IgniteClient => ((IgniteConnection)DbConnection).Client;
+
+    private ISql Sql => IgniteClient.Sql;
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteCommand.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteCommand.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.DataCommon;
 
 using System;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteCommand.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteCommand.cs
@@ -15,10 +15,13 @@
 
 namespace Apache.Ignite.EntityFrameworkCore.DataCommon;
 
+#nullable disable // TODO: Remove nullable disable.
+
 using System;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Apache.Ignite.Sql;
@@ -26,7 +29,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 
 public class IgniteCommand : DbCommand
 {
-    private IgniteParameterCollection? _parameters = null;
+    private IgniteParameterCollection _parameters = null;
 
     public override void Cancel()
     {

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteConnection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteConnection.cs
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Apache.Ignite.EntityFrameworkCore.DataCommon;
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+public sealed class IgniteConnection : DbConnection
+{
+    private readonly IgniteClientConfiguration _config;
+
+    private IIgniteClient? _igniteClient;
+
+    public IgniteConnection(string connectionString)
+    {
+        // TODO: Parse connection string?
+        _config = new IgniteClientConfiguration(connectionString);
+        ConnectionString = connectionString;
+    }
+
+    public override string ConnectionString { get; set; }
+
+    public override string Database => string.Empty;
+
+    public override ConnectionState State => _igniteClient == null ? ConnectionState.Closed : ConnectionState.Open;
+
+    public override string DataSource => string.Empty;
+
+    // TODO: Set once connected.
+    public override string ServerVersion { get; }
+
+    public int DefaultTimeout { get; set; }
+
+    public IIgniteClient? Client => _igniteClient;
+
+    public override void ChangeDatabase(string databaseName)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void Close()
+    {
+        _igniteClient?.Dispose();
+        _igniteClient = null;
+    }
+
+    public override void Open() => OpenAsync(CancellationToken.None).GetAwaiter().GetResult();
+
+    public override async Task OpenAsync(CancellationToken cancellationToken)
+    {
+        _igniteClient ??= await IgniteClient.StartAsync(_config);
+    }
+
+    protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) =>
+        BeginDbTransactionAsync(isolationLevel, CancellationToken.None).AsTask().GetAwaiter().GetResult();
+
+    protected override async ValueTask<DbTransaction> BeginDbTransactionAsync(
+        IsolationLevel isolationLevel,
+        CancellationToken cancellationToken)
+    {
+        var tx = await _igniteClient!.Transactions.BeginAsync();
+
+        return new IgniteTransaction(tx, isolationLevel, this);
+    }
+
+    protected override DbCommand CreateDbCommand() => new IgniteCommand
+    {
+        Connection = this,
+        CommandTimeout = DefaultTimeout
+    };
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Close();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteConnection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteConnection.cs
@@ -43,7 +43,7 @@ public sealed class IgniteConnection : DbConnection
     public override string DataSource => string.Empty;
 
     // TODO: Set once connected.
-    public override string ServerVersion { get; }
+    public override string ServerVersion => "TODO";
 
     public int DefaultTimeout { get; set; }
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteParameter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteParameter.cs
@@ -1,0 +1,36 @@
+namespace Apache.Ignite.EntityFrameworkCore.DataCommon;
+
+using System;
+using System.Data;
+using System.Data.Common;
+using Apache.Ignite.Sql;
+
+public class IgniteParameter : DbParameter
+{
+    public IgniteParameter()
+    {
+    }
+
+    public override void ResetDbType()
+    {
+        throw new NotImplementedException();
+    }
+
+    public ColumnType ColumnType { get; set; }
+
+    public override DbType DbType { get; set; }
+
+    public override ParameterDirection Direction { get; set; }
+
+    public override bool IsNullable { get; set; }
+
+    public override string ParameterName { get; set; }
+
+    public override string SourceColumn { get; set; }
+
+    public override object Value { get; set; }
+
+    public override bool SourceColumnNullMapping { get; set; }
+
+    public override int Size { get; set; }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteParameter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteParameter.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.DataCommon;
 
 using System;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteParameterCollection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteParameterCollection.cs
@@ -1,0 +1,148 @@
+namespace Apache.Ignite.EntityFrameworkCore.DataCommon;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using Apache.Ignite.Sql;
+
+public class IgniteParameterCollection : DbParameterCollection
+{
+    private readonly List<IgniteParameter> _parameters = new();
+
+    protected internal IgniteParameterCollection()
+    {
+    }
+
+    public override int Count
+        => _parameters.Count;
+
+    public override object SyncRoot
+        => ((ICollection)_parameters).SyncRoot;
+
+    public new virtual IgniteParameter this[int index]
+    {
+        get => _parameters[index];
+        set
+        {
+            if (_parameters[index] == value)
+            {
+                return;
+            }
+
+            _parameters[index] = value;
+        }
+    }
+
+    public object[] ToObjectArray()
+        => _parameters.Select(x => x.Value).ToArray();
+
+    public override int Add(object value)
+    {
+        _parameters.Add((IgniteParameter)value);
+
+        return Count - 1;
+    }
+
+    public virtual IgniteParameter Add(IgniteParameter value)
+    {
+        _parameters.Add(value);
+
+        return value;
+    }
+
+    public virtual IgniteParameter Add(string? parameterName, ColumnType type)
+        => Add(new IgniteParameter()
+        {
+            ParameterName = parameterName,
+            ColumnType = type
+        });
+
+    public override void AddRange(Array values)
+        => AddRange(values.Cast<IgniteParameter>());
+
+    public virtual void AddRange(IEnumerable<IgniteParameter> values)
+        => _parameters.AddRange(values);
+
+    public override void Clear()
+        => _parameters.Clear();
+
+    public override bool Contains(object value)
+        => Contains((IgniteParameter)value);
+
+    public virtual bool Contains(IgniteParameter value)
+        => _parameters.Contains(value);
+
+    public override bool Contains(string value)
+        => IndexOf(value) != -1;
+
+    public override void CopyTo(Array array, int index)
+        => CopyTo((IgniteParameter[])array, index);
+
+    public virtual void CopyTo(IgniteParameter[] array, int index)
+        => _parameters.CopyTo(array, index);
+
+    public override IEnumerator GetEnumerator()
+        => _parameters.GetEnumerator();
+
+    protected override DbParameter GetParameter(int index)
+        => this[index];
+
+    protected override DbParameter GetParameter(string parameterName)
+        => GetParameter(IndexOfChecked(parameterName));
+
+    public override int IndexOf(object value)
+        => IndexOf((IgniteParameter)value);
+
+    public virtual int IndexOf(IgniteParameter value)
+        => _parameters.IndexOf(value);
+
+    public override int IndexOf(string parameterName)
+    {
+        for (var index = 0; index < _parameters.Count; index++)
+        {
+            if (_parameters[index].ParameterName == parameterName)
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    public override void Insert(int index, object value)
+        => Insert(index, (IgniteParameter)value);
+
+    public virtual void Insert(int index, IgniteParameter value)
+        => _parameters.Insert(index, value);
+
+    public override void Remove(object value)
+        => Remove((IgniteParameter)value);
+
+    public virtual void Remove(IgniteParameter value)
+        => _parameters.Remove(value);
+
+    public override void RemoveAt(int index)
+        => _parameters.RemoveAt(index);
+
+    public override void RemoveAt(string parameterName)
+        => RemoveAt(IndexOfChecked(parameterName));
+
+    protected override void SetParameter(int index, DbParameter value)
+        => this[index] = (IgniteParameter)value;
+
+    protected override void SetParameter(string parameterName, DbParameter value)
+        => SetParameter(IndexOfChecked(parameterName), value);
+
+    private int IndexOfChecked(string parameterName)
+    {
+        var index = IndexOf(parameterName);
+        if (index == -1)
+        {
+            throw new IndexOutOfRangeException($"Parameter not found: {parameterName}");
+        }
+
+        return index;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteParameterCollection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteParameterCollection.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.DataCommon;
 
 using System;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteSaveChangesDataReader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteSaveChangesDataReader.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.DataCommon;
 
 using System;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteSaveChangesDataReader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteSaveChangesDataReader.cs
@@ -1,0 +1,152 @@
+namespace Apache.Ignite.EntityFrameworkCore.DataCommon;
+
+using System;
+using System.Collections;
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+/// <summary>
+/// Data reader for <see cref="CommandSource.SaveChanges"/>.
+/// EF expects a reader, but Ignite only returns the number of rows affected.
+/// </summary>
+public class IgniteSaveChangesDataReader : DbDataReader
+{
+    public IgniteSaveChangesDataReader(int rowsAffected)
+    {
+        RecordsAffected = rowsAffected;
+    }
+
+    public override bool GetBoolean(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override byte GetByte(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override char GetChar(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string GetDataTypeName(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override DateTime GetDateTime(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override decimal GetDecimal(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override double GetDouble(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override Type GetFieldType(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override float GetFloat(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override Guid GetGuid(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override short GetInt16(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override int GetInt32(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override long GetInt64(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string GetName(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override int GetOrdinal(string name)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string GetString(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override object GetValue(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override int GetValues(object[] values)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override bool IsDBNull(int ordinal)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override int FieldCount { get; }
+
+    public override object this[int ordinal] => throw new NotImplementedException();
+
+    public override object this[string name] => throw new NotImplementedException();
+
+    public override int RecordsAffected { get; }
+
+    public override bool HasRows { get; }
+
+    public override bool IsClosed { get; }
+
+    public override bool NextResult()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override bool Read()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override int Depth { get; }
+
+    public override IEnumerator GetEnumerator()
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteTransaction.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteTransaction.cs
@@ -1,0 +1,40 @@
+namespace Apache.Ignite.EntityFrameworkCore.DataCommon;
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Ignite.Transactions;
+
+public class IgniteTransaction : DbTransaction
+{
+    private readonly ITransaction _tx;
+
+    public IgniteTransaction(ITransaction tx, IsolationLevel isolationLevel, DbConnection connection)
+    {
+        _tx = tx;
+        IsolationLevel = isolationLevel;
+        DbConnection = connection;
+    }
+
+    public override void Commit()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void Rollback()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override async Task CommitAsync(CancellationToken cancellationToken) =>
+        await _tx.CommitAsync();
+
+    public override async Task RollbackAsync(string savepointName, CancellationToken cancellationToken) =>
+        await _tx.RollbackAsync();
+
+    protected override DbConnection DbConnection { get; }
+
+    public override IsolationLevel IsolationLevel { get; }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteTransaction.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/DataCommon/IgniteTransaction.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.DataCommon;
 
 using System;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Diagnostics/Internal/IgniteLoggingDefinitions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Diagnostics/Internal/IgniteLoggingDefinitions.cs
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Apache.Ignite.EntityFrameworkCore.Diagnostics.Internal;
+
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+public class IgniteLoggingDefinitions : RelationalLoggingDefinitions
+{
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Extensions/IgniteDbContextOptionsBuilderExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Extensions/IgniteDbContextOptionsBuilderExtensions.cs
@@ -1,0 +1,111 @@
+namespace Apache.Ignite.EntityFrameworkCore.Extensions;
+
+using System;
+using System.Data.Common;
+using Apache.Ignite.EntityFrameworkCore.Infrastructure;
+using Apache.Ignite.EntityFrameworkCore.Infrastructure.Internal;
+using Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+public static class IgniteDbContextOptionsBuilderExtensions
+{
+    public static DbContextOptionsBuilder UseIgnite(
+        this DbContextOptionsBuilder optionsBuilder,
+        Action<IgniteDbContextOptionsBuilder>? igniteOptionsAction = null)
+    {
+        ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(GetOrCreateExtension(optionsBuilder));
+
+        ConfigureWarnings(optionsBuilder);
+
+        igniteOptionsAction?.Invoke(new IgniteDbContextOptionsBuilder(optionsBuilder));
+
+        return optionsBuilder;
+    }
+
+    public static DbContextOptionsBuilder UseIgnite(
+        this DbContextOptionsBuilder optionsBuilder,
+        string? connectionString,
+        Action<IgniteDbContextOptionsBuilder>? igniteOptionsAction = null)
+    {
+        var extension = (IgniteOptionsExtension)GetOrCreateExtension(optionsBuilder).WithConnectionString(connectionString);
+        ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+        ConfigureWarnings(optionsBuilder);
+
+        igniteOptionsAction?.Invoke(new IgniteDbContextOptionsBuilder(optionsBuilder));
+
+        return optionsBuilder;
+    }
+
+    public static DbContextOptionsBuilder UseIgnite(
+        this DbContextOptionsBuilder optionsBuilder,
+        DbConnection connection,
+        Action<IgniteDbContextOptionsBuilder>? igniteOptionsAction = null)
+        => UseIgnite(optionsBuilder, connection, false, igniteOptionsAction);
+
+    public static DbContextOptionsBuilder UseIgnite(
+        this DbContextOptionsBuilder optionsBuilder,
+        DbConnection connection,
+        bool contextOwnsConnection,
+        Action<IgniteDbContextOptionsBuilder>? igniteOptionsAction = null)
+    {
+        Check.NotNull(connection, nameof(connection));
+
+        var extension = (IgniteOptionsExtension)GetOrCreateExtension(optionsBuilder).WithConnection(connection, contextOwnsConnection);
+        ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+        ConfigureWarnings(optionsBuilder);
+
+        igniteOptionsAction?.Invoke(new IgniteDbContextOptionsBuilder(optionsBuilder));
+
+        return optionsBuilder;
+    }
+
+    public static DbContextOptionsBuilder<TContext> UseIgnite<TContext>(
+        this DbContextOptionsBuilder<TContext> optionsBuilder,
+        Action<IgniteDbContextOptionsBuilder>? igniteOptionsAction = null)
+        where TContext : DbContext
+        => (DbContextOptionsBuilder<TContext>)UseIgnite(
+            (DbContextOptionsBuilder)optionsBuilder, igniteOptionsAction);
+
+    public static DbContextOptionsBuilder<TContext> UseIgnite<TContext>(
+        this DbContextOptionsBuilder<TContext> optionsBuilder,
+        string? connectionString,
+        Action<IgniteDbContextOptionsBuilder>? igniteOptionsAction = null)
+        where TContext : DbContext
+        => (DbContextOptionsBuilder<TContext>)UseIgnite(
+            (DbContextOptionsBuilder)optionsBuilder, connectionString, igniteOptionsAction);
+
+    public static DbContextOptionsBuilder<TContext> UseIgnite<TContext>(
+        this DbContextOptionsBuilder<TContext> optionsBuilder,
+        DbConnection connection,
+        Action<IgniteDbContextOptionsBuilder>? igniteOptionsAction = null)
+        where TContext : DbContext
+        => (DbContextOptionsBuilder<TContext>)UseIgnite(
+            (DbContextOptionsBuilder)optionsBuilder, connection, igniteOptionsAction);
+
+    public static DbContextOptionsBuilder<TContext> UseIgnite<TContext>(
+        this DbContextOptionsBuilder<TContext> optionsBuilder,
+        DbConnection connection,
+        bool contextOwnsConnection,
+        Action<IgniteDbContextOptionsBuilder>? igniteOptionsAction = null)
+        where TContext : DbContext
+        => (DbContextOptionsBuilder<TContext>)UseIgnite(
+            (DbContextOptionsBuilder)optionsBuilder, connection, contextOwnsConnection, igniteOptionsAction);
+
+    private static IgniteOptionsExtension GetOrCreateExtension(DbContextOptionsBuilder options)
+        => options.Options.FindExtension<IgniteOptionsExtension>()
+            ?? new IgniteOptionsExtension();
+
+    private static void ConfigureWarnings(DbContextOptionsBuilder optionsBuilder)
+    {
+        var coreOptionsExtension
+            = optionsBuilder.Options.FindExtension<CoreOptionsExtension>()
+            ?? new CoreOptionsExtension();
+
+        coreOptionsExtension = RelationalOptionsExtension.WithDefaultWarningConfiguration(coreOptionsExtension);
+
+        ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(coreOptionsExtension);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Extensions/IgniteDbContextOptionsBuilderExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Extensions/IgniteDbContextOptionsBuilderExtensions.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Extensions;
 
 using System;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Extensions/IgniteServiceCollectionExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Extensions/IgniteServiceCollectionExtensions.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Extensions;
 
 using System;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Extensions/IgniteServiceCollectionExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Extensions/IgniteServiceCollectionExtensions.cs
@@ -1,0 +1,72 @@
+namespace Apache.Ignite.EntityFrameworkCore.Extensions;
+
+using System;
+using Apache.Ignite.EntityFrameworkCore.Diagnostics.Internal;
+using Apache.Ignite.EntityFrameworkCore.Infrastructure;
+using Apache.Ignite.EntityFrameworkCore.Infrastructure.Internal;
+using Apache.Ignite.EntityFrameworkCore.Migrations;
+using Apache.Ignite.EntityFrameworkCore.Migrations.Internal;
+using Apache.Ignite.EntityFrameworkCore.Query.Internal;
+using Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+using Apache.Ignite.EntityFrameworkCore.Update.Internal;
+using Metadata.Conventions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Update;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Ignite-specific extension methods for <see cref="IServiceCollection" />.
+/// </summary>
+public static class IgniteServiceCollectionExtensions
+{
+    public static IServiceCollection AddIgnite<TContext>(
+        this IServiceCollection serviceCollection,
+        string? connectionString,
+        Action<IgniteDbContextOptionsBuilder>? igniteOptionsAction = null,
+        Action<DbContextOptionsBuilder>? optionsAction = null)
+        where TContext : DbContext
+        => serviceCollection.AddDbContext<TContext>(
+            (_, options) =>
+            {
+                optionsAction?.Invoke(options);
+                options.UseIgnite(connectionString, igniteOptionsAction);
+            });
+
+    public static IServiceCollection AddEntityFrameworkIgnite(this IServiceCollection serviceCollection)
+    {
+        var builder = new EntityFrameworkRelationalServicesBuilder(serviceCollection)
+            .TryAdd<IParameterNameGeneratorFactory, IgniteParameterNameGeneratorFactory>()
+            .TryAdd<IRelationalCommandBuilderFactory, IgniteRelationalCommandBuilderFactory>()
+            .TryAdd<LoggingDefinitions, IgniteLoggingDefinitions>()
+            .TryAdd<IDatabaseProvider, DatabaseProvider<IgniteOptionsExtension>>()
+            .TryAdd<IRelationalTypeMappingSource, IgniteTypeMappingSource>()
+            .TryAdd<ISqlGenerationHelper, IgniteSqlGenerationHelper>()
+            .TryAdd<IModelValidator, IgniteModelValidator>()
+            .TryAdd<IProviderConventionSetBuilder, IgniteConventionSetBuilder>()
+            .TryAdd<IModificationCommandBatchFactory, IgniteModificationCommandBatchFactory>()
+            .TryAdd<IRelationalConnection>(p => p.GetRequiredService<IIgniteRelationalConnection>())
+            .TryAdd<IMigrationsSqlGenerator, IgniteMigrationsSqlGenerator>()
+            .TryAdd<IRelationalDatabaseCreator, IgniteDatabaseCreator>()
+            .TryAdd<IHistoryRepository, IgniteHistoryRepository>()
+            .TryAdd<IRelationalQueryStringFactory, IgniteQueryStringFactory>()
+            .TryAdd<IMethodCallTranslatorProvider, IgniteMethodCallTranslatorProvider>()
+            .TryAdd<IMemberTranslatorProvider, IgniteMemberTranslatorProvider>()
+            .TryAdd<IQuerySqlGeneratorFactory, IgniteQuerySqlGeneratorFactory>()
+            .TryAdd<IRelationalSqlTranslatingExpressionVisitorFactory, IgniteSqlTranslatingExpressionVisitorFactory>()
+            .TryAdd<IQueryTranslationPostprocessorFactory, IgniteQueryTranslationPostprocessorFactory>()
+            .TryAdd<IUpdateSqlGenerator, IgniteUpdateSqlGenerator>()
+            .TryAdd<ISqlExpressionFactory, IgniteSqlExpressionFactory>()
+            .TryAddProviderSpecificServices(
+                b => b.TryAddScoped<IIgniteRelationalConnection, IgniteRelationalConnection>());
+
+        builder.TryAddCoreServices();
+
+        return serviceCollection;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Extensions/Internal/IgniteLoggerExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Extensions/Internal/IgniteLoggerExtensions.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Extensions.Internal;
 
 using System;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Extensions/Internal/IgniteLoggerExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Extensions/Internal/IgniteLoggerExtensions.cs
@@ -1,0 +1,78 @@
+namespace Apache.Ignite.EntityFrameworkCore.Extensions.Internal;
+
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+public static class IgniteLoggerExtensions
+{
+    public static void ForeignKeyReferencesMissingTableWarning(
+        this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+        string? id,
+        string? tableName,
+        string? principalTableName)
+    {
+    }
+
+    public static void ForeignKeyPrincipalColumnMissingWarning(
+        this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+        string? foreignKeyName,
+        string? tableName,
+        string? principalColumnName,
+        string? principalTableName)
+    {
+    }
+
+    public static void IndexFound(
+        this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+        string? indexName,
+        string? tableName,
+        bool? unique)
+    {
+    }
+
+    public static void ForeignKeyFound(
+        this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+        string? tableName,
+        long id,
+        string? principalTableName,
+        string? deleteAction)
+    {
+    }
+
+    public static void PrimaryKeyFound(
+        this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+        string? primaryKeyName,
+        string? tableName)
+    {
+    }
+
+    public static void UniqueConstraintFound(
+        this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+        string? uniqueConstraintName,
+        string? tableName)
+    {
+    }
+
+    public static void UnexpectedConnectionTypeWarning(
+        this IDiagnosticsLogger<DbLoggerCategory.Infrastructure> diagnostics,
+        Type connectionType)
+    {
+    }
+
+    public static void OutOfRangeWarning(
+        this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+        string? columnName,
+        string? tableName,
+        string? type)
+    {
+    }
+
+    public static void FormatWarning(
+        this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+        string? columnName,
+        string? tableName,
+        string? type)
+    {
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Infrastructure/IgniteDbContextOptionsBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Infrastructure/IgniteDbContextOptionsBuilder.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Infrastructure;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Infrastructure/IgniteDbContextOptionsBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Infrastructure/IgniteDbContextOptionsBuilder.cs
@@ -1,0 +1,18 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Infrastructure;
+
+using Internal;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+public class IgniteDbContextOptionsBuilder : RelationalDbContextOptionsBuilder<IgniteDbContextOptionsBuilder, IgniteOptionsExtension>
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="IgniteDbContextOptionsBuilder" /> class.
+    /// </summary>
+    /// <param name="optionsBuilder">The options builder.</param>
+    public IgniteDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuilder)
+        : base(optionsBuilder)
+    {
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Infrastructure/IgniteDbContextOptionsBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Infrastructure/IgniteDbContextOptionsBuilder.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 public class IgniteDbContextOptionsBuilder : RelationalDbContextOptionsBuilder<IgniteDbContextOptionsBuilder, IgniteOptionsExtension>
 {
     /// <summary>
-    ///     Initializes a new instance of the <see cref="IgniteDbContextOptionsBuilder" /> class.
+    /// Initializes a new instance of the <see cref="IgniteDbContextOptionsBuilder" /> class.
     /// </summary>
     /// <param name="optionsBuilder">The options builder.</param>
     public IgniteDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuilder)

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Infrastructure/Internal/IgniteModelValidator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Infrastructure/Internal/IgniteModelValidator.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Infrastructure.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Infrastructure/Internal/IgniteModelValidator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Infrastructure/Internal/IgniteModelValidator.cs
@@ -1,0 +1,56 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Infrastructure.Internal;
+
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+public class IgniteModelValidator : RelationalModelValidator
+{
+    public IgniteModelValidator(
+        ModelValidatorDependencies dependencies,
+        RelationalModelValidatorDependencies relationalDependencies)
+        : base(dependencies, relationalDependencies)
+    {
+    }
+
+    public override void Validate(IModel model, IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
+    {
+        base.Validate(model, logger);
+
+        ValidateNoSchemas(model, logger);
+        ValidateNoSequences(model, logger);
+        ValidateNoStoredProcedures(model, logger);
+    }
+
+    protected virtual void ValidateNoSchemas(
+        IModel model,
+        IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
+    {
+        // TODO
+    }
+
+    protected virtual void ValidateNoSequences(
+        IModel model,
+        IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
+    {
+        // TODO
+    }
+
+    protected virtual void ValidateNoStoredProcedures(
+        IModel model,
+        IDiagnosticsLogger<DbLoggerCategory.Model.Validation> logger)
+    {
+        foreach (var entityType in model.GetEntityTypes())
+        {
+            if (entityType.GetInsertStoredProcedure() is not null
+                || entityType.GetUpdateStoredProcedure() is not null
+                || entityType.GetDeleteStoredProcedure() is not null)
+            {
+                throw new InvalidOperationException("Stored procedures are not supported in Ignite: " + entityType.DisplayName());
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Infrastructure/Internal/IgniteOptionsExtension.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Infrastructure/Internal/IgniteOptionsExtension.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Infrastructure.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Infrastructure/Internal/IgniteOptionsExtension.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Infrastructure/Internal/IgniteOptionsExtension.cs
@@ -1,0 +1,69 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Infrastructure.Internal;
+
+using System.Collections.Generic;
+using System.Text;
+using Extensions;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+public class IgniteOptionsExtension : RelationalOptionsExtension
+{
+    private DbContextOptionsExtensionInfo? _info;
+
+    public IgniteOptionsExtension()
+    {
+    }
+
+    protected IgniteOptionsExtension(IgniteOptionsExtension copyFrom)
+        : base(copyFrom)
+    {
+    }
+
+    public override DbContextOptionsExtensionInfo Info
+        => _info ??= new ExtensionInfo(this);
+
+    protected override RelationalOptionsExtension Clone()
+        => new IgniteOptionsExtension(this);
+
+    public override void ApplyServices(IServiceCollection services)
+        => services.AddEntityFrameworkIgnite();
+
+    private sealed class ExtensionInfo : RelationalExtensionInfo
+    {
+        private string? _logFragment;
+
+        public ExtensionInfo(IDbContextOptionsExtension extension)
+            : base(extension)
+        {
+        }
+
+        private new IgniteOptionsExtension Extension
+            => (IgniteOptionsExtension)base.Extension;
+
+        public override bool IsDatabaseProvider
+            => true;
+
+        public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
+            => other is ExtensionInfo;
+
+        public override string LogFragment
+        {
+            get
+            {
+                if (_logFragment == null)
+                {
+                    var builder = new StringBuilder();
+
+                    builder.Append(base.LogFragment);
+
+                    _logFragment = builder.ToString();
+                }
+
+                return _logFragment;
+            }
+        }
+
+        public override void PopulateDebugInfo(IDictionary<string, string> debugInfo) => debugInfo["Ignite"] = "1";
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Metadata/Conventions/IgniteConventionSetBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Metadata/Conventions/IgniteConventionSetBuilder.cs
@@ -1,0 +1,23 @@
+namespace Apache.Ignite.EntityFrameworkCore.Metadata.Conventions;
+
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+public class IgniteConventionSetBuilder : RelationalConventionSetBuilder
+{
+    public IgniteConventionSetBuilder(
+        ProviderConventionSetBuilderDependencies dependencies,
+        RelationalConventionSetBuilderDependencies relationalDependencies)
+        : base(dependencies, relationalDependencies)
+    {
+    }
+
+    public override ConventionSet CreateConventionSet()
+    {
+        var conventionSet = base.CreateConventionSet();
+
+        conventionSet.Replace<SharedTableConvention>(new IgniteSharedTableConvention(Dependencies, RelationalDependencies));
+
+        return conventionSet;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Metadata/Conventions/IgniteConventionSetBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Metadata/Conventions/IgniteConventionSetBuilder.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Metadata.Conventions;
 
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Metadata/Conventions/IgniteSharedTableConvention.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Metadata/Conventions/IgniteSharedTableConvention.cs
@@ -1,0 +1,18 @@
+namespace Apache.Ignite.EntityFrameworkCore.Metadata.Conventions;
+
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+public class IgniteSharedTableConvention : SharedTableConvention
+{
+    public IgniteSharedTableConvention(
+        ProviderConventionSetBuilderDependencies dependencies,
+        RelationalConventionSetBuilderDependencies relationalDependencies)
+        : base(dependencies, relationalDependencies)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override bool CheckConstraintsUniqueAcrossTables
+        => false;
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Metadata/Conventions/IgniteSharedTableConvention.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Metadata/Conventions/IgniteSharedTableConvention.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Metadata.Conventions;
 
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Migrations/IgniteMigrationsSqlGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Migrations/IgniteMigrationsSqlGenerator.cs
@@ -1,8 +1,23 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Migrations;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using Common;
@@ -712,17 +727,21 @@ public class IgniteMigrationsSqlGenerator : MigrationsSqlGenerator
         // No-op.
     }
 
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:Fields should be private", Justification = "Private class.")]
     private sealed class RebuildContext
     {
-        public ICollection<MigrationOperation> OperationsToReplace { get; } = new List<MigrationOperation>();
-        public IDictionary<string, AddColumnOperation> AddColumnsDeferred { get; } = new Dictionary<string, AddColumnOperation>();
-        public ICollection<string> DropColumnsDeferred { get; } = new HashSet<string>();
         public readonly IDictionary<string, AlterColumnOperation> AlterColumnsDeferred = new Dictionary<string, AlterColumnOperation>();
 
-        public readonly IDictionary<string, RenameColumnOperation> RenameColumnsDeferred =
-            new Dictionary<string, RenameColumnOperation>();
+        public readonly IDictionary<string, RenameColumnOperation> RenameColumnsDeferred = new Dictionary<string, RenameColumnOperation>();
+
+        public ICollection<MigrationOperation> OperationsToReplace { get; } = new List<MigrationOperation>();
+
+        public IDictionary<string, AddColumnOperation> AddColumnsDeferred { get; } = new Dictionary<string, AddColumnOperation>();
+
+        public ICollection<string> DropColumnsDeferred { get; } = new HashSet<string>();
 
         public ICollection<string> CreateIndexesDeferred { get; } = new HashSet<string>();
+
         public ICollection<MigrationOperation> OperationsToWarnFor { get; } = new List<MigrationOperation>();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Migrations/IgniteMigrationsSqlGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Migrations/IgniteMigrationsSqlGenerator.cs
@@ -1,0 +1,728 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Migrations;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteMigrationsSqlGenerator : MigrationsSqlGenerator
+{
+    public IgniteMigrationsSqlGenerator(MigrationsSqlGeneratorDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    public override IReadOnlyList<MigrationCommand> Generate(
+        IReadOnlyList<MigrationOperation> operations,
+        IModel? model = null,
+        MigrationsSqlGenerationOptions options = MigrationsSqlGenerationOptions.Default)
+        => base.Generate(RewriteOperations(operations, model), model, options);
+
+    private IReadOnlyList<MigrationOperation> RewriteOperations(
+        IReadOnlyList<MigrationOperation> migrationOperations,
+        IModel? model)
+    {
+        var operations = new List<MigrationOperation>();
+        var rebuilds = new Dictionary<(string Table, string? Schema), RebuildContext>();
+        foreach (var operation in migrationOperations)
+        {
+            switch (operation)
+            {
+                case AddPrimaryKeyOperation:
+                case AddUniqueConstraintOperation:
+                case AddCheckConstraintOperation:
+                case AlterTableOperation:
+                case DropCheckConstraintOperation:
+                case DropForeignKeyOperation:
+                case DropPrimaryKeyOperation:
+                case DropUniqueConstraintOperation:
+                {
+                    var tableOperation = (ITableMigrationOperation)operation;
+                    var rebuild = rebuilds.GetOrAddNew((tableOperation.Table, tableOperation.Schema));
+                    rebuild.OperationsToReplace.Add(operation);
+
+                    operations.Add(operation);
+
+                    break;
+                }
+
+                case DropColumnOperation dropColumnOperation:
+                {
+                    var rebuild = rebuilds.GetOrAddNew((dropColumnOperation.Table, dropColumnOperation.Schema));
+                    rebuild.OperationsToReplace.Add(dropColumnOperation);
+                    rebuild.DropColumnsDeferred.Add(dropColumnOperation.Name);
+
+                    operations.Add(dropColumnOperation);
+
+                    break;
+                }
+
+                case AddForeignKeyOperation foreignKeyOperation:
+                {
+                    var table = operations
+                        .OfType<CreateTableOperation>()
+                        .FirstOrDefault(o => o.Name == foreignKeyOperation.Table);
+
+                    if (table != null)
+                    {
+                        table.ForeignKeys.Add(foreignKeyOperation);
+                    }
+                    else
+                    {
+                        var rebuild = rebuilds.GetOrAddNew((foreignKeyOperation.Table, foreignKeyOperation.Schema));
+                        rebuild.OperationsToReplace.Add(foreignKeyOperation);
+
+                        operations.Add(foreignKeyOperation);
+                    }
+
+                    break;
+                }
+
+                case AlterColumnOperation alterColumnOperation:
+                {
+                    var rebuild = rebuilds.GetOrAddNew((alterColumnOperation.Table, alterColumnOperation.Schema));
+                    rebuild.OperationsToReplace.Add(alterColumnOperation);
+                    rebuild.AlterColumnsDeferred.Add(alterColumnOperation.Name, alterColumnOperation);
+
+                    operations.Add(alterColumnOperation);
+
+                    break;
+                }
+
+                case CreateIndexOperation createIndexOperation:
+                {
+                    // TODO: CREATE INDEX hangs in Ignite, skip for now.
+                    // if (rebuilds.TryGetValue((createIndexOperation.Table, createIndexOperation.Schema), out var rebuild)
+                    //     && (rebuild.AddColumnsDeferred.Keys.Intersect(createIndexOperation.Columns).Any()
+                    //         || rebuild.RenameColumnsDeferred.Keys.Intersect(createIndexOperation.Columns).Any()))
+                    // {
+                    //     rebuild.OperationsToReplace.Add(createIndexOperation);
+                    //     rebuild.CreateIndexesDeferred.Add(createIndexOperation.Name);
+                    // }
+                    //
+                    // operations.Add(createIndexOperation);
+                    break;
+                }
+
+                case RenameIndexOperation renameIndexOperation:
+                {
+                    var index = renameIndexOperation.Table != null
+                        ? model?.GetRelationalModel().FindTable(renameIndexOperation.Table, renameIndexOperation.Schema)
+                            ?.Indexes.FirstOrDefault(i => i.Name == renameIndexOperation.NewName)
+                        : null;
+                    if (index != null)
+                    {
+                        operations.Add(
+                            new DropIndexOperation
+                            {
+                                Table = renameIndexOperation.Table,
+                                Schema = renameIndexOperation.Schema,
+                                Name = renameIndexOperation.Name
+                            });
+
+                        operations.Add(CreateIndexOperation.CreateFrom(index));
+                    }
+                    else
+                    {
+                        operations.Add(renameIndexOperation);
+                    }
+
+                    break;
+                }
+
+                case AddColumnOperation addColumnOperation:
+                {
+                    if (rebuilds.TryGetValue((addColumnOperation.Table, addColumnOperation.Schema), out var rebuild)
+                        && rebuild.DropColumnsDeferred.Contains(addColumnOperation.Name))
+                    {
+                        rebuild.OperationsToReplace.Add(addColumnOperation);
+                        rebuild.AddColumnsDeferred.Add(addColumnOperation.Name, addColumnOperation);
+                    }
+                    else if (addColumnOperation.Comment != null)
+                    {
+                        rebuilds.GetOrAddNew((addColumnOperation.Table, addColumnOperation.Schema));
+                    }
+
+                    operations.Add(addColumnOperation);
+
+                    break;
+                }
+
+                case RenameColumnOperation renameColumnOperation:
+                {
+                    if (rebuilds.TryGetValue((renameColumnOperation.Table, renameColumnOperation.Schema), out var rebuild))
+                    {
+                        if (rebuild.DropColumnsDeferred.Contains(renameColumnOperation.NewName))
+                        {
+                            rebuild.OperationsToReplace.Add(renameColumnOperation);
+                            rebuild.DropColumnsDeferred.Add(renameColumnOperation.Name);
+                            rebuild.RenameColumnsDeferred.Add(renameColumnOperation.NewName, renameColumnOperation);
+                        }
+                    }
+
+                    operations.Add(renameColumnOperation);
+
+                    break;
+                }
+
+                case RenameTableOperation renameTableOperation:
+                {
+                    if (rebuilds.Remove((renameTableOperation.Name, renameTableOperation.Schema), out var rebuild))
+                    {
+                        rebuilds.Add(
+                            (renameTableOperation.NewName ?? renameTableOperation.Name, renameTableOperation.NewSchema), rebuild);
+                    }
+
+                    operations.Add(renameTableOperation);
+
+                    break;
+                }
+
+                case CreateTableOperation:
+                case AlterSequenceOperation:
+                case CreateSequenceOperation:
+                case DropIndexOperation:
+                case DropSchemaOperation:
+                case DropSequenceOperation:
+                case DropTableOperation:
+                case EnsureSchemaOperation:
+                case RenameSequenceOperation:
+                case RestartSequenceOperation:
+                {
+                    operations.Add(operation);
+
+                    break;
+                }
+
+                case DeleteDataOperation:
+                case InsertDataOperation:
+                case UpdateDataOperation:
+                {
+                    var tableOperation = (ITableMigrationOperation)operation;
+                    if (rebuilds.TryGetValue((tableOperation.Table, tableOperation.Schema), out var rebuild))
+                    {
+                        rebuild.OperationsToWarnFor.Add(operation);
+                    }
+
+                    operations.Add(operation);
+
+                    break;
+                }
+
+                default:
+                {
+                    foreach (var rebuild in rebuilds.Values)
+                    {
+                        rebuild.OperationsToWarnFor.Add(operation);
+                    }
+
+                    operations.Add(operation);
+
+                    break;
+                }
+            }
+        }
+
+        var skippedRebuilds = new List<(string Table, string? Schema)>();
+        var indexesToRebuild = new List<ITableIndex>();
+        foreach (var (key, rebuildContext) in rebuilds)
+        {
+            var table = model?.GetRelationalModel().FindTable(key.Table, key.Schema);
+            if (table == null)
+            {
+                skippedRebuilds.Add(key);
+
+                continue;
+            }
+
+            foreach (var operationToWarnFor in rebuildContext.OperationsToWarnFor)
+            {
+                // TODO: Log warning
+            }
+
+            foreach (var operationToReplace in rebuildContext.OperationsToReplace)
+            {
+                operations.Remove(operationToReplace);
+            }
+
+            var createTableOperation = new CreateTableOperation
+            {
+                Name = "ef_temp_" + table.Name,
+                Schema = table.Schema,
+                Comment = table.Comment
+            };
+
+            var primaryKey = table.PrimaryKey;
+            if (primaryKey != null)
+            {
+                createTableOperation.PrimaryKey = AddPrimaryKeyOperation.CreateFrom(primaryKey);
+            }
+
+            foreach (var column in table.Columns.Where(c => c.Order.HasValue).OrderBy(c => c.Order!.Value)
+                         .Concat(table.Columns.Where(c => !c.Order.HasValue)))
+            {
+                if (!column.TryGetDefaultValue(out var defaultValue))
+                {
+                    defaultValue = null;
+                }
+
+                var addColumnOperation = new AddColumnOperation
+                {
+                    Name = column.Name,
+                    ColumnType = column.StoreType,
+                    IsNullable = column.IsNullable,
+                    DefaultValue = rebuildContext.AddColumnsDeferred.TryGetValue(column.Name, out var originalOperation)
+                        && !originalOperation.IsNullable
+                            ? originalOperation.DefaultValue
+                            : defaultValue,
+                    DefaultValueSql = column.DefaultValueSql,
+                    ComputedColumnSql = column.ComputedColumnSql,
+                    IsStored = column.IsStored,
+                    Comment = column.Comment,
+                    Collation = column.Collation,
+                    Table = createTableOperation.Name
+                };
+                addColumnOperation.AddAnnotations(column.GetAnnotations());
+                createTableOperation.Columns.Add(addColumnOperation);
+            }
+
+            foreach (var foreignKey in table.ForeignKeyConstraints)
+            {
+                createTableOperation.ForeignKeys.Add(AddForeignKeyOperation.CreateFrom(foreignKey));
+            }
+
+            foreach (var uniqueConstraint in table.UniqueConstraints.Where(c => !c.GetIsPrimaryKey()))
+            {
+                createTableOperation.UniqueConstraints.Add(AddUniqueConstraintOperation.CreateFrom(uniqueConstraint));
+            }
+
+            foreach (var checkConstraint in table.CheckConstraints)
+            {
+                createTableOperation.CheckConstraints.Add(AddCheckConstraintOperation.CreateFrom(checkConstraint));
+            }
+
+            createTableOperation.AddAnnotations(table.GetAnnotations());
+            operations.Add(createTableOperation);
+
+            foreach (var index in table.Indexes)
+            {
+                if (index.IsUnique && rebuildContext.CreateIndexesDeferred.Contains(index.Name))
+                {
+                    var createIndexOperation = CreateIndexOperation.CreateFrom(index);
+                    createIndexOperation.Table = createTableOperation.Name;
+                    operations.Add(createIndexOperation);
+                }
+                else
+                {
+                    indexesToRebuild.Add(index);
+                }
+            }
+
+            var intoBuilder = new StringBuilder();
+            var selectBuilder = new StringBuilder();
+            var first = true;
+            foreach (var column in table.Columns)
+            {
+                if (column.ComputedColumnSql != null
+                    || rebuildContext.AddColumnsDeferred.ContainsKey(column.Name))
+                {
+                    continue;
+                }
+
+                if (first)
+                {
+                    first = false;
+                }
+                else
+                {
+                    intoBuilder.Append(", ");
+                    selectBuilder.Append(", ");
+                }
+
+                intoBuilder.Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(column.Name));
+
+                var defaultValue = rebuildContext.AlterColumnsDeferred.TryGetValue(column.Name, out var alterColumnOperation)
+                    && alterColumnOperation is { IsNullable: false, OldColumn.IsNullable: true }
+                        ? alterColumnOperation.DefaultValue
+                        : null;
+                if (defaultValue != null)
+                {
+                    selectBuilder.Append("IFNULL(");
+                }
+
+                selectBuilder.Append(
+                    Dependencies.SqlGenerationHelper.DelimitIdentifier(
+                        rebuildContext.RenameColumnsDeferred.TryGetValue(column.Name, out var renameColumnOperation)
+                            ? renameColumnOperation.Name
+                            : column.Name));
+
+                if (defaultValue != null)
+                {
+                    var defaultValueTypeMapping = (column.StoreType == null
+                            ? null
+                            : Dependencies.TypeMappingSource.FindMapping(defaultValue.GetType(), column.StoreType))
+                        ?? Dependencies.TypeMappingSource.GetMappingForValue(defaultValue);
+
+                    selectBuilder
+                        .Append(", ")
+                        .Append(defaultValueTypeMapping.GenerateSqlLiteral(defaultValue))
+                        .Append(')');
+                }
+            }
+
+            operations.Add(
+                new SqlOperation
+                {
+                    Sql = new StringBuilder()
+                        .Append("INSERT INTO ")
+                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(createTableOperation.Name))
+                        .Append(" (")
+                        .Append(intoBuilder)
+                        .AppendLine(")")
+                        .Append("SELECT ")
+                        .Append(selectBuilder)
+                        .AppendLine()
+                        .Append("FROM ")
+                        .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(table.Name))
+                        .Append(Dependencies.SqlGenerationHelper.StatementTerminator)
+                        .ToString()
+                });
+        }
+
+        foreach (var skippedRebuild in skippedRebuilds)
+        {
+            rebuilds.Remove(skippedRebuild);
+        }
+
+        if (rebuilds.Any())
+        {
+            operations.Add(
+                new SqlOperation { Sql = "PRAGMA foreign_keys = 0;", SuppressTransaction = true });
+        }
+
+        foreach (var ((table, schema), _) in rebuilds)
+        {
+            operations.Add(
+                new DropTableOperation { Name = table, Schema = schema });
+            operations.Add(
+                new RenameTableOperation
+                {
+                    Name = "ef_temp_" + table,
+                    Schema = schema,
+                    NewName = table,
+                    NewSchema = schema
+                });
+        }
+
+        if (rebuilds.Any())
+        {
+            operations.Add(
+                new SqlOperation { Sql = "PRAGMA foreign_keys = 1;", SuppressTransaction = true });
+        }
+
+        foreach (var index in indexesToRebuild)
+        {
+            operations.Add(CreateIndexOperation.CreateFrom(index));
+        }
+
+        return operations;
+    }
+
+    protected override void Generate(AlterDatabaseOperation operation, IModel? model, MigrationCommandListBuilder builder)
+    {
+        builder
+            .Append("SELECT InitSpatialMetaData()")
+            .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
+        EndStatement(builder);
+    }
+
+    protected override void Generate(
+        DropIndexOperation operation,
+        IModel? model,
+        MigrationCommandListBuilder builder,
+        bool terminate)
+    {
+        builder
+            .Append("DROP INDEX ")
+            .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name));
+
+        if (terminate)
+        {
+            builder
+                .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
+                .EndCommand();
+        }
+    }
+
+    protected override void Generate(RenameIndexOperation operation, IModel? model, MigrationCommandListBuilder builder)
+        => throw new NotSupportedException(
+            IgniteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
+
+    protected override void Generate(RenameTableOperation operation, IModel? model, MigrationCommandListBuilder builder)
+    {
+        if (operation.NewName != null
+            && operation.NewName != operation.Name)
+        {
+            builder
+                .Append("ALTER TABLE ")
+                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                .Append(" RENAME TO ")
+                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.NewName))
+                .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
+                .EndCommand();
+        }
+    }
+
+    protected override void Generate(RenameColumnOperation operation, IModel? model, MigrationCommandListBuilder builder)
+        => builder
+            .Append("ALTER TABLE ")
+            .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table))
+            .Append(" RENAME COLUMN ")
+            .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
+            .Append(" TO ")
+            .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.NewName))
+            .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
+            .EndCommand();
+
+    protected override void Generate(
+        CreateTableOperation operation,
+        IModel? model,
+        MigrationCommandListBuilder builder,
+        bool terminate = true)
+    {
+        builder
+            .Append("CREATE TABLE ")
+            .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name, operation.Schema))
+            .AppendLine(" (");
+
+        using (builder.Indent())
+        {
+            if (!string.IsNullOrEmpty(operation.Comment))
+            {
+                builder
+                    .AppendLines(Dependencies.SqlGenerationHelper.GenerateComment(operation.Comment))
+                    .AppendLine();
+            }
+
+            CreateTableColumns(operation, model, builder);
+            CreateTableConstraints(operation, model, builder);
+            builder.AppendLine();
+        }
+
+        builder.Append(")");
+
+        if (terminate)
+        {
+            builder.AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
+            EndStatement(builder);
+        }
+    }
+
+    protected override void CreateTableColumns(
+        CreateTableOperation operation,
+        IModel? model,
+        MigrationCommandListBuilder builder)
+    {
+        if (operation.Columns.All(c => string.IsNullOrEmpty(c.Comment)))
+        {
+            base.CreateTableColumns(operation, model, builder);
+        }
+        else
+        {
+            CreateTableColumnsWithComments(operation, model, builder);
+        }
+    }
+
+    private void CreateTableColumnsWithComments(
+        CreateTableOperation operation,
+        IModel? model,
+        MigrationCommandListBuilder builder)
+    {
+        for (var i = 0; i < operation.Columns.Count; i++)
+        {
+            var column = operation.Columns[i];
+
+            if (i > 0)
+            {
+                builder.AppendLine();
+            }
+
+            if (!string.IsNullOrEmpty(column.Comment))
+            {
+                builder.AppendLines(Dependencies.SqlGenerationHelper.GenerateComment(column.Comment));
+            }
+
+            ColumnDefinition(column, model, builder);
+
+            if (i != operation.Columns.Count - 1)
+            {
+                builder.AppendLine(",");
+            }
+        }
+    }
+
+    protected override void Generate(
+        AddForeignKeyOperation operation,
+        IModel? model,
+        MigrationCommandListBuilder builder,
+        bool terminate = true)
+        => throw new NotSupportedException(
+            IgniteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
+
+    protected override void Generate(
+        AddPrimaryKeyOperation operation,
+        IModel? model,
+        MigrationCommandListBuilder builder,
+        bool terminate = true)
+        => throw new NotSupportedException(
+            IgniteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
+
+    protected override void Generate(AddUniqueConstraintOperation operation, IModel? model, MigrationCommandListBuilder builder)
+        => throw new NotSupportedException(
+            IgniteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
+
+    protected override void Generate(AddCheckConstraintOperation operation, IModel? model, MigrationCommandListBuilder builder)
+        => throw new NotSupportedException(
+            IgniteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
+
+    protected override void Generate(
+        DropColumnOperation operation,
+        IModel? model,
+        MigrationCommandListBuilder builder,
+        bool terminate = true)
+        => throw new NotSupportedException(
+            IgniteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
+
+    protected override void Generate(
+        DropForeignKeyOperation operation,
+        IModel? model,
+        MigrationCommandListBuilder builder,
+        bool terminate = true)
+        => throw new NotSupportedException(
+            IgniteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
+
+    protected override void Generate(
+        DropPrimaryKeyOperation operation,
+        IModel? model,
+        MigrationCommandListBuilder builder,
+        bool terminate = true)
+        => throw new NotSupportedException(
+            IgniteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
+
+    protected override void Generate(DropUniqueConstraintOperation operation, IModel? model, MigrationCommandListBuilder builder)
+        => throw new NotSupportedException(
+            IgniteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
+
+    protected override void Generate(DropCheckConstraintOperation operation, IModel? model, MigrationCommandListBuilder builder)
+        => throw new NotSupportedException(
+            IgniteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
+
+    protected override void Generate(AlterColumnOperation operation, IModel? model, MigrationCommandListBuilder builder)
+        => throw new NotSupportedException(
+            IgniteStrings.InvalidMigrationOperation(operation.GetType().ShortDisplayName()));
+
+    protected override void ComputedColumnDefinition(
+        string? schema,
+        string table,
+        string name,
+        ColumnOperation operation,
+        IModel? model,
+        MigrationCommandListBuilder builder)
+    {
+        builder.Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(name));
+
+        builder
+            .Append(" AS (")
+            .Append(operation.ComputedColumnSql!)
+            .Append(")");
+
+        if (operation.IsStored == true)
+        {
+            builder.Append(" STORED");
+        }
+
+        if (operation.Collation != null)
+        {
+            builder
+                .Append(" COLLATE ")
+                .Append(operation.Collation);
+        }
+    }
+
+    protected override void Generate(EnsureSchemaOperation operation, IModel? model, MigrationCommandListBuilder builder)
+    {
+    }
+
+    protected override void Generate(DropSchemaOperation operation, IModel? model, MigrationCommandListBuilder builder)
+    {
+    }
+
+    protected override void Generate(RestartSequenceOperation operation, IModel? model, MigrationCommandListBuilder builder)
+        => throw new NotSupportedException(IgniteStrings.SequencesNotSupported);
+
+    protected override void Generate(CreateSequenceOperation operation, IModel? model, MigrationCommandListBuilder builder)
+        => throw new NotSupportedException(IgniteStrings.SequencesNotSupported);
+
+    protected override void Generate(RenameSequenceOperation operation, IModel? model, MigrationCommandListBuilder builder)
+        => throw new NotSupportedException(IgniteStrings.SequencesNotSupported);
+
+    protected override void Generate(AlterSequenceOperation operation, IModel? model, MigrationCommandListBuilder builder)
+        => throw new NotSupportedException(IgniteStrings.SequencesNotSupported);
+
+    protected override void Generate(DropSequenceOperation operation, IModel? model, MigrationCommandListBuilder builder)
+        => throw new NotSupportedException(IgniteStrings.SequencesNotSupported);
+
+    protected override void PrimaryKeyConstraint(AddPrimaryKeyOperation operation, IModel? model, MigrationCommandListBuilder builder)
+    {
+        // Ignite-specific: no constraints.
+        // if (operation.Name != null)
+        // {
+        //     builder
+        //         .Append("CONSTRAINT ")
+        //         .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
+        //         .Append(" ");
+        // }
+        builder
+            .Append("PRIMARY KEY ");
+
+        IndexTraits(operation, model, builder);
+
+        builder.Append("(")
+            .Append(ColumnList(operation.Columns))
+            .Append(")");
+    }
+
+    protected override void ForeignKeyConstraint(AddForeignKeyOperation operation, IModel? model, MigrationCommandListBuilder builder)
+    {
+        // Ignite-specific: no constraints.
+        // No-op.
+    }
+
+    protected override void CreateTableForeignKeys(CreateTableOperation operation, IModel? model, MigrationCommandListBuilder builder)
+    {
+        // Ignite-specific: no constraints.
+        // No-op.
+    }
+
+    private sealed class RebuildContext
+    {
+        public ICollection<MigrationOperation> OperationsToReplace { get; } = new List<MigrationOperation>();
+        public IDictionary<string, AddColumnOperation> AddColumnsDeferred { get; } = new Dictionary<string, AddColumnOperation>();
+        public ICollection<string> DropColumnsDeferred { get; } = new HashSet<string>();
+        public readonly IDictionary<string, AlterColumnOperation> AlterColumnsDeferred = new Dictionary<string, AlterColumnOperation>();
+
+        public readonly IDictionary<string, RenameColumnOperation> RenameColumnsDeferred =
+            new Dictionary<string, RenameColumnOperation>();
+
+        public ICollection<string> CreateIndexesDeferred { get; } = new HashSet<string>();
+        public ICollection<MigrationOperation> OperationsToWarnFor { get; } = new List<MigrationOperation>();
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Migrations/Internal/IgniteHistoryRepository.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Migrations/Internal/IgniteHistoryRepository.cs
@@ -1,0 +1,50 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Migrations.Internal;
+
+using System;
+using Common;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteHistoryRepository : HistoryRepository
+{
+    public IgniteHistoryRepository(HistoryRepositoryDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    protected override string ExistsSql
+    {
+        get
+        {
+            var stringTypeMapping = Dependencies.TypeMappingSource.GetMapping(typeof(string));
+
+            return
+                $"""
+                 SELECT COUNT(*) FROM "IGNITE_MASTER_TODO" 
+                                 WHERE "name" = {stringTypeMapping.GenerateSqlLiteral(TableName)} 
+                                   AND "type" = 'table';
+                 """;
+        }
+    }
+
+    protected override bool InterpretExistsResult(object? value)
+        => (long)value! != 0L;
+
+    public override string GetCreateIfNotExistsScript()
+    {
+        var script = GetCreateScript();
+
+        const string createTable = "CREATE TABLE";
+        return script.Insert(script.IndexOf(createTable, StringComparison.Ordinal) + createTable.Length, " IF NOT EXISTS");
+    }
+
+    public override string GetBeginIfNotExistsScript(string migrationId)
+        => throw new NotSupportedException(IgniteStrings.MigrationScriptGenerationNotSupported);
+
+    public override string GetBeginIfExistsScript(string migrationId)
+        => throw new NotSupportedException(IgniteStrings.MigrationScriptGenerationNotSupported);
+
+    public override string GetEndIfScript()
+        => throw new NotSupportedException(IgniteStrings.MigrationScriptGenerationNotSupported);
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Migrations/Internal/IgniteHistoryRepository.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Migrations/Internal/IgniteHistoryRepository.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Migrations.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteCharMethodTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteCharMethodTranslator.cs
@@ -1,0 +1,46 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+public class IgniteCharMethodTranslator : IMethodCallTranslator
+{
+    private static readonly Dictionary<MethodInfo, string> SupportedMethods = new()
+    {
+        { typeof(char).GetRuntimeMethod(nameof(char.ToLower), new[] { typeof(char) })!, "lower" },
+        { typeof(char).GetRuntimeMethod(nameof(char.ToUpper), new[] { typeof(char) })!, "upper" }
+    };
+
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    public IgniteCharMethodTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (SupportedMethods.TryGetValue(method, out var sqlFunctionName))
+        {
+            return _sqlExpressionFactory.Function(
+                sqlFunctionName,
+                arguments,
+                nullable: true,
+                argumentsPropagateNullability: arguments.Select(_ => true).ToList(),
+                method.ReturnType,
+                arguments[0].TypeMapping);
+        }
+
+        return null;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteCharMethodTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteCharMethodTranslator.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateOnlyMemberTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateOnlyMemberTranslator.cs
@@ -1,0 +1,44 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+public class IgniteDateOnlyMemberTranslator : IMemberTranslator
+{
+    private static readonly Dictionary<string, string> DatePartMapping
+        = new()
+        {
+            { nameof(DateOnly.Year), "%Y" },
+            { nameof(DateOnly.Month), "%m" },
+            { nameof(DateOnly.DayOfYear), "%j" },
+            { nameof(DateOnly.Day), "%d" },
+            { nameof(DateOnly.DayOfWeek), "%w" }
+        };
+
+    private readonly IgniteSqlExpressionFactory _sqlExpressionFactory;
+
+    public IgniteDateOnlyMemberTranslator(IgniteSqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MemberInfo member,
+        Type returnType,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        => member.DeclaringType == typeof(DateOnly) && DatePartMapping.TryGetValue(member.Name, out var datePart)
+            ? _sqlExpressionFactory.Convert(
+                _sqlExpressionFactory.Strftime(
+                    typeof(string),
+                    datePart,
+                    instance!),
+                returnType)
+            : null;
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateOnlyMemberTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateOnlyMemberTranslator.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateOnlyMethodTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateOnlyMethodTranslator.cs
@@ -1,0 +1,36 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+public class IgniteDateOnlyMethodTranslator : IMethodCallTranslator
+{
+    private readonly IgniteSqlExpressionFactory _sqlExpressionFactory;
+
+    public IgniteDateOnlyMethodTranslator(IgniteSqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    public SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (method.DeclaringType == typeof(DateOnly)
+            && method.Name == nameof(DateOnly.FromDateTime)
+            && arguments.Count == 1)
+        {
+            return _sqlExpressionFactory.Date(method.ReturnType, arguments[0]);
+        }
+
+        return null;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateOnlyMethodTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateOnlyMethodTranslator.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateTimeMemberTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateTimeMemberTranslator.cs
@@ -1,0 +1,146 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+public class IgniteDateTimeMemberTranslator : IMemberTranslator
+{
+    private static readonly Dictionary<string, string> DatePartMapping
+        = new()
+        {
+            { nameof(DateTime.Year), "%Y" },
+            { nameof(DateTime.Month), "%m" },
+            { nameof(DateTime.DayOfYear), "%j" },
+            { nameof(DateTime.Day), "%d" },
+            { nameof(DateTime.Hour), "%H" },
+            { nameof(DateTime.Minute), "%M" },
+            { nameof(DateTime.Second), "%S" },
+            { nameof(DateTime.DayOfWeek), "%w" }
+        };
+
+    private readonly IgniteSqlExpressionFactory _sqlExpressionFactory;
+
+    public IgniteDateTimeMemberTranslator(IgniteSqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MemberInfo member,
+        Type returnType,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (member.DeclaringType == typeof(DateTime))
+        {
+            var memberName = member.Name;
+
+            if (DatePartMapping.TryGetValue(memberName, out var datePart))
+            {
+                return _sqlExpressionFactory.Convert(
+                    _sqlExpressionFactory.Strftime(
+                        typeof(string),
+                        datePart,
+                        instance!),
+                    returnType);
+            }
+
+            if (memberName == nameof(DateTime.Ticks))
+            {
+                return _sqlExpressionFactory.Convert(
+                    _sqlExpressionFactory.Multiply(
+                        _sqlExpressionFactory.Subtract(
+                            _sqlExpressionFactory.Function(
+                                "julianday",
+                                new[] { instance! },
+                                nullable: true,
+                                argumentsPropagateNullability: new[] { true },
+                                typeof(double)),
+                            _sqlExpressionFactory.Constant(1721425.5)), // NB: Result of julianday('0001-01-01 00:00:00')
+                        _sqlExpressionFactory.Constant(TimeSpan.TicksPerDay)),
+                    typeof(long));
+            }
+
+            if (memberName == nameof(DateTime.Millisecond))
+            {
+                return _sqlExpressionFactory.Modulo(
+                    _sqlExpressionFactory.Multiply(
+                        _sqlExpressionFactory.Convert(
+                            _sqlExpressionFactory.Strftime(
+                                typeof(string),
+                                "%f",
+                                instance!),
+                            typeof(double)),
+                        _sqlExpressionFactory.Constant(1000)),
+                    _sqlExpressionFactory.Constant(1000));
+            }
+
+            var format = "%Y-%m-%d %H:%M:%f";
+            SqlExpression timestring;
+            var modifiers = new List<SqlExpression>();
+
+            switch (memberName)
+            {
+                case nameof(DateTime.Now):
+                    timestring = _sqlExpressionFactory.Constant("now");
+                    modifiers.Add(_sqlExpressionFactory.Constant("localtime"));
+                    break;
+
+                case nameof(DateTime.UtcNow):
+                    timestring = _sqlExpressionFactory.Constant("now");
+                    break;
+
+                case nameof(DateTime.Date):
+                    timestring = instance!;
+                    modifiers.Add(_sqlExpressionFactory.Constant("start of day"));
+                    break;
+
+                case nameof(DateTime.Today):
+                    timestring = _sqlExpressionFactory.Constant("now");
+                    modifiers.Add(_sqlExpressionFactory.Constant("localtime"));
+                    modifiers.Add(_sqlExpressionFactory.Constant("start of day"));
+                    break;
+
+                case nameof(DateTime.TimeOfDay):
+                    format = "%H:%M:%f";
+                    timestring = instance!;
+                    break;
+
+                default:
+                    return null;
+            }
+
+            return _sqlExpressionFactory.Function(
+                "rtrim",
+                new SqlExpression[]
+                {
+                    _sqlExpressionFactory.Function(
+                        "rtrim",
+                        new SqlExpression[]
+                        {
+                            _sqlExpressionFactory.Strftime(
+                                returnType,
+                                format,
+                                timestring,
+                                modifiers),
+                            _sqlExpressionFactory.Constant("0")
+                        },
+                        nullable: true,
+                        argumentsPropagateNullability: new[] { true, false },
+                        returnType),
+                    _sqlExpressionFactory.Constant(".")
+                },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true, false },
+                returnType);
+        }
+
+        return null;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateTimeMemberTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateTimeMemberTranslator.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateTimeMethodTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateTimeMethodTranslator.cs
@@ -1,0 +1,134 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+public class IgniteDateTimeMethodTranslator : IMethodCallTranslator
+{
+    private static readonly MethodInfo AddMilliseconds
+        = typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddMilliseconds), new[] { typeof(double) })!;
+
+    private static readonly MethodInfo AddTicks
+        = typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddTicks), new[] { typeof(long) })!;
+
+    private readonly Dictionary<MethodInfo, string> _methodInfoToUnitSuffix = new()
+    {
+        { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddYears), new[] { typeof(int) })!, " years" },
+        { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddMonths), new[] { typeof(int) })!, " months" },
+        { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddDays), new[] { typeof(double) })!, " days" },
+        { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddHours), new[] { typeof(double) })!, " hours" },
+        { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddMinutes), new[] { typeof(double) })!, " minutes" },
+        { typeof(DateTime).GetRuntimeMethod(nameof(DateTime.AddSeconds), new[] { typeof(double) })!, " seconds" },
+        { typeof(DateOnly).GetRuntimeMethod(nameof(DateOnly.AddYears), new[] { typeof(int) })!, " years" },
+        { typeof(DateOnly).GetRuntimeMethod(nameof(DateOnly.AddMonths), new[] { typeof(int) })!, " months" },
+        { typeof(DateOnly).GetRuntimeMethod(nameof(DateOnly.AddDays), new[] { typeof(int) })!, " days" }
+    };
+
+    private readonly IgniteSqlExpressionFactory _sqlExpressionFactory;
+
+    public IgniteDateTimeMethodTranslator(IgniteSqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        => method.DeclaringType == typeof(DateTime)
+            ? TranslateDateTime(instance, method, arguments)
+            : method.DeclaringType == typeof(DateOnly)
+                ? TranslateDateOnly(instance, method, arguments)
+                : null;
+
+    private SqlExpression? TranslateDateTime(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments)
+    {
+        SqlExpression? modifier = null;
+        if (AddMilliseconds.Equals(method))
+        {
+            modifier = _sqlExpressionFactory.Add(
+                _sqlExpressionFactory.Convert(
+                    _sqlExpressionFactory.Divide(
+                        arguments[0],
+                        _sqlExpressionFactory.Constant(1000.0)),
+                    typeof(string)),
+                _sqlExpressionFactory.Constant(" seconds"));
+        }
+        else if (AddTicks.Equals(method))
+        {
+            modifier = _sqlExpressionFactory.Add(
+                _sqlExpressionFactory.Convert(
+                    _sqlExpressionFactory.Divide(
+                        arguments[0],
+                        _sqlExpressionFactory.Constant((double)TimeSpan.TicksPerSecond)),
+                    typeof(string)),
+                _sqlExpressionFactory.Constant(" seconds"));
+        }
+        else if (_methodInfoToUnitSuffix.TryGetValue(method, out var unitSuffix))
+        {
+            modifier = _sqlExpressionFactory.Add(
+                _sqlExpressionFactory.Convert(arguments[0], typeof(string)),
+                _sqlExpressionFactory.Constant(unitSuffix));
+        }
+
+        if (modifier != null)
+        {
+            return _sqlExpressionFactory.Function(
+                "rtrim",
+                new SqlExpression[]
+                {
+                    _sqlExpressionFactory.Function(
+                        "rtrim",
+                        new SqlExpression[]
+                        {
+                            _sqlExpressionFactory.Strftime(
+                                method.ReturnType,
+                                "%Y-%m-%d %H:%M:%f",
+                                instance!,
+                                new[] { modifier }),
+                            _sqlExpressionFactory.Constant("0")
+                        },
+                        nullable: true,
+                        argumentsPropagateNullability: new[] { true, false },
+                        method.ReturnType),
+                    _sqlExpressionFactory.Constant(".")
+                },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true, false },
+                method.ReturnType);
+        }
+
+        return null;
+    }
+
+    private SqlExpression? TranslateDateOnly(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments)
+    {
+        if (instance is not null && _methodInfoToUnitSuffix.TryGetValue(method, out var unitSuffix))
+        {
+            return _sqlExpressionFactory.Date(
+                method.ReturnType,
+                instance,
+                new[]
+                {
+                    _sqlExpressionFactory.Add(
+                        _sqlExpressionFactory.Convert(arguments[0], typeof(string)),
+                        _sqlExpressionFactory.Constant(unitSuffix))
+                });
+        }
+
+        return null;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateTimeMethodTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteDateTimeMethodTranslator.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteMathTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteMathTranslator.cs
@@ -1,0 +1,170 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+public class IgniteMathTranslator : IMethodCallTranslator
+{
+    private static readonly Dictionary<MethodInfo, string> SupportedMethods = new()
+    {
+        { typeof(Math).GetMethod(nameof(Math.Abs), new[] { typeof(double) })!, "abs" },
+        { typeof(Math).GetMethod(nameof(Math.Abs), new[] { typeof(float) })!, "abs" },
+        { typeof(Math).GetMethod(nameof(Math.Abs), new[] { typeof(int) })!, "abs" },
+        { typeof(Math).GetMethod(nameof(Math.Abs), new[] { typeof(long) })!, "abs" },
+        { typeof(Math).GetMethod(nameof(Math.Abs), new[] { typeof(sbyte) })!, "abs" },
+        { typeof(Math).GetMethod(nameof(Math.Abs), new[] { typeof(short) })!, "abs" },
+        { typeof(Math).GetMethod(nameof(Math.Acos), new[] { typeof(double) })!, "acos" },
+        { typeof(Math).GetMethod(nameof(Math.Acosh), new[] { typeof(double) })!, "acosh" },
+        { typeof(Math).GetMethod(nameof(Math.Asin), new[] { typeof(double) })!, "asin" },
+        { typeof(Math).GetMethod(nameof(Math.Asinh), new[] { typeof(double) })!, "asinh" },
+        { typeof(Math).GetMethod(nameof(Math.Atan), new[] { typeof(double) })!, "atan" },
+        { typeof(Math).GetMethod(nameof(Math.Atan2), new[] { typeof(double), typeof(double) })!, "atan2" },
+        { typeof(Math).GetMethod(nameof(Math.Atanh), new[] { typeof(double) })!, "atanh" },
+        { typeof(Math).GetMethod(nameof(Math.Ceiling), new[] { typeof(double) })!, "ceiling" },
+        { typeof(Math).GetMethod(nameof(Math.Cos), new[] { typeof(double) })!, "cos" },
+        { typeof(Math).GetMethod(nameof(Math.Cosh), new[] { typeof(double) })!, "cosh" },
+        { typeof(Math).GetMethod(nameof(Math.Exp), new[] { typeof(double) })!, "exp" },
+        { typeof(Math).GetMethod(nameof(Math.Floor), new[] { typeof(double) })!, "floor" },
+        { typeof(Math).GetMethod(nameof(Math.Log), new[] { typeof(double) })!, "ln" },
+        { typeof(Math).GetMethod(nameof(Math.Log2), new[] { typeof(double) })!, "log2" },
+        { typeof(Math).GetMethod(nameof(Math.Log10), new[] { typeof(double) })!, "log10" },
+        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(byte), typeof(byte) })!, "max" },
+        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(double), typeof(double) })!, "max" },
+        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(float), typeof(float) })!, "max" },
+        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(int), typeof(int) })!, "max" },
+        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(long), typeof(long) })!, "max" },
+        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(sbyte), typeof(sbyte) })!, "max" },
+        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(short), typeof(short) })!, "max" },
+        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(uint), typeof(uint) })!, "max" },
+        { typeof(Math).GetMethod(nameof(Math.Max), new[] { typeof(ushort), typeof(ushort) })!, "max" },
+        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(byte), typeof(byte) })!, "min" },
+        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(double), typeof(double) })!, "min" },
+        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(float), typeof(float) })!, "min" },
+        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(int), typeof(int) })!, "min" },
+        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(long), typeof(long) })!, "min" },
+        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(sbyte), typeof(sbyte) })!, "min" },
+        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(short), typeof(short) })!, "min" },
+        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(uint), typeof(uint) })!, "min" },
+        { typeof(Math).GetMethod(nameof(Math.Min), new[] { typeof(ushort), typeof(ushort) })!, "min" },
+        { typeof(Math).GetMethod(nameof(Math.Pow), new[] { typeof(double), typeof(double) })!, "pow" },
+        { typeof(Math).GetMethod(nameof(Math.Round), new[] { typeof(double) })!, "round" },
+        { typeof(Math).GetMethod(nameof(Math.Sign), new[] { typeof(double) })!, "sign" },
+        { typeof(Math).GetMethod(nameof(Math.Sign), new[] { typeof(float) })!, "sign" },
+        { typeof(Math).GetMethod(nameof(Math.Sign), new[] { typeof(long) })!, "sign" },
+        { typeof(Math).GetMethod(nameof(Math.Sign), new[] { typeof(sbyte) })!, "sign" },
+        { typeof(Math).GetMethod(nameof(Math.Sign), new[] { typeof(short) })!, "sign" },
+        { typeof(Math).GetMethod(nameof(Math.Sin), new[] { typeof(double) })!, "sin" },
+        { typeof(Math).GetMethod(nameof(Math.Sinh), new[] { typeof(double) })!, "sinh" },
+        { typeof(Math).GetMethod(nameof(Math.Sqrt), new[] { typeof(double) })!, "sqrt" },
+        { typeof(Math).GetMethod(nameof(Math.Tan), new[] { typeof(double) })!, "tan" },
+        { typeof(Math).GetMethod(nameof(Math.Tanh), new[] { typeof(double) })!, "tanh" },
+        { typeof(Math).GetMethod(nameof(Math.Truncate), new[] { typeof(double) })!, "trunc" },
+        { typeof(double).GetRuntimeMethod(nameof(double.DegreesToRadians), new[] { typeof(double) })!, "radians" },
+        { typeof(double).GetRuntimeMethod(nameof(double.RadiansToDegrees), new[] { typeof(double) })!, "degrees" },
+        { typeof(MathF).GetMethod(nameof(MathF.Acos), new[] { typeof(float) })!, "acos" },
+        { typeof(MathF).GetMethod(nameof(MathF.Acosh), new[] { typeof(float) })!, "acosh" },
+        { typeof(MathF).GetMethod(nameof(MathF.Asin), new[] { typeof(float) })!, "asin" },
+        { typeof(MathF).GetMethod(nameof(MathF.Asinh), new[] { typeof(float) })!, "asinh" },
+        { typeof(MathF).GetMethod(nameof(MathF.Atan), new[] { typeof(float) })!, "atan" },
+        { typeof(MathF).GetMethod(nameof(MathF.Atan2), new[] { typeof(float), typeof(float) })!, "atan2" },
+        { typeof(MathF).GetMethod(nameof(MathF.Atanh), new[] { typeof(float) })!, "atanh" },
+        { typeof(MathF).GetMethod(nameof(MathF.Ceiling), new[] { typeof(float) })!, "ceiling" },
+        { typeof(MathF).GetMethod(nameof(MathF.Cos), new[] { typeof(float) })!, "cos" },
+        { typeof(MathF).GetMethod(nameof(MathF.Cosh), new[] { typeof(float) })!, "cosh" },
+        { typeof(MathF).GetMethod(nameof(MathF.Exp), new[] { typeof(float) })!, "exp" },
+        { typeof(MathF).GetMethod(nameof(MathF.Floor), new[] { typeof(float) })!, "floor" },
+        { typeof(MathF).GetMethod(nameof(MathF.Log), new[] { typeof(float) })!, "ln" },
+        { typeof(MathF).GetMethod(nameof(MathF.Log10), new[] { typeof(float) })!, "log10" },
+        { typeof(MathF).GetMethod(nameof(MathF.Log2), new[] { typeof(float) })!, "log2" },
+        { typeof(MathF).GetMethod(nameof(MathF.Pow), new[] { typeof(float), typeof(float) })!, "pow" },
+        { typeof(MathF).GetMethod(nameof(MathF.Round), new[] { typeof(float) })!, "round" },
+        { typeof(MathF).GetMethod(nameof(MathF.Sin), new[] { typeof(float) })!, "sin" },
+        { typeof(MathF).GetMethod(nameof(MathF.Sinh), new[] { typeof(float) })!, "sinh" },
+        { typeof(MathF).GetMethod(nameof(MathF.Sqrt), new[] { typeof(float) })!, "sqrt" },
+        { typeof(MathF).GetMethod(nameof(MathF.Tan), new[] { typeof(float) })!, "tan" },
+        { typeof(MathF).GetMethod(nameof(MathF.Tanh), new[] { typeof(float) })!, "tanh" },
+        { typeof(MathF).GetMethod(nameof(MathF.Truncate), new[] { typeof(float) })!, "trunc" },
+        { typeof(float).GetRuntimeMethod(nameof(float.DegreesToRadians), new[] { typeof(float) })!, "radians" },
+        { typeof(float).GetRuntimeMethod(nameof(float.RadiansToDegrees), new[] { typeof(float) })!, "degrees" }
+    };
+
+    private static readonly List<MethodInfo> _roundWithDecimalMethods = new()
+    {
+        typeof(Math).GetMethod(nameof(Math.Round), new[] { typeof(double), typeof(int) })!,
+        typeof(MathF).GetMethod(nameof(MathF.Round), new[] { typeof(float), typeof(int) })!
+    };
+
+    private static readonly List<MethodInfo> _logWithBaseMethods = new()
+    {
+        typeof(Math).GetMethod(nameof(Math.Log), new[] { typeof(double), typeof(double) })!,
+        typeof(MathF).GetMethod(nameof(MathF.Log), new[] { typeof(float), typeof(float) })!
+    };
+
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    public IgniteMathTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (SupportedMethods.TryGetValue(method, out var sqlFunctionName))
+        {
+            var typeMapping = ExpressionExtensions.InferTypeMapping(arguments.ToArray());
+            var newArguments = arguments
+                .Select(a => _sqlExpressionFactory.ApplyTypeMapping(a, typeMapping))
+                .ToList();
+
+            return _sqlExpressionFactory.Function(
+                sqlFunctionName,
+                newArguments,
+                nullable: true,
+                argumentsPropagateNullability: newArguments.Select(_ => true).ToList(),
+                method.ReturnType,
+                typeMapping);
+        }
+
+        if (_roundWithDecimalMethods.Contains(method))
+        {
+            return _sqlExpressionFactory.Function(
+                "round",
+                arguments,
+                nullable: true,
+                argumentsPropagateNullability: new[] { true, true },
+                method.ReturnType,
+                arguments[0].TypeMapping);
+        }
+
+        if (_logWithBaseMethods.Contains(method))
+        {
+            var a = arguments[0];
+            var newBase = arguments[1];
+            var typeMapping = ExpressionExtensions.InferTypeMapping(a, newBase);
+
+            return _sqlExpressionFactory.Function(
+                "log",
+                new[]
+                {
+                    _sqlExpressionFactory.ApplyTypeMapping(newBase, typeMapping), _sqlExpressionFactory.ApplyTypeMapping(a, typeMapping)
+                },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true, true },
+                method.ReturnType,
+                typeMapping);
+        }
+
+        return null;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteMathTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteMathTranslator.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteMemberTranslatorProvider.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteMemberTranslatorProvider.cs
@@ -1,0 +1,21 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using Microsoft.EntityFrameworkCore.Query;
+
+public class IgniteMemberTranslatorProvider : RelationalMemberTranslatorProvider
+{
+    public IgniteMemberTranslatorProvider(RelationalMemberTranslatorProviderDependencies dependencies)
+        : base(dependencies)
+    {
+        var sqlExpressionFactory = (IgniteSqlExpressionFactory)dependencies.SqlExpressionFactory;
+
+        AddTranslators(
+            new IMemberTranslator[]
+            {
+                new IgniteDateTimeMemberTranslator(sqlExpressionFactory),
+                new IgniteStringLengthTranslator(sqlExpressionFactory),
+                new IgniteDateOnlyMemberTranslator(sqlExpressionFactory)
+            });
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteMemberTranslatorProvider.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteMemberTranslatorProvider.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteMethodCallTranslatorProvider.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteMethodCallTranslatorProvider.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 
 using Microsoft.EntityFrameworkCore.Query;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteMethodCallTranslatorProvider.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteMethodCallTranslatorProvider.cs
@@ -1,0 +1,23 @@
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using Microsoft.EntityFrameworkCore.Query;
+
+public class IgniteMethodCallTranslatorProvider : RelationalMethodCallTranslatorProvider
+{
+    public IgniteMethodCallTranslatorProvider(RelationalMethodCallTranslatorProviderDependencies dependencies)
+        : base(dependencies)
+    {
+        var sqlExpressionFactory = (IgniteSqlExpressionFactory)dependencies.SqlExpressionFactory;
+
+        AddTranslators(
+            new IMethodCallTranslator[]
+            {
+                new IgniteCharMethodTranslator(sqlExpressionFactory),
+                new IgniteDateOnlyMethodTranslator(sqlExpressionFactory),
+                new IgniteDateTimeMethodTranslator(sqlExpressionFactory),
+                new IgniteMathTranslator(sqlExpressionFactory),
+                new IgniteObjectToStringTranslator(sqlExpressionFactory),
+                new IgniteStringMethodTranslator(sqlExpressionFactory),
+            });
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteObjectToStringTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteObjectToStringTranslator.cs
@@ -1,0 +1,91 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+public class IgniteObjectToStringTranslator : IMethodCallTranslator
+{
+    private static readonly HashSet<Type> TypeMapping = new()
+    {
+        typeof(bool),
+        typeof(byte),
+        typeof(byte[]),
+        typeof(char),
+        typeof(DateOnly),
+        typeof(DateTime),
+        typeof(DateTimeOffset),
+        typeof(decimal),
+        typeof(double),
+        typeof(float),
+        typeof(Guid),
+        typeof(int),
+        typeof(long),
+        typeof(sbyte),
+        typeof(short),
+        typeof(TimeOnly),
+        typeof(TimeSpan),
+        typeof(uint),
+        typeof(ushort)
+    };
+
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    public IgniteObjectToStringTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (instance == null || method.Name != nameof(ToString) || arguments.Count != 0)
+        {
+            return null;
+        }
+
+        if (instance.TypeMapping?.ClrType == typeof(string))
+        {
+            return instance;
+        }
+
+        if (instance.Type == typeof(bool))
+        {
+            if (instance is ColumnExpression { IsNullable: true })
+            {
+                return _sqlExpressionFactory.Case(
+                    new[]
+                    {
+                        new CaseWhenClause(
+                            _sqlExpressionFactory.Equal(instance, _sqlExpressionFactory.Constant(false)),
+                            _sqlExpressionFactory.Constant(false.ToString())),
+                        new CaseWhenClause(
+                            _sqlExpressionFactory.Equal(instance, _sqlExpressionFactory.Constant(true)),
+                            _sqlExpressionFactory.Constant(true.ToString()))
+                    },
+                    _sqlExpressionFactory.Constant(null));
+            }
+
+            return _sqlExpressionFactory.Case(
+                new[]
+                {
+                    new CaseWhenClause(
+                        _sqlExpressionFactory.Equal(instance, _sqlExpressionFactory.Constant(false)),
+                        _sqlExpressionFactory.Constant(false.ToString()))
+                },
+                _sqlExpressionFactory.Constant(true.ToString()));
+        }
+
+        return TypeMapping.Contains(instance.Type)
+            ? _sqlExpressionFactory.Convert(instance, typeof(string))
+            : null;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteObjectToStringTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteObjectToStringTranslator.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQuerySqlGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQuerySqlGenerator.cs
@@ -1,0 +1,126 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using System;
+using System.Linq.Expressions;
+using Common;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+public class IgniteQuerySqlGenerator : QuerySqlGenerator
+{
+    public IgniteQuerySqlGenerator(QuerySqlGeneratorDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    protected override string GetOperator(SqlBinaryExpression binaryExpression)
+        => binaryExpression.OperatorType == ExpressionType.Add
+            && binaryExpression.Type == typeof(string)
+                ? " || "
+                : base.GetOperator(binaryExpression);
+
+    protected override void GenerateLimitOffset(SelectExpression selectExpression)
+    {
+        if (selectExpression.Limit != null
+            || selectExpression.Offset != null)
+        {
+            Sql.AppendLine()
+                .Append("LIMIT ");
+
+            Visit(
+                selectExpression.Limit
+                ?? new SqlConstantExpression(Expression.Constant(-1), selectExpression.Offset!.TypeMapping));
+
+            if (selectExpression.Offset != null)
+            {
+                Sql.Append(" OFFSET ");
+
+                Visit(selectExpression.Offset);
+            }
+        }
+    }
+
+    protected override void GenerateSetOperationOperand(SetOperationBase setOperation, SelectExpression operand)
+        => Visit(operand);
+
+    protected override Expression VisitSqlUnary(SqlUnaryExpression sqlUnaryExpression)
+    {
+        switch (sqlUnaryExpression.OperatorType)
+        {
+            case ExpressionType.Convert:
+                if (sqlUnaryExpression.Operand.Type == typeof(char)
+                    && sqlUnaryExpression.Type.IsInteger())
+                {
+                    Sql.Append("unicode(");
+                    Visit(sqlUnaryExpression.Operand);
+                    Sql.Append(")");
+
+                    return sqlUnaryExpression;
+                }
+
+                if (sqlUnaryExpression.Operand.Type.IsInteger()
+                    && sqlUnaryExpression.Type == typeof(char))
+                {
+                    Sql.Append("char(");
+                    Visit(sqlUnaryExpression.Operand);
+                    Sql.Append(")");
+
+                    return sqlUnaryExpression;
+                }
+
+                goto default;
+
+            default:
+                return base.VisitSqlUnary(sqlUnaryExpression);
+        }
+    }
+
+    protected override bool TryGetOperatorInfo(SqlExpression expression, out int precedence, out bool isAssociative)
+    {
+        (precedence, isAssociative) = expression switch
+        {
+            SqlBinaryExpression sqlBinaryExpression => sqlBinaryExpression.OperatorType switch
+            {
+                ExpressionType.Multiply => (900, true),
+                ExpressionType.Divide => (900, false),
+                ExpressionType.Modulo => (900, false),
+                ExpressionType.Add when sqlBinaryExpression.Type == typeof(string) => (1000, true),
+                ExpressionType.Add when sqlBinaryExpression.Type != typeof(string) => (800, true),
+                ExpressionType.Subtract => (800, false),
+                ExpressionType.And => (600, true),
+                ExpressionType.Or => (600, true),
+                ExpressionType.LessThan => (500, false),
+                ExpressionType.LessThanOrEqual => (500, false),
+                ExpressionType.GreaterThan => (500, false),
+                ExpressionType.GreaterThanOrEqual => (500, false),
+                ExpressionType.Equal => (500, false),
+                ExpressionType.NotEqual => (500, false),
+                ExpressionType.AndAlso => (200, true),
+                ExpressionType.OrElse => (100, true),
+
+                _ => default,
+            },
+
+            SqlUnaryExpression sqlUnaryExpression => sqlUnaryExpression.OperatorType switch
+            {
+                ExpressionType.Convert => (1300, false),
+                ExpressionType.Not when sqlUnaryExpression.Type != typeof(bool) => (1200, false),
+                ExpressionType.Negate => (1200, false),
+                ExpressionType.Equal => (500, false), // IS NULL
+                ExpressionType.NotEqual => (500, false), // IS NOT NULL
+                ExpressionType.Not when sqlUnaryExpression.Type == typeof(bool) => (300, false),
+
+                _ => default,
+            },
+
+            CollateExpression => (1100, false),
+            LikeExpression => (500, false),
+            JsonScalarExpression => (1000, true),
+
+            _ => default,
+        };
+
+        return precedence != default;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQuerySqlGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQuerySqlGenerator.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQuerySqlGeneratorFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQuerySqlGeneratorFactory.cs
@@ -1,0 +1,20 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using Microsoft.EntityFrameworkCore.Query;
+
+public class IgniteQuerySqlGeneratorFactory : IQuerySqlGeneratorFactory
+{
+    public IgniteQuerySqlGeneratorFactory(QuerySqlGeneratorDependencies dependencies)
+    {
+        Dependencies = dependencies;
+    }
+
+    /// <summary>
+    ///     Relational provider-specific dependencies for this service.
+    /// </summary>
+    protected virtual QuerySqlGeneratorDependencies Dependencies { get; }
+
+    public virtual QuerySqlGenerator Create()
+        => new IgniteQuerySqlGenerator(Dependencies);
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQuerySqlGeneratorFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQuerySqlGeneratorFactory.cs
@@ -10,9 +10,6 @@ public class IgniteQuerySqlGeneratorFactory : IQuerySqlGeneratorFactory
         Dependencies = dependencies;
     }
 
-    /// <summary>
-    ///     Relational provider-specific dependencies for this service.
-    /// </summary>
     protected virtual QuerySqlGeneratorDependencies Dependencies { get; }
 
     public virtual QuerySqlGenerator Create()

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQuerySqlGeneratorFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQuerySqlGeneratorFactory.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQueryStringFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQueryStringFactory.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQueryStringFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQueryStringFactory.cs
@@ -1,0 +1,45 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using System;
+using System.Data.Common;
+using System.Text;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteQueryStringFactory : IRelationalQueryStringFactory
+{
+    private readonly IRelationalTypeMappingSource _typeMapper;
+
+    public IgniteQueryStringFactory(IRelationalTypeMappingSource typeMapper)
+    {
+        _typeMapper = typeMapper;
+    }
+
+    public virtual string Create(DbCommand command)
+    {
+        if (command.Parameters.Count == 0)
+        {
+            return command.CommandText;
+        }
+
+        var builder = new StringBuilder();
+        foreach (DbParameter parameter in command.Parameters)
+        {
+            var value = parameter.Value;
+            builder
+                .Append(".param set ")
+                .Append(parameter.ParameterName)
+                .Append(' ')
+                .AppendLine(
+                    value == null || value == DBNull.Value
+                        ? "NULL"
+                        : _typeMapper.FindMapping(value.GetType())?.GenerateSqlLiteral(value)
+                        ?? value.ToString());
+        }
+
+        return builder
+            .AppendLine()
+            .Append(command.CommandText).ToString();
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQueryTranslationPostprocessor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQueryTranslationPostprocessor.cs
@@ -1,4 +1,18 @@
-﻿
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 
 using System;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQueryTranslationPostprocessor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQueryTranslationPostprocessor.cs
@@ -1,0 +1,52 @@
+﻿
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Common;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+public class IgniteQueryTranslationPostprocessor : RelationalQueryTranslationPostprocessor
+{
+    private readonly ApplyValidatingVisitor _applyValidator = new();
+
+    public IgniteQueryTranslationPostprocessor(
+        QueryTranslationPostprocessorDependencies dependencies,
+        RelationalQueryTranslationPostprocessorDependencies relationalDependencies,
+        QueryCompilationContext queryCompilationContext)
+        : base(dependencies, relationalDependencies, queryCompilationContext)
+    {
+    }
+
+    public override Expression Process(Expression query)
+    {
+        var result = base.Process(query);
+        _applyValidator.Visit(result);
+
+        return result;
+    }
+
+    private sealed class ApplyValidatingVisitor : ExpressionVisitor
+    {
+        protected override Expression VisitExtension(Expression extensionExpression)
+        {
+            if (extensionExpression is ShapedQueryExpression shapedQueryExpression)
+            {
+                Visit(shapedQueryExpression.QueryExpression);
+                Visit(shapedQueryExpression.ShaperExpression);
+
+                return extensionExpression;
+            }
+
+            if (extensionExpression is SelectExpression selectExpression
+                && selectExpression.Tables.Any(t => t is CrossApplyExpression or OuterApplyExpression))
+            {
+                throw new InvalidOperationException(IgniteStrings.ApplyNotSupported);
+            }
+
+            return base.VisitExtension(extensionExpression);
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQueryTranslationPostprocessorFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQueryTranslationPostprocessorFactory.cs
@@ -1,4 +1,18 @@
-﻿
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 
 using Microsoft.EntityFrameworkCore.Query;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQueryTranslationPostprocessorFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQueryTranslationPostprocessorFactory.cs
@@ -1,0 +1,31 @@
+﻿
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using Microsoft.EntityFrameworkCore.Query;
+
+public class IgniteQueryTranslationPostprocessorFactory : IQueryTranslationPostprocessorFactory
+{
+    public IgniteQueryTranslationPostprocessorFactory(
+        QueryTranslationPostprocessorDependencies dependencies,
+        RelationalQueryTranslationPostprocessorDependencies relationalDependencies)
+    {
+        Dependencies = dependencies;
+        RelationalDependencies = relationalDependencies;
+    }
+
+    /// <summary>
+    ///     Dependencies for this service.
+    /// </summary>
+    protected virtual QueryTranslationPostprocessorDependencies Dependencies { get; }
+
+    /// <summary>
+    ///     Relational provider-specific dependencies for this service.
+    /// </summary>
+    protected virtual RelationalQueryTranslationPostprocessorDependencies RelationalDependencies { get; }
+
+    public virtual QueryTranslationPostprocessor Create(QueryCompilationContext queryCompilationContext)
+        => new IgniteQueryTranslationPostprocessor(
+            Dependencies,
+            RelationalDependencies,
+            queryCompilationContext);
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQueryTranslationPostprocessorFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteQueryTranslationPostprocessorFactory.cs
@@ -13,14 +13,8 @@ public class IgniteQueryTranslationPostprocessorFactory : IQueryTranslationPostp
         RelationalDependencies = relationalDependencies;
     }
 
-    /// <summary>
-    ///     Dependencies for this service.
-    /// </summary>
     protected virtual QueryTranslationPostprocessorDependencies Dependencies { get; }
 
-    /// <summary>
-    ///     Relational provider-specific dependencies for this service.
-    /// </summary>
     protected virtual RelationalQueryTranslationPostprocessorDependencies RelationalDependencies { get; }
 
     public virtual QueryTranslationPostprocessor Create(QueryCompilationContext queryCompilationContext)

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlExpressionFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlExpressionFactory.cs
@@ -1,0 +1,84 @@
+﻿
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteSqlExpressionFactory : SqlExpressionFactory
+{
+    public IgniteSqlExpressionFactory(SqlExpressionFactoryDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    public virtual SqlFunctionExpression Strftime(
+        Type returnType,
+        string format,
+        SqlExpression timestring,
+        IEnumerable<SqlExpression>? modifiers = null,
+        RelationalTypeMapping? typeMapping = null)
+    {
+        modifiers ??= Enumerable.Empty<SqlExpression>();
+
+        // If the inner call is another strftime then shortcut a double call
+        if (timestring is SqlFunctionExpression { Name: "rtrim" } rtrimFunction
+            && rtrimFunction.Arguments!.Count == 2
+            && rtrimFunction.Arguments[0] is SqlFunctionExpression { Name: "rtrim" } rtrimFunction2
+            && rtrimFunction2.Arguments!.Count == 2
+            && rtrimFunction2.Arguments[0] is SqlFunctionExpression { Name: "strftime" } strftimeFunction
+            && strftimeFunction.Arguments!.Count > 1)
+        {
+            // Use its timestring parameter directly in place of ours
+            timestring = strftimeFunction.Arguments[1];
+
+            // Prepend its modifier arguments (if any) to the current call
+            modifiers = strftimeFunction.Arguments.Skip(2).Concat(modifiers);
+        }
+
+        if (timestring is SqlFunctionExpression { Name: "date" } dateFunction)
+        {
+            timestring = dateFunction.Arguments![0];
+            modifiers = dateFunction.Arguments.Skip(1).Concat(modifiers);
+        }
+
+        var finalArguments = new[] { Constant(format), timestring }.Concat(modifiers);
+
+        return Function(
+            "strftime",
+            finalArguments,
+            nullable: true,
+            argumentsPropagateNullability: finalArguments.Select(_ => true),
+            returnType,
+            typeMapping);
+    }
+
+    public virtual SqlFunctionExpression Date(
+        Type returnType,
+        SqlExpression timestring,
+        IEnumerable<SqlExpression>? modifiers = null,
+        RelationalTypeMapping? typeMapping = null)
+    {
+        modifiers ??= Enumerable.Empty<SqlExpression>();
+
+        if (timestring is SqlFunctionExpression { Name: "date" } dateFunction)
+        {
+            timestring = dateFunction.Arguments![0];
+            modifiers = dateFunction.Arguments.Skip(1).Concat(modifiers);
+        }
+
+        var finalArguments = new[] { timestring }.Concat(modifiers);
+
+        return Function(
+            "date",
+            finalArguments,
+            nullable: true,
+            argumentsPropagateNullability: finalArguments.Select(_ => true),
+            returnType,
+            typeMapping);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlExpressionFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlExpressionFactory.cs
@@ -1,4 +1,18 @@
-﻿
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 
 using System;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlTranslatingExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlTranslatingExpressionVisitor.cs
@@ -228,7 +228,6 @@ public class IgniteSqlTranslatingExpressionVisitor : RelationalSqlTranslatingExp
         return visitedExpression;
     }
 
-    /// <inheritdoc />
     protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
     {
         var method = methodCallExpression.Method;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlTranslatingExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlTranslatingExpressionVisitor.cs
@@ -1,0 +1,513 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+public class IgniteSqlTranslatingExpressionVisitor : RelationalSqlTranslatingExpressionVisitor
+{
+    private readonly QueryCompilationContext _queryCompilationContext;
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    private static readonly MethodInfo StringStartsWithMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.StartsWith), new[] { typeof(string) })!;
+
+    private static readonly MethodInfo StringEndsWithMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.EndsWith), new[] { typeof(string) })!;
+
+    private static readonly MethodInfo EscapeLikePatternParameterMethod =
+        typeof(IgniteSqlTranslatingExpressionVisitor).GetTypeInfo().GetDeclaredMethod(nameof(ConstructLikePatternParameter))!;
+
+    private const char LikeEscapeChar = '\\';
+    private const string LikeEscapeString = "\\";
+
+    private static readonly IReadOnlyDictionary<ExpressionType, IReadOnlyCollection<Type>> RestrictedBinaryExpressions
+        = new Dictionary<ExpressionType, IReadOnlyCollection<Type>>
+        {
+            [ExpressionType.Add] = new HashSet<Type>
+            {
+                typeof(DateOnly),
+                typeof(DateTime),
+                typeof(DateTimeOffset),
+                typeof(TimeOnly),
+                typeof(TimeSpan)
+            },
+            [ExpressionType.Divide] = new HashSet<Type>
+            {
+                typeof(TimeOnly),
+                typeof(TimeSpan),
+                typeof(ulong)
+            },
+            [ExpressionType.GreaterThan] = new HashSet<Type>
+            {
+                typeof(DateTimeOffset),
+                typeof(TimeSpan),
+                typeof(ulong)
+            },
+            [ExpressionType.GreaterThanOrEqual] = new HashSet<Type>
+            {
+                typeof(DateTimeOffset),
+                typeof(TimeSpan),
+                typeof(ulong)
+            },
+            [ExpressionType.LessThan] = new HashSet<Type>
+            {
+                typeof(DateTimeOffset),
+                typeof(TimeSpan),
+                typeof(ulong)
+            },
+            [ExpressionType.LessThanOrEqual] = new HashSet<Type>
+            {
+                typeof(DateTimeOffset),
+                typeof(TimeSpan),
+                typeof(ulong)
+            },
+            [ExpressionType.Modulo] = new HashSet<Type> { typeof(ulong) },
+            [ExpressionType.Multiply] = new HashSet<Type>
+            {
+                typeof(TimeOnly),
+                typeof(TimeSpan),
+                typeof(ulong)
+            },
+            [ExpressionType.Subtract] = new HashSet<Type>
+            {
+                typeof(DateOnly),
+                typeof(DateTime),
+                typeof(DateTimeOffset),
+                typeof(TimeOnly),
+                typeof(TimeSpan)
+            }
+        };
+
+    private static readonly IReadOnlyDictionary<Type, string> ModuloFunctions = new Dictionary<Type, string>
+    {
+        { typeof(decimal), "ef_mod" },
+        { typeof(double), "mod" },
+        { typeof(float), "mod" }
+    };
+
+    private static readonly bool UseOldBehavior32432 =
+        AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue32432", out var enabled32432) && enabled32432;
+
+    public IgniteSqlTranslatingExpressionVisitor(
+        RelationalSqlTranslatingExpressionVisitorDependencies dependencies,
+        QueryCompilationContext queryCompilationContext,
+        QueryableMethodTranslatingExpressionVisitor queryableMethodTranslatingExpressionVisitor)
+        : base(dependencies, queryCompilationContext, queryableMethodTranslatingExpressionVisitor)
+    {
+        _queryCompilationContext = queryCompilationContext;
+        _sqlExpressionFactory = dependencies.SqlExpressionFactory;
+    }
+
+    protected override Expression VisitUnary(UnaryExpression unaryExpression)
+    {
+        if (unaryExpression.NodeType == ExpressionType.ArrayLength
+            && unaryExpression.Operand.Type == typeof(byte[]))
+        {
+            return Visit(unaryExpression.Operand) is SqlExpression sqlExpression
+                ? Dependencies.SqlExpressionFactory.Function(
+                    "length",
+                    new[] { sqlExpression },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    typeof(int))
+                : QueryCompilationContext.NotTranslatedExpression;
+        }
+
+        var visitedExpression = base.VisitUnary(unaryExpression);
+        if (visitedExpression == QueryCompilationContext.NotTranslatedExpression)
+        {
+            return QueryCompilationContext.NotTranslatedExpression;
+        }
+
+        if (visitedExpression is SqlUnaryExpression { OperatorType: ExpressionType.Negate } sqlUnary)
+        {
+            var operandType = GetProviderType(sqlUnary.Operand);
+            if (operandType == typeof(decimal))
+            {
+                return Dependencies.SqlExpressionFactory.Function(
+                    name: "ef_negate",
+                    new[] { sqlUnary.Operand },
+                    nullable: true,
+                    new[] { true },
+                    visitedExpression.Type);
+            }
+
+            if (operandType == typeof(TimeOnly)
+                || operandType == typeof(TimeSpan))
+            {
+                return QueryCompilationContext.NotTranslatedExpression;
+            }
+        }
+
+        return visitedExpression;
+    }
+
+    protected override Expression VisitBinary(BinaryExpression binaryExpression)
+    {
+        // See issue#16428
+        //if (binaryExpression.NodeType == ExpressionType.ArrayIndex
+        //    && binaryExpression.Left.Type == typeof(byte[]))
+        //{
+        //    var left = Visit(binaryExpression.Left);
+        //    var right = Visit(binaryExpression.Right);
+
+        //    if (left is SqlExpression leftSql
+        //        && right is SqlExpression rightSql)
+        //    {
+        //        return Dependencies.SqlExpressionFactory.Function(
+        //            "unicode",
+        //            new SqlExpression[]
+        //            {
+        //                Dependencies.SqlExpressionFactory.Function(
+        //                    "substr",
+        //                    new SqlExpression[]
+        //                    {
+        //                        leftSql,
+        //                        Dependencies.SqlExpressionFactory.Add(
+        //                            Dependencies.SqlExpressionFactory.ApplyDefaultTypeMapping(rightSql),
+        //                            Dependencies.SqlExpressionFactory.Constant(1)),
+        //                        Dependencies.SqlExpressionFactory.Constant(1)
+        //                    },
+        //                    nullable: true,
+        //                    argumentsPropagateNullability: new[] { true, true, true },
+        //                    typeof(byte[]))
+        //            },
+        //            nullable: true,
+        //            argumentsPropagateNullability: new[] { true },
+        //            binaryExpression.Type);
+        //    }
+        //}
+
+        if (!(base.VisitBinary(binaryExpression) is SqlExpression visitedExpression))
+        {
+            return QueryCompilationContext.NotTranslatedExpression;
+        }
+
+        if (visitedExpression is SqlBinaryExpression sqlBinary)
+        {
+            if (sqlBinary.OperatorType == ExpressionType.Modulo
+                && (ModuloFunctions.TryGetValue(GetProviderType(sqlBinary.Left), out var function)
+                    || ModuloFunctions.TryGetValue(GetProviderType(sqlBinary.Right), out function)))
+            {
+                return Dependencies.SqlExpressionFactory.Function(
+                    function,
+                    new[] { sqlBinary.Left, sqlBinary.Right },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true, true },
+                    visitedExpression.Type,
+                    visitedExpression.TypeMapping);
+            }
+
+            if (AttemptDecimalCompare(sqlBinary))
+            {
+                return DoDecimalCompare(visitedExpression, sqlBinary.OperatorType, sqlBinary.Left, sqlBinary.Right);
+            }
+
+            if (AttemptDecimalArithmetic(sqlBinary))
+            {
+                return DoDecimalArithmetics(visitedExpression, sqlBinary.OperatorType, sqlBinary.Left, sqlBinary.Right);
+            }
+
+            if (RestrictedBinaryExpressions.TryGetValue(sqlBinary.OperatorType, out var restrictedTypes)
+                && (restrictedTypes.Contains(GetProviderType(sqlBinary.Left))
+                    || restrictedTypes.Contains(GetProviderType(sqlBinary.Right))))
+            {
+                return QueryCompilationContext.NotTranslatedExpression;
+            }
+        }
+
+        return visitedExpression;
+    }
+
+    /// <inheritdoc />
+    protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+    {
+        var method = methodCallExpression.Method;
+
+        if (method == StringStartsWithMethodInfo
+            && TryTranslateStartsEndsWith(
+                methodCallExpression.Object!, methodCallExpression.Arguments[0], startsWith: true, out var translation1))
+        {
+            return translation1;
+        }
+
+        if (method == StringEndsWithMethodInfo
+            && TryTranslateStartsEndsWith(
+                methodCallExpression.Object!, methodCallExpression.Arguments[0], startsWith: false, out var translation2))
+        {
+            return translation2;
+        }
+
+        return base.VisitMethodCall(methodCallExpression);
+
+        bool TryTranslateStartsEndsWith(
+            Expression instance,
+            Expression pattern,
+            bool startsWith,
+            [NotNullWhen(true)] out SqlExpression? translation)
+        {
+            if (Visit(instance) is not SqlExpression translatedInstance
+                || Visit(pattern) is not SqlExpression translatedPattern)
+            {
+                translation = null;
+                return false;
+            }
+
+            var stringTypeMapping = ExpressionExtensions.InferTypeMapping(translatedInstance, translatedPattern);
+
+            translatedInstance = _sqlExpressionFactory.ApplyTypeMapping(translatedInstance, stringTypeMapping);
+            translatedPattern = _sqlExpressionFactory.ApplyTypeMapping(translatedPattern, stringTypeMapping);
+
+            switch (translatedPattern)
+            {
+                case SqlConstantExpression patternConstant:
+                {
+                    translation = patternConstant.Value switch
+                    {
+                        null => _sqlExpressionFactory.Like(translatedInstance, _sqlExpressionFactory.Constant(null, stringTypeMapping)),
+
+                        // In .NET, all strings start with/end with/contain the empty string, but SQL LIKE return false for empty patterns.
+                        // Return % which always matches instead.
+                        // Note that we don't just return a true constant, since null strings shouldn't match even an empty string
+                        // (but SqlNullabilityProcess will convert this to a true constant if the instance is non-nullable)
+                        "" => _sqlExpressionFactory.Like(translatedInstance, _sqlExpressionFactory.Constant("%")),
+
+                        string s => s.Any(IsLikeWildChar)
+                            ? _sqlExpressionFactory.Like(
+                                translatedInstance,
+                                _sqlExpressionFactory.Constant(startsWith ? EscapeLikePattern(s) + '%' : '%' + EscapeLikePattern(s)),
+                                _sqlExpressionFactory.Constant(LikeEscapeString))
+                            : _sqlExpressionFactory.Like(
+                                translatedInstance,
+                                _sqlExpressionFactory.Constant(startsWith ? s + '%' : '%' + s)),
+
+                        _ => throw new UnreachableException()
+                    };
+
+                    return true;
+                }
+
+                case SqlParameterExpression patternParameter
+                    when patternParameter.Name.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal):
+                {
+                    // The pattern is a parameter, register a runtime parameter that will contain the rewritten LIKE pattern, where
+                    // all special characters have been escaped.
+                    var lambda = Expression.Lambda(
+                        Expression.Call(
+                            EscapeLikePatternParameterMethod,
+                            QueryCompilationContext.QueryContextParameter,
+                            Expression.Constant(patternParameter.Name),
+                            Expression.Constant(startsWith)),
+                        QueryCompilationContext.QueryContextParameter);
+
+                    var escapedPatternParameter = UseOldBehavior32432
+                        ? _queryCompilationContext.RegisterRuntimeParameter(patternParameter.Name + "_rewritten", lambda)
+                        : _queryCompilationContext.RegisterRuntimeParameter(
+                            $"{patternParameter.Name}_{(startsWith ? "startswith" : "endswith")}", lambda);
+
+                    translation = _sqlExpressionFactory.Like(
+                        translatedInstance,
+                        new SqlParameterExpression(escapedPatternParameter.Name!, escapedPatternParameter.Type, stringTypeMapping),
+                        _sqlExpressionFactory.Constant(LikeEscapeString));
+
+                    return true;
+                }
+
+                default:
+                    // The pattern is a column or a complex expression; the possible special characters in the pattern cannot be escaped,
+                    // preventing us from translating to LIKE.
+                    if (startsWith)
+                    {
+                        translation = _sqlExpressionFactory.AndAlso(
+                            _sqlExpressionFactory.IsNotNull(translatedInstance),
+                            _sqlExpressionFactory.AndAlso(
+                                _sqlExpressionFactory.IsNotNull(translatedPattern),
+                                _sqlExpressionFactory.OrElse(
+                                    _sqlExpressionFactory.Equal(
+                                        _sqlExpressionFactory.Function(
+                                            "substr",
+                                            new[]
+                                            {
+                                                translatedInstance,
+                                                _sqlExpressionFactory.Constant(1),
+                                                _sqlExpressionFactory.Function(
+                                                    "length",
+                                                    new[] { translatedPattern },
+                                                    nullable: true,
+                                                    argumentsPropagateNullability: new[] { true },
+                                                    typeof(int))
+                                            },
+                                            nullable: true,
+                                            argumentsPropagateNullability: new[] { true, false, true },
+                                            typeof(string),
+                                            stringTypeMapping),
+                                        translatedPattern),
+                                    _sqlExpressionFactory.Equal(translatedPattern, _sqlExpressionFactory.Constant(string.Empty)))));
+                    }
+                    else
+                    {
+                        translation =
+                            _sqlExpressionFactory.AndAlso(
+                                _sqlExpressionFactory.IsNotNull(translatedInstance),
+                                _sqlExpressionFactory.AndAlso(
+                                    _sqlExpressionFactory.IsNotNull(translatedPattern),
+                                    _sqlExpressionFactory.OrElse(
+                                        _sqlExpressionFactory.Equal(
+                                            _sqlExpressionFactory.Function(
+                                                "substr",
+                                                new[]
+                                                {
+                                                    translatedInstance,
+                                                    _sqlExpressionFactory.Negate(
+                                                        _sqlExpressionFactory.Function(
+                                                            "length",
+                                                            new[] { translatedPattern },
+                                                            nullable: true,
+                                                            argumentsPropagateNullability: new[] { true },
+                                                            typeof(int)))
+                                                },
+                                                nullable: true,
+                                                argumentsPropagateNullability: new[] { true, true },
+                                                typeof(string),
+                                                stringTypeMapping),
+                                            translatedPattern),
+                                        _sqlExpressionFactory.Equal(translatedPattern, _sqlExpressionFactory.Constant(string.Empty)))));
+                    }
+
+                    return true;
+            }
+        }
+    }
+
+    private static string? ConstructLikePatternParameter(
+        QueryContext queryContext,
+        string baseParameterName,
+        bool startsWith)
+        => queryContext.ParameterValues[baseParameterName] switch
+        {
+            null => null,
+
+            // In .NET, all strings start/end with the empty string, but SQL LIKE return false for empty patterns.
+            // Return % which always matches instead.
+            "" => "%",
+
+            string s => startsWith ? EscapeLikePattern(s) + '%' : '%' + EscapeLikePattern(s),
+
+            _ => throw new UnreachableException()
+        };
+
+    private static bool IsLikeWildChar(char c)
+        => c is '%' or '_';
+
+    private static string EscapeLikePattern(string pattern)
+    {
+        var builder = new StringBuilder();
+        foreach (var c in pattern)
+        {
+            if (IsLikeWildChar(c) || c == LikeEscapeChar)
+            {
+                builder.Append(LikeEscapeChar);
+            }
+
+            builder.Append(c);
+        }
+
+        return builder.ToString();
+    }
+
+    [return: NotNullIfNotNull(nameof(expression))]
+    private static Type? GetProviderType(SqlExpression? expression)
+        => expression == null
+            ? null
+            : (expression.TypeMapping?.Converter?.ProviderClrType
+                ?? expression.TypeMapping?.ClrType
+                ?? expression.Type);
+
+    private static bool AreOperandsDecimals(SqlBinaryExpression sqlExpression)
+        => GetProviderType(sqlExpression.Left) == typeof(decimal)
+            && GetProviderType(sqlExpression.Right) == typeof(decimal);
+
+    private static bool AttemptDecimalCompare(SqlBinaryExpression sqlBinary)
+        => AreOperandsDecimals(sqlBinary)
+            && new[]
+            {
+                ExpressionType.GreaterThan, ExpressionType.GreaterThanOrEqual, ExpressionType.LessThan, ExpressionType.LessThanOrEqual
+            }.Contains(sqlBinary.OperatorType);
+
+    private Expression DoDecimalCompare(SqlExpression visitedExpression, ExpressionType op, SqlExpression left, SqlExpression right)
+    {
+        var actual = Dependencies.SqlExpressionFactory.Function(
+            name: "ef_compare",
+            new[] { left, right },
+            nullable: true,
+            new[] { true, true },
+            typeof(int));
+        var oracle = Dependencies.SqlExpressionFactory.Constant(value: 0);
+
+        return op switch
+        {
+            ExpressionType.GreaterThan => Dependencies.SqlExpressionFactory.GreaterThan(left: actual, right: oracle),
+            ExpressionType.GreaterThanOrEqual => Dependencies.SqlExpressionFactory.GreaterThanOrEqual(left: actual, right: oracle),
+            ExpressionType.LessThan => Dependencies.SqlExpressionFactory.LessThan(left: actual, right: oracle),
+            ExpressionType.LessThanOrEqual => Dependencies.SqlExpressionFactory.LessThanOrEqual(left: actual, right: oracle),
+            _ => visitedExpression
+        };
+    }
+
+    private static bool AttemptDecimalArithmetic(SqlBinaryExpression sqlBinary)
+        => AreOperandsDecimals(sqlBinary)
+            && new[] { ExpressionType.Add, ExpressionType.Subtract, ExpressionType.Multiply, ExpressionType.Divide }.Contains(
+                sqlBinary.OperatorType);
+
+    [SuppressMessage("ReSharper", "SwitchExpressionHandlesSomeKnownEnumValuesWithExceptionInDefault", Justification = "Reviewed.")]
+    private Expression DoDecimalArithmetics(SqlExpression visitedExpression, ExpressionType op, SqlExpression left, SqlExpression right)
+    {
+        return op switch
+        {
+            ExpressionType.Add => DecimalArithmeticExpressionFactoryMethod(ResolveFunctionNameFromExpressionType(op), left, right),
+            ExpressionType.Divide => DecimalArithmeticExpressionFactoryMethod(ResolveFunctionNameFromExpressionType(op), left, right),
+            ExpressionType.Multiply => DecimalArithmeticExpressionFactoryMethod(ResolveFunctionNameFromExpressionType(op), left, right),
+            ExpressionType.Subtract => DecimalSubtractExpressionFactoryMethod(left, right),
+            _ => visitedExpression
+        };
+
+        static string ResolveFunctionNameFromExpressionType(ExpressionType expressionType)
+            => expressionType switch
+            {
+                ExpressionType.Add => "ef_add",
+                ExpressionType.Divide => "ef_divide",
+                ExpressionType.Multiply => "ef_multiply",
+                ExpressionType.Subtract => "ef_add",
+                _ => throw new InvalidOperationException()
+            };
+
+        Expression DecimalArithmeticExpressionFactoryMethod(string name, SqlExpression left, SqlExpression right)
+            => Dependencies.SqlExpressionFactory.Function(
+                name,
+                new[] { left, right },
+                nullable: true,
+                new[] { true, true },
+                visitedExpression.Type);
+
+        Expression DecimalSubtractExpressionFactoryMethod(SqlExpression left, SqlExpression right)
+        {
+            var subtrahend = Dependencies.SqlExpressionFactory.Function(
+                "ef_negate",
+                new[] { right },
+                nullable: true,
+                new[] { true },
+                visitedExpression.Type);
+
+            return DecimalArithmeticExpressionFactoryMethod(ResolveFunctionNameFromExpressionType(op), left, subtrahend);
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlTranslatingExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlTranslatingExpressionVisitor.cs
@@ -153,40 +153,6 @@ public class IgniteSqlTranslatingExpressionVisitor : RelationalSqlTranslatingExp
 
     protected override Expression VisitBinary(BinaryExpression binaryExpression)
     {
-        // See issue#16428
-        //if (binaryExpression.NodeType == ExpressionType.ArrayIndex
-        //    && binaryExpression.Left.Type == typeof(byte[]))
-        //{
-        //    var left = Visit(binaryExpression.Left);
-        //    var right = Visit(binaryExpression.Right);
-
-        //    if (left is SqlExpression leftSql
-        //        && right is SqlExpression rightSql)
-        //    {
-        //        return Dependencies.SqlExpressionFactory.Function(
-        //            "unicode",
-        //            new SqlExpression[]
-        //            {
-        //                Dependencies.SqlExpressionFactory.Function(
-        //                    "substr",
-        //                    new SqlExpression[]
-        //                    {
-        //                        leftSql,
-        //                        Dependencies.SqlExpressionFactory.Add(
-        //                            Dependencies.SqlExpressionFactory.ApplyDefaultTypeMapping(rightSql),
-        //                            Dependencies.SqlExpressionFactory.Constant(1)),
-        //                        Dependencies.SqlExpressionFactory.Constant(1)
-        //                    },
-        //                    nullable: true,
-        //                    argumentsPropagateNullability: new[] { true, true, true },
-        //                    typeof(byte[]))
-        //            },
-        //            nullable: true,
-        //            argumentsPropagateNullability: new[] { true },
-        //            binaryExpression.Type);
-        //    }
-        //}
-
         if (!(base.VisitBinary(binaryExpression) is SqlExpression visitedExpression))
         {
             return QueryCompilationContext.NotTranslatedExpression;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlTranslatingExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlTranslatingExpressionVisitor.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlTranslatingExpressionVisitorFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlTranslatingExpressionVisitorFactory.cs
@@ -11,9 +11,6 @@ public class IgniteSqlTranslatingExpressionVisitorFactory : IRelationalSqlTransl
         Dependencies = dependencies;
     }
 
-    /// <summary>
-    ///     Relational provider-specific dependencies for this service.
-    /// </summary>
     protected virtual RelationalSqlTranslatingExpressionVisitorDependencies Dependencies { get; }
 
     public virtual RelationalSqlTranslatingExpressionVisitor Create(

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlTranslatingExpressionVisitorFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlTranslatingExpressionVisitorFactory.cs
@@ -1,0 +1,26 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using Microsoft.EntityFrameworkCore.Query;
+
+public class IgniteSqlTranslatingExpressionVisitorFactory : IRelationalSqlTranslatingExpressionVisitorFactory
+{
+    public IgniteSqlTranslatingExpressionVisitorFactory(
+        RelationalSqlTranslatingExpressionVisitorDependencies dependencies)
+    {
+        Dependencies = dependencies;
+    }
+
+    /// <summary>
+    ///     Relational provider-specific dependencies for this service.
+    /// </summary>
+    protected virtual RelationalSqlTranslatingExpressionVisitorDependencies Dependencies { get; }
+
+    public virtual RelationalSqlTranslatingExpressionVisitor Create(
+        QueryCompilationContext queryCompilationContext,
+        QueryableMethodTranslatingExpressionVisitor queryableMethodTranslatingExpressionVisitor)
+        => new IgniteSqlTranslatingExpressionVisitor(
+            Dependencies,
+            queryCompilationContext,
+            queryableMethodTranslatingExpressionVisitor);
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlTranslatingExpressionVisitorFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteSqlTranslatingExpressionVisitorFactory.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteStringLengthTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteStringLengthTranslator.cs
@@ -1,0 +1,34 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using System;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+public class IgniteStringLengthTranslator : IMemberTranslator
+{
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    public IgniteStringLengthTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MemberInfo member,
+        Type returnType,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        => instance?.Type == typeof(string)
+            && member.Name == nameof(string.Length)
+                ? _sqlExpressionFactory.Function(
+                    "length",
+                    new[] { instance },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    returnType)
+                : null;
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteStringLengthTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteStringLengthTranslator.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteStringMethodTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteStringMethodTranslator.cs
@@ -1,0 +1,305 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+public class IgniteStringMethodTranslator : IMethodCallTranslator
+{
+    private static readonly MethodInfo IndexOfMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.IndexOf), new[] { typeof(string) })!;
+
+    private static readonly MethodInfo ReplaceMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.Replace), new[] { typeof(string), typeof(string) })!;
+
+    private static readonly MethodInfo ToLowerMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.ToLower), Type.EmptyTypes)!;
+
+    private static readonly MethodInfo ToUpperMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.ToUpper), Type.EmptyTypes)!;
+
+    private static readonly MethodInfo SubstringMethodInfoWithOneArg
+        = typeof(string).GetRuntimeMethod(nameof(string.Substring), new[] { typeof(int) })!;
+
+    private static readonly MethodInfo SubstringMethodInfoWithTwoArgs
+        = typeof(string).GetRuntimeMethod(nameof(string.Substring), new[] { typeof(int), typeof(int) })!;
+
+    private static readonly MethodInfo IsNullOrWhiteSpaceMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.IsNullOrWhiteSpace), new[] { typeof(string) })!;
+
+    // Method defined in netcoreapp2.0 only
+    private static readonly MethodInfo TrimStartMethodInfoWithoutArgs
+        = typeof(string).GetRuntimeMethod(nameof(string.TrimStart), Type.EmptyTypes)!;
+
+    private static readonly MethodInfo TrimStartMethodInfoWithCharArg
+        = typeof(string).GetRuntimeMethod(nameof(string.TrimStart), new[] { typeof(char) })!;
+
+    private static readonly MethodInfo TrimEndMethodInfoWithoutArgs
+        = typeof(string).GetRuntimeMethod(nameof(string.TrimEnd), Type.EmptyTypes)!;
+
+    private static readonly MethodInfo TrimEndMethodInfoWithCharArg
+        = typeof(string).GetRuntimeMethod(nameof(string.TrimEnd), new[] { typeof(char) })!;
+
+    private static readonly MethodInfo TrimMethodInfoWithoutArgs
+        = typeof(string).GetRuntimeMethod(nameof(string.Trim), Type.EmptyTypes)!;
+
+    private static readonly MethodInfo TrimMethodInfoWithCharArg
+        = typeof(string).GetRuntimeMethod(nameof(string.Trim), new[] { typeof(char) })!;
+
+    // Method defined in netstandard2.0
+    private static readonly MethodInfo TrimStartMethodInfoWithCharArrayArg
+        = typeof(string).GetRuntimeMethod(nameof(string.TrimStart), new[] { typeof(char[]) })!;
+
+    private static readonly MethodInfo TrimEndMethodInfoWithCharArrayArg
+        = typeof(string).GetRuntimeMethod(nameof(string.TrimEnd), new[] { typeof(char[]) })!;
+
+    private static readonly MethodInfo TrimMethodInfoWithCharArrayArg
+        = typeof(string).GetRuntimeMethod(nameof(string.Trim), new[] { typeof(char[]) })!;
+
+    private static readonly MethodInfo ContainsMethodInfo
+        = typeof(string).GetRuntimeMethod(nameof(string.Contains), new[] { typeof(string) })!;
+
+    private static readonly MethodInfo FirstOrDefaultMethodInfoWithoutArgs
+        = typeof(Enumerable).GetRuntimeMethods().Single(
+            m => m.Name == nameof(Enumerable.FirstOrDefault)
+                && m.GetParameters().Length == 1).MakeGenericMethod(typeof(char));
+
+    private static readonly MethodInfo LastOrDefaultMethodInfoWithoutArgs
+        = typeof(Enumerable).GetRuntimeMethods().Single(
+            m => m.Name == nameof(Enumerable.LastOrDefault)
+                && m.GetParameters().Length == 1).MakeGenericMethod(typeof(char));
+
+    private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
+    public IgniteStringMethodTranslator(ISqlExpressionFactory sqlExpressionFactory)
+    {
+        _sqlExpressionFactory = sqlExpressionFactory;
+    }
+
+    public virtual SqlExpression? Translate(
+        SqlExpression? instance,
+        MethodInfo method,
+        IReadOnlyList<SqlExpression> arguments,
+        IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+    {
+        if (instance != null)
+        {
+            if (IndexOfMethodInfo.Equals(method))
+            {
+                var argument = arguments[0];
+                var stringTypeMapping = ExpressionExtensions.InferTypeMapping(instance, argument);
+
+                return _sqlExpressionFactory.Subtract(
+                    _sqlExpressionFactory.Function(
+                        "instr",
+                        new[]
+                        {
+                            _sqlExpressionFactory.ApplyTypeMapping(instance, stringTypeMapping),
+                            _sqlExpressionFactory.ApplyTypeMapping(argument, stringTypeMapping)
+                        },
+                        nullable: true,
+                        argumentsPropagateNullability: new[] { true, true },
+                        method.ReturnType),
+                    _sqlExpressionFactory.Constant(1));
+            }
+
+            if (ReplaceMethodInfo.Equals(method))
+            {
+                var firstArgument = arguments[0];
+                var secondArgument = arguments[1];
+                var stringTypeMapping = ExpressionExtensions.InferTypeMapping(instance, firstArgument, secondArgument);
+
+                return _sqlExpressionFactory.Function(
+                    "replace",
+                    new[]
+                    {
+                        _sqlExpressionFactory.ApplyTypeMapping(instance, stringTypeMapping),
+                        _sqlExpressionFactory.ApplyTypeMapping(firstArgument, stringTypeMapping),
+                        _sqlExpressionFactory.ApplyTypeMapping(secondArgument, stringTypeMapping)
+                    },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true, true, true },
+                    method.ReturnType,
+                    stringTypeMapping);
+            }
+
+            if (ToLowerMethodInfo.Equals(method)
+                || ToUpperMethodInfo.Equals(method))
+            {
+                return _sqlExpressionFactory.Function(
+                    ToLowerMethodInfo.Equals(method) ? "lower" : "upper",
+                    new[] { instance },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true },
+                    method.ReturnType,
+                    instance.TypeMapping);
+            }
+
+            if (SubstringMethodInfoWithOneArg.Equals(method))
+            {
+                return _sqlExpressionFactory.Function(
+                    "substr",
+                    new[] { instance, _sqlExpressionFactory.Add(arguments[0], _sqlExpressionFactory.Constant(1)) },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true, true },
+                    method.ReturnType,
+                    instance.TypeMapping);
+            }
+
+            if (SubstringMethodInfoWithTwoArgs.Equals(method))
+            {
+                return _sqlExpressionFactory.Function(
+                    "substr",
+                    new[] { instance, _sqlExpressionFactory.Add(arguments[0], _sqlExpressionFactory.Constant(1)), arguments[1] },
+                    nullable: true,
+                    argumentsPropagateNullability: new[] { true, true, true },
+                    method.ReturnType,
+                    instance.TypeMapping);
+            }
+
+            if (TrimStartMethodInfoWithoutArgs.Equals(method)
+                || TrimStartMethodInfoWithCharArg.Equals(method)
+                || TrimStartMethodInfoWithCharArrayArg.Equals(method))
+            {
+                return ProcessTrimMethod(instance, arguments, "ltrim");
+            }
+
+            if (TrimEndMethodInfoWithoutArgs.Equals(method)
+                || TrimEndMethodInfoWithCharArg.Equals(method)
+                || TrimEndMethodInfoWithCharArrayArg.Equals(method))
+            {
+                return ProcessTrimMethod(instance, arguments, "rtrim");
+            }
+
+            if (TrimMethodInfoWithoutArgs.Equals(method)
+                || TrimMethodInfoWithCharArg.Equals(method)
+                || TrimMethodInfoWithCharArrayArg.Equals(method))
+            {
+                return ProcessTrimMethod(instance, arguments, "trim");
+            }
+
+            if (ContainsMethodInfo.Equals(method))
+            {
+                var pattern = arguments[0];
+                var stringTypeMapping = ExpressionExtensions.InferTypeMapping(instance, pattern);
+
+                instance = _sqlExpressionFactory.ApplyTypeMapping(instance, stringTypeMapping);
+                pattern = _sqlExpressionFactory.ApplyTypeMapping(pattern, stringTypeMapping);
+
+                // Note: we add IS NOT NULL checks here since we don't do null semantics/compensation for comparison (greater-than)
+                return
+                    _sqlExpressionFactory.AndAlso(
+                        _sqlExpressionFactory.IsNotNull(instance),
+                        _sqlExpressionFactory.AndAlso(
+                            _sqlExpressionFactory.IsNotNull(pattern),
+                            _sqlExpressionFactory.GreaterThan(
+                                _sqlExpressionFactory.Function(
+                                    "instr",
+                                    new[] { instance, pattern },
+                                    nullable: true,
+                                    argumentsPropagateNullability: new[] { true, true },
+                                    typeof(int)),
+                                _sqlExpressionFactory.Constant(0))));
+            }
+        }
+
+        if (IsNullOrWhiteSpaceMethodInfo.Equals(method))
+        {
+            var argument = arguments[0];
+
+            return _sqlExpressionFactory.OrElse(
+                _sqlExpressionFactory.IsNull(argument),
+                _sqlExpressionFactory.Equal(
+                    _sqlExpressionFactory.Function(
+                        "trim",
+                        new[] { argument },
+                        nullable: true,
+                        argumentsPropagateNullability: new[] { true },
+                        argument.Type,
+                        argument.TypeMapping),
+                    _sqlExpressionFactory.Constant(string.Empty)));
+        }
+
+        if (FirstOrDefaultMethodInfoWithoutArgs.Equals(method))
+        {
+            var argument = arguments[0];
+            return _sqlExpressionFactory.Function(
+                "substr",
+                new[] { argument, _sqlExpressionFactory.Constant(1), _sqlExpressionFactory.Constant(1) },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true, true, true },
+                method.ReturnType);
+        }
+
+        if (LastOrDefaultMethodInfoWithoutArgs.Equals(method))
+        {
+            var argument = arguments[0];
+            return _sqlExpressionFactory.Function(
+                "substr",
+                new[]
+                {
+                    argument,
+                    _sqlExpressionFactory.Function(
+                        "length",
+                        new[] { argument },
+                        nullable: true,
+                        argumentsPropagateNullability: new[] { true },
+                        typeof(int)),
+                    _sqlExpressionFactory.Constant(1)
+                },
+                nullable: true,
+                argumentsPropagateNullability: new[] { true, true, true },
+                method.ReturnType);
+        }
+
+        return null;
+    }
+
+    private SqlExpression? ProcessTrimMethod(SqlExpression instance, IReadOnlyList<SqlExpression> arguments, string functionName)
+    {
+        var typeMapping = instance.TypeMapping;
+        if (typeMapping == null)
+        {
+            return null;
+        }
+
+        var sqlArguments = new List<SqlExpression> { instance };
+        if (arguments.Count == 1)
+        {
+            var constantValue = (arguments[0] as SqlConstantExpression)?.Value;
+            var charactersToTrim = new List<char>();
+
+            if (constantValue is char singleChar)
+            {
+                charactersToTrim.Add(singleChar);
+            }
+            else if (constantValue is char[] charArray)
+            {
+                charactersToTrim.AddRange(charArray);
+            }
+            else
+            {
+                return null;
+            }
+
+            if (charactersToTrim.Count > 0)
+            {
+                sqlArguments.Add(_sqlExpressionFactory.Constant(new string(charactersToTrim.ToArray()), typeMapping));
+            }
+        }
+
+        return _sqlExpressionFactory.Function(
+            functionName,
+            sqlArguments,
+            nullable: true,
+            argumentsPropagateNullability: sqlArguments.Select(_ => true).ToList(),
+            typeof(string),
+            typeMapping);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteStringMethodTranslator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Query/Internal/IgniteStringMethodTranslator.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Query.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IIgniteRelationalConnection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IIgniteRelationalConnection.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IIgniteRelationalConnection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IIgniteRelationalConnection.cs
@@ -1,0 +1,17 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <remarks>
+///     The service lifetime is <see cref="ServiceLifetime.Scoped" />. This means that each
+///     <see cref="DbContext" /> instance will use its own instance of this service.
+///     The implementation may depend on other services registered with any lifetime.
+///     The implementation does not need to be thread-safe.
+/// </remarks>
+public interface IIgniteRelationalConnection : IRelationalConnection
+{
+    IIgniteRelationalConnection CreateReadOnlyConnection();
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IIgniteRelationalConnection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IIgniteRelationalConnection.cs
@@ -1,17 +1,6 @@
 
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.Extensions.DependencyInjection;
 
-/// <remarks>
-///     The service lifetime is <see cref="ServiceLifetime.Scoped" />. This means that each
-///     <see cref="DbContext" /> instance will use its own instance of this service.
-///     The implementation may depend on other services registered with any lifetime.
-///     The implementation does not need to be thread-safe.
-/// </remarks>
-public interface IIgniteRelationalConnection : IRelationalConnection
-{
-    IIgniteRelationalConnection CreateReadOnlyConnection();
-}
+public interface IIgniteRelationalConnection : IRelationalConnection;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteByteArrayTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteByteArrayTypeMapping.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteByteArrayTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteByteArrayTypeMapping.cs
@@ -1,0 +1,28 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using System.Data;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteByteArrayTypeMapping : ByteArrayTypeMapping
+{
+    public static new IgniteByteArrayTypeMapping Default { get; } = new(IgniteTypeMappingSource.BlobTypeName);
+
+    public IgniteByteArrayTypeMapping(string storeType, DbType? dbType = System.Data.DbType.Binary)
+        : this(
+            new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(
+                    typeof(byte[])),
+                storeType,
+                dbType: dbType))
+    {
+    }
+
+    protected IgniteByteArrayTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters)
+    {
+    }
+
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+        => new IgniteByteArrayTypeMapping(parameters);
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDatabaseCreator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDatabaseCreator.cs
@@ -1,0 +1,48 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using System.Diagnostics;
+using DataCommon;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteDatabaseCreator : RelationalDatabaseCreator
+{
+    private readonly IIgniteRelationalConnection _connection;
+
+    public IgniteDatabaseCreator(
+        RelationalDatabaseCreatorDependencies dependencies,
+        IIgniteRelationalConnection connection)
+        : base(dependencies)
+    {
+        _connection = connection;
+    }
+
+    public override void Create()
+    {
+        // No-op.
+        // "Database" always exists in Ignite.
+    }
+
+    public override bool Exists()
+    {
+        // "Database" always exists in Ignite.
+        return true;
+    }
+
+    public override bool HasTables()
+    {
+        var conn = (IgniteConnection)_connection.DbConnection;
+        conn.Open();
+
+        var igniteClient = conn.Client;
+        Debug.Assert(igniteClient != null, "igniteClient != null");
+
+        var tables = igniteClient.Tables.GetTablesAsync().GetAwaiter().GetResult();
+        return tables.Count > 0;
+    }
+
+    public override void Delete()
+    {
+        // No-op.
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDatabaseCreator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDatabaseCreator.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDateOnlyTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDateOnlyTypeMapping.cs
@@ -1,0 +1,30 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using System.Data;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteDateOnlyTypeMapping : DateOnlyTypeMapping
+{
+    private const string DateOnlyFormatConst = @"'{0:yyyy\-MM\-dd}'";
+
+    public static new IgniteDateOnlyTypeMapping Default { get; } = new(IgniteTypeMappingSource.TextTypeName);
+
+    public IgniteDateOnlyTypeMapping(
+        string storeType,
+        DbType? dbType = System.Data.DbType.Date)
+        : base(storeType, dbType)
+    {
+    }
+
+    protected IgniteDateOnlyTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters)
+    {
+    }
+
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+        => new IgniteDateOnlyTypeMapping(parameters);
+
+    protected override string SqlLiteralFormatString
+        => DateOnlyFormatConst;
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDateOnlyTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDateOnlyTypeMapping.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDateTimeOffsetTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDateTimeOffsetTypeMapping.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDateTimeOffsetTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDateTimeOffsetTypeMapping.cs
@@ -1,0 +1,35 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using System;
+using System.Data;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteDateTimeOffsetTypeMapping : DateTimeOffsetTypeMapping
+{
+    private const string DateTimeOffsetFormatConst = @"'{0:yyyy\-MM\-dd HH\:mm\:ss.FFFFFFFzzz}'";
+
+    public static new IgniteDateTimeOffsetTypeMapping Default { get; } = new(IgniteTypeMappingSource.TextTypeName);
+
+    public IgniteDateTimeOffsetTypeMapping(
+        string storeType,
+        DbType? dbType = System.Data.DbType.DateTimeOffset)
+        : base(
+            new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(typeof(DateTimeOffset)),
+                storeType,
+                dbType: dbType))
+    {
+    }
+
+    protected IgniteDateTimeOffsetTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters)
+    {
+    }
+
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+        => new IgniteDateTimeOffsetTypeMapping(parameters);
+
+    protected override string SqlLiteralFormatString
+        => DateTimeOffsetFormatConst;
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDateTimeTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDateTimeTypeMapping.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDateTimeTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDateTimeTypeMapping.cs
@@ -1,0 +1,35 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using System;
+using System.Data;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteDateTimeTypeMapping : DateTimeTypeMapping
+{
+    private const string DateTimeFormatConst = @"'{0:yyyy\-MM\-dd HH\:mm\:ss.FFFFFFF}'";
+
+    public static new IgniteDateTimeTypeMapping Default { get; } = new(IgniteTypeMappingSource.TextTypeName);
+
+    public IgniteDateTimeTypeMapping(
+        string storeType,
+        DbType? dbType = System.Data.DbType.DateTime)
+        : this(
+            new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(typeof(DateTime)),
+                storeType,
+                dbType: dbType))
+    {
+    }
+
+    protected IgniteDateTimeTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters)
+    {
+    }
+
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+        => new IgniteDateTimeTypeMapping(parameters);
+
+    protected override string SqlLiteralFormatString
+        => DateTimeFormatConst;
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDecimalTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDecimalTypeMapping.cs
@@ -1,0 +1,36 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using System.Data;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteDecimalTypeMapping : DecimalTypeMapping
+{
+    public static new IgniteDecimalTypeMapping Default { get; } = new(IgniteTypeMappingSource.TextTypeName);
+
+    public IgniteDecimalTypeMapping(string storeType, DbType? dbType = System.Data.DbType.Decimal)
+        : this(
+            new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(
+                    typeof(decimal)),
+                storeType,
+                dbType: dbType))
+    {
+    }
+
+    protected IgniteDecimalTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters)
+    {
+    }
+
+    /// <summary>
+    ///     Creates a copy of this mapping.
+    /// </summary>
+    /// <param name="parameters">The parameters for this mapping.</param>
+    /// <returns>The newly created mapping.</returns>
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+        => new IgniteDecimalTypeMapping(parameters);
+
+    protected override string SqlLiteralFormatString
+        => "'" + base.SqlLiteralFormatString + "'";
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDecimalTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDecimalTypeMapping.cs
@@ -23,11 +23,6 @@ public class IgniteDecimalTypeMapping : DecimalTypeMapping
     {
     }
 
-    /// <summary>
-    ///     Creates a copy of this mapping.
-    /// </summary>
-    /// <param name="parameters">The parameters for this mapping.</param>
-    /// <returns>The newly created mapping.</returns>
     protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
         => new IgniteDecimalTypeMapping(parameters);
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDecimalTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteDecimalTypeMapping.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteGuidTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteGuidTypeMapping.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 
 using Microsoft.EntityFrameworkCore.Storage;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteGuidTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteGuidTypeMapping.cs
@@ -1,0 +1,16 @@
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using System.Data;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteGuidTypeMapping : GuidTypeMapping
+{
+    public static readonly IgniteGuidTypeMapping Default = new(
+        IgniteTypeMappingSource.GuidTypeName,
+        System.Data.DbType.Guid);
+
+    public IgniteGuidTypeMapping(string storeType, DbType? dbType)
+        : base(storeType, dbType)
+    {
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteGuidTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteGuidTypeMapping.cs
@@ -1,16 +1,11 @@
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 
-using System.Data;
 using Microsoft.EntityFrameworkCore.Storage;
 
 public class IgniteGuidTypeMapping : GuidTypeMapping
 {
-    public static readonly IgniteGuidTypeMapping Default = new(
-        IgniteTypeMappingSource.GuidTypeName,
-        System.Data.DbType.Guid);
-
-    public IgniteGuidTypeMapping(string storeType, DbType? dbType)
-        : base(storeType, dbType)
+    public IgniteGuidTypeMapping(string storeType)
+        : base(storeType, System.Data.DbType.Guid)
     {
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteParameterNameGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteParameterNameGenerator.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 
 using Microsoft.EntityFrameworkCore.Storage;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteParameterNameGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteParameterNameGenerator.cs
@@ -1,0 +1,14 @@
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteParameterNameGenerator : ParameterNameGenerator
+{
+    private int _count;
+
+    public override string GenerateNext()
+        => "?" + _count++;
+
+    public override void Reset()
+        => _count = 0;
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteParameterNameGeneratorFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteParameterNameGeneratorFactory.cs
@@ -9,15 +9,8 @@ public class IgniteParameterNameGeneratorFactory : IParameterNameGeneratorFactor
         Dependencies = dependencies;
     }
 
-    /// <summary>
-    ///     Relational provider-specific dependencies for this service.
-    /// </summary>
     protected virtual ParameterNameGeneratorDependencies Dependencies { get; }
 
-    /// <summary>
-    ///     Creates a new <see cref="ParameterNameGenerator" />.
-    /// </summary>
-    /// <returns>The newly created generator.</returns>
     public virtual ParameterNameGenerator Create()
         => new IgniteParameterNameGenerator();
 }

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteParameterNameGeneratorFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteParameterNameGeneratorFactory.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 
 using Microsoft.EntityFrameworkCore.Storage;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteParameterNameGeneratorFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteParameterNameGeneratorFactory.cs
@@ -1,0 +1,23 @@
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteParameterNameGeneratorFactory : IParameterNameGeneratorFactory
+{
+    public IgniteParameterNameGeneratorFactory(ParameterNameGeneratorDependencies dependencies)
+    {
+        Dependencies = dependencies;
+    }
+
+    /// <summary>
+    ///     Relational provider-specific dependencies for this service.
+    /// </summary>
+    protected virtual ParameterNameGeneratorDependencies Dependencies { get; }
+
+    /// <summary>
+    ///     Creates a new <see cref="ParameterNameGenerator" />.
+    /// </summary>
+    /// <returns>The newly created generator.</returns>
+    public virtual ParameterNameGenerator Create()
+        => new IgniteParameterNameGenerator();
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalCommand.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalCommand.cs
@@ -1,0 +1,25 @@
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using DataCommon;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteRelationalCommand : RelationalCommand
+{
+    public IgniteRelationalCommand(RelationalCommandBuilderDependencies dependencies, string commandText, IReadOnlyList<IRelationalParameter> parameters)
+        : base(dependencies, commandText, parameters)
+    {
+    }
+
+    public override DbCommand CreateDbCommand(RelationalCommandParameterObject parameterObject, Guid commandId, DbCommandMethod commandMethod)
+    {
+        var cmd = (IgniteCommand)base.CreateDbCommand(parameterObject, commandId, commandMethod);
+
+        cmd.CommandSource = parameterObject.CommandSource;
+
+        return cmd;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalCommand.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalCommand.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 
 using System;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalCommandBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalCommandBuilder.cs
@@ -1,0 +1,89 @@
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteRelationalCommandBuilder : IRelationalCommandBuilder
+{
+    private readonly List<IRelationalParameter> _parameters = new List<IRelationalParameter>();
+    private readonly IndentedStringBuilder _commandTextBuilder = new IndentedStringBuilder();
+
+    public IgniteRelationalCommandBuilder(RelationalCommandBuilderDependencies dependencies)
+    {
+        Dependencies = dependencies;
+    }
+
+    /// <summary>
+    ///     Relational provider-specific dependencies for this service.
+    /// </summary>
+    protected virtual RelationalCommandBuilderDependencies Dependencies { get; }
+
+    /// <inheritdoc />
+    [Obsolete("Code trying to add parameter should add type mapped parameter using TypeMappingSource directly.")]
+    public virtual IRelationalTypeMappingSource TypeMappingSource
+    {
+        get => Dependencies.TypeMappingSource;
+    }
+
+    /// <inheritdoc />
+    public virtual IRelationalCommand Build()
+    {
+        return new IgniteRelationalCommand(Dependencies, _commandTextBuilder.ToString(), Parameters);
+    }
+
+    /// <summary>Gets the command text.</summary>
+    public override string ToString() => _commandTextBuilder.ToString();
+
+    /// <inheritdoc />
+    public virtual IReadOnlyList<IRelationalParameter> Parameters
+    {
+        get => _parameters;
+    }
+
+    /// <inheritdoc />
+    public virtual IRelationalCommandBuilder AddParameter(IRelationalParameter parameter)
+    {
+        _parameters.Add(parameter);
+        return this;
+    }
+
+    /// <inheritdoc />
+    public virtual IRelationalCommandBuilder RemoveParameterAt(int index)
+    {
+        _parameters.RemoveAt(index);
+        return this;
+    }
+
+    /// <inheritdoc />
+    public virtual IRelationalCommandBuilder Append(string value)
+    {
+        _commandTextBuilder.Append(value);
+        return this;
+    }
+
+    /// <inheritdoc />
+    public virtual IRelationalCommandBuilder AppendLine()
+    {
+        _commandTextBuilder.AppendLine();
+        return this;
+    }
+
+    /// <inheritdoc />
+    public virtual IRelationalCommandBuilder IncrementIndent()
+    {
+        _commandTextBuilder.IncrementIndent();
+        return this;
+    }
+
+    /// <inheritdoc />
+    public virtual IRelationalCommandBuilder DecrementIndent()
+    {
+        _commandTextBuilder.DecrementIndent();
+        return this;
+    }
+
+    /// <inheritdoc />
+    public virtual int CommandTextLength => _commandTextBuilder.Length;
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalCommandBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalCommandBuilder.cs
@@ -15,25 +15,16 @@ public class IgniteRelationalCommandBuilder : IRelationalCommandBuilder
         Dependencies = dependencies;
     }
 
-    /// <summary>
-    ///     Relational provider-specific dependencies for this service.
-    /// </summary>
     protected virtual RelationalCommandBuilderDependencies Dependencies { get; }
 
-    /// <inheritdoc />
     [Obsolete("Code trying to add parameter should add type mapped parameter using TypeMappingSource directly.")]
-    public virtual IRelationalTypeMappingSource TypeMappingSource
-    {
-        get => Dependencies.TypeMappingSource;
-    }
+    public virtual IRelationalTypeMappingSource TypeMappingSource => Dependencies.TypeMappingSource;
 
-    /// <inheritdoc />
     public virtual IRelationalCommand Build()
     {
         return new IgniteRelationalCommand(Dependencies, _commandTextBuilder.ToString(), Parameters);
     }
 
-    /// <summary>Gets the command text.</summary>
     public override string ToString() => _commandTextBuilder.ToString();
 
     /// <inheritdoc />

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalCommandBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalCommandBuilder.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 
 using System;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalCommandBuilderFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalCommandBuilderFactory.cs
@@ -1,0 +1,17 @@
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteRelationalCommandBuilderFactory : IRelationalCommandBuilderFactory
+{
+    public IgniteRelationalCommandBuilderFactory(
+        RelationalCommandBuilderDependencies dependencies)
+    {
+        Dependencies = dependencies;
+    }
+
+    protected virtual RelationalCommandBuilderDependencies Dependencies { get; }
+
+    public virtual IRelationalCommandBuilder Create()
+        => new IgniteRelationalCommandBuilder(Dependencies);
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalCommandBuilderFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalCommandBuilderFactory.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 
 using Microsoft.EntityFrameworkCore.Storage;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalConnection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalConnection.cs
@@ -1,7 +1,6 @@
 
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 
-using System;
 using System.Data.Common;
 using System.Linq;
 using DataCommon;
@@ -43,11 +42,6 @@ public class IgniteRelationalConnection : RelationalConnection, IIgniteRelationa
         InitializeDbConnection(connection);
 
         return connection;
-    }
-
-    public virtual IIgniteRelationalConnection CreateReadOnlyConnection()
-    {
-        throw new NotImplementedException();
     }
 
     private void InitializeDbConnection(DbConnection connection)

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalConnection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalConnection.cs
@@ -1,4 +1,3 @@
-
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 
 using System.Data.Common;

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalConnection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalConnection.cs
@@ -1,0 +1,68 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using System;
+using System.Data.Common;
+using System.Linq;
+using DataCommon;
+using Extensions.Internal;
+using Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteRelationalConnection : RelationalConnection, IIgniteRelationalConnection
+{
+    private readonly IDiagnosticsLogger<DbLoggerCategory.Infrastructure> _logger;
+    private readonly int? _commandTimeout;
+
+    public IgniteRelationalConnection(
+        RelationalConnectionDependencies dependencies,
+        IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger)
+        : base(dependencies)
+    {
+        _logger = logger;
+
+        var optionsExtension = dependencies.ContextOptions.Extensions.OfType<IgniteOptionsExtension>().FirstOrDefault();
+        if (optionsExtension != null)
+        {
+            var relationalOptions = RelationalOptionsExtension.Extract(dependencies.ContextOptions);
+            _commandTimeout = relationalOptions.CommandTimeout;
+
+            if (relationalOptions.Connection != null)
+            {
+                InitializeDbConnection(relationalOptions.Connection);
+            }
+        }
+    }
+
+    protected override DbConnection CreateDbConnection()
+    {
+        var connection = new IgniteConnection(GetValidatedConnectionString());
+        InitializeDbConnection(connection);
+
+        return connection;
+    }
+
+    public virtual IIgniteRelationalConnection CreateReadOnlyConnection()
+    {
+        throw new NotImplementedException();
+    }
+
+    private void InitializeDbConnection(DbConnection connection)
+    {
+        if (connection is IgniteConnection igniteConn)
+        {
+            if (_commandTimeout.HasValue)
+            {
+                igniteConn.DefaultTimeout = _commandTimeout.Value;
+            }
+
+        }
+        else
+        {
+            _logger.UnexpectedConnectionTypeWarning(connection.GetType());
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalConnection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteRelationalConnection.cs
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 
 using System.Data.Common;
@@ -51,7 +66,6 @@ public class IgniteRelationalConnection : RelationalConnection, IIgniteRelationa
             {
                 igniteConn.DefaultTimeout = _commandTimeout.Value;
             }
-
         }
         else
         {

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteSqlGenerationHelper.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteSqlGenerationHelper.cs
@@ -1,0 +1,38 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using System.Text;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteSqlGenerationHelper : RelationalSqlGenerationHelper
+{
+    public IgniteSqlGenerationHelper(RelationalSqlGenerationHelperDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    public override string StartTransactionStatement
+        => "BEGIN TRANSACTION" + StatementTerminator;
+
+    public override string DelimitIdentifier(string name, string? schema)
+        => base.DelimitIdentifier(name);
+
+    public override void DelimitIdentifier(StringBuilder builder, string name, string? schema)
+        => base.DelimitIdentifier(builder, name);
+
+    public override string GenerateParameterName(string name) => "?";
+
+    public override void GenerateParameterName(StringBuilder builder, string name) => builder.Append('?');
+
+    public override string GenerateParameterNamePlaceholder(string name)
+    {
+        // TODO: ??
+        return base.GenerateParameterNamePlaceholder(name);
+    }
+
+    public override void GenerateParameterNamePlaceholder(StringBuilder builder, string name)
+    {
+        // TODO: ??
+        base.GenerateParameterNamePlaceholder(builder, name);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteSqlGenerationHelper.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteSqlGenerationHelper.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteStringTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteStringTypeMapping.cs
@@ -22,20 +22,11 @@ public class IgniteStringTypeMapping : StringTypeMapping
     {
     }
 
-    /// <summary>
-    ///     Initializes a new instance of the <see cref="IgniteStringTypeMapping" /> class.
-    /// </summary>
-    /// <param name="parameters">Parameter object for <see cref="RelationalTypeMapping" />.</param>
     protected IgniteStringTypeMapping(RelationalTypeMappingParameters parameters)
         : base(parameters)
     {
     }
 
-    /// <summary>
-    ///     Creates a copy of this mapping.
-    /// </summary>
-    /// <param name="parameters">The parameters for this mapping.</param>
-    /// <returns>The newly created mapping.</returns>
     protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
         => new IgniteStringTypeMapping(parameters);
 }

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteStringTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteStringTypeMapping.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteStringTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteStringTypeMapping.cs
@@ -1,0 +1,41 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using System.Data;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Json;
+
+public class IgniteStringTypeMapping : StringTypeMapping
+{
+    public static new IgniteStringTypeMapping Default { get; } = new(IgniteTypeMappingSource.TextTypeName);
+
+    public IgniteStringTypeMapping(
+        string storeType,
+        DbType? dbType = null,
+        bool unicode = false,
+        int? size = null)
+        : base(
+            new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(
+                    typeof(string), jsonValueReaderWriter: JsonStringReaderWriter.Instance), storeType, StoreTypePostfix.None, dbType,
+                unicode, size))
+    {
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="IgniteStringTypeMapping" /> class.
+    /// </summary>
+    /// <param name="parameters">Parameter object for <see cref="RelationalTypeMapping" />.</param>
+    protected IgniteStringTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters)
+    {
+    }
+
+    /// <summary>
+    ///     Creates a copy of this mapping.
+    /// </summary>
+    /// <param name="parameters">The parameters for this mapping.</param>
+    /// <returns>The newly created mapping.</returns>
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+        => new IgniteStringTypeMapping(parameters);
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteTimeOnlyTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteTimeOnlyTypeMapping.cs
@@ -26,11 +26,6 @@ public class IgniteTimeOnlyTypeMapping : TimeOnlyTypeMapping
     {
     }
 
-    /// <summary>
-    ///     Creates a copy of this mapping.
-    /// </summary>
-    /// <param name="parameters">The parameters for this mapping.</param>
-    /// <returns>The newly created mapping.</returns>
     protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
         => new IgniteTimeOnlyTypeMapping(parameters);
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteTimeOnlyTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteTimeOnlyTypeMapping.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteTimeOnlyTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteTimeOnlyTypeMapping.cs
@@ -1,0 +1,46 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using System;
+using System.Data;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Json;
+
+public class IgniteTimeOnlyTypeMapping : TimeOnlyTypeMapping
+{
+    public static new IgniteTimeOnlyTypeMapping Default { get; } = new(IgniteTypeMappingSource.TextTypeName);
+
+    public IgniteTimeOnlyTypeMapping(
+        string storeType,
+        DbType? dbType = System.Data.DbType.Time)
+        : base(
+            new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(typeof(TimeOnly), jsonValueReaderWriter: JsonTimeOnlyReaderWriter.Instance),
+                storeType,
+                dbType: dbType))
+    {
+    }
+
+    protected IgniteTimeOnlyTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters)
+    {
+    }
+
+    /// <summary>
+    ///     Creates a copy of this mapping.
+    /// </summary>
+    /// <param name="parameters">The parameters for this mapping.</param>
+    /// <returns>The newly created mapping.</returns>
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+        => new IgniteTimeOnlyTypeMapping(parameters);
+
+    /// <inheritdoc />
+    protected override string GenerateNonNullSqlLiteral(object value)
+    {
+        var timeOnly = (TimeOnly)value;
+
+        return timeOnly.Ticks % TimeSpan.TicksPerSecond == 0
+            ? FormattableString.Invariant($@"'{value:HH\:mm\:ss}'")
+            : FormattableString.Invariant($@"'{value:HH\:mm\:ss\.fffffff}'");
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteTypeMappingSource.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteTypeMappingSource.cs
@@ -1,0 +1,139 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Common;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteTypeMappingSource : RelationalTypeMappingSource
+{
+    internal const string IntegerTypeName = "INTEGER";
+    internal const string RealTypeName = "REAL";
+    internal const string BlobTypeName = "BLOB";
+    internal const string TextTypeName = "VARCHAR";
+    internal const string GuidTypeName = "UUID";
+
+    private static readonly LongTypeMapping Integer = new(IntegerTypeName);
+    private static readonly DoubleTypeMapping Real = new(RealTypeName);
+    private static readonly IgniteByteArrayTypeMapping Blob = IgniteByteArrayTypeMapping.Default;
+    private static readonly IgniteStringTypeMapping Text = IgniteStringTypeMapping.Default;
+
+    private readonly Dictionary<Type, RelationalTypeMapping> _clrTypeMappings = new()
+    {
+        { typeof(string), Text },
+        { typeof(byte[]), Blob },
+        { typeof(bool), new BoolTypeMapping(IntegerTypeName) },
+        { typeof(byte), new ByteTypeMapping(IntegerTypeName) },
+        { typeof(char), new CharTypeMapping(TextTypeName) },
+        { typeof(int), new IntTypeMapping(IntegerTypeName) },
+        { typeof(long), Integer },
+        { typeof(sbyte), new SByteTypeMapping(IntegerTypeName) },
+        { typeof(short), new ShortTypeMapping(IntegerTypeName) },
+        { typeof(uint), new UIntTypeMapping(IntegerTypeName) },
+        { typeof(ulong), IgniteULongTypeMapping.Default },
+        { typeof(ushort), new UShortTypeMapping(IntegerTypeName) },
+        { typeof(DateTime), IgniteDateTimeTypeMapping.Default },
+        { typeof(DateTimeOffset), IgniteDateTimeOffsetTypeMapping.Default },
+        { typeof(TimeSpan), new TimeSpanTypeMapping(TextTypeName) },
+        { typeof(DateOnly), IgniteDateOnlyTypeMapping.Default },
+        { typeof(TimeOnly), IgniteTimeOnlyTypeMapping.Default },
+        { typeof(decimal), IgniteDecimalTypeMapping.Default },
+        { typeof(double), Real },
+        { typeof(float), new FloatTypeMapping(RealTypeName) },
+        { typeof(Guid), IgniteGuidTypeMapping.Default },
+    };
+
+    private readonly Dictionary<string, RelationalTypeMapping> _storeTypeMappings = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { IntegerTypeName, Integer },
+        { RealTypeName, Real },
+        { BlobTypeName, Blob },
+        { TextTypeName, Text }
+    };
+
+    public IgniteTypeMappingSource(
+        TypeMappingSourceDependencies dependencies,
+        RelationalTypeMappingSourceDependencies relationalDependencies)
+        : base(dependencies, relationalDependencies)
+    {
+    }
+
+    protected override RelationalTypeMapping? FindMapping(in RelationalTypeMappingInfo mappingInfo)
+    {
+        var mapping = base.FindMapping(mappingInfo)
+            ?? FindRawMapping(mappingInfo);
+
+        return mapping != null
+            && mappingInfo.StoreTypeName != null
+                ? mapping.WithStoreTypeAndSize(mappingInfo.StoreTypeName, null)
+                : mapping;
+    }
+
+    private RelationalTypeMapping? FindRawMapping(RelationalTypeMappingInfo mappingInfo)
+    {
+        var clrType = mappingInfo.ClrType;
+        if (clrType == typeof(byte[]) && mappingInfo.ElementTypeMapping != null)
+        {
+            return null;
+        }
+
+        if (clrType != null
+            && _clrTypeMappings.TryGetValue(clrType, out var mapping))
+        {
+            return mapping;
+        }
+
+        var storeTypeName = mappingInfo.StoreTypeName;
+        if (storeTypeName != null
+            && _storeTypeMappings.TryGetValue(storeTypeName, out mapping)
+            && (clrType == null || mapping.ClrType.UnwrapNullableType() == clrType))
+        {
+            return mapping;
+        }
+
+        if (storeTypeName != null)
+        {
+            var affinityTypeMapping = _typeRules.Select(r => r(storeTypeName)).FirstOrDefault(r => r != null);
+
+            if (affinityTypeMapping != null)
+            {
+                return clrType == null || affinityTypeMapping.ClrType.UnwrapNullableType() == clrType
+                    ? affinityTypeMapping
+                    : null;
+            }
+
+            if (clrType == null || clrType == typeof(byte[]))
+            {
+                return Blob;
+            }
+        }
+
+        return null;
+    }
+
+    private readonly Func<string, RelationalTypeMapping?>[] _typeRules =
+    {
+        name => Contains(name, "INT")
+            ? Integer
+            : null,
+        name => Contains(name, "CHAR")
+            || Contains(name, "CLOB")
+            || Contains(name, "TEXT")
+                ? Text
+                : null,
+        name => Contains(name, "BLOB")
+            ? Blob
+            : null,
+        name => Contains(name, "REAL")
+            || Contains(name, "FLOA")
+            || Contains(name, "DOUB")
+                ? Real
+                : null
+    };
+
+    private static bool Contains(string haystack, string needle)
+        => haystack.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0;
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteTypeMappingSource.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteTypeMappingSource.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 
@@ -43,7 +57,7 @@ public class IgniteTypeMappingSource : RelationalTypeMappingSource
         { typeof(decimal), IgniteDecimalTypeMapping.Default },
         { typeof(double), Real },
         { typeof(float), new FloatTypeMapping(RealTypeName) },
-        { typeof(Guid), IgniteGuidTypeMapping.Default },
+        { typeof(Guid), new IgniteGuidTypeMapping(GuidTypeName) },
     };
 
     private readonly Dictionary<string, RelationalTypeMapping> _storeTypeMappings = new(StringComparer.OrdinalIgnoreCase)

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteULongTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteULongTypeMapping.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteULongTypeMapping.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Storage/Internal/IgniteULongTypeMapping.cs
@@ -1,0 +1,26 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Storage.Internal;
+
+using System.Data;
+using Microsoft.EntityFrameworkCore.Storage;
+
+public class IgniteULongTypeMapping : ULongTypeMapping
+{
+    public static new IgniteULongTypeMapping Default { get; } = new(IgniteTypeMappingSource.IntegerTypeName);
+
+    public IgniteULongTypeMapping(string storeType, DbType? dbType = System.Data.DbType.UInt64)
+        : base(storeType, dbType)
+    {
+    }
+
+    protected IgniteULongTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters)
+    {
+    }
+
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+        => new IgniteULongTypeMapping(parameters);
+
+    protected override string GenerateNonNullSqlLiteral(object value)
+        => new LongTypeMapping(StoreType).GenerateSqlLiteral((long)(ulong)value);
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Update/Internal/IgniteModificationCommandBatchFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Update/Internal/IgniteModificationCommandBatchFactory.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Update.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Update/Internal/IgniteModificationCommandBatchFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Update/Internal/IgniteModificationCommandBatchFactory.cs
@@ -1,0 +1,18 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Update.Internal;
+
+using Microsoft.EntityFrameworkCore.Update;
+
+public class IgniteModificationCommandBatchFactory : IModificationCommandBatchFactory
+{
+    public IgniteModificationCommandBatchFactory(
+        ModificationCommandBatchFactoryDependencies dependencies)
+    {
+        Dependencies = dependencies;
+    }
+
+    protected virtual ModificationCommandBatchFactoryDependencies Dependencies { get; }
+
+    public virtual ModificationCommandBatch Create()
+        => new SingularModificationCommandBatch(Dependencies);
+}

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Update/Internal/IgniteUpdateSqlGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Update/Internal/IgniteUpdateSqlGenerator.cs
@@ -1,3 +1,17 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Apache.Ignite.EntityFrameworkCore.Update.Internal;
 

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Update/Internal/IgniteUpdateSqlGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Update/Internal/IgniteUpdateSqlGenerator.cs
@@ -33,11 +33,6 @@ public class IgniteUpdateSqlGenerator : UpdateAndSelectSqlGenerator
         return ResultSetMapping.NoResults;
     }
 
-    /// <summary>
-    ///     Appends a <c>WHERE</c> condition checking rows affected.
-    /// </summary>
-    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
-    /// <param name="expectedRowsAffected">The expected number of rows affected.</param>
     protected override void AppendRowsAffectedWhereCondition(StringBuilder commandStringBuilder, int expectedRowsAffected)
     {
         Check.NotNull(commandStringBuilder, nameof(commandStringBuilder));

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Update/Internal/IgniteUpdateSqlGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFrameworkCore/Update/Internal/IgniteUpdateSqlGenerator.cs
@@ -1,0 +1,50 @@
+
+namespace Apache.Ignite.EntityFrameworkCore.Update.Internal;
+
+using System;
+using System.Text;
+using Common;
+using Microsoft.EntityFrameworkCore.Update;
+
+public class IgniteUpdateSqlGenerator : UpdateAndSelectSqlGenerator
+{
+    public IgniteUpdateSqlGenerator(UpdateSqlGeneratorDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    protected override void AppendIdentityWhereCondition(StringBuilder commandStringBuilder, IColumnModification columnModification)
+    {
+        Check.NotNull(commandStringBuilder, nameof(commandStringBuilder));
+        Check.NotNull(columnModification, nameof(columnModification));
+
+        // SqlGenerationHelper.DelimitIdentifier(commandStringBuilder, "rowid");
+        // commandStringBuilder.Append(" = ").Append("last_insert_rowid()");
+        throw new NotSupportedException("Ignite does not support identity columns.");
+    }
+
+    protected override ResultSetMapping AppendSelectAffectedCountCommand(
+        StringBuilder commandStringBuilder,
+        string name,
+        string? schema,
+        int commandPosition)
+    {
+        // Ignite-specific: no-op, affected rows in ResultSet.
+        return ResultSetMapping.NoResults;
+    }
+
+    /// <summary>
+    ///     Appends a <c>WHERE</c> condition checking rows affected.
+    /// </summary>
+    /// <param name="commandStringBuilder">The builder to which the SQL should be appended.</param>
+    /// <param name="expectedRowsAffected">The expected number of rows affected.</param>
+    protected override void AppendRowsAffectedWhereCondition(StringBuilder commandStringBuilder, int expectedRowsAffected)
+    {
+        Check.NotNull(commandStringBuilder, nameof(commandStringBuilder));
+
+        throw new NotSupportedException("Ignite does not support affected rows check.");
+    }
+
+    public override string GenerateNextSequenceValueOperation(string name, string? schema)
+        => throw new NotSupportedException(IgniteStrings.SequencesNotSupported);
+}

--- a/modules/platforms/dotnet/Apache.Ignite.sln
+++ b/modules/platforms/dotnet/Apache.Ignite.sln
@@ -24,6 +24,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apache.Ignite.Benchmarks", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apache.Ignite.Internal.Generators", "Apache.Ignite.Internal.Generators\Apache.Ignite.Internal.Generators.csproj", "{7BC74F53-FF5F-4CBF-A559-9E4BE3A63A0F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apache.Ignite.EntityFrameworkCore", "Apache.Ignite.EntityFrameworkCore\Apache.Ignite.EntityFrameworkCore.csproj", "{C33E3201-71A9-40FA-AE69-C3F325E285D8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apache.Ignite.EntityFrameworkCore.Tests", "Apache.Ignite.EntityFrameworkCore.Tests\Apache.Ignite.EntityFrameworkCore.Tests.csproj", "{30752D89-C9EB-4116-913E-BEBB49CEBB10}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,5 +53,13 @@ Global
 		{7BC74F53-FF5F-4CBF-A559-9E4BE3A63A0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7BC74F53-FF5F-4CBF-A559-9E4BE3A63A0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7BC74F53-FF5F-4CBF-A559-9E4BE3A63A0F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C33E3201-71A9-40FA-AE69-C3F325E285D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C33E3201-71A9-40FA-AE69-C3F325E285D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C33E3201-71A9-40FA-AE69-C3F325E285D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C33E3201-71A9-40FA-AE69-C3F325E285D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{30752D89-C9EB-4116-913E-BEBB49CEBB10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{30752D89-C9EB-4116-913E-BEBB49CEBB10}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30752D89-C9EB-4116-913E-BEBB49CEBB10}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{30752D89-C9EB-4116-913E-BEBB49CEBB10}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/modules/platforms/dotnet/global.json
+++ b/modules/platforms/dotnet/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "6.0.100",
+        "version": "8.0.204",
         "rollForward": "latestMinor"
     }
 }


### PR DESCRIPTION
Proof of concept: Entity Framework Core provider for Apache Ignite 3.

[BasicTest.cs](https://github.com/apache/ignite-3/pull/3675/files#diff-d49026d1c4da64c17d01dcf7a4db099861aeaa5c637057b984cd091746d9cb46) provides a working demo:
* Creates 2 tables
* Populates data
* Performs a query

**Implementation Details**
* EF Core implements most of the logic for SQL generation, change tracking and so on
* Our part, the provider, is about two things:
  1. Connecting to the DB and performing queries
  2. SQL customization (type mapping, supported features, syntax quirks)  

**But we already have a [LINQ provider](https://github.com/apache/ignite-3/blob/main/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/README.md), what is the difference?**
Think micro-ORM vs full-blown one. 

Ignite LINQ provider:
* Comes in the box, very lightweight
* Can do LINQ without any setup, literally one line
* Limited DML
* No DDL

EF Core:
* Separate package
* Full-blown ORM, extremely powerful
* Familiar to any .NET developer, same API for many databases
* TBD: more

**More Info**
* EF Core is the most popular ORM for .NET. Provides an abstract way of working with a database without writing any SQL by hand. Includes DDL, DML, migrations.
* Providers exist for many databases: https://learn.microsoft.com/en-us/ef/core/providers/
* Writing a provider: https://learn.microsoft.com/en-us/ef/core/providers/writing-a-provider
* Reference implementation: https://github.com/dotnet/efcore/tree/main/src/EFCore.Sqlite.Core