### PR TITLE
IGNITE-22164 Sql. Fixed conversion from SqlMerge AST to relational expression when columns defined in different order.

### DIFF
--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
@@ -245,7 +245,13 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
 
         sql(sql);
 
-        // ---- all flds covered on NOT MATCHED but columns in different order
+        assertQuery("SELECT * FROM test2 ORDER BY k1")
+                .returns(222, 222, 1, 300, "1")
+                .returns(333, 333, 0, 100, "")
+                .returns(444, 444, 2, 200, null)
+                .check();
+
+        // ---- all fields covered on NOT MATCHED but columns in different order
         clearAndPopulateMergeTable2();
 
         sql = "MERGE INTO test2 dst USING test1 src ON dst.a = src.a "
@@ -256,6 +262,20 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
 
         assertQuery("SELECT * FROM test2 ORDER BY k1")
                 .returns(222, 222, 1, 300, "1")
+                .returns(333, 333, 0, 100, "")
+                .returns(444, 444, 2, 200, null)
+                .check();
+
+        // ---- all fields covered on NOT MATCHED but columns in different order and with filter
+        clearAndPopulateMergeTable2();
+
+        sql = "MERGE INTO test2 dst USING (SELECT * FROM test1 WHERE a = 0) src ON dst.a = src.a "
+                + "WHEN MATCHED THEN UPDATE SET b = src.b, a = src.a "
+                + "WHEN NOT MATCHED THEN INSERT (k1, k2, c, a, b) VALUES (src.k1, src.k2, src.c, src.a, src.b)";
+
+        sql(sql);
+
+        assertQuery("SELECT * FROM test2 ORDER BY k1")
                 .returns(333, 333, 0, 100, "")
                 .returns(444, 444, 2, 200, null)
                 .check();

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
@@ -245,6 +245,15 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
 
         sql(sql);
 
+        // ---- all flds covered on NOT MATCHED but columns in different order
+        clearAndPopulateMergeTable2();
+
+        sql = "MERGE INTO test2 dst USING test1 src ON dst.a = src.a "
+                + "WHEN MATCHED THEN UPDATE SET b = src.b, a = src.a "
+                + "WHEN NOT MATCHED THEN INSERT (k1, k2, c, a, b) VALUES (src.k1, src.k2, src.c, src.a, src.b)";
+
+        sql(sql);
+
         assertQuery("SELECT * FROM test2 ORDER BY k1")
                 .returns(222, 222, 1, 300, "1")
                 .returns(333, 333, 0, 100, "")

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/IgniteSqlToRelConvertor.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/IgniteSqlToRelConvertor.java
@@ -270,15 +270,17 @@ public class IgniteSqlToRelConvertor extends SqlToRelConverter {
             if (input instanceof LogicalProject) {
                 level1InsertExprs = ((LogicalProject) input).getProjects();
             } else {
-                // TODO calcite issue
+                // TODO https://issues.apache.org/jira/browse/IGNITE-22293
+                // convertInsert() may return LogicalTableModify without projection in the input.
+                // As a workaround for this case, we additionally build required column expressions.
                 RelDataType rowType = input.getRowType();
                 RexNode sourceRef = rexBuilder.makeRangeReference(rowType, 0, false);
                 ArrayList<String> targetColumnNames = new ArrayList<>(rowType.getFieldCount());
-                ArrayList<RexNode> projects = new ArrayList<>(rowType.getFieldCount());
+                ArrayList<RexNode> columnExprs = new ArrayList<>(rowType.getFieldCount());
 
-                collectInsertTargets(insertCall, sourceRef, targetColumnNames, projects);
+                collectInsertTargets(insertCall, sourceRef, targetColumnNames, columnExprs);
 
-                level1InsertExprs = projects;
+                level1InsertExprs = columnExprs;
             }
 
             numLevel1Exprs = level1InsertExprs.size();

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/IgniteSqlToRelConvertor.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/IgniteSqlToRelConvertor.java
@@ -274,13 +274,11 @@ public class IgniteSqlToRelConvertor extends SqlToRelConverter {
                 // convertInsert() may return LogicalTableModify without projection in the input.
                 // As a workaround for this case, we additionally build required column expressions.
                 RelDataType rowType = input.getRowType();
-                RexNode sourceRef = rexBuilder.makeRangeReference(rowType, 0, false);
-                ArrayList<String> targetColumnNames = new ArrayList<>(rowType.getFieldCount());
-                ArrayList<RexNode> columnExprs = new ArrayList<>(rowType.getFieldCount());
-
-                collectInsertTargets(insertCall, sourceRef, targetColumnNames, columnExprs);
-
-                level1InsertExprs = columnExprs;
+                level1InsertExprs = new ArrayList<>(rowType.getFieldCount());
+                int pos = 0;
+                for (RelDataTypeField type : rowType.getFieldList()) {
+                    level1InsertExprs.add(rexBuilder.makeInputRef(type.getType(), pos++));
+                }
             }
 
             numLevel1Exprs = level1InsertExprs.size();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22164

Issue description.

Schema with 2 tables.
```
TABLE TEST1(C1 INT, C2 INT)

TABLE TEST2(C1 INT, C2 INT)
```

`SqlToRelConverter` for the following insert statement
```
INSERT INTO TEST1 (C1, C2) SELECT C1, C2 FROM TEST2
```

produces the following rel node.
```
LogicalTableModify(table=[[PUBLIC, TEST1]], operation=[INSERT], flattened=[false])
  LogicalProject(C1=[$0], C2=[$1])
    LogicalTableScan(table=[[PUBLIC, TEST2]])
```

But if we swap columns C1 and C2.
```
INSERT INTO TEST1 (C2, C1) SELECT C2, C1 FROM TEST2
```
the result will be
```
LogicalTableModify(table=[[PUBLIC, TEST1]], operation=[INSERT], flattened=[false])
  LogicalTableScan(table=[[PUBLIC, TEST2]])
```

`convertMerge()` expects projection in the input of table modify node and fails with the following
```
Caused by: java.lang.ClassCastException: class org.apache.ignite.internal.sql.engine.rel.logical.IgniteLogicalTableScan cannot be cast to class org.apache.calcite.rel.logical.LogicalProject
```

Calcite issue: https://issues.apache.org/jira/browse/CALCITE-6412

As a naive workaround, an additional assembly of column expressions has been added to `convertMerge()` :thinking: 