### PR TITLE
IGNITE-22355 TableManagerTest's static mocks from #mockManagersAndCreateTableWithDelay don't work properly

### DIFF
--- a/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/TableManagerTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/TableManagerTest.java
@@ -57,10 +57,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -73,7 +72,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.LongFunction;
-import org.apache.ignite.internal.affinity.AffinityUtils;
 import org.apache.ignite.internal.affinity.Assignment;
 import org.apache.ignite.internal.affinity.Assignments;
 import org.apache.ignite.internal.catalog.CatalogManager;
@@ -735,16 +733,8 @@ public class TableManagerTest extends IgniteAbstractTest {
                     .thenReturn(mock(SchemaDescriptor.class));
         }
 
-        try (MockedStatic<AffinityUtils> affinityServiceMock = mockStatic(AffinityUtils.class)) {
-            ArrayList<List<ClusterNode>> assignment = new ArrayList<>(PARTITIONS);
-
-            for (int part = 0; part < PARTITIONS; part++) {
-                assignment.add(new ArrayList<>(Collections.singleton(node)));
-            }
-
-            affinityServiceMock.when(() -> AffinityUtils.calculateAssignments(any(), anyInt(), anyInt()))
-                    .thenReturn(assignment);
-        }
+        when(distributionZoneManager.dataNodes(anyLong(), anyInt(), anyInt()))
+                .thenReturn(completedFuture(Set.of(NODE_NAME)));
 
         TableManager tableManager = createTableManager(tblManagerFut);
 

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/TableManagerTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/TableManagerTest.java
@@ -153,6 +153,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 /** Tests scenarios for table manager. */
+// TODO: test demands for reworking https://issues.apache.org/jira/browse/IGNITE-22388
 @ExtendWith({MockitoExtension.class, ConfigurationExtension.class})
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class TableManagerTest extends IgniteAbstractTest {
@@ -178,6 +179,7 @@ public class TableManagerTest extends IgniteAbstractTest {
     private static final String ZONE_NAME = "zone1";
 
     /** Topology service. */
+    // TODO: useless field for now https://issues.apache.org/jira/browse/IGNITE-22388
     @Mock
     private TopologyService ts;
 
@@ -722,12 +724,14 @@ public class TableManagerTest extends IgniteAbstractTest {
             return completedFuture(raftGrpSrvcMock);
         });
 
+        // TODO: useless code https://issues.apache.org/jira/browse/IGNITE-22388
         when(ts.getByConsistentId(any())).thenReturn(new ClusterNodeImpl(
                 UUID.randomUUID().toString(),
                 consistentId,
                 new NetworkAddress("localhost", 47500)
         ));
 
+        // TODO: should be removed or reworked https://issues.apache.org/jira/browse/IGNITE-22388
         try (MockedStatic<SchemaUtils> schemaServiceMock = mockStatic(SchemaUtils.class)) {
             schemaServiceMock.when(() -> SchemaUtils.prepareSchemaDescriptor(any()))
                     .thenReturn(mock(SchemaDescriptor.class));


### PR DESCRIPTION
JIRA ticket: [IGNITE-22355 | `TableManagerTest`'s static mocks from `#mockManagersAndCreateTableWithDelay` don't work properly](https://issues.apache.org/jira/browse/IGNITE-22355)

**Description**

In tests table creation method there is code like below:

```java
try (MockedStatic<AffinityUtils> affinityServiceMock = mockStatic(AffinityUtils.class)) {
    ArrayList<List<ClusterNode>> assignment = new ArrayList<>(PARTITIONS);

    for (int part = 0; part < PARTITIONS; part++) {
        assignment.add(new ArrayList<>(Collections.singleton(node)));
    }

    affinityServiceMock.when(() -> AffinityUtils.calculateAssignments(any(), anyInt(), anyInt()))
            .thenReturn(assignment);
}
```

As the result `AffinityUtils#calculateAssignments` calls outside of try-with-resources returns list of empty sets, but desired behavior is list of sets with the given node. It's become critical and leads to failure of all `tableManagerStopTest*` tests if a test is rely on assignments check, like in https://issues.apache.org/jira/browse/IGNITE-22315 

**Solution**

Due to [this Mockito's issue](https://github.com/mockito/mockito/issues/2142) static mocks aren't accessible from a different threads. I tired to use static mock as a field:

```java
private MockedStatic<AffinityUtils> affinityUtilsStaticMock;

@BeforeEach
void before() throws NodeStoppingException {
    affinityUtilsStaticMock = mockStatic(AffinityUtils.class);
    // ...
}
// ...
private TableViewInternal mockManagersAndCreateTableWithDelay(
            String tableName,
            CompletableFuture<TableManager> tblManagerFut,
            @Nullable Phaser phaser
    ) throws Exception {
    // ...
    ArrayList<List<ClusterNode>> assignment = new ArrayList<>(PARTITIONS);

    for (int part = 0; part < PARTITIONS; part++) {
        assignment.add(new ArrayList<>(Collections.singleton(node)));
    }

    affinityUtilsStaticMock.when(() -> AffinityUtils.calculateAssignments(any(), anyInt(), anyInt())).thenReturn(assignment);

    TableManager tableManager = createTableManager(tblManagerFut);
    // ...
}
// ...
void after() throws Exception {
    ComponentContext componentContext = new ComponentContext();
    closeAll(
        // ...
        affinityUtilsStaticMock
    );
}
```

But inside inside `TableManager#getOrCreateAssignments` it didn't works, the place:

```java
assignmentsFuture = distributionZoneManager.dataNodes(causalityToken, catalogVersion, zoneDescriptor.id())
        .thenApply(dataNodes -> AffinityUtils.calculateAssignments(
                dataNodes,
                zoneDescriptor.partitions(),
                zoneDescriptor.replicas()
    )//...
```

returns a list with size `zoneDescriptor.partitions()` of empty node set as the ticket describes as problem. In debug we can check is the mocking still works with:

```java
Mockito.mockingDetails(AffinityUtils.class).isMock()
```

and it returns `false`. In oppisite, we can check that after `.when(...)` statement the same check returns `true`.

The temporal solution is to mock `DistributionZoneManager#dataNodes` with non-empty set with `node1` inside:

```java
when(distributionZoneManager.dataNodes(anyLong(), anyInt(), anyInt()))
                .thenReturn(completedFuture(Set.of(NODE_NAME)));
```

where `NODE_NAME` is `node1`.

Then, non-mocked `AffinityUtils#calculateAssignments` returns a list with size `zoneDescriptor.partitions()` (in the case partitions equals 32) of non-empty node set with `node1` inside as desired.

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)