### PR TITLE
IGNITE-20503 Sql. Support big clusters by mapping service

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/ExecutionTarget.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/ExecutionTarget.java
@@ -44,15 +44,4 @@ public interface ExecutionTarget {
      * @throws ColocationMappingException In case these targets can't be colocated.
      */
     ExecutionTarget colocateWith(ExecutionTarget other) throws ColocationMappingException;
-
-    /**
-     * Finalises target by choosing exactly one node for targets with multiple options.
-     *
-     * <p>Some targets may have several options, so we have to pick one in order to get
-     * correct results. Call to this methods resolves this ambiguity by truncating all
-     * but one option. Which exactly option will be left is implementation defined.
-     *
-     * @return Finalised target.
-     */
-    ExecutionTarget finalise();
 }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/FragmentMapper.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/FragmentMapper.java
@@ -30,6 +30,7 @@ import org.apache.calcite.rel.SingleRel;
 import org.apache.calcite.rel.core.SetOp;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.ignite.internal.sql.engine.exec.NodeWithConsistencyToken;
+import org.apache.ignite.internal.sql.engine.exec.mapping.smallcluster.AbstractTarget;
 import org.apache.ignite.internal.sql.engine.metadata.RelMetadataQueryEx;
 import org.apache.ignite.internal.sql.engine.prepare.Fragment;
 import org.apache.ignite.internal.sql.engine.rel.IgniteCorrelatedNestedLoopJoin;
