### PR TITLE
IGNITE-22184 Fix race in ItClusterManagerTest#testJoinInvalidTag

### DIFF
--- a/modules/cluster-management/src/testFixtures/java/org/apache/ignite/internal/cluster/management/MockNode.java
+++ b/modules/cluster-management/src/testFixtures/java/org/apache/ignite/internal/cluster/management/MockNode.java
@@ -222,6 +222,10 @@ public class MockNode {
         return clusterService;
     }
 
+    public Path workDir() {
+        return workDir;
+    }
+
     CompletableFuture<Set<LogicalNode>> logicalTopologyNodes() {
         return clusterManager().logicalTopology().thenApply(LogicalTopologySnapshot::nodes);
     }


### PR DESCRIPTION
Previously the test could fail if the following order of events occurred:
1. A cluster is restarted.
2. A node hosting the CMG starts with an empty state.
3. The other node starts with the previous state and tries to connect to the leader.
4. Initialization request arrives, Raft group starts but the second node is able to send the join request faster, than the request with the cluster state is applied.

I fixed this by first starting the CMG node, initializing it and only then starting the other node.

https://issues.apache.org/jira/browse/IGNITE-22184

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)