### PR TITLE
IGNITE-21167 Sql. Jdbc. Raise a clearer error message when the tx control statement is used in non-autocommit mode

### DIFF
--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/JdbcHandlerBase.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/JdbcHandlerBase.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client.handler;
+
+import static org.apache.ignite.internal.jdbc.proto.IgniteQueryErrorCode.UNSUPPORTED_OPERATION;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import org.apache.ignite.internal.binarytuple.BinaryTupleReader;
+import org.apache.ignite.internal.jdbc.proto.event.JdbcQuerySingleResult;
+import org.apache.ignite.internal.jdbc.proto.event.Response;
+import org.apache.ignite.internal.lang.IgniteInternalCheckedException;
+import org.apache.ignite.internal.logger.IgniteLogger;
+import org.apache.ignite.internal.logger.Loggers;
+import org.apache.ignite.internal.sql.engine.AsyncSqlCursor;
+import org.apache.ignite.internal.sql.engine.InternalSqlRow;
+import org.apache.ignite.internal.sql.engine.TxControlInsideExternalTxNotSupportedException;
+import org.apache.ignite.internal.util.AsyncCursor.BatchedResult;
+import org.apache.ignite.internal.util.ExceptionUtils;
+import org.apache.ignite.sql.ColumnMetadata;
+import org.apache.ignite.sql.ColumnType;
+import org.apache.ignite.sql.ResultSetMetadata;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Contains common methods used to process jdbc requests.
+ */
+abstract class JdbcHandlerBase {
+    /** Logger. */
+    private final IgniteLogger log;
+
+    /** Client registry resources. */
+    protected final ClientResourceRegistry resources;
+
+    JdbcHandlerBase(ClientResourceRegistry resources) {
+        this.resources = resources;
+        this.log = Loggers.forClass(this.getClass());
+    }
+
+    /**
+     * Creates jdbc result for the cursor.
+     *
+     * @param cur Sql cursor for query.
+     * @param pageSize Page size.
+     * @return JdbcQuerySingleResult filled with first batch of data.
+     */
+    CompletionStage<JdbcQuerySingleResult> createJdbcResult(AsyncSqlCursor<InternalSqlRow> cur, int pageSize) {
+        return cur.requestNextAsync(pageSize).thenApply(batch -> {
+            boolean hasNext = batch.hasMore();
+
+            long cursorId;
+            try {
+                cursorId = resources.put(new ClientResource(cur, cur::closeAsync));
+            } catch (IgniteInternalCheckedException e) {
+                cur.closeAsync();
+
+                return new JdbcQuerySingleResult(Response.STATUS_FAILED,
+                        "Unable to store query cursor.");
+            }
+
+            switch (cur.queryType()) {
+                case EXPLAIN:
+                case QUERY: {
+                    List<ColumnMetadata> columns = cur.metadata().columns();
+
+                    return buildSingleRequest(batch, columns, cursorId, !hasNext);
+                }
+                case DML: {
+                    if (!validateDmlResult(cur.metadata(), hasNext)) {
+                        return new JdbcQuerySingleResult(Response.STATUS_FAILED, "Unexpected result for DML query");
+                    }
+
+                    long updCount = (long) batch.items().get(0).get(0);
+
+                    return new JdbcQuerySingleResult(cursorId, updCount);
+                }
+                case DDL:
+                case TX_CONTROL:
+                    return new JdbcQuerySingleResult(cursorId, 0);
+                default:
+                    return new JdbcQuerySingleResult(UNSUPPORTED_OPERATION,
+                            "Query type is not supported yet [queryType=" + cur.queryType() + ']');
+            }
+        });
+    }
+
+    private static JdbcQuerySingleResult buildSingleRequest(
+            BatchedResult<InternalSqlRow> batch,
+            List<ColumnMetadata> columns,
+            long cursorId,
+            boolean hasNext
+    ) {
+        List<BinaryTupleReader> rows = new ArrayList<>(batch.items().size());
+        for (InternalSqlRow item : batch.items()) {
+            rows.add(item.asBinaryTuple());
+        }
+
+        int[] decimalScales = new int[columns.size()];
+        List<ColumnType> schema = new ArrayList<>(columns.size());
+
+        int countOfDecimal = 0;
+        for (ColumnMetadata column : columns) {
+            schema.add(column.type());
+            if (column.type() == ColumnType.DECIMAL) {
+                decimalScales[countOfDecimal++] = column.scale();
+            }
+        }
+        decimalScales = Arrays.copyOf(decimalScales, countOfDecimal);
+
+        return new JdbcQuerySingleResult(cursorId, rows, schema, decimalScales, hasNext);
+    }
+
+    JdbcQuerySingleResult createErrorResult(String logMessage, Throwable origin, @Nullable String errMessagePrefix) {
+        Throwable ex = ExceptionUtils.unwrapCause(origin);
+
+        log.info(logMessage, ex);
+
+        String errorMessage;
+
+        if (ex instanceof TxControlInsideExternalTxNotSupportedException) {
+            errorMessage = "Transaction control statements are not supported when autocommit mode is disabled";
+        } else {
+            errorMessage = getErrorMessage(ex);
+        }
+
+        return new JdbcQuerySingleResult(Response.STATUS_FAILED, (errMessagePrefix == null ? "" : errMessagePrefix) + errorMessage);
+    }
+
+    /**
+     * Validate dml result. Check if it stores only one value of Long type.
+     *
+     * @param meta Fetched data from cursor.
+     * @param next  HasNext flag.
+     * @return Boolean value indicates if data is valid or not.
+     */
+    private static boolean validateDmlResult(ResultSetMetadata meta, boolean next) {
+        if (next) {
+            return false;
+        }
+
+        if (meta.columns().size() != 1) {
+            return false;
+        }
+
+        return meta.columns().get(0).type() == ColumnType.INT64;
+    }
+
+    /**
+     * Get a message of given exception for further sending to the client.
+     *
+     * @param t Throwable.
+     * @return String filled with exception message.
+     */
+    @Nullable static String getErrorMessage(Throwable t) {
+        Throwable cause = ExceptionUtils.unwrapCause(t);
+        return cause.getMessage();
+    }
+}

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/JdbcQueryEventHandlerImpl.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/JdbcQueryEventHandlerImpl.java
@@ -18,7 +18,6 @@
 package org.apache.ignite.client.handler;
 
 import static org.apache.ignite.internal.jdbc.proto.IgniteQueryErrorCode.UNKNOWN;
