### PR TITLE
IGNITE-22086 Thin client: initialize observableTimestamp in handshake

### DIFF
--- a/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerMetricsTest.java
+++ b/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerMetricsTest.java
@@ -151,7 +151,7 @@ public class ItClientHandlerMetricsTest extends BaseIgniteAbstractTest {
         ItClientHandlerTestUtils.connectAndHandshake(serverModule);
 
         assertTrue(
-                IgniteTestUtils.waitForCondition(() -> testServer.metrics().bytesSent() == 80, 1000),
+                IgniteTestUtils.waitForCondition(() -> testServer.metrics().bytesSent() == 89, 1000),
                 () -> "bytesSent: " + testServer.metrics().bytesSent());
 
         assertTrue(
@@ -161,7 +161,7 @@ public class ItClientHandlerMetricsTest extends BaseIgniteAbstractTest {
         ItClientHandlerTestUtils.connectAndHandshake(serverModule, false, true);
 
         assertTrue(
-                IgniteTestUtils.waitForCondition(() -> testServer.metrics().bytesSent() == 185, 1000),
+                IgniteTestUtils.waitForCondition(() -> testServer.metrics().bytesSent() == 194, 1000),
                 () -> "bytesSent: " + testServer.metrics().bytesSent());
 
         assertTrue(

--- a/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerTest.java
+++ b/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerTest.java
@@ -135,6 +135,7 @@ public class ItClientHandlerTest extends BaseIgniteAbstractTest {
             final var nodeName = unpacker.unpackString();
             unpacker.skipValue(); // Cluster id.
             unpacker.skipValue(); // Cluster name.
+            unpacker.skipValue(); // Observable timestamp.
 
             unpacker.skipValue(); // Major.
             unpacker.skipValue(); // Minor.
@@ -150,7 +151,7 @@ public class ItClientHandlerTest extends BaseIgniteAbstractTest {
             unpacker.skipValue(extensionsLen);
 
             assertArrayEquals(MAGIC, magic);
-            assertEquals(72, len);
+            assertEquals(81, len);
             assertEquals(3, major);
             assertEquals(0, minor);
             assertEquals(0, patch);
@@ -275,6 +276,7 @@ public class ItClientHandlerTest extends BaseIgniteAbstractTest {
             final var nodeName = unpacker.unpackString();
             unpacker.skipValue(); // Cluster id.
             unpacker.skipValue(); // Cluster name.
+            unpacker.skipValue(); // Observable timestamp.
 
             unpacker.skipValue(); // Major.
             unpacker.skipValue(); // Minor.
@@ -289,7 +291,7 @@ public class ItClientHandlerTest extends BaseIgniteAbstractTest {
             unpacker.skipValue(extensionsLen);
 
             assertArrayEquals(MAGIC, magic);
-            assertEquals(72, len);
+            assertEquals(81, len);
             assertEquals(3, major);
             assertEquals(0, minor);
             assertEquals(0, patch);

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -375,14 +375,14 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
             packer.packUuid(tag.clusterId());
             packer.packString(tag.clusterName());
 
+            packer.packLong(observableTimestamp(null));
+
             // Pack current version
             packer.packByte(IgniteProductVersion.CURRENT_VERSION.major());
             packer.packByte(IgniteProductVersion.CURRENT_VERSION.minor());
             packer.packByte(IgniteProductVersion.CURRENT_VERSION.maintenance());
             packer.packByteNullable(IgniteProductVersion.CURRENT_VERSION.patch());
             packer.packStringNullable(IgniteProductVersion.CURRENT_VERSION.preRelease());
-
-            packer.packLong(observableTimestamp(null));
 
             packer.packBinaryHeader(0); // Features.
             packer.packInt(0); // Extensions.

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -382,6 +382,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
             packer.packByteNullable(IgniteProductVersion.CURRENT_VERSION.patch());
             packer.packStringNullable(IgniteProductVersion.CURRENT_VERSION.preRelease());
 
+            packer.packLong(observableTimestamp(null));
+
             packer.packBinaryHeader(0); // Features.
             packer.packInt(0); // Extensions.
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientChannel.java
@@ -18,7 +18,6 @@
 package org.apache.ignite.internal.client;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import org.jetbrains.annotations.Nullable;
 
 /**

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientChannel.java
@@ -72,18 +72,4 @@ public interface ClientChannel extends AutoCloseable {
      * @return Protocol context.
      */
     ProtocolContext protocolContext();
-
-    /**
-     * Add topology change listener.
-     *
-     * @param listener Listener.
-     */
-    void addPartitionAssignmentChangeListener(Consumer<Long> listener);
-
-    /**
-     * Add observable timestamp listener.
-     *
-     * @param listener Listener.
-     */
-    void addObservableTimestampListener(Consumer<Long> listener);
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientChannelFactory.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientChannelFactory.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.client;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import org.apache.ignite.internal.client.io.ClientConnectionMultiplexer;
 
 /**
@@ -36,5 +37,7 @@ public interface ClientChannelFactory {
     CompletableFuture<ClientChannel> create(
             ClientChannelConfiguration cfg,
             ClientConnectionMultiplexer multiplexer,
-            ClientMetricSource metrics);
+            ClientMetricSource metrics,
+            Consumer<Long> assignmentChangeListener,
+            Consumer<Long> observableTimestampListener);
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -810,12 +810,14 @@ public final class ReliableChannel implements AutoCloseable {
                             new IgniteClientConnectionException(CONNECTION_ERR, "Reconnect is not allowed due to applied throttling"));
                 }
 
-                chFut0 = chFactory.create(
+                CompletableFuture<ClientChannel> createFut = chFactory.create(
                         chCfg,
                         connMgr,
                         metrics,
                         ReliableChannel.this::onPartitionAssignmentChanged,
-                        ReliableChannel.this::onObservableTimestampReceived).thenApply(ch -> {
+                        ReliableChannel.this::onObservableTimestampReceived);
+
+                chFut0 = createFut.thenApply(ch -> {
                     var oldClusterId = clusterId.compareAndExchange(null, ch.protocolContext().clusterId());
 
                     if (oldClusterId != null && !oldClusterId.equals(ch.protocolContext().clusterId())) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -26,13 +26,11 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import java.net.InetSocketAddress;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
@@ -93,10 +91,10 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
     private final Map<Long, CompletableFuture<PayloadInputChannel>> notificationHandlers = new ConcurrentHashMap<>();
 
     /** Topology change listeners. */
-    private final Collection<Consumer<Long>> assignmentChangeListeners = new CopyOnWriteArrayList<>();
+    private final Consumer<Long> assignmentChangeListener;
 
     /** Observable timestamp listeners. */
-    private final Collection<Consumer<Long>> observableTimestampListeners = new CopyOnWriteArrayList<>();
+    private final Consumer<Long> observableTimestampListener;
 
     /** Closed flag. */
     private final AtomicBoolean closed = new AtomicBoolean();
@@ -128,10 +126,16 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
      * @param cfg Config.
      * @param metrics Metrics.
      */
-    private TcpClientChannel(ClientChannelConfiguration cfg, ClientMetricSource metrics) {
+    private TcpClientChannel(
+            ClientChannelConfiguration cfg,
+            ClientMetricSource metrics,
+            Consumer<Long> assignmentChangeListener,
+            Consumer<Long> observableTimestampListener) {
         validateConfiguration(cfg);
         this.cfg = cfg;
         this.metrics = metrics;
+        this.assignmentChangeListener = assignmentChangeListener;
+        this.observableTimestampListener = observableTimestampListener;
 
         log = ClientUtils.logger(cfg.clientConfiguration(), TcpClientChannel.class);
 
@@ -183,9 +187,12 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
     static CompletableFuture<ClientChannel> createAsync(
             ClientChannelConfiguration cfg,
             ClientConnectionMultiplexer connMgr,
-            ClientMetricSource metrics) {
+            ClientMetricSource metrics,
+            Consumer<Long> assignmentChangeListener,
+            Consumer<Long> observableTimestampListener) {
         //noinspection resource - returned from method.
-        return new TcpClientChannel(cfg, metrics).initAsync(connMgr);
+        return new TcpClientChannel(cfg, metrics, assignmentChangeListener, observableTimestampListener)
+                .initAsync(connMgr);
     }
 
     /** {@inheritDoc} */
@@ -422,10 +429,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
 
     private void handleObservableTimestamp(ClientMessageUnpacker unpacker) {
         long observableTimestamp = unpacker.unpackLong();
-
-        for (Consumer<Long> listener : observableTimestampListeners) {
-            listener.accept(observableTimestamp);
-        }
+        observableTimestampListener.accept(observableTimestamp);
     }
 
     private void handlePartitionAssignmentChange(int flags, ClientMessageUnpacker unpacker) {
@@ -435,9 +439,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
             }
 
             long maxStartTime = unpacker.unpackLong();
-            for (Consumer<Long> listener : assignmentChangeListeners) {
-                listener.accept(maxStartTime);
-            }
+            assignmentChangeListener.accept(maxStartTime);
         }
     }
 
@@ -523,17 +525,6 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
     @Override
     public ProtocolContext protocolContext() {
         return protocolCtx;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void addPartitionAssignmentChangeListener(Consumer<Long> listener) {
-        assignmentChangeListeners.add(listener);
-    }
-
-    @Override
-    public void addObservableTimestampListener(Consumer<Long> listener) {
-        observableTimestampListeners.add(listener);
     }
 
     private static void validateConfiguration(ClientChannelConfiguration cfg) {
@@ -644,6 +635,9 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
             unpacker.unpackByte(); // cluster version maintenance
             unpacker.unpackByteNullable(); // cluster version patch
             unpacker.unpackStringNullable(); // cluster version pre release
+
+            long observableTimestamp = unpacker.unpackLong();
+            observableTimestampListener.accept(observableTimestamp);
 
             var featuresLen = unpacker.unpackBinaryHeader();
             unpacker.skipValues(featuresLen);

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -630,14 +630,14 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
             var clusterId = unpacker.unpackUuid();
             var clusterName = unpacker.unpackString();
 
+            long observableTimestamp = unpacker.unpackLong();
+            observableTimestampListener.accept(observableTimestamp);
+
             unpacker.unpackByte(); // cluster version major
             unpacker.unpackByte(); // cluster version minor
             unpacker.unpackByte(); // cluster version maintenance
             unpacker.unpackByteNullable(); // cluster version patch
             unpacker.unpackStringNullable(); // cluster version pre release
-
-            long observableTimestamp = unpacker.unpackLong();
-            observableTimestampListener.accept(observableTimestamp);
 
             var featuresLen = unpacker.unpackBinaryHeader();
             unpacker.skipValues(featuresLen);

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
@@ -229,12 +229,12 @@ public class ClientMetricsTest extends BaseIgniteAbstractTest {
         client = clientBuilder().build();
 
         assertEquals(15, metrics().bytesSent());
-        assertEquals(76, metrics().bytesReceived());
+        assertEquals(85, metrics().bytesReceived());
 
         client.tables().tables();
 
         assertEquals(21, metrics().bytesSent());
-        assertEquals(97, metrics().bytesReceived());
+        assertEquals(106, metrics().bytesReceived());
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/ObservableTimestampPropagationTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ObservableTimestampPropagationTest.java
@@ -75,7 +75,11 @@ public class ObservableTimestampPropagationTest extends BaseIgniteAbstractTest {
         TransactionOptions roOpts = new TransactionOptions().readOnly(true);
 
         // +2 because logical time is incremented on every call to nowLong - for replica tracker and for handshake.
-        assertEquals((currentServerTimestamp.get() << LOGICAL_TIME_BITS_SIZE) + 2, ch.observableTimestamp());
+        assertEquals(
+                (currentServerTimestamp.get() << LOGICAL_TIME_BITS_SIZE) + 2,
+                ch.observableTimestamp(),
+                "Handshake should initialize observable timestamp");
+
         assertNull(lastObservableTimestamp());
 
         // RW TX does not propagate timestamp.

--- a/modules/client/src/test/java/org/apache/ignite/client/ObservableTimestampPropagationTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ObservableTimestampPropagationTest.java
@@ -74,6 +74,8 @@ public class ObservableTimestampPropagationTest extends BaseIgniteAbstractTest {
         ReliableChannel ch = IgniteTestUtils.getFieldValue(client, "ch");
         TransactionOptions roOpts = new TransactionOptions().readOnly(true);
 
+        // +2 because logical time is incremented on every call to nowLong - for replica tracker and for handshake.
+        assertEquals((currentServerTimestamp.get() << LOGICAL_TIME_BITS_SIZE) + 2, ch.observableTimestamp());
         assertNull(lastObservableTimestamp());
 
         // RW TX does not propagate timestamp.

--- a/modules/client/src/test/java/org/apache/ignite/internal/client/RepeatedFinishClientTransactionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/internal/client/RepeatedFinishClientTransactionTest.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.when;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import org.apache.ignite.internal.client.tx.ClientTransaction;
 import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
 import org.junit.jupiter.api.Test;

--- a/modules/client/src/test/java/org/apache/ignite/internal/client/RepeatedFinishClientTransactionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/internal/client/RepeatedFinishClientTransactionTest.java
@@ -204,16 +204,6 @@ public class RepeatedFinishClientTransactionTest extends BaseIgniteAbstractTest 
         }
 
         @Override
-        public void addPartitionAssignmentChangeListener(Consumer<Long> listener) {
-            // No-op.
-        }
-
-        @Override
-        public void addObservableTimestampListener(Consumer<Long> listener) {
-            // No-op.
-        }
-
-        @Override
         public void close() {
             // No-op.
         }

--- a/modules/platforms/cpp/ignite/client/detail/node_connection.h
+++ b/modules/platforms/cpp/ignite/client/detail/node_connection.h
@@ -261,6 +261,7 @@ private:
 
     /** Configuration. */
     const ignite_client_configuration &m_configuration;
+    void on_observable_timestamp_changed(int64_t observable_timestamp) const;
 };
 
 } // namespace ignite::detail

--- a/modules/platforms/cpp/ignite/client/detail/node_connection.h
+++ b/modules/platforms/cpp/ignite/client/detail/node_connection.h
@@ -232,6 +232,13 @@ private:
      */
     std::shared_ptr<response_handler> find_handler_unsafe(std::int64_t req_id);
 
+    /**
+     * Notify event handler about observable timestamp change.
+     *
+     * @param observable_timestamp New observable timestamp.
+     */
+    void on_observable_timestamp_changed(int64_t observable_timestamp) const;
+
     /** Handshake complete. */
     bool m_handshake_complete{false};
 
@@ -261,7 +268,6 @@ private:
 
     /** Configuration. */
     const ignite_client_configuration &m_configuration;
-    void on_observable_timestamp_changed(int64_t observable_timestamp) const;
 };
 
 } // namespace ignite::detail

--- a/modules/platforms/cpp/ignite/protocol/messages.cpp
+++ b/modules/platforms/cpp/ignite/protocol/messages.cpp
@@ -69,6 +69,8 @@ handshake_response parse_handshake_response(bytes_view message) {
     res.context.set_cluster_id(reader.read_uuid());
     res.context.set_cluster_name(reader.read_string());
 
+    res.observable_timestamp = reader.read_int64();
+
     auto dbms_ver_major = reader.read_uint8();
     auto dbms_ver_minor = reader.read_uint8();
     auto dbms_ver_maintenance = reader.read_uint8();

--- a/modules/platforms/cpp/ignite/protocol/messages.h
+++ b/modules/platforms/cpp/ignite/protocol/messages.h
@@ -62,6 +62,9 @@ struct handshake_response {
 
     /** Protocol context. */
     protocol_context context{};
+
+    /** Observable timestamp. */
+    int64_t observable_timestamp;
 };
 
 /**

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -93,6 +93,8 @@ namespace Apache.Ignite.Tests
 
         public Guid ClusterId { get; set; }
 
+        public string ClusterName { get; set; } = "fake-cluster";
+
         public string[] PartitionAssignment { get; set; }
 
         public long PartitionAssignmentTimestamp { get; set; }
@@ -164,7 +166,19 @@ namespace Apache.Ignite.Tests
             handshakeWriter.Write(0); // Idle timeout.
             handshakeWriter.Write(Node.Id); // Node id.
             handshakeWriter.Write(Node.Name); // Node name (consistent id).
+
             handshakeWriter.Write(ClusterId);
+            handshakeWriter.Write(ClusterName);
+
+            handshakeWriter.Write(ObservableTimestamp);
+
+            // Cluster version.
+            handshakeWriter.Write(1);
+            handshakeWriter.Write(2);
+            handshakeWriter.Write(3);
+            handshakeWriter.Write(4);
+            handshakeWriter.Write("-abcd");
+
             handshakeWriter.WriteBinaryHeader(0); // Features.
             handshakeWriter.Write(0); // Extensions.
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -92,15 +92,15 @@ public class MetricsTests
         using var client = await server.ConnectClientAsync();
 
         AssertMetric(MetricNames.BytesSent, 15);
-        AssertMetric(MetricNames.BytesReceived, 63);
+        AssertMetric(MetricNames.BytesReceived, 88);
 
         await client.Tables.GetTablesAsync();
 
         AssertMetric(MetricNames.BytesSent, 21);
-        AssertMetric(MetricNames.BytesReceived, 72);
+        AssertMetric(MetricNames.BytesReceived, 97);
 
         AssertTaggedMetric(MetricNames.BytesSent, 21, server, client);
-        AssertTaggedMetric(MetricNames.BytesReceived, 72, server, client);
+        AssertTaggedMetric(MetricNames.BytesReceived, 97, server, client);
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
@@ -23,6 +23,7 @@ namespace Apache.Ignite.Tests.Transactions
     using System.Threading.Tasks;
     using System.Transactions;
     using Ignite.Transactions;
+    using Internal;
     using NUnit.Framework;
     using Table;
     using TransactionOptions = Ignite.Transactions.TransactionOptions;
@@ -286,8 +287,17 @@ namespace Apache.Ignite.Tests.Transactions
         [Test]
         public async Task TestObservableTimestampPropagation([Values(true, false)] bool sql)
         {
-            using var server = new FakeServer();
+            using var server = new FakeServer
+            {
+                ObservableTimestamp = 111
+            };
+
             using var client = await server.ConnectClientAsync();
+
+            Assert.AreEqual(
+                server.ObservableTimestamp,
+                client.GetFieldValue<ClientFailoverSocket>("_socket").ObservableTimestamp,
+                "Handshake should initialize observable timestamp");
 
             server.ObservableTimestamp = 123;
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
@@ -285,6 +285,15 @@ namespace Apache.Ignite.Tests.Transactions
         }
 
         [Test]
+        public async Task TestObservableTimestampIsInitializedFromHandshake()
+        {
+            using var client = await IgniteClient.StartAsync(new() { Endpoints = { "127.0.0.1:" + ServerPort } });
+            var observableTimestamp = client.GetFieldValue<ClientFailoverSocket>("_socket").ObservableTimestamp;
+
+            Assert.Greater(observableTimestamp, 0);
+        }
+
+        [Test]
         public async Task TestObservableTimestampPropagation([Values(true, false)] bool sql)
         {
             using var server = new FakeServer

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -353,7 +353,18 @@ namespace Apache.Ignite.Internal
             var idleTimeoutMs = reader.ReadInt64();
             var clusterNodeId = reader.ReadString();
             var clusterNodeName = reader.ReadString();
+
             var clusterId = reader.ReadGuid();
+            var clusterName = reader.ReadString();
+
+            var observableTimestamp = reader.ReadInt64();
+
+            // Cluster version.
+            reader.Skip(); // Major.
+            reader.Skip(); // Minor.
+            reader.Skip(); // Maintenance.
+            reader.Skip(); // Patch.
+            reader.Skip(); // Pre-release.
 
             reader.Skip(); // Features.
             reader.Skip(); // Extensions.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ConnectionContext.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ConnectionContext.cs
@@ -28,11 +28,13 @@ namespace Apache.Ignite.Internal
     /// <param name="IdleTimeout">Server idle timeout.</param>
     /// <param name="ClusterNode">Cluster node.</param>
     /// <param name="ClusterId">Cluster id.</param>
+    /// <param name="ClusterName">Cluster name.</param>
     /// <param name="SslInfo">SSL info.</param>
     internal record ConnectionContext(
         ClientProtocolVersion Version,
         TimeSpan IdleTimeout,
         ClusterNode ClusterNode,
         Guid ClusterId,
+        string ClusterName,
         ISslInfo? SslInfo);
 }


### PR DESCRIPTION
Before this fix we propagated `observableTimestamp` to the client with every response, but not on handshake. As a result, the very first operation from the client has `observableTimestamp = 0`, which can lead to causality issues.