### PR TITLE
IGNITE-22061 Use compact representation of BigDecimal to improve values size estimation

### DIFF
--- a/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/BinaryTupleBuilder.java
+++ b/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/BinaryTupleBuilder.java
@@ -19,7 +19,6 @@ package org.apache.ignite.internal.binarytuple;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.math.RoundingMode;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.CharBuffer;
@@ -315,15 +314,7 @@ public class BinaryTupleBuilder {
      * @return {@code this} for chaining.
      */
     public BinaryTupleBuilder appendDecimalNotNull(BigDecimal value, int scale) {
-        if (value.scale() > scale) {
-            value = value.setScale(scale, RoundingMode.HALF_UP);
-        }
-
-        BigDecimal noZeros = value.stripTrailingZeros();
-        if (noZeros.scale() <= Short.MAX_VALUE && noZeros.scale() >= Short.MIN_VALUE) {
-            // Use more compact representation if possible.
-            value = noZeros;
-        }
+        value = BinaryTupleCommon.shrinkDecimal(value, scale);
 
         // See CatalogUtils.MAX_DECIMAL_SCALE = Short.MAX_VALUE
         if (value.scale() > Short.MAX_VALUE) {

--- a/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/BinaryTupleCommon.java
+++ b/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/BinaryTupleCommon.java
@@ -17,6 +17,8 @@
 
 package org.apache.ignite.internal.binarytuple;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import org.apache.ignite.internal.lang.IgniteInternalException;
 
 /**
@@ -99,5 +101,26 @@ public class BinaryTupleCommon {
         }
 
         throw new IgniteInternalException("Too big binary tuple size");
+    }
+
+    /**
+     * Converts specified {@link BigDecimal} value to a more compact form, if possible.
+     *
+     * @param value Field value.
+     * @param scale Maximum scale.
+     * @return Decimal with a scale reduced to the specified scale and trimmed trailing zeros.
+     */
+    public static BigDecimal shrinkDecimal(BigDecimal value, int scale) {
+        if (value.scale() > scale) {
+            value = value.setScale(scale, RoundingMode.HALF_UP);
+        }
+
+        BigDecimal noZeros = value.stripTrailingZeros();
+        if (noZeros.scale() <= Short.MAX_VALUE && noZeros.scale() >= Short.MIN_VALUE) {
+            // Use more compact representation if possible.
+            return noZeros;
+        }
+
+        return value;
     }
 }

--- a/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/Marshaller.java
+++ b/modules/marshaller-common/src/main/java/org/apache/ignite/internal/marshaller/Marshaller.java
@@ -192,6 +192,15 @@ public abstract class Marshaller {
     public abstract void writeObject(@Nullable Object obj, MarshallerWriter writer) throws MarshallerException;
 
     /**
+     * Write field values to a row.
+     *
+     * @param values Object field values.
+     * @param writer Row writer.
+     * @throws MarshallerException If failed.
+     */
+    public abstract void writeFieldValues(Object[] values, MarshallerWriter writer) throws MarshallerException;
+
+    /**
      * Write the specified field of an object to a row.
      *
      * @param obj Object.
@@ -200,6 +209,16 @@ public abstract class Marshaller {
      * @throws MarshallerException If failed.
      */
     public abstract void writeField(@Nullable Object obj, MarshallerWriter writer, int fldIdx) throws MarshallerException;
+
+    /**
+     * Write the specified field value to a row.
+     *
+     * @param writer Row writer.
+     * @param fldIdx Field index.
+     * @param value Field value.
+     * @throws MarshallerException If failed.
+     */
+    public abstract void writeFieldValue(MarshallerWriter writer, int fldIdx, @Nullable Object value) throws MarshallerException;
 
     /**
      * Marshaller for objects of natively supported types.
@@ -240,10 +259,26 @@ public abstract class Marshaller {
 
         /** {@inheritDoc} */
         @Override
+        public void writeFieldValues(Object[] values, MarshallerWriter writer) throws MarshallerException {
+            assert values.length == 1 : values.length;
+
+            fieldAccessor.writeValue(writer, values[0]);
+        }
+
+        /** {@inheritDoc} */
+        @Override
         public void writeField(Object obj, MarshallerWriter writer, int fldIdx) throws MarshallerException {
             assert fldIdx == 0;
 
             fieldAccessor.write(writer, obj);
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void writeFieldValue(MarshallerWriter writer, int fldIdx, @Nullable Object value) throws MarshallerException {
+            assert fldIdx == 0;
+
+            fieldAccessor.writeValue(writer, value);
         }
     }
 
@@ -296,8 +331,22 @@ public abstract class Marshaller {
 
         /** {@inheritDoc} */
         @Override
+        public void writeFieldValues(Object[] values, MarshallerWriter writer) throws MarshallerException {
+            for (int fldIdx = 0; fldIdx < fieldAccessors.length; fldIdx++) {
+                fieldAccessors[fldIdx].writeValue(writer, values[fldIdx]);
+            }
+        }
+
+        /** {@inheritDoc} */
+        @Override
         public void writeField(@Nullable Object obj, MarshallerWriter writer, int fldIdx) throws MarshallerException {
             fieldAccessors[fldIdx].write(writer, obj);
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void writeFieldValue(MarshallerWriter writer, int fldIdx, @Nullable Object value) throws MarshallerException {
+            fieldAccessors[fldIdx].writeValue(writer, value);
         }
     }
 
@@ -318,7 +367,17 @@ public abstract class Marshaller {
         }
 
         @Override
-        public void writeField(Object obj, MarshallerWriter writer, int fldIdx) throws MarshallerException {
+        public void writeField(Object obj, MarshallerWriter writer, int fldIdx) {
+
+        }
+
+        @Override
+        public void writeFieldValue(MarshallerWriter writer, int fldIdx, @Nullable Object value) {
+
+        }
+
+        @Override
+        public void writeFieldValues(Object[] values, MarshallerWriter writer) {
 
         }
     }

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
@@ -79,6 +79,8 @@ public final class MarshallerUtil {
      */
     public static Object shrinkValue(Object value, NativeType type) {
         if (type.spec() == NativeTypeSpec.DECIMAL) {
+            assert type instanceof DecimalNativeType;
+
             return BinaryTupleCommon.shrinkDecimal((BigDecimal) value, ((DecimalNativeType) type).scale());
         }
 

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
@@ -77,11 +77,11 @@ public final class MarshallerUtil {
      * @param type Mapped type.
      * @return Value in a more compact form, or the original value if it cannot be compacted.
      */
-    public static Object shrinkValue(Object value, NativeType type) {
+    public static <T> T shrinkValue(T value, NativeType type) {
         if (type.spec() == NativeTypeSpec.DECIMAL) {
             assert type instanceof DecimalNativeType;
 
-            return BinaryTupleCommon.shrinkDecimal((BigDecimal) value, ((DecimalNativeType) type).scale());
+            return (T) BinaryTupleCommon.shrinkDecimal((BigDecimal) value, ((DecimalNativeType) type).scale());
         }
 
         return value;

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
@@ -27,6 +27,7 @@ import org.apache.ignite.internal.schema.Column;
 import org.apache.ignite.internal.schema.InvalidTypeException;
 import org.apache.ignite.internal.type.DecimalNativeType;
 import org.apache.ignite.internal.type.NativeType;
+import org.apache.ignite.internal.type.NativeTypeSpec;
 import org.apache.ignite.internal.util.ObjectFactory;
 
 /**
@@ -67,6 +68,21 @@ public final class MarshallerUtil {
             default:
                 throw new InvalidTypeException("Unsupported variable-length type: " + type);
         }
+    }
+
+    /**
+     * Converts the passed value to a more compact form, if possible.
+     *
+     * @param value Field value.
+     * @param type Mapped type.
+     * @return Value in a more compact form, or the original value if it cannot be compacted.
+     */
+    public static Object shrinkValue(Object value, NativeType type) {
+        if (type.spec() == NativeTypeSpec.DECIMAL) {
+            return BinaryTupleCommon.shrinkDecimal((BigDecimal) value, ((DecimalNativeType) type).scale());
+        }
+
+        return value;
     }
 
     /**

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/KvMarshallerImpl.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/KvMarshallerImpl.java
@@ -155,7 +155,7 @@ public class KvMarshallerImpl<K, V> implements KvMarshaller<K, V> {
      */
     private MarshallerRowBuilder createRowBuilder(Object key) throws MarshallerException {
         try {
-            return ObjectStatistics.createRowBuilder(schema, keyMarsh, key);
+            return MarshallerRowBuilder.createRowBuilder(schema, keyMarsh, key);
         } catch (Throwable e) {
             throw new MarshallerException(e.getMessage(), e);
         }
@@ -171,7 +171,7 @@ public class KvMarshallerImpl<K, V> implements KvMarshaller<K, V> {
      */
     private MarshallerRowBuilder createRowBuilder(Object key, @Nullable Object val) throws MarshallerException {
         try {
-            return ObjectStatistics.createRowBuilder(schema, keyMarsh, valMarsh, key, val);
+            return MarshallerRowBuilder.createRowBuilder(schema, keyMarsh, valMarsh, key, val);
         } catch (Throwable e) {
             throw new MarshallerException(e.getMessage(), e);
         }

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/MarshallerRowBuilder.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/MarshallerRowBuilder.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.schema.marshaller.reflection;
+
+import java.util.List;
+import org.apache.ignite.internal.marshaller.Marshaller;
+import org.apache.ignite.internal.marshaller.MarshallerException;
+import org.apache.ignite.internal.schema.BinaryRow;
+import org.apache.ignite.internal.schema.Column;
+import org.apache.ignite.internal.schema.SchemaDescriptor;
+import org.apache.ignite.internal.schema.row.RowAssembler;
+
+/**
+ * Helper to build a binary row.
+ */
+abstract class MarshallerRowBuilder {
+    /** Build binary row. */
+    abstract BinaryRow build() throws MarshallerException;
+
+    static MarshallerRowBuilder forKey(
+            RowAssembler asm,
+            Marshaller keyMarsh,
+            Object[] values
+    ) {
+        return new KeyOnlyBuilder(asm, keyMarsh, values);
+    }
+
+    static MarshallerRowBuilder forRow(
+            SchemaDescriptor schema,
+            RowAssembler asm,
+            Marshaller keyMarsh,
+            Marshaller valMarsh,
+            Object[] values
+    ) {
+        return new KeyValueBuilder(schema, asm, keyMarsh, valMarsh, values);
+    }
+
+    static class KeyOnlyBuilder extends MarshallerRowBuilder {
+        final RowAssembler asm;
+        final Marshaller keyMarsh;
+        final Object[] values;
+
+        KeyOnlyBuilder(RowAssembler asm, Marshaller keyMarsh, Object[] values) {
+            this.asm = asm;
+            this.keyMarsh = keyMarsh;
+            this.values = values;
+        }
+
+        @Override
+        BinaryRow build() throws MarshallerException {
+            RowWriter writer = new RowWriter(asm);
+
+            keyMarsh.writeFieldValues(values, writer);
+
+            return asm.build();
+        }
+    }
+
+    static class KeyValueBuilder extends KeyOnlyBuilder {
+        private final SchemaDescriptor schema;
+        private final Marshaller valMarsh;
+
+        KeyValueBuilder(SchemaDescriptor schema, RowAssembler asm, Marshaller keyMarsh, Marshaller valMarsh, Object[] values) {
+            super(asm, keyMarsh, values);
+
+            this.valMarsh = valMarsh;
+            this.schema = schema;
+        }
+
+        @Override
+        BinaryRow build() throws MarshallerException {
+            RowWriter writer = new RowWriter(asm);
+
+            List<Column> columns = schema.columns();
+
+            for (int i = 0; i < columns.size(); i++) {
+                Column column = columns.get(i);
+
+                if (column.positionInKey() >= 0) {
+                    keyMarsh.writeFieldValue(writer, column.positionInKey(), values[i]);
+                } else {
+                    valMarsh.writeFieldValue(writer, column.positionInValue(), values[i]);
+                }
+            }
+
+            return asm.build();
+        }
+    }
+}

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/RecordMarshallerImpl.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/RecordMarshallerImpl.java
@@ -26,7 +26,6 @@ import org.apache.ignite.internal.schema.Column;
 import org.apache.ignite.internal.schema.SchemaDescriptor;
 import org.apache.ignite.internal.schema.marshaller.RecordMarshaller;
 import org.apache.ignite.internal.schema.row.Row;
-import org.apache.ignite.internal.schema.row.RowAssembler;
 import org.apache.ignite.table.mapper.Mapper;
 import org.apache.ignite.table.mapper.PojoMapper;
 import org.jetbrains.annotations.Nullable;
@@ -88,11 +87,9 @@ public class RecordMarshallerImpl<R> implements RecordMarshaller<R> {
     public Row marshal(R rec) throws MarshallerException {
         assert recClass.isInstance(rec);
 
-        final RowAssembler asm = createAssembler(Objects.requireNonNull(rec), rec);
+        MarshallerRowBuilder rowBuilder = createRowBuilder(Objects.requireNonNull(rec), rec);
 
-        recMarsh.writeObject(rec, new RowWriter(asm));
-
-        return Row.wrapBinaryRow(schema, asm.build());
+        return Row.wrapBinaryRow(schema, rowBuilder.build());
     }
 
     /** {@inheritDoc} */
@@ -100,11 +97,9 @@ public class RecordMarshallerImpl<R> implements RecordMarshaller<R> {
     public Row marshalKey(R rec) throws MarshallerException {
         assert recClass.isInstance(rec);
 
-        final RowAssembler asm = createAssembler(Objects.requireNonNull(rec));
+        MarshallerRowBuilder rowBuilder = createRowBuilder(Objects.requireNonNull(rec));
 
-        keyMarsh.writeObject(rec, new RowWriter(asm));
-
-        return Row.wrapKeyOnlyBinaryRow(schema, asm.build());
+        return Row.wrapKeyOnlyBinaryRow(schema, rowBuilder.build());
     }
 
     /** {@inheritDoc} */
@@ -129,31 +124,31 @@ public class RecordMarshallerImpl<R> implements RecordMarshaller<R> {
     }
 
     /**
-     * Creates {@link RowAssembler} for key.
+     * Creates {@link MarshallerRowBuilder} for key.
      *
      * @param key Key object.
-     * @return Row assembler.
+     * @return Binary row.
      * @throws MarshallerException If failed to read key object content.
      */
-    private RowAssembler createAssembler(Object key) throws MarshallerException {
+    private MarshallerRowBuilder createRowBuilder(Object key) throws MarshallerException {
         try {
-            return ObjectStatistics.createAssembler(schema, keyMarsh, key);
+            return ObjectStatistics.createRowBuilder(schema, keyMarsh, key);
         } catch (Throwable e) {
             throw new MarshallerException(e.getMessage(), e);
         }
     }
 
     /**
-     * Creates {@link RowAssembler} for key-value pair.
+     * Creates {@link MarshallerRowBuilder} for key-value pair.
      *
      * @param key Key object.
      * @param val Value object.
-     * @return Row assembler.
+     * @return Binary row.
      * @throws MarshallerException If failed to read key or value object content.
      */
-    private RowAssembler createAssembler(Object key, Object val) throws MarshallerException {
+    private MarshallerRowBuilder createRowBuilder(Object key, Object val) throws MarshallerException {
         try {
-            return ObjectStatistics.createAssembler(schema, keyMarsh, valMarsh, key, val);
+            return ObjectStatistics.createRowBuilder(schema, keyMarsh, valMarsh, key, val);
         } catch (Throwable e) {
             throw new MarshallerException(e.getMessage(), e);
         }

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/RecordMarshallerImpl.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/reflection/RecordMarshallerImpl.java
@@ -132,7 +132,7 @@ public class RecordMarshallerImpl<R> implements RecordMarshaller<R> {
      */
     private MarshallerRowBuilder createRowBuilder(Object key) throws MarshallerException {
         try {
-            return ObjectStatistics.createRowBuilder(schema, keyMarsh, key);
+            return MarshallerRowBuilder.createRowBuilder(schema, keyMarsh, key);
         } catch (Throwable e) {
             throw new MarshallerException(e.getMessage(), e);
         }
@@ -148,7 +148,7 @@ public class RecordMarshallerImpl<R> implements RecordMarshaller<R> {
      */
     private MarshallerRowBuilder createRowBuilder(Object key, Object val) throws MarshallerException {
         try {
-            return ObjectStatistics.createRowBuilder(schema, keyMarsh, valMarsh, key, val);
+            return MarshallerRowBuilder.createRowBuilder(schema, keyMarsh, valMarsh, key, val);
         } catch (Throwable e) {
             throw new MarshallerException(e.getMessage(), e);
         }

--- a/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/reflection/ObjectStatisticsTest.java
+++ b/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/reflection/ObjectStatisticsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.schema.marshaller.reflection;
+
+import static org.apache.ignite.internal.schema.marshaller.MarshallerUtil.sizeInBytes;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import org.apache.ignite.internal.binarytuple.BinaryTupleBuilder;
+import org.apache.ignite.internal.binarytuple.BinaryTupleCommon;
+import org.apache.ignite.internal.catalog.commands.CatalogUtils;
+import org.apache.ignite.internal.marshaller.Marshaller;
+import org.apache.ignite.internal.marshaller.MarshallerException;
+import org.apache.ignite.internal.marshaller.MarshallersProvider;
+import org.apache.ignite.internal.marshaller.ReflectionMarshallersProvider;
+import org.apache.ignite.internal.schema.Column;
+import org.apache.ignite.internal.schema.SchemaDescriptor;
+import org.apache.ignite.internal.type.NativeTypes;
+import org.apache.ignite.table.mapper.Mapper;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Marshaller object statistics test.
+ */
+public class ObjectStatisticsTest {
+    private static final int PRECISION = 10;
+
+    private static final int HUGE_DECIMAL_SCALE = Short.MAX_VALUE * 10;
+
+    /** The test checks that when calculating the row size, the passed decimal value is compacted. */
+    @ParameterizedTest(name = "scale = {0}")
+    @ValueSource(ints = {3, 1024, CatalogUtils.MAX_DECIMAL_SCALE - PRECISION})
+    void testDecimalSizeEstimation(int columnScale) throws MarshallerException {
+        SchemaDescriptor schema = new SchemaDescriptor(1,
+                new Column[]{new Column("KEY", NativeTypes.decimalOf(PRECISION, columnScale), false)},
+                new Column[]{new Column("UNUSED", NativeTypes.INT32, true)});
+
+        MarshallersProvider marshallers = new ReflectionMarshallersProvider();
+        Marshaller marshaller = marshallers.getKeysMarshaller(schema.marshallerSchema(), Mapper.of(BigDecimal.class), true, false);
+
+        BigDecimal hugeScaledDecimal = new BigDecimal(1, new MathContext(PRECISION))
+                .setScale(HUGE_DECIMAL_SCALE, RoundingMode.HALF_UP);
+
+        assertThat(sizeInBytes(hugeScaledDecimal), is(greaterThan(16384)));
+
+        ObjectStatistics statistics = ObjectStatistics.collectObjectStats(schema, schema.keyColumns(), marshaller, hugeScaledDecimal);
+        assertThat(statistics.estimatedValueSize(), is(3));
+        assertThat(sizeInBytes((BigDecimal) statistics.value(0)), is(3));
+
+        BinaryTupleBuilder builder = new BinaryTupleBuilder(1, statistics.estimatedValueSize());
+        builder.appendDecimal(statistics.value(0), columnScale);
+        assertThat(builder.build().capacity(), is(statistics.estimatedValueSize() + BinaryTupleCommon.HEADER_SIZE + 1));
+    }
+}

--- a/modules/table/src/main/java/org/apache/ignite/internal/schema/marshaller/TupleMarshallerImpl.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/schema/marshaller/TupleMarshallerImpl.java
@@ -190,11 +190,11 @@ public class TupleMarshallerImpl implements TupleMarshaller {
             col.validate(val);
 
             if (val != null) {
-                val = MarshallerUtil.shrinkValue(val, col.type());
-
                 if (colType.spec().fixedLength()) {
                     estimatedValueSize += colType.sizeInBytes();
                 } else {
+                    val = MarshallerUtil.shrinkValue(val, col.type());
+
                     estimatedValueSize += getValueSize(val, colType);
                 }
             }

--- a/modules/table/src/test/java/org/apache/ignite/internal/schema/marshaller/TupleMarshallerStatisticsTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/schema/marshaller/TupleMarshallerStatisticsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.schema.marshaller;
+
+import static org.apache.ignite.internal.schema.marshaller.MarshallerUtil.sizeInBytes;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import org.apache.ignite.internal.binarytuple.BinaryTupleBuilder;
+import org.apache.ignite.internal.binarytuple.BinaryTupleCommon;
+import org.apache.ignite.internal.catalog.commands.CatalogUtils;
+import org.apache.ignite.internal.schema.Column;
+import org.apache.ignite.internal.schema.SchemaDescriptor;
+import org.apache.ignite.internal.schema.marshaller.TupleMarshallerImpl.ValuesWithStatistics;
+import org.apache.ignite.internal.table.impl.TestTupleBuilder;
+import org.apache.ignite.internal.type.NativeTypes;
+import org.apache.ignite.table.Tuple;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests binary tuple size estimation in {@link TupleMarshallerImpl}.
+ */
+public class TupleMarshallerStatisticsTest {
+    private static final int PRECISION = 10;
+
+    private static final int HUGE_DECIMAL_SCALE = Short.MAX_VALUE * 10;
+
+    /** The test checks that when calculating the tuple size, the passed decimal value is compacted. */
+    @ParameterizedTest(name = "scale = {0}")
+    @ValueSource(ints = {3, 1024, CatalogUtils.MAX_DECIMAL_SCALE - PRECISION})
+    public void testDecimalSizeEstimation(int columnScale) {
+        SchemaDescriptor schema = new SchemaDescriptor(1,
+                new Column[]{new Column("KEY", NativeTypes.decimalOf(PRECISION, columnScale), false)},
+                new Column[]{new Column("UNUSED", NativeTypes.INT32, true)});
+
+        TupleMarshallerImpl marshaller = new TupleMarshallerImpl(schema);
+
+        BigDecimal hugeScaledDecimal = new BigDecimal(1, new MathContext(PRECISION))
+                .setScale(HUGE_DECIMAL_SCALE, RoundingMode.HALF_UP);
+        Tuple tuple = new TestTupleBuilder().set("KEY", hugeScaledDecimal);
+
+        assertThat(sizeInBytes(hugeScaledDecimal), is(greaterThan(16384)));
+
+        ValuesWithStatistics statistics = new ValuesWithStatistics();
+        marshaller.gatherStatistics(schema.keyColumns(), tuple, statistics);
+        assertThat(statistics.estimatedValueSize(), is(3));
+        BigDecimal compactedValue = (BigDecimal) statistics.value("KEY");
+        assertNotNull(compactedValue);
+        assertThat(sizeInBytes(compactedValue), is(3));
+
+        BinaryTupleBuilder builder = new BinaryTupleBuilder(1, statistics.estimatedValueSize());
+        builder.appendDecimal(compactedValue, columnScale);
+        assertThat(builder.build().capacity(), is(statistics.estimatedValueSize() + BinaryTupleCommon.HEADER_SIZE + 1));
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22061

**Issue description:**
Binary tuple stores bigdecimal in compact form after [IGNITE-21745](https://issues.apache.org/jira/browse/IGNITE-21745).

But `TupleMarshallerImpl.gatherStatistics()` and `ObjectStatistics.collectObjectStats()` estimate the size of `BigDecimal`s, without compaction, which can cause the pre-allocated buffer in the `BinaryTupleBuilder` to be significantly larger than required.

**Implementation notes:**
* Added conversion to compact form when collecting statistics for BigDecimals in `TupleMarshallerImpl.gatherStatistics()` and `ObjectStatistics.collectObjectStats()`.
* Marshallers have been slightly reworked to store values ​​obtained when collecting statistics.