-import static org.apache.ignite.internal.jdbc.proto.IgniteQueryErrorCode.UNSUPPORTED_OPERATION;
 import static org.apache.ignite.internal.sql.engine.SqlQueryType.DML;
 import static org.apache.ignite.internal.util.ArrayUtils.OBJECT_EMPTY_ARRAY;
 import static org.apache.ignite.internal.util.CompletableFutures.nullCompletedFuture;
@@ -27,16 +26,11 @@ import static org.apache.ignite.lang.ErrorGroups.Client.CONNECTION_ERR;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import java.sql.Statement;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.ignite.client.handler.requests.jdbc.JdbcMetadataCatalog;
 import org.apache.ignite.client.handler.requests.jdbc.JdbcQueryCursor;
-import org.apache.ignite.internal.binarytuple.BinaryTupleReader;
 import org.apache.ignite.internal.jdbc.proto.JdbcQueryEventHandler;
 import org.apache.ignite.internal.jdbc.proto.JdbcStatementType;
 import org.apache.ignite.internal.jdbc.proto.event.JdbcBatchExecuteRequest;
@@ -57,32 +51,21 @@ import org.apache.ignite.internal.jdbc.proto.event.JdbcQuerySingleResult;
 import org.apache.ignite.internal.jdbc.proto.event.Response;
 import org.apache.ignite.internal.lang.IgniteInternalCheckedException;
 import org.apache.ignite.internal.lang.IgniteInternalException;