@@ -559,7 +560,11 @@ class FragmentMapper {
 
         @Override
         public List<ColocationGroup> createColocationGroups() {
-            ExecutionTarget finalised = target.finalise();
+            ExecutionTarget finalised = target;
+
+            if (target instanceof AbstractTarget) {
+                finalised = ((AbstractTarget) target).finalise();
+            }
 
             List<String> nodes = context.targetFactory().resolveNodes(finalised);
             Int2ObjectMap<NodeWithConsistencyToken> assignments = context.targetFactory().resolveAssignments(finalised);

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/MappingContext.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/MappingContext.java
@@ -38,7 +38,7 @@ class MappingContext {
         this.localNode = localNode;
         this.nodes = nodes;
 
-        if (nodes.size() > 63) {
+        if (nodes.size() > 64) {
             this.targetFactory = new BigClusterFactory(nodes);
         } else {
             this.targetFactory = new SmallClusterFactory(nodes);

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/MappingContext.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/MappingContext.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.sql.engine.exec.mapping;
 
 import java.util.List;
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.ignite.internal.sql.engine.exec.mapping.bigcluster.BigClusterFactory;
 import org.apache.ignite.internal.sql.engine.exec.mapping.smallcluster.SmallClusterFactory;
 import org.apache.ignite.internal.sql.engine.util.Commons;
 
@@ -37,11 +38,11 @@ class MappingContext {
         this.localNode = localNode;
         this.nodes = nodes;
 
-        if (nodes.size() > 64) {
-            throw new UnsupportedOperationException("https://issues.apache.org/jira/browse/IGNITE-20503");
+        if (nodes.size() > 63) {
+            this.targetFactory = new BigClusterFactory(nodes);
+        } else {
+            this.targetFactory = new SmallClusterFactory(nodes);
         }
-
-        this.targetFactory = new SmallClusterFactory(nodes);
     }
 
     public RelOptCluster cluster() {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/MappingContext.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/MappingContext.java
@@ -20,7 +20,6 @@ package org.apache.ignite.internal.sql.engine.exec.mapping;
 import java.util.List;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.ignite.internal.sql.engine.exec.mapping.bigcluster.BigClusterFactory;
-import org.apache.ignite.internal.sql.engine.exec.mapping.smallcluster.SmallClusterFactory;
 import org.apache.ignite.internal.sql.engine.util.Commons;
 
 /**
@@ -38,11 +37,7 @@ class MappingContext {
         this.localNode = localNode;
         this.nodes = nodes;
 
-        if (nodes.size() > 63) {
-            this.targetFactory = new BigClusterFactory(nodes);
-        } else {
-            this.targetFactory = new SmallClusterFactory(nodes);
-        }
+        this.targetFactory = new BigClusterFactory(nodes);
     }
 
     public RelOptCluster cluster() {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/MappingContext.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/MappingContext.java
@@ -20,6 +20,7 @@ package org.apache.ignite.internal.sql.engine.exec.mapping;
 import java.util.List;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.ignite.internal.sql.engine.exec.mapping.bigcluster.BigClusterFactory;
+import org.apache.ignite.internal.sql.engine.exec.mapping.smallcluster.SmallClusterFactory;
 import org.apache.ignite.internal.sql.engine.util.Commons;
 
 /**
@@ -37,7 +38,11 @@ class MappingContext {
         this.localNode = localNode;
         this.nodes = nodes;
 
-        this.targetFactory = new BigClusterFactory(nodes);
+        if (nodes.size() > 63) {
+            this.targetFactory = new BigClusterFactory(nodes);
+        } else {
+            this.targetFactory = new SmallClusterFactory(nodes);
+        }
     }
 
     public RelOptCluster cluster() {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/bigcluster/AbstractTarget.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/bigcluster/AbstractTarget.java
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.internal.sql.engine.exec.mapping.smallcluster;
-
-import static org.apache.ignite.internal.util.IgniteUtils.isPow2;
+package org.apache.ignite.internal.sql.engine.exec.mapping.bigcluster;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
 import java.util.List;
 import org.apache.ignite.internal.sql.engine.exec.NodeWithConsistencyToken;
 import org.apache.ignite.internal.sql.engine.exec.mapping.ColocationMappingException;
@@ -34,26 +34,31 @@ import org.apache.ignite.internal.sql.engine.exec.mapping.ExecutionTarget;
  * <p>Children of this class are primary used for dispatching an execution to a corresponding
  * colocation method.
  */
-public abstract class AbstractTarget implements ExecutionTarget {
-    final long nodes;
+abstract class AbstractTarget implements ExecutionTarget {
+    /** Participating nodes. */
+    final BitSet nodes;
 
-    AbstractTarget(long nodes) {
+    AbstractTarget(BitSet nodes) {
         this.nodes = nodes;
+
+        assert !nodes.isEmpty();
     }
 
     List<String> nodes(List<String> nodeNames) {
-        if (isPow2(nodes)) {
-            int idx = Long.numberOfTrailingZeros(nodes);
+        int cardinality = nodes.cardinality();
+
+        if (cardinality == 1) {
+            int idx = nodes.nextSetBit(0);
 
             return List.of(nodeNames.get(idx));
         }
 
-        int count = Long.bitCount(nodes);
-        List<String> result = new ArrayList<>(count);
+        List<String> result = new ArrayList<>(cardinality);
 
-        for (int bit = 1, idx = 0; bit <= nodes; bit <<= 1, idx++) {
-            if ((nodes & bit) != 0) {
-                result.add(nodeNames.get(idx));
+        for (int idx = nodes.nextSetBit(0); idx >= 0; idx = nodes.nextSetBit(idx + 1)) {
+            result.add(nodeNames.get(idx));
+            if (idx == Integer.MAX_VALUE) {
+                break;
             }
         }
 
@@ -67,27 +72,21 @@ public abstract class AbstractTarget implements ExecutionTarget {
 
         PartitionedTarget partitionedTarget = (PartitionedTarget) this;
 
-        Int2ObjectMap<NodeWithConsistencyToken> result = new Int2ObjectOpenHashMap<>(partitionedTarget.partitionsNodes.length);
+        int partitionsNodes = partitionedTarget.partitionsNodes.length;
 
-        for (int partNo = 0; partNo < partitionedTarget.partitionsNodes.length; partNo++) {
-            long partitionNodes = partitionedTarget.partitionsNodes[partNo];
+        Int2ObjectMap<NodeWithConsistencyToken> result = new Int2ObjectOpenHashMap<>(partitionsNodes);
 
-            assert isPow2(partitionNodes);
-
-            int idx = Long.numberOfTrailingZeros(partitionNodes);
+        for (int partNo = 0; partNo < partitionsNodes; partNo++) {
+            int partitionNode = partitionedTarget.partitionsNodes[partNo];
 
             result.put(partNo, new NodeWithConsistencyToken(
-                    nodeNames.get(idx),
+                    nodeNames.get(partitionNode),
                     partitionedTarget.enlistmentConsistencyTokens[partNo]
             ));
         }
 
         return result;
     }
-
-    abstract boolean finalised();
-
-    public abstract ExecutionTarget finalise();
 
     abstract ExecutionTarget colocate(AllOfTarget other) throws ColocationMappingException;
 
@@ -98,7 +97,7 @@ public abstract class AbstractTarget implements ExecutionTarget {
     abstract ExecutionTarget colocate(SomeOfTarget other) throws ColocationMappingException;
 
     static ExecutionTarget colocate(AllOfTarget allOf, AllOfTarget otherAllOf) throws ColocationMappingException {
-        if (allOf.nodes != otherAllOf.nodes) {
+        if (!allOf.nodes.equals(otherAllOf.nodes)) {
             throw new ColocationMappingException("Targets are not colocated");
         }
 
@@ -106,15 +105,11 @@ public abstract class AbstractTarget implements ExecutionTarget {
     }
 
     static ExecutionTarget colocate(AllOfTarget allOf, OneOfTarget oneOf) throws ColocationMappingException {
-        if ((allOf.nodes & oneOf.nodes) == 0) {
-            throw new ColocationMappingException("Targets are not colocated");
+        if (allOf.nodes.cardinality() == 1 && oneOf.nodes.get(allOf.nodes.nextSetBit(0))) {
+            return allOf;
         }
 
-        if (!isPow2(allOf.nodes)) {
-            throw new ColocationMappingException("Targets are not colocated");
-        }
-
-        return allOf;
+        throw new ColocationMappingException("Targets are not colocated");
     }
 
     static ExecutionTarget colocate(AllOfTarget allOf, PartitionedTarget partitioned) throws ColocationMappingException {
@@ -122,9 +117,10 @@ public abstract class AbstractTarget implements ExecutionTarget {
     }
 
     static ExecutionTarget colocate(AllOfTarget allOf, SomeOfTarget someOf) throws ColocationMappingException {
-        long newNodes = allOf.nodes & someOf.nodes;
+        BitSet newNodes = (BitSet) allOf.nodes.clone();
+        newNodes.and(someOf.nodes);
 
-        if (allOf.nodes != newNodes) {
+        if (newNodes.cardinality() != allOf.nodes.cardinality()) {
             throw new ColocationMappingException("Targets are not colocated");
         }
 
@@ -132,9 +128,10 @@ public abstract class AbstractTarget implements ExecutionTarget {
     }
 
     static ExecutionTarget colocate(OneOfTarget oneOf, OneOfTarget anotherOneOf) throws ColocationMappingException {
-        long newNodes = oneOf.nodes & anotherOneOf.nodes;
+        BitSet newNodes = (BitSet) oneOf.nodes.clone();
+        newNodes.and(anotherOneOf.nodes);
 
-        if (newNodes == 0) {
+        if (newNodes.isEmpty()) {
             throw new ColocationMappingException("Targets are not colocated");
         }
 
@@ -142,11 +139,7 @@ public abstract class AbstractTarget implements ExecutionTarget {
     }
 
     static ExecutionTarget colocate(OneOfTarget oneOf, PartitionedTarget partitioned) throws ColocationMappingException {
-        if ((oneOf.nodes & partitioned.nodes) == 0) {
-            throw new ColocationMappingException("Targets are not colocated");
-        }
-
-        if (!isPow2((partitioned.nodes))) {
+        if (!oneOf.nodes.intersects(partitioned.nodes) || partitioned.nodes.cardinality() != 1) {
             throw new ColocationMappingException("Targets are not colocated");
         }
 
@@ -154,9 +147,10 @@ public abstract class AbstractTarget implements ExecutionTarget {
     }
 
     static ExecutionTarget colocate(OneOfTarget oneOf, SomeOfTarget someOf) throws ColocationMappingException {
-        long newNodes = oneOf.nodes & someOf.nodes;
+        BitSet newNodes = (BitSet) oneOf.nodes.clone();
+        newNodes.and(someOf.nodes);
 
-        if (newNodes == 0) {
+        if (newNodes.isEmpty()) {
             throw new ColocationMappingException("Targets are not colocated");
         }
 
@@ -168,54 +162,33 @@ public abstract class AbstractTarget implements ExecutionTarget {
             throw new ColocationMappingException("Partitioned targets with mot matching numbers of partitioned are not colocated");
         }
 
-        boolean finalised = true;
-        long[] newPartitionsNodes = new long[partitioned.partitionsNodes.length];
-        for (int partNo = 0; partNo < partitioned.partitionsNodes.length; partNo++) {
-            long newNodes = partitioned.partitionsNodes[partNo] & otherPartitioned.partitionsNodes[partNo];
-
-            if (newNodes == 0) {
-                throw new ColocationMappingException("Targets are not colocated");
-            }
-
-            if (partitioned.enlistmentConsistencyTokens[partNo] != otherPartitioned.enlistmentConsistencyTokens[partNo]) {
-                throw new ColocationMappingException("Partitioned targets have different terms");
-            }
-
-            newPartitionsNodes[partNo] = newNodes;
-            finalised = finalised && isPow2(newNodes);
+        if (!Arrays.equals(partitioned.partitionsNodes, otherPartitioned.partitionsNodes)) {
+            throw new ColocationMappingException("Targets are not colocated");
         }
 
-        return new PartitionedTarget(finalised, newPartitionsNodes, partitioned.enlistmentConsistencyTokens);
+        return partitioned;
     }
 
     static ExecutionTarget colocate(PartitionedTarget partitioned, SomeOfTarget someOf) throws ColocationMappingException {
-        boolean finalised = true;
-        long[] newPartitionsNodes = new long[partitioned.partitionsNodes.length];
         for (int partNo = 0; partNo < partitioned.partitionsNodes.length; partNo++) {
-            long newNodes = partitioned.partitionsNodes[partNo] & someOf.nodes;
+            boolean contain = someOf.nodes.get(partitioned.partitionsNodes[partNo]);
 
-            if (newNodes == 0) {
+            if (!contain) {
                 throw new ColocationMappingException("Targets are not colocated");
             }
-
-            newPartitionsNodes[partNo] = newNodes;
-            finalised = finalised && isPow2(newNodes);
         }
 
-        return new PartitionedTarget(finalised, newPartitionsNodes, partitioned.enlistmentConsistencyTokens);
+        return partitioned;
     }
 
     static ExecutionTarget colocate(SomeOfTarget someOf, SomeOfTarget otherSomeOf) throws ColocationMappingException {
-        long newNodes = someOf.nodes & otherSomeOf.nodes;
+        BitSet newNodes = (BitSet) someOf.nodes.clone();
+        newNodes.and(otherSomeOf.nodes);
 
-        if (newNodes == 0) {
+        if (newNodes.isEmpty()) {
             throw new ColocationMappingException("Targets are not colocated");
         }
 
         return new SomeOfTarget(newNodes);
-    }
-
-    static long pickOne(long nodes) {
-        return Long.lowestOneBit(nodes);
     }
 }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/bigcluster/AllOfTarget.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/bigcluster/AllOfTarget.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.exec.mapping.bigcluster;
+
+import java.util.BitSet;
+import java.util.List;
+import org.apache.ignite.internal.sql.engine.exec.mapping.ColocationMappingException;
+import org.apache.ignite.internal.sql.engine.exec.mapping.ExecutionTarget;
+import org.apache.ignite.internal.sql.engine.exec.mapping.ExecutionTargetFactory;
+
+/**
+ * Represents a target that should be executed on all of the given nodes.
+ *
+ * <p>See javadoc of {@link ExecutionTargetFactory#allOf(List)} for details.
+ */
+class AllOfTarget extends AbstractTarget {
+    AllOfTarget(BitSet nodes) {
+        super(nodes);
+    }
+
+    @Override
+    public ExecutionTarget colocateWith(ExecutionTarget other) throws ColocationMappingException {
+        return ((AbstractTarget) other).colocate(this);
+    }
+
+    @Override
+    ExecutionTarget colocate(AllOfTarget other) throws ColocationMappingException {
+        return colocate(this, other);
+    }
+
+    @Override
+    ExecutionTarget colocate(OneOfTarget other) throws ColocationMappingException {
+        return colocate(this, other);
+    }
+
+    @Override
+    ExecutionTarget colocate(PartitionedTarget other) throws ColocationMappingException {
+        return colocate(this, other);
+    }
+
+    @Override
+    ExecutionTarget colocate(SomeOfTarget other) throws ColocationMappingException {
+        return colocate(this, other);
+    }
+}

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/bigcluster/BigClusterFactory.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/bigcluster/BigClusterFactory.java
@@ -27,15 +27,15 @@ import org.apache.ignite.internal.sql.engine.exec.mapping.ExecutionTarget;
 import org.apache.ignite.internal.sql.engine.exec.mapping.ExecutionTargetFactory;
 
 /**
- * A factory that able to create targets for cluster with up to 64 nodes.
+ * A factory that able to create targets for more than 64 nodes.
  */
 public class BigClusterFactory implements ExecutionTargetFactory {
-    private final List<String> nodes;
+    private final List<String> participatingNodes;
     private final Object2IntMap<String> nodeNameToId;
 
     /** Constructor. */
     public BigClusterFactory(List<String> nodes) {
-        this.nodes = nodes;
+        participatingNodes = nodes;
 
         nodeNameToId = new Object2IntOpenHashMap<>(nodes.size());
         nodeNameToId.defaultReturnValue(-1);
@@ -83,18 +83,18 @@ public class BigClusterFactory implements ExecutionTargetFactory {
     public List<String> resolveNodes(ExecutionTarget target) {
         assert target instanceof AbstractTarget : target == null ? "<null>" : target.getClass().getCanonicalName();
 
-        return ((AbstractTarget) target).nodes(nodes);
+        return ((AbstractTarget) target).nodes(participatingNodes);
     }
 
     @Override
     public Int2ObjectMap<NodeWithConsistencyToken> resolveAssignments(ExecutionTarget target) {
         assert target instanceof AbstractTarget : target == null ? "<null>" : target.getClass().getCanonicalName();
 
-        return ((AbstractTarget) target).assignments(nodes);
+        return ((AbstractTarget) target).assignments(participatingNodes);
     }
 
     private BitSet nodeListToMap(List<String> incNodes) {
-        BitSet nodesMap = new BitSet(nodes.size());
+        BitSet nodesMap = new BitSet(participatingNodes.size());
 
         for (String nodeName : incNodes) {
             int idx = nodeNameToId.getInt(nodeName);

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/bigcluster/OneOfTarget.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/bigcluster/OneOfTarget.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.exec.mapping.bigcluster;
+
+import java.util.BitSet;
+import java.util.List;
+import org.apache.ignite.internal.sql.engine.exec.mapping.ColocationMappingException;
+import org.apache.ignite.internal.sql.engine.exec.mapping.ExecutionTarget;
+import org.apache.ignite.internal.sql.engine.exec.mapping.ExecutionTargetFactory;
+
+/**
+ * Represents a target that should be executed on exactly one node from given list.
+ *
+ * <p>See javadoc of {@link ExecutionTargetFactory#oneOf(List)} for details.
+ */
+class OneOfTarget extends AbstractTarget {
+
+    OneOfTarget(BitSet nodes) {
+        super(nodes);
+    }
+
+    @Override
+    public List<String> nodes(List<String> nodeNames) {
+        int idx = nodes.nextSetBit(0);
+
+        return List.of(nodeNames.get(idx));
+    }
+
+    @Override
+    public ExecutionTarget colocateWith(ExecutionTarget other) throws ColocationMappingException {
+        return ((AbstractTarget) other).colocate(this);
+    }
+
+    @Override
+    public ExecutionTarget colocate(AllOfTarget other) throws ColocationMappingException {
+        return colocate(other, this);
+    }
+
+    @Override
+    public ExecutionTarget colocate(OneOfTarget other) throws ColocationMappingException {
+        return colocate(this, other);
+    }
+
+    @Override
+    public ExecutionTarget colocate(PartitionedTarget other) throws ColocationMappingException {
+        return colocate(this, other);
+    }
+
+    @Override
+    public ExecutionTarget colocate(SomeOfTarget other) throws ColocationMappingException {
+        return colocate(this, other);
+    }
+}

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/bigcluster/PartitionedTarget.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/bigcluster/PartitionedTarget.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.exec.mapping.bigcluster;
+
+import java.util.BitSet;
+import java.util.List;
+import org.apache.ignite.internal.sql.engine.exec.mapping.ColocationMappingException;
+import org.apache.ignite.internal.sql.engine.exec.mapping.ExecutionTarget;
+import org.apache.ignite.internal.sql.engine.exec.mapping.ExecutionTargetFactory;
+
+/**
+ * Represents a target that consists of a number of primary partitions.
+ *
+ * <p>See javadoc of {@link ExecutionTargetFactory#partitioned(List)} for details.
+ */
+class PartitionedTarget extends AbstractTarget {
+    final int[] partitionsNodes;
+    final long[] enlistmentConsistencyTokens;
+
+    PartitionedTarget(int[] partitionsNodes, long[] enlistmentConsistencyTokens) {
+        super(computeNodes(partitionsNodes));
+
+        this.partitionsNodes = partitionsNodes;
+        this.enlistmentConsistencyTokens = enlistmentConsistencyTokens;
+    }
+
+    @Override
+    public ExecutionTarget colocateWith(ExecutionTarget other) throws ColocationMappingException {
+        return ((AbstractTarget) other).colocate(this);
+    }
+
+    @Override
+    ExecutionTarget colocate(AllOfTarget other) throws ColocationMappingException {
+        return colocate(other, this);
+    }
+
+    @Override
+    ExecutionTarget colocate(OneOfTarget other) throws ColocationMappingException {
+        return colocate(other, this);
+    }
+
+    @Override
+    ExecutionTarget colocate(PartitionedTarget other) throws ColocationMappingException {
+        return colocate(this, other);
+    }
+
+    @Override
+    ExecutionTarget colocate(SomeOfTarget other) throws ColocationMappingException {
+        return colocate(this, other);
+    }
+
+    private static BitSet computeNodes(int[] partitionsNodes) {
+        BitSet bs = new BitSet(partitionsNodes.length);
+
+        for (int node : partitionsNodes) {
+            bs.set(node);
+        }
+
+        return bs;
+    }
+}

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/bigcluster/SomeOfTarget.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/bigcluster/SomeOfTarget.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.exec.mapping.bigcluster;
+
+import java.util.BitSet;
+import java.util.List;
+import org.apache.ignite.internal.sql.engine.exec.mapping.ColocationMappingException;
+import org.apache.ignite.internal.sql.engine.exec.mapping.ExecutionTarget;
+import org.apache.ignite.internal.sql.engine.exec.mapping.ExecutionTargetFactory;
+
+/**
+ * Represents a target that may be executed on a non empty subset of the given nodes.
+ *
+ * <p>See javadoc of {@link ExecutionTargetFactory#someOf(List)} for details.
+ */
+class SomeOfTarget extends AbstractTarget {
+    SomeOfTarget(BitSet nodes) {
+        super(nodes);
+    }
+
+    @Override
+    public ExecutionTarget colocateWith(ExecutionTarget other) throws ColocationMappingException {
+        return ((AbstractTarget) other).colocate(this);
+    }
+
+    @Override
+    ExecutionTarget colocate(AllOfTarget other) throws ColocationMappingException {
+        return colocate(other, this);
+    }
+
+    @Override
+    ExecutionTarget colocate(OneOfTarget other) throws ColocationMappingException {
+        return colocate(other, this);
+    }
+
+    @Override
+    ExecutionTarget colocate(PartitionedTarget other) throws ColocationMappingException {
+        return colocate(other, this);
+    }
+
+    @Override
+    ExecutionTarget colocate(SomeOfTarget other) throws ColocationMappingException {
+        return colocate(this, other);
+    }
+}

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/smallcluster/SmallClusterFactory.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/mapping/smallcluster/SmallClusterFactory.java
@@ -34,8 +34,8 @@ public class SmallClusterFactory implements ExecutionTargetFactory {
 
     /** Constructor. */
     public SmallClusterFactory(List<String> nodes) {
-        if (nodes.size() > 63) {
-            throw new IllegalArgumentException("Supported up to 63 nodes, but was " + nodes.size());
+        if (nodes.size() > 64) {
+            throw new IllegalArgumentException("Supported up to 64 nodes, but was " + nodes.size());
         }
 
         this.nodes = nodes;

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/benchmarks/MappingBenchmark.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/benchmarks/MappingBenchmark.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.benchmarks;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.ignite.internal.sql.engine.exec.NodeWithConsistencyToken;
+import org.apache.ignite.internal.sql.engine.exec.mapping.ColocationMappingException;
+import org.apache.ignite.internal.sql.engine.exec.mapping.ExecutionTarget;
+import org.apache.ignite.internal.sql.engine.exec.mapping.ExecutionTargetFactory;
+import org.apache.ignite.internal.sql.engine.exec.mapping.bigcluster.BigClusterFactory;
+import org.apache.ignite.internal.sql.engine.exec.mapping.smallcluster.AbstractTarget;
+import org.apache.ignite.internal.sql.engine.exec.mapping.smallcluster.SmallClusterFactory;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/** Mapping part benchmark.
+ *
+ * <p>Note: seems more accurate results can be obtained after boosting disabling:
+ * linux: echo "1" | sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo
+ */
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Threads(1)
+@State(Scope.Benchmark)
+public class MappingBenchmark {
+    private ExecutionTarget oneOfSmall;
+    private ExecutionTarget someOfSmall;
+    private ExecutionTarget part1Small;
+    private ExecutionTarget part2Small;
+    private ExecutionTarget allOfSmall;
+
+    private ExecutionTarget oneOfBig;
+    private ExecutionTarget someOfBig;
+    private ExecutionTarget part1Big;
+    private ExecutionTarget part2Big;
+    private ExecutionTarget allOfBig;
+
+    /** Prepare the plan of the query. */
+    @Setup
+    public void setUp() {
+        List<String> nodes = List.of("n1", "n2", "n3", "n4", "n5");
+        List<String> oneOfNodes = List.of("n1", "n3");
+        List<NodeWithConsistencyToken> partNodes =
+                List.of(new NodeWithConsistencyToken("n3", 1));
+
+        ExecutionTargetFactory targetFactorySmall = new SmallClusterFactory(nodes);
+        ExecutionTargetFactory targetFactoryBig = new BigClusterFactory(nodes);
+
+        oneOfSmall = targetFactorySmall.oneOf(oneOfNodes);
+        someOfSmall = targetFactorySmall.someOf(nodes);
+        allOfSmall = targetFactorySmall.allOf(List.of("n3"));
+        part1Small = targetFactorySmall.partitioned(partNodes);
+        part2Small = targetFactorySmall.partitioned(partNodes);
+
+        oneOfBig = targetFactoryBig.oneOf(oneOfNodes);
+        someOfBig = targetFactoryBig.someOf(nodes);
+        allOfBig = targetFactoryBig.allOf(List.of("n3"));
+        part1Big = targetFactoryBig.partitioned(partNodes);
+        part2Big = targetFactoryBig.partitioned(partNodes);
+    }
+
+    /** Measure small cluster mapping implementation. */
+    @Benchmark
+    public void benchSmall(Blackhole bh) throws ColocationMappingException {
+        finalise(oneOfSmall.colocateWith(oneOfSmall), bh);
+        finalise(oneOfSmall.colocateWith(someOfSmall), bh);
+        finalise(oneOfSmall.colocateWith(allOfSmall), bh);
+        finalise(oneOfSmall.colocateWith(part1Small), bh);
+
+        finalise(someOfSmall.colocateWith(someOfSmall), bh);
+        finalise(someOfSmall.colocateWith(part1Small), bh);
+        finalise(someOfSmall.colocateWith(allOfSmall), bh);
+
+        finalise(part1Small.colocateWith(part2Small), bh);
+    }
+
+    private static void finalise(ExecutionTarget target, Blackhole bh) {
+        bh.consume(((AbstractTarget) target).finalise());
+    }
+
+    /** Measure huge cluster mapping implementation. */
+    @Benchmark
+    public void benchBig(Blackhole bh) throws ColocationMappingException {
+        bh.consume(oneOfBig.colocateWith(oneOfBig));
+        bh.consume(oneOfBig.colocateWith(someOfBig));
+        bh.consume(oneOfBig.colocateWith(allOfBig));
+        bh.consume(oneOfBig.colocateWith(part1Big));
+
+        bh.consume(someOfBig.colocateWith(someOfBig));
+        bh.consume(someOfBig.colocateWith(part1Big));
+        bh.consume(someOfBig.colocateWith(allOfBig));
+
+        bh.consume(part1Big.colocateWith(part2Big));
+    }
+
+    /**
+     * Runs the benchmark.
+     *
+     * @param args args
+     * @throws Exception if something goes wrong
+     */
+    public static void main(String[] args) throws Exception {
+        Options build = new OptionsBuilder()
+                .include(MappingBenchmark.class.getName())
+                .build();
+
+        new Runner(build).run();
+    }
+}

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/benchmarks/MappingBenchmark.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/benchmarks/MappingBenchmark.java
@@ -59,12 +59,16 @@ public class MappingBenchmark {
     private ExecutionTarget someOfSmall;
     private ExecutionTarget part1Small;
     private ExecutionTarget part2Small;
+    private ExecutionTarget part1SmallMore;
+    private ExecutionTarget part2SmallMore;
     private ExecutionTarget allOfSmall;
 
     private ExecutionTarget oneOfBig;
     private ExecutionTarget someOfBig;
     private ExecutionTarget part1Big;
     private ExecutionTarget part2Big;
+    private ExecutionTarget part1BigMore;
+    private ExecutionTarget part2BigMore;
     private ExecutionTarget allOfBig;
 
     /** Prepare the plan of the query. */
@@ -74,6 +78,10 @@ public class MappingBenchmark {
         List<String> oneOfNodes = List.of("n1", "n3");
         List<NodeWithConsistencyToken> partNodes =
                 List.of(new NodeWithConsistencyToken("n3", 1));
+        List<NodeWithConsistencyToken> partNodesMore =
+                List.of(new NodeWithConsistencyToken("n3", 1),
+                        new NodeWithConsistencyToken("n4", 2),
+                        new NodeWithConsistencyToken("n5", 3));
 
         ExecutionTargetFactory targetFactorySmall = new SmallClusterFactory(nodes);
         ExecutionTargetFactory targetFactoryBig = new BigClusterFactory(nodes);
@@ -83,12 +91,16 @@ public class MappingBenchmark {
         allOfSmall = targetFactorySmall.allOf(List.of("n3"));
         part1Small = targetFactorySmall.partitioned(partNodes);
         part2Small = targetFactorySmall.partitioned(partNodes);
+        part1SmallMore = targetFactorySmall.partitioned(partNodesMore);
+        part2SmallMore = targetFactorySmall.partitioned(partNodesMore);
 
         oneOfBig = targetFactoryBig.oneOf(oneOfNodes);
         someOfBig = targetFactoryBig.someOf(nodes);
         allOfBig = targetFactoryBig.allOf(List.of("n3"));
         part1Big = targetFactoryBig.partitioned(partNodes);
         part2Big = targetFactoryBig.partitioned(partNodes);
+        part1BigMore = targetFactoryBig.partitioned(partNodesMore);
+        part2BigMore = targetFactoryBig.partitioned(partNodesMore);
     }
 
     /** Measure small cluster mapping implementation. */
@@ -104,6 +116,12 @@ public class MappingBenchmark {
         finalise(someOfSmall.colocateWith(allOfSmall), bh);
 
         finalise(part1Small.colocateWith(part2Small), bh);
+    }
+
+    /** Measure small cluster mapping partitioned only implementation. */
+    @Benchmark
+    public void benchSmallPartitionedOnly(Blackhole bh) throws ColocationMappingException {
+        finalise(part1SmallMore.colocateWith(part2SmallMore), bh);
     }
 
     private static void finalise(ExecutionTarget target, Blackhole bh) {
@@ -123,6 +141,12 @@ public class MappingBenchmark {
         bh.consume(someOfBig.colocateWith(allOfBig));
 
         bh.consume(part1Big.colocateWith(part2Big));
+    }
+
+    /** Measure huge cluster mapping partitioned only implementation. */
+    @Benchmark
+    public void benchBigPartitionedOnly(Blackhole bh) throws ColocationMappingException {
+        bh.consume(part1BigMore.colocateWith(part2BigMore));
     }
 
     /**

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/benchmarks/MappingBenchmark.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/benchmarks/MappingBenchmark.java
@@ -48,7 +48,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  * linux: echo "1" | sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo
  */
 @Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @Fork(1)

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/benchmarks/SqlBenchmark.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/benchmarks/SqlBenchmark.java
@@ -47,7 +47,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 /**
  * A micro-benchmark of sql execution.
  */
-@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/benchmarks/SqlBenchmark.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/benchmarks/SqlBenchmark.java
@@ -47,7 +47,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 /**
  * A micro-benchmark of sql execution.
  */
-@Warmup(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)


### PR DESCRIPTION
SqlBenchmark:
big cluster mapping implementation
```
Benchmark                      Mode  Cnt    Score   Error  Units
SqlBenchmark.selectAllSimple  thrpt   20  205.076 ± 3.504  ops/s
```

small cluster mapping implementation
```
Benchmark                      Mode  Cnt    Score   Error  Units
SqlBenchmark.selectAllSimple  thrpt   20  205.251 ± 9.775  ops/s
```
---
```
Benchmark                     Mode  Cnt        Score       Error  Units
Benchmark                                    Mode  Cnt         Score         Error  Units
MappingBenchmark.benchBig                   thrpt   10   4398392.466 ±  340668.001  ops/s
MappingBenchmark.benchBigPartitionedOnly    thrpt   10  46567579.309 ± 2731802.736  ops/s
MappingBenchmark.benchSmall                 thrpt   10   4829595.861 ±   16053.724  ops/s
MappingBenchmark.benchSmallPartitionedOnly  thrpt   10  17689787.947 ±  445053.549  ops/s
```