### PR TITLE
IGNITE-21962 Fix client tests relying on specific product version

### DIFF
--- a/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerMetricsTest.java
+++ b/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerMetricsTest.java
@@ -23,15 +23,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.SocketException;
 import java.nio.file.Path;
+import java.util.Properties;
 import org.apache.ignite.client.handler.configuration.ClientConnectorConfiguration;
 import org.apache.ignite.internal.configuration.testframework.ConfigurationExtension;
 import org.apache.ignite.internal.configuration.testframework.InjectConfiguration;
 import org.apache.ignite.internal.network.configuration.NetworkConfiguration;
+import org.apache.ignite.internal.properties.IgniteProperties;
 import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
 import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.internal.testframework.WorkDirectory;
 import org.apache.ignite.internal.testframework.WorkDirectoryExtension;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +46,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(WorkDirectoryExtension.class)
 @ExtendWith(ConfigurationExtension.class)
 public class ItClientHandlerMetricsTest extends BaseIgniteAbstractTest {
+    private static String igniteVersion;
+
+    private static Properties props;
+
     @InjectConfiguration
     private NetworkConfiguration networkConfiguration;
 
@@ -54,10 +62,22 @@ public class ItClientHandlerMetricsTest extends BaseIgniteAbstractTest {
     private Path workDir;
 
     @AfterEach
-    void tearDown() throws Exception {
+    void tearDown() {
         if (testServer != null) {
             testServer.tearDown();
         }
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        props = IgniteTestUtils.getFieldValue(null, IgniteProperties.class, "PROPS");
+        igniteVersion = props.getProperty(IgniteProperties.VERSION);
+        props.setProperty(IgniteProperties.VERSION, "3.0.0-SNAPSHOT");
+    }
+
+    @AfterAll
+    static void afterAll() {
+        props.setProperty(IgniteProperties.VERSION, igniteVersion);
     }
 
     @Test

--- a/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerTest.java
+++ b/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerTest.java
@@ -271,33 +271,21 @@ public class ItClientHandlerTest extends BaseIgniteAbstractTest {
             final var success = unpacker.tryUnpackNil();
             assertTrue(success);
 
-            final var idleTimeout = unpacker.unpackLong();
-            final var nodeId = unpacker.unpackString();
-            final var nodeName = unpacker.unpackString();
+            var idleTimeout = unpacker.unpackLong();
+            var nodeId = unpacker.unpackString();
+            var nodeName = unpacker.unpackString();
+
             unpacker.skipValue(); // Cluster id.
-            unpacker.skipValue(); // Cluster name.
-            unpacker.skipValue(); // Observable timestamp.
-
-            unpacker.skipValue(); // Major.
-            unpacker.skipValue(); // Minor.
-            unpacker.skipValue(); // Maintenance.
-            unpacker.skipValue(); // Patch.
-            unpacker.skipValue(); // Pre release.
-
-            var featuresLen = unpacker.unpackBinaryHeader();
-            unpacker.skipValue(featuresLen);
-
-            var extensionsLen = unpacker.unpackInt();
-            unpacker.skipValue(extensionsLen);
+            var clusterName = unpacker.unpackString();
 
             assertArrayEquals(MAGIC, magic);
-            assertEquals(81, len);
             assertEquals(3, major);
             assertEquals(0, minor);
             assertEquals(0, patch);
             assertEquals(5000, idleTimeout);
             assertEquals("id", nodeId);
             assertEquals("consistent-id", nodeName);
+            assertEquals("Test Server", clusterName);
         }
     }
 

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
@@ -20,6 +20,8 @@ package org.apache.ignite.client;
 import static org.apache.ignite.client.fakes.FakeIgniteTables.TABLE_ONE_COLUMN;
 import static org.apache.ignite.internal.sql.engine.util.SqlTestUtils.assertThrowsSqlException;
 import static org.apache.ignite.internal.util.IgniteUtils.closeAll;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -229,12 +231,14 @@ public class ClientMetricsTest extends BaseIgniteAbstractTest {
         client = clientBuilder().build();
 
         assertEquals(15, metrics().bytesSent());
-        assertEquals(85, metrics().bytesReceived());
+
+        long handshakeReceived = metrics().bytesReceived();
+        assertThat(handshakeReceived, greaterThan(80L));
 
         client.tables().tables();
 
         assertEquals(21, metrics().bytesSent());
-        assertEquals(106, metrics().bytesReceived());
+        assertEquals(handshakeReceived + 21, metrics().bytesReceived());
     }
 
     @Test


### PR DESCRIPTION
Fix tests that rely on a specific value of `IgniteProductVersion.CURRENT_VERSION`:

* `ItClientHandlerMetricsTest`: Override version in props to ensure consistent results
* `ItClientHandlerTest`: Remove response size check
* `ClientMetricsTest`: Simplify check