-import org.apache.ignite.internal.logger.IgniteLogger;
-import org.apache.ignite.internal.logger.Loggers;
 import org.apache.ignite.internal.sql.engine.AsyncSqlCursor;
 import org.apache.ignite.internal.sql.engine.InternalSqlRow;
 import org.apache.ignite.internal.sql.engine.QueryProcessor;
 import org.apache.ignite.internal.sql.engine.QueryProperty;
 import org.apache.ignite.internal.sql.engine.SqlQueryType;
-import org.apache.ignite.internal.sql.engine.TxControlInsideExternalTxNotSupportedException;
 import org.apache.ignite.internal.sql.engine.property.SqlProperties;
 import org.apache.ignite.internal.sql.engine.property.SqlPropertiesHelper;
 import org.apache.ignite.internal.tx.InternalTransaction;
-import org.apache.ignite.internal.util.AsyncCursor.BatchedResult;
-import org.apache.ignite.internal.util.ExceptionUtils;
-import org.apache.ignite.sql.ColumnMetadata;
-import org.apache.ignite.sql.ColumnType;
-import org.apache.ignite.sql.ResultSetMetadata;
 import org.apache.ignite.tx.IgniteTransactions;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Jdbc query event handler implementation.
  */
-public class JdbcQueryEventHandlerImpl implements JdbcQueryEventHandler {
-    /** Logger. */
-    private static final IgniteLogger LOG = Loggers.forClass(JdbcQueryEventHandlerImpl.class);
-
+public class JdbcQueryEventHandlerImpl extends JdbcHandlerBase implements JdbcQueryEventHandler {
     /** {@link SqlQueryType}s allowed in JDBC select statements. **/
     private static final Set<SqlQueryType> SELECT_STATEMENT_QUERIES = Set.of(SqlQueryType.QUERY, SqlQueryType.EXPLAIN);
 
@@ -94,9 +77,6 @@ public class JdbcQueryEventHandlerImpl implements JdbcQueryEventHandler {
 
     /** Jdbc metadata info. */
     private final JdbcMetadataCatalog meta;
-
-    /** Current JDBC cursors. */
-    private final ClientResourceRegistry resources;
 
     /** Ignite transactions API. */
     private final IgniteTransactions igniteTransactions;
@@ -115,9 +95,10 @@ public class JdbcQueryEventHandlerImpl implements JdbcQueryEventHandler {
             ClientResourceRegistry resources,
             IgniteTransactions igniteTransactions
     ) {
+        super(resources);
+
         this.processor = processor;
         this.meta = meta;
-        this.resources = resources;
         this.igniteTransactions = igniteTransactions;
     }
 
@@ -170,21 +151,8 @@ public class JdbcQueryEventHandlerImpl implements JdbcQueryEventHandler {
                 req.arguments() == null ? OBJECT_EMPTY_ARRAY : req.arguments()
         );
 
-        return result.thenCompose(cursor -> createJdbcResult(new JdbcQueryCursor<>(req.maxRows(), cursor), req))
-                .exceptionally(t -> {
-                    Throwable ex = ExceptionUtils.unwrapCause(t);
-
-                    LOG.info("Exception while executing query [query=" + req.sqlQuery() + "]", ex);
-
-                    if (ex instanceof TxControlInsideExternalTxNotSupportedException) {
-                        return new JdbcQuerySingleResult(
-                                Response.STATUS_FAILED, "Transaction control statements are not supported in non-autocommit mode");
-                    }
-
-                    String msg = getErrorMessage(t);
-
-                    return new JdbcQuerySingleResult(Response.STATUS_FAILED, msg);
-                });
+        return result.thenCompose(cursor -> createJdbcResult(new JdbcQueryCursor<>(req.maxRows(), cursor), req.pageSize()))
+                .exceptionally(t -> createErrorResult("Exception while executing query [query=" + req.sqlQuery() + "]", t, null));
     }
 
     private static SqlProperties createProperties(JdbcStatementType stmtType, boolean multiStatement, ZoneId timeZoneId) {
@@ -356,110 +324,6 @@ public class JdbcQueryEventHandlerImpl implements JdbcQueryEventHandler {
 
             return new JdbcFinishTxResult();
         });
-    }
-
-    /**
-     * Get a message of given exception for further sending to the client.
-     *
-     * @param t Throwable.
-     * @return String filled with exception message.
-     */
-    @Nullable private String getErrorMessage(Throwable t) {
-        Throwable cause = ExceptionUtils.unwrapCause(t);
-        return cause.getMessage();
-    }
-
-    /**
-     * Creates jdbc result for the cursor.
-     *
-     * @param cur Sql cursor for query.
-     * @param req Execution request.
-     * @return JdbcQuerySingleResult filled with first batch of data.
-     */
-    private CompletionStage<JdbcQuerySingleResult> createJdbcResult(AsyncSqlCursor<InternalSqlRow> cur, JdbcQueryExecuteRequest req) {
-        return cur.requestNextAsync(req.pageSize()).thenApply(batch -> {
-            boolean hasNext = batch.hasMore();
-
-            long cursorId;
-            try {
-                cursorId = resources.put(new ClientResource(cur, cur::closeAsync));
-            } catch (IgniteInternalCheckedException e) {
-                cur.closeAsync();
-
-                return new JdbcQuerySingleResult(Response.STATUS_FAILED,
-                        "Unable to store query cursor.");
-            }
-
-            switch (cur.queryType()) {
-                case EXPLAIN:
-                case QUERY: {
-                    List<ColumnMetadata> columns = cur.metadata().columns();
-
-                    return buildSingleRequest(batch, columns, cursorId, !hasNext);
-                }
-                case DML: {
-                    if (!validateDmlResult(cur.metadata(), hasNext)) {
-                        return new JdbcQuerySingleResult(Response.STATUS_FAILED,
-                                "Unexpected result for DML [query=" + req.sqlQuery() + ']');
-                    }
-
-                    long updCount = (long) batch.items().get(0).get(0);
-
-                    return new JdbcQuerySingleResult(cursorId, updCount);
-                }
-                case DDL:
-                case TX_CONTROL:
-                    return new JdbcQuerySingleResult(cursorId, 0);
-                default:
-                    return new JdbcQuerySingleResult(UNSUPPORTED_OPERATION,
-                            "Query type is not supported yet [queryType=" + cur.queryType() + ']');
-            }
-        });
-    }
-
-    static JdbcQuerySingleResult buildSingleRequest(
-            BatchedResult<InternalSqlRow> batch,
-            List<ColumnMetadata> columns,
-            long cursorId,
-            boolean hasNext
-    ) {
-        List<BinaryTupleReader> rows = new ArrayList<>(batch.items().size());
-        for (InternalSqlRow item : batch.items()) {
-            rows.add(item.asBinaryTuple());
-        }
-
-        int[] decimalScales = new int[columns.size()];
-        List<ColumnType> schema = new ArrayList<>(columns.size());
-
-        int countOfDecimal = 0;
-        for (ColumnMetadata column : columns) {
-            schema.add(column.type());
-            if (column.type() == ColumnType.DECIMAL) {
-                decimalScales[countOfDecimal++] = column.scale();
-            }
-        }
-        decimalScales = Arrays.copyOf(decimalScales, countOfDecimal);
-
-        return new JdbcQuerySingleResult(cursorId, rows, schema, decimalScales, hasNext);
-    }
-
-    /**
-     * Validate dml result. Check if it stores only one value of Long type.
-     *
-     * @param meta Fetched data from cursor.
-     * @param next  HasNext flag.
-     * @return Boolean value indicates if data is valid or not.
-     */
-    private boolean validateDmlResult(ResultSetMetadata meta, boolean next) {
-        if (next) {
-            return false;
-        }
-
-        if (meta.columns().size() != 1) {
-            return false;
-        }
-
-        return meta.columns().get(0).type() == ColumnType.INT64;
     }
 
     static class JdbcConnectionContext {

--- a/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcMultiStatementSelfTest.java
+++ b/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcMultiStatementSelfTest.java
@@ -422,11 +422,16 @@ public class ItJdbcMultiStatementSelfTest extends AbstractJdbcSelfTest {
     }
 
     @Test
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-21167")
+    @SuppressWarnings("ThrowableNotThrown")
     public void testAutoCommitFalseWithEmptyTx() throws Exception {
-        String txErrMsg = "Transaction control statement cannot be executed within an external transaction";
+        String txErrMsg = "Transaction control statements are not supported in non-autocommit mode";
         conn.setAutoCommit(false);
+
         assertThrowsSqlException(txErrMsg, () -> stmt.execute("START TRANSACTION; SELECT 1; COMMIT;"));
+        assertThrowsSqlException(txErrMsg, () -> stmt.execute("COMMIT;"));
+
+        stmt.execute("SELECT 1; COMMIT;");
+        assertThrowsSqlException(txErrMsg, () -> stmt.getMoreResults());
     }
 
     @Test

--- a/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcMultiStatementSelfTest.java
+++ b/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcMultiStatementSelfTest.java
@@ -381,20 +381,6 @@ public class ItJdbcMultiStatementSelfTest extends AbstractJdbcSelfTest {
     }
 
     @Test
-    public void testAutoCommitFalseNonCompleted() throws Exception {
-        String txErrMsg = "Transaction control statement cannot be executed within an external transaction";
-        conn.setAutoCommit(false);
-        assertThrowsSqlException(txErrMsg, () -> stmt.execute("COMMIT"));
-
-        boolean res = stmt.execute("SELECT 1;COMMIT");
-        assertTrue(res);
-        assertNotNull(stmt.getResultSet());
-        assertThrowsSqlException(txErrMsg, () -> stmt.getMoreResults());
-
-        assertThrowsSqlException(txErrMsg, () -> stmt.execute("START TRANSACTION; SELECT 1;"));
-    }
-
-    @Test
     public void testAutoCommitFalse() throws Exception {
         conn.setAutoCommit(false);
 
@@ -423,14 +409,16 @@ public class ItJdbcMultiStatementSelfTest extends AbstractJdbcSelfTest {
 
     @Test
     @SuppressWarnings("ThrowableNotThrown")
-    public void testAutoCommitFalseWithEmptyTx() throws Exception {
-        String txErrMsg = "Transaction control statements are not supported in non-autocommit mode";
+    public void testAutoCommitFalseTxControlStatementsNotSupported() throws Exception {
+        String txErrMsg = "Transaction control statements are not supported when autocommit mode is disabled";
         conn.setAutoCommit(false);
+        assertThrowsSqlException(txErrMsg, () -> stmt.execute("START TRANSACTION; SELECT 1; COMMIT"));
+        assertThrowsSqlException(txErrMsg, () -> stmt.execute("COMMIT"));
+        assertThrowsSqlException(txErrMsg, () -> stmt.execute("START TRANSACTION"));
 
-        assertThrowsSqlException(txErrMsg, () -> stmt.execute("START TRANSACTION; SELECT 1; COMMIT;"));
-        assertThrowsSqlException(txErrMsg, () -> stmt.execute("COMMIT;"));
-
-        stmt.execute("SELECT 1; COMMIT;");
+        boolean res = stmt.execute("SELECT 1;COMMIT");
+        assertTrue(res);
+        assertNotNull(stmt.getResultSet());
         assertThrowsSqlException(txErrMsg, () -> stmt.getMoreResults());
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-21167

In jdbc handler exception message has changed from
`Transaction control statement cannot be executed within an external transaction`
to more understandable
`Transaction control statements are not supported when autocommit mode is disabled`

`JdbcHandlerBase` abstract class was introduced to handle such errors uniformly.