### PR TITLE
IGNITE-21979: Extend test coverage for SQL F781(Self-referencing operations)

### DIFF
--- a/modules/sql-engine/src/integrationTest/sql/dml/test_self_referencing.test
+++ b/modules/sql-engine/src/integrationTest/sql/dml/test_self_referencing.test
@@ -94,3 +94,14 @@ SELECT a, val FROM test
 1	AAAA
 2	BB
 3	CC
+
+# DELETE
+
+statement ok
+DELETE FROM test WHERE a IN (SELECT a FROM test WHERE val = 'AAAA')
+
+query IT rowsort
+SELECT a, val FROM test
+----
+2	BB
+3	CC

--- a/modules/sql-engine/src/integrationTest/sql/dml/test_self_referencing.test
+++ b/modules/sql-engine/src/integrationTest/sql/dml/test_self_referencing.test
@@ -1,0 +1,96 @@
+# Test for self-referencing table without using Feature F781
+statement ok
+CREATE TABLE test (a INTEGER, val VARCHAR)
+
+statement ok
+INSERT INTO test VALUES (1, 'A'), (2, 'B')
+
+# INSERT
+
+statement ok
+INSERT INTO test (a, val) SELECT a, 'C' FROM test WHERE a IN (SELECT a FROM test WHERE val = 'A')
+
+query IT rowsort
+SELECT a, val FROM test
+----
+1	A
+1	C
+2	B
+
+statement ok
+INSERT INTO test (val, a) VALUES ('D', (SELECT COUNT(*) FROM test))
+
+query IT rowsort
+SELECT a, val FROM test
+----
+1	A
+1	C
+2	B
+3	D
+
+# Clean up
+
+statement ok
+DELETE FROM test
+
+statement ok
+INSERT INTO test VALUES (1, 'A'), (2, 'B')
+
+# UPDATE
+
+statement ok
+UPDATE test SET a = 11 WHERE a IN (SELECT a FROM test WHERE val = 'A')
+
+query IT rowsort
+SELECT a, val FROM test
+----
+11	A
+2	B
+
+statement ok
+UPDATE test SET a = (SELECT a + 1 FROM test WHERE val = 'A')
+
+query IT rowsort
+SELECT a, val FROM test
+----
+12	A
+12	B
+
+# Clean up
+
+statement ok
+DELETE FROM test
+
+statement ok
+INSERT INTO test VALUES (1, 'A'), (2, 'B')
+
+# MERGE
+
+statement ok
+MERGE INTO test dst USING test src ON dst.a = src.a WHEN MATCHED THEN UPDATE SET val = src.val || dst.val
+
+query IT rowsort
+SELECT a, val FROM test
+----
+1	AA
+2	BB
+
+statement ok
+MERGE INTO test dst USING test src ON dst.a = src.a + 1 WHEN NOT MATCHED THEN INSERT (a, val) VALUES (3, 'CC')
+
+query IT rowsort
+SELECT a, val FROM test
+----
+1	AA
+2	BB
+3	CC
+
+statement ok
+MERGE INTO test dst USING (SELECT * FROM test WHERE val = 'AA') src ON dst.a = src.a WHEN MATCHED THEN UPDATE SET val = src.val || dst.val
+
+query IT rowsort
+SELECT a, val FROM test
+----
+1	AAAA
+2	BB
+3	CC


### PR DESCRIPTION
Self-referencing in DML operations.

https://issues.apache.org/jira/browse/IGNITE-21979

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)