### PR TITLE
Restrict substring args to INTEGER type family

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/exp/IgniteSqlFunctions.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/exp/IgniteSqlFunctions.java
@@ -231,7 +231,9 @@ public class IgniteSqlFunctions {
         return SqlFunctions.substring(c, s);
     }
 
-    /** SQL SUBSTRING(string FROM ...) function. */
+    /** 
+     * SQL SUBSTRING(string FROM ...) function with BIGINT arguments.
+     */
     public static String substring(String c, BigDecimal s) {
         if (s.compareTo(BigDecimal.ONE) <= 0) {
             return c;
@@ -246,7 +248,9 @@ public class IgniteSqlFunctions {
         return SqlFunctions.substring(c, s, l);
     }
 
-    /** SQL SUBSTRING(string FROM ...) function. */
+    /**
+     * SQL SUBSTRING(string FROM ...) function with BIGINT arguments.
+     */
     public static String substring(String c, int s, BigDecimal l) {
         if (s < 0) {
             if (l.signum() > 0) {
@@ -258,7 +262,9 @@ public class IgniteSqlFunctions {
         return SqlFunctions.substring(c, s, l0);
     }
 
-    /** SQL SUBSTRING(string FROM ...) function. */
+    /** 
+     * SQL SUBSTRING(string FROM ...) function with BIGINT arguments. 
+     */
     public static String substring(String c, BigDecimal s, BigDecimal l) {
         if (s.signum() < 0) {
             if (l.signum() > 0) {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/fun/IgniteSqlOperatorTable.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/fun/IgniteSqlOperatorTable.java
@@ -17,7 +17,6 @@
 
 package org.apache.ignite.internal.sql.engine.sql.fun;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.SqlBasicFunction;
@@ -32,8 +31,6 @@ import org.apache.calcite.sql.fun.SqlSubstringFunction;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
-import org.apache.calcite.sql.type.SqlSingleOperandTypeChecker;
-import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeTransforms;
 import org.apache.calcite.sql.util.ReflectiveSqlOperatorTable;
@@ -108,12 +105,6 @@ public class IgniteSqlOperatorTable extends ReflectiveSqlOperatorTable {
                     null,
                     OperandTypes.STRING_INTEGER_OPTIONAL_INTEGER,
                     SqlFunctionCategory.STRING);
-
-    private static final SqlSingleOperandTypeChecker STRING_NUMERIC_OPTIONAL_NUMERIC =
-            OperandTypes.family(
-                    ImmutableList.of(SqlTypeFamily.STRING, SqlTypeFamily.NUMERIC,
-                            SqlTypeFamily.NUMERIC), i -> i == 2);
-
     public static final SqlFunction SUBSTRING =
             new SqlFunction(
                     "SUBSTRING",
@@ -121,9 +112,7 @@ public class IgniteSqlOperatorTable extends ReflectiveSqlOperatorTable {
                     ReturnTypes.ARG0_NULLABLE_VARYING,
                     null,
                     OperandTypes.STRING_INTEGER_OPTIONAL_INTEGER
-                            .or(STRING_NUMERIC_OPTIONAL_NUMERIC)
-                            .or(OperandTypes.STRING_INTEGER)
-                            .or(OperandTypes.STRING_NUMERIC),
+                            .or(OperandTypes.STRING_INTEGER),
                     SqlFunctionCategory.STRING);
 
     /**


### PR DESCRIPTION
SUBSTRING should only accept types of the INTEGER type family for its numeric arguments.

After this patch the following queries should be rejected by the validator:

- `SELECT SUBSTRING('aaa', 1.2)`
- `SELECT SUBSTRING('aaa', 1.2::REAL)`
- `SELECT SUBSTRING('aaa', 1.2::DOUBLE)`
- `SELECT SUBSTRING('aaa', 2::DECIMAL(2))`
...
- `SELECT SUBSTRING('aaa', 2, 2::DECIMAL(2))`
---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)