### PR TITLE
IGNITE-19234 Enable and fix group reentry logic for volatile storages

### DIFF
--- a/modules/affinity/src/main/java/org/apache/ignite/internal/affinity/Assignments.java
+++ b/modules/affinity/src/main/java/org/apache/ignite/internal/affinity/Assignments.java
@@ -108,6 +108,22 @@ public class Assignments implements Serializable {
     }
 
     /**
+     * Adds an assignment to this collection of assignments.
+     *
+     * @param assignment Assignment to add.
+     */
+    public void add(Assignment assignment) {
+        nodes.add(assignment);
+    }
+
+    /**
+     * Returns {@code true} if this collection has no assignments, {@code false} if it has some assignments.
+     */
+    public boolean isEmpty() {
+        return nodes.isEmpty();
+    }
+
+    /**
      * Serializes the instance into an array of bytes.
      */
     public byte[] toBytes() {

--- a/modules/table/src/integrationTest/java/org/apache/ignite/internal/raftsnapshot/ItTableRaftSnapshotsTest.java
+++ b/modules/table/src/integrationTest/java/org/apache/ignite/internal/raftsnapshot/ItTableRaftSnapshotsTest.java
@@ -65,6 +65,7 @@ import org.apache.ignite.internal.raft.server.impl.JraftServerImpl;
 import org.apache.ignite.internal.replicator.TablePartitionId;
 import org.apache.ignite.internal.replicator.command.SafeTimeSyncCommand;
 import org.apache.ignite.internal.storage.pagememory.PersistentPageMemoryStorageEngine;
+import org.apache.ignite.internal.storage.pagememory.VolatilePageMemoryStorageEngine;
 import org.apache.ignite.internal.storage.rocksdb.RocksDbStorageEngine;
 import org.apache.ignite.internal.table.distributed.raft.snapshot.incoming.IncomingSnapshotCopier;
 import org.apache.ignite.internal.table.distributed.raft.snapshot.message.SnapshotMetaResponse;
@@ -172,9 +173,8 @@ class ItTableRaftSnapshotsTest extends IgniteIntegrationTest {
     @ParameterizedTest
     @ValueSource(strings = {
             RocksDbStorageEngine.ENGINE_NAME,
-            PersistentPageMemoryStorageEngine.ENGINE_NAME
-            // TODO: uncomment when https://issues.apache.org/jira/browse/IGNITE-19234 is fixed
-//            VolatilePageMemoryStorageEngine.ENGINE_NAME
+            PersistentPageMemoryStorageEngine.ENGINE_NAME,
+            VolatilePageMemoryStorageEngine.ENGINE_NAME
     })
     void leaderFeedsFollowerWithSnapshot(String storageEngine) throws Exception {
         testLeaderFeedsFollowerWithSnapshot(storageEngine);

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/PartitionReplicatorNodeRecovery.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/PartitionReplicatorNodeRecovery.java
@@ -20,17 +20,20 @@ package org.apache.ignite.internal.table.distributed;
 import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.ignite.internal.util.CompletableFutures.nullCompletedFuture;
 import static org.apache.ignite.internal.util.CompletableFutures.trueCompletedFuture;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.IntFunction;
@@ -43,6 +46,8 @@ import org.apache.ignite.internal.raft.PeersAndLearners;
 import org.apache.ignite.internal.replicator.TablePartitionId;
 import org.apache.ignite.internal.storage.MvPartitionStorage;
 import org.apache.ignite.internal.storage.RowId;
+import org.apache.ignite.internal.storage.StorageClosedException;
+import org.apache.ignite.internal.storage.StorageRebalanceException;
 import org.apache.ignite.internal.storage.engine.MvTableStorage;
 import org.apache.ignite.internal.table.InternalTable;
 import org.apache.ignite.internal.table.TableViewInternal;
@@ -52,6 +57,7 @@ import org.apache.ignite.internal.utils.RebalanceUtilEx;
 import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.TopologyEventHandler;
 import org.apache.ignite.network.TopologyService;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Code specific to recovering a partition replicator group node. This includes a case when we lost metadata
@@ -70,6 +76,8 @@ class PartitionReplicatorNodeRecovery {
 
     private final TopologyService topologyService;
 
+    private final Executor storageAccessExecutor;
+
     /** Obtains a TableImpl instance by a table ID. */
     private final IntFunction<TableViewInternal> tableById;
 
@@ -77,11 +85,13 @@ class PartitionReplicatorNodeRecovery {
             MetaStorageManager metaStorageManager,
             MessagingService messagingService,
             TopologyService topologyService,
+            Executor storageAccessExecutor,
             IntFunction<TableViewInternal> tableById
     ) {
         this.metaStorageManager = metaStorageManager;
         this.messagingService = messagingService;
         this.topologyService = topologyService;
+        this.storageAccessExecutor = storageAccessExecutor;
         this.tableById = tableById;
     }
 
@@ -100,39 +110,53 @@ class PartitionReplicatorNodeRecovery {
 
                 HasDataRequest msg = (HasDataRequest) message;
 
-                int tableId = msg.tableId();
-                int partitionId = msg.partitionId();
-
-                boolean storageHasData = false;
-
-                TableViewInternal table = tableById.apply(tableId);
-
-                if (table != null) {
-                    MvTableStorage storage = table.internalTable().storage();
-
-                    MvPartitionStorage mvPartition = storage.getMvPartition(partitionId);
-
-                    // If node's recovery process is incomplete (no partition storage), then we consider this node's
-                    // partition storage empty.
-                    if (mvPartition != null) {
-                        storageHasData = mvPartition.closestRowId(RowId.lowestRowId(partitionId)) != null;
-                    }
-                }
-
-                messagingService.respond(sender, TABLE_MESSAGES_FACTORY.hasDataResponse().result(storageHasData).build(), correlationId);
+                storageAccessExecutor.execute(() -> handleHasDataRequest(msg, sender, correlationId));
             }
         });
     }
 
+    private void handleHasDataRequest(HasDataRequest msg, ClusterNode sender, Long correlationId) {
+        int tableId = msg.tableId();
+        int partitionId = msg.partitionId();
+
+        Boolean storageHasData = null;
+
+        TableViewInternal table = tableById.apply(tableId);
+
+        if (table != null) {
+            MvTableStorage storage = table.internalTable().storage();
+
+            MvPartitionStorage mvPartition = storage.getMvPartition(partitionId);
+
+            if (mvPartition != null) {
+                try {
+                    storageHasData = mvPartition.closestRowId(RowId.lowestRowId(partitionId)) != null;
+                } catch (StorageClosedException | StorageRebalanceException ignored) {
+                    // Ignoring so we'll return null for storageHasData meaning that we have no idea.
+                }
+            }
+        }
+
+        messagingService.respond(sender, TABLE_MESSAGES_FACTORY.hasDataResponse().result(storageHasData).build(), correlationId);
+    }
+
     /**
-     * Returns a future that completes with a decision: should we start the corresponding group locally or not.
+     * Initiates group reentry (that is, exits the group and then enters it again) if there is a possibility that
+     * this node lost its Raft metastorage state. This trick allows to solve the double-voting problem (this node
+     * could vote for one candidate, then do a restart (losing its Raft metastorage, including votedFor field), then
+     * vote for another candidate in the same term. As a result of removing itself and adding self back, the term
+     * will be incremented, so the possible old vote will be invalidated.
+     *
+     * <p>The possibility of losing the Raft metastorage state is detected by checking if the partition storage is
+     * volatile (and hence Raft metastorage is also volatile).
      *
      * @param tablePartitionId ID of the table partition.
      * @param internalTable Table we are working with.
      * @param newConfiguration New configuration that is going to be applied if we'll start the group.
      * @param localMemberAssignment Assignment of this node in this group.
+     * @return A future that completes with a decision: should we start the corresponding group locally or not.
      */
-    CompletableFuture<Boolean> shouldStartGroup(
+    CompletableFuture<Boolean> initiateGroupReentryIfNeeded(
             TablePartitionId tablePartitionId,
             InternalTable internalTable,
             PeersAndLearners newConfiguration,
@@ -164,14 +188,14 @@ class PartitionReplicatorNodeRecovery {
         // No majority and not a full partition restart - need to 'remove, then add' nodes
         // with current partition.
         return waitForPeersAndQueryDataNodesCount(tableId, partId, newConfiguration.peers())
-                .thenApply(dataNodesCount -> {
-                    boolean fullPartitionRestart = dataNodesCount == 0;
+                .thenApply(dataNodesCounts -> {
+                    boolean fullPartitionRestart = dataNodesCounts.nodesSurelyEmpty == newConfiguration.peers().size();
 
                     if (fullPartitionRestart) {
                         return true;
                     }
 
-                    boolean majorityAvailable = dataNodesCount >= (newConfiguration.peers().size() / 2) + 1;
+                    boolean majorityAvailable = dataNodesCounts.nodesSurelyHavingData >= (newConfiguration.peers().size() / 2) + 1;
 
                     if (majorityAvailable) {
                         RebalanceUtilEx.startPeerRemoval(tablePartitionId, localMemberAssignment, metaStorageManager);
@@ -193,13 +217,13 @@ class PartitionReplicatorNodeRecovery {
      * @param tblId Table id.
      * @param partId Partition id.
      * @param peers Raft peers.
-     * @return A future that will hold the quantity of data nodes.
+     * @return A future that will hold the counts of data nodes.
      */
-    private CompletableFuture<Long> waitForPeersAndQueryDataNodesCount(int tblId, int partId, Collection<Peer> peers) {
+    private CompletableFuture<DataNodesCounts> waitForPeersAndQueryDataNodesCount(int tblId, int partId, Collection<Peer> peers) {
         HasDataRequest request = TABLE_MESSAGES_FACTORY.hasDataRequest().tableId(tblId).partitionId(partId).build();
 
         return allPeersAreInTopology(peers)
-                .thenCompose(unused -> queryDataNodesCount(peers, request));
+                .thenCompose(unused -> queryDataNodesCounts(peers, request));
     }
 
     private CompletableFuture<?> allPeersAreInTopology(Collection<Peer> peers) {
@@ -274,7 +298,7 @@ class PartitionReplicatorNodeRecovery {
                 .thenCompose(identity());
     }
 
-    private CompletableFuture<Long> queryDataNodesCount(Collection<Peer> peers, HasDataRequest request) {
+    private CompletableFuture<DataNodesCounts> queryDataNodesCounts(Collection<Peer> peers, HasDataRequest request) {
         //noinspection unchecked
         CompletableFuture<Boolean>[] requestFutures = peers.stream()
                 .map(Peer::consistentId)
@@ -287,10 +311,28 @@ class PartitionReplicatorNodeRecovery {
 
                             return ((HasDataResponse) response).result();
                         })
-                        .exceptionally(unused -> false))
+                        .exceptionally(unused -> null))
                 .toArray(CompletableFuture[]::new);
 
         return allOf(requestFutures)
-                .thenApply(unused -> Arrays.stream(requestFutures).filter(CompletableFuture::join).count());
+                .thenApply(unused -> {
+                    List<@Nullable Boolean> hasDataFlags = Arrays.stream(requestFutures)
+                            .map(CompletableFuture::join)
+                            .collect(toList());
+
+                    long nodesSurelyHavingData = hasDataFlags.stream().filter(flag -> flag != null && flag).count();
+                    long nodesSurelyEmpty = hasDataFlags.stream().filter(flag -> flag != null && !flag).count();
+                    return new DataNodesCounts(nodesSurelyHavingData, nodesSurelyEmpty);
+                });
+    }
+
+    private static class DataNodesCounts {
+        private final long nodesSurelyHavingData;
+        private final long nodesSurelyEmpty;
+
+        private DataNodesCounts(long nodesSurelyHavingData, long nodesSurelyEmpty) {
+            this.nodesSurelyHavingData = nodesSurelyHavingData;
+            this.nodesSurelyEmpty = nodesSurelyEmpty;
+        }
     }
 }

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
@@ -287,7 +287,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
     /**
      * Versioned value for tracking RAFT groups initialization and starting completion.
      *
-     * <p>Only explicitly updated in {@link #startLocalPartitionsAndClients(CompletableFuture, TableImpl, int)}.
+     * <p>Only explicitly updated in {@link #startLocalPartitionsAndClients(CompletableFuture, TableImpl, int, boolean)}.
      *
      * <p>Completed strictly after {@link #localPartitionsVv}.
      */
@@ -385,7 +385,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
     /** Versioned value used only at manager startup to correctly fire table creation events. */
     private final IncrementalVersionedValue<Void> startVv;
 
-    /** Ends at the {@link #stop()} with an {@link NodeStoppingException}. */
+    /** Ends at the {@link #stopAsync()} with an {@link NodeStoppingException}. */
     private final CompletableFuture<Void> stopManagerFuture = new CompletableFuture<>();
 
     /** Configuration for {@link StorageUpdateHandler}. */
@@ -570,6 +570,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
                 metaStorageMgr,
                 messagingService,
                 topologyService,
+                partitionOperationsExecutor,
                 tableId -> tablesById().get(tableId)
         );
 
@@ -830,12 +831,14 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
      * @param assignmentsFuture Table assignments.
      * @param table Initialized table entity.
      * @param zoneId Zone id.
+     * @param isRecovery {@code true} if the node is being started up.
      * @return future, which will be completed when the partitions creations done.
      */
     private CompletableFuture<Void> startLocalPartitionsAndClients(
             CompletableFuture<List<Assignments>> assignmentsFuture,
             TableImpl table,
-            int zoneId
+            int zoneId,
+            boolean isRecovery
     ) {
         int tableId = table.tableId();
 
@@ -858,7 +861,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
                                 assignments.get(partId),
                                 null,
                                 zoneId,
-                                false
+                                isRecovery
                         )
                         .whenComplete((res, ex) -> {
                             if (ex != null) {
@@ -934,7 +937,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
 
         if (localMemberAssignment != null) {
             CompletableFuture<Boolean> shouldStartGroupFut = isRecovery
-                    ? partitionReplicatorNodeRecovery.shouldStartGroup(
+                    ? partitionReplicatorNodeRecovery.initiateGroupReentryIfNeeded(
                             replicaGrpId,
                             internalTbl,
                             newConfiguration,
@@ -1392,7 +1395,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
 
                             registerIndexesToTable(table, catalogService, partitionSet, schemaRegistry, lwm);
                         }
-                        return startLocalPartitionsAndClients(assignmentsFuture, table, zoneDescriptor.id());
+                        return startLocalPartitionsAndClients(assignmentsFuture, table, zoneDescriptor.id(), onNodeRecovery);
                     }
             ), ioExecutor);
         });
@@ -2528,7 +2531,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
 
     /**
      * Returns the future that will complete when, either the future from the argument or {@link #stopManagerFuture} will complete,
-     * successfully or exceptionally. Allows to protect from getting stuck at {@link #stop()} when someone is blocked (by using
+     * successfully or exceptionally. Allows to protect from getting stuck at {@link #stopAsync()} when someone is blocked (by using
      * {@link #busyLock}) for a long time.
      *
      * @param future Future.

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/message/DataPresence.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/message/DataPresence.java
@@ -18,10 +18,14 @@
 package org.apache.ignite.internal.table.distributed.message;
 
 /**
- * Whether a node has data or not (or it's not known).
+ * Whether a node has data or not (or it's not known because it did not respond in time, or the corresopnding storage is
+ * already closed or still being rebalanced to).
  */
 public enum DataPresence {
+    /** The storage is empty. */
     EMPTY,
+    /** The storage has some data. */
     HAS_DATA,
+    /** We don't know for some reason. */
     UNKNOWN
 }

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/message/DataPresence.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/message/DataPresence.java
@@ -17,24 +17,11 @@
 
 package org.apache.ignite.internal.table.distributed.message;
 
-import org.apache.ignite.internal.network.NetworkMessage;
-import org.apache.ignite.internal.network.annotations.Transferable;
-import org.apache.ignite.internal.table.distributed.TableMessageGroup;
-
 /**
- * A response to the {@link HasDataRequest}.
+ * Whether a node has data or not (or it's not known).
  */
-@Transferable(TableMessageGroup.HAS_DATA_RESPONSE)
-public interface HasDataResponse extends NetworkMessage {
-    /**
-     * Data presence indicator.
-     */
-    default DataPresence presence() {
-        return DataPresence.valueOf(presenceString());
-    }
-
-    /**
-     * String representation of {@link #presence()}.
-     */
-    String presenceString();
+public enum DataPresence {
+    EMPTY,
+    HAS_DATA,
+    UNKNOWN
 }

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/message/HasDataResponse.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/message/HasDataResponse.java
@@ -20,12 +20,17 @@ package org.apache.ignite.internal.table.distributed.message;
 import org.apache.ignite.internal.network.NetworkMessage;
 import org.apache.ignite.internal.network.annotations.Transferable;
 import org.apache.ignite.internal.table.distributed.TableMessageGroup;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A response to the {@link HasDataRequest}.
  */
 @Transferable(TableMessageGroup.HAS_DATA_RESPONSE)
 public interface HasDataResponse extends NetworkMessage {
-    /** {@code true} if a node has data for a partition of a table, {@code false} otherwise. */
-    boolean result();
+    /**
+     * {@code true} if a node surely has data for a partition of a table, {@code false} if it surely hasn't data, {@code null} if the
+     * information is not available (for instance, the partition is being rebalanced).
+     */
+    @Nullable
+    Boolean result();
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-19234

The reentry logic (see IGNITE-16668) was erroneously disabled. This commit enables it back and contains fixes required to make it work (due to changes made to the common rebalancing code since it was disabled).