### PR TITLE
IGNITE-22287 Remove decimal scale from packObjectAsBinaryTuple

### DIFF
--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientBinaryTupleUtils.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientBinaryTupleUtils.java
@@ -59,7 +59,7 @@ public class ClientBinaryTupleUtils {
 
         int typeId = reader.intValue(index);
         ColumnType type = ColumnTypeConverter.fromIdOrThrow(typeId);
-        int valIdx = index + 2;
+        int valIdx = index + 1;
 
         switch (type) {
             case INT8:
@@ -81,7 +81,7 @@ public class ClientBinaryTupleUtils {
                 return reader.doubleValue(valIdx);
 
             case DECIMAL:
-                return reader.decimalValue(valIdx, reader.intValue(index + 1));
+                return reader.decimalValue(valIdx, -1);
 
             case UUID:
                 return reader.uuidValue(valIdx);
@@ -124,7 +124,7 @@ public class ClientBinaryTupleUtils {
         }
     }
 
-    static Function<Integer, Object> readerForType(BinaryTupleReader binTuple, ColumnType type) {
+    private static Function<Integer, Object> readerForType(BinaryTupleReader binTuple, ColumnType type) {
         switch (type) {
             case INT8:
                 return binTuple::byteValue;
@@ -200,62 +200,62 @@ public class ClientBinaryTupleUtils {
             builder.appendNull(); // Scale.
             builder.appendNull(); // Value.
         } else if (obj instanceof Boolean) {
-            appendTypeAndScale(builder, ColumnType.BOOLEAN);
+            appendColumnType(builder, ColumnType.BOOLEAN);
             builder.appendBoolean((Boolean) obj);
         } else if (obj instanceof Byte) {
-            appendTypeAndScale(builder, ColumnType.INT8);
+            appendColumnType(builder, ColumnType.INT8);
             builder.appendByte((Byte) obj);
         } else if (obj instanceof Short) {
-            appendTypeAndScale(builder, ColumnType.INT16);
+            appendColumnType(builder, ColumnType.INT16);
             builder.appendShort((Short) obj);
         } else if (obj instanceof Integer) {
-            appendTypeAndScale(builder, ColumnType.INT32);
+            appendColumnType(builder, ColumnType.INT32);
             builder.appendInt((Integer) obj);
         } else if (obj instanceof Long) {
-            appendTypeAndScale(builder, ColumnType.INT64);
+            appendColumnType(builder, ColumnType.INT64);
             builder.appendLong((Long) obj);
         } else if (obj instanceof Float) {
-            appendTypeAndScale(builder, ColumnType.FLOAT);
+            appendColumnType(builder, ColumnType.FLOAT);
             builder.appendFloat((Float) obj);
         } else if (obj instanceof Double) {
-            appendTypeAndScale(builder, ColumnType.DOUBLE);
+            appendColumnType(builder, ColumnType.DOUBLE);
             builder.appendDouble((Double) obj);
         } else if (obj instanceof BigDecimal) {
             BigDecimal bigDecimal = (BigDecimal) obj;
-            appendTypeAndScale(builder, ColumnType.DECIMAL, bigDecimal.scale());
+            appendColumnType(builder, ColumnType.DECIMAL);
             builder.appendDecimal(bigDecimal, bigDecimal.scale());
         } else if (obj instanceof UUID) {
-            appendTypeAndScale(builder, ColumnType.UUID);
+            appendColumnType(builder, ColumnType.UUID);
             builder.appendUuid((UUID) obj);
         } else if (obj instanceof String) {
-            appendTypeAndScale(builder, ColumnType.STRING);
+            appendColumnType(builder, ColumnType.STRING);
             builder.appendString((String) obj);
         } else if (obj instanceof byte[]) {
-            appendTypeAndScale(builder, ColumnType.BYTE_ARRAY);
+            appendColumnType(builder, ColumnType.BYTE_ARRAY);
             builder.appendBytes((byte[]) obj);
         } else if (obj instanceof BitSet) {
-            appendTypeAndScale(builder, ColumnType.BITMASK);
+            appendColumnType(builder, ColumnType.BITMASK);
             builder.appendBitmask((BitSet) obj);
         } else if (obj instanceof LocalDate) {
-            appendTypeAndScale(builder, ColumnType.DATE);
+            appendColumnType(builder, ColumnType.DATE);
             builder.appendDate((LocalDate) obj);
         } else if (obj instanceof LocalTime) {
-            appendTypeAndScale(builder, ColumnType.TIME);
+            appendColumnType(builder, ColumnType.TIME);
             builder.appendTime((LocalTime) obj);
         } else if (obj instanceof LocalDateTime) {
-            appendTypeAndScale(builder, ColumnType.DATETIME);
+            appendColumnType(builder, ColumnType.DATETIME);
             builder.appendDateTime((LocalDateTime) obj);
         } else if (obj instanceof Instant) {
-            appendTypeAndScale(builder, ColumnType.TIMESTAMP);
+            appendColumnType(builder, ColumnType.TIMESTAMP);
             builder.appendTimestamp((Instant) obj);
         } else if (obj instanceof BigInteger) {
-            appendTypeAndScale(builder, ColumnType.NUMBER);
+            appendColumnType(builder, ColumnType.NUMBER);
             builder.appendNumber((BigInteger) obj);
         } else if (obj instanceof Duration) {
-            appendTypeAndScale(builder, ColumnType.DURATION);
+            appendColumnType(builder, ColumnType.DURATION);
             builder.appendDuration((Duration) obj);
         } else if (obj instanceof Period) {
-            appendTypeAndScale(builder, ColumnType.PERIOD);
+            appendColumnType(builder, ColumnType.PERIOD);
             builder.appendPeriod((Period) obj);
         } else {
             throw unsupportedTypeException(obj.getClass());
@@ -473,14 +473,8 @@ public class ClientBinaryTupleUtils {
         }
     }
 
-    private static void appendTypeAndScale(BinaryTupleBuilder builder, ColumnType type, int scale) {
+    private static void appendColumnType(BinaryTupleBuilder builder, ColumnType type) {
         builder.appendInt(type.id());
-        builder.appendInt(scale);
-    }
-
-    private static void appendTypeAndScale(BinaryTupleBuilder builder, ColumnType type) {
-        builder.appendInt(type.id());
-        builder.appendInt(0);
     }
 
     private static IgniteException unsupportedTypeException(int dataType) {

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientBinaryTupleUtils.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientBinaryTupleUtils.java
@@ -197,7 +197,6 @@ public class ClientBinaryTupleUtils {
     public static void appendObject(BinaryTupleBuilder builder, Object obj) {
         if (obj == null) {
             builder.appendNull(); // Type.
-            builder.appendNull(); // Scale.
             builder.appendNull(); // Value.
         } else if (obj instanceof Boolean) {
             appendColumnType(builder, ColumnType.BOOLEAN);

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessagePacker.java
@@ -614,7 +614,7 @@ public class ClientMessagePacker implements AutoCloseable {
 
         // Builder with inline schema.
         // Every element in vals is represented by 3 tuple elements: type, scale, value.
-        var builder = new BinaryTupleBuilder(vals.length * 3);
+        var builder = new BinaryTupleBuilder(vals.length * 2);
 
         for (Object arg : vals) {
             ClientBinaryTupleUtils.appendObject(builder, arg);
@@ -639,7 +639,7 @@ public class ClientMessagePacker implements AutoCloseable {
 
         // Builder with inline schema.
         // Value is represented by 3 tuple elements: type, scale, value.
-        var builder = new BinaryTupleBuilder(3, 3);
+        var builder = new BinaryTupleBuilder(2);
         ClientBinaryTupleUtils.appendObject(builder, val);
 
         packBinaryTuple(builder);

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientMessageUnpacker.java
@@ -736,7 +736,7 @@ public class ClientMessageUnpacker implements AutoCloseable {
      * @return BatchedArguments object with the unpacked arguments.
      */
     @SuppressWarnings("unused")
-    public BatchedArguments unpackObjectArrayFromBinaryTupleArray() {
+    public @Nullable BatchedArguments unpackObjectArrayFromBinaryTupleArray() {
         assert refCnt > 0 : "Unpacker is closed";
 
         if (tryUnpackNil()) {
@@ -763,7 +763,7 @@ public class ClientMessageUnpacker implements AutoCloseable {
      *
      * @return Object array.
      */
-    public Object[] unpackObjectArrayFromBinaryTuple(int size) {
+    public Object @Nullable [] unpackObjectArrayFromBinaryTuple(int size) {
         assert refCnt > 0 : "Unpacker is closed";
 
         if (tryUnpackNil()) {
@@ -771,10 +771,10 @@ public class ClientMessageUnpacker implements AutoCloseable {
         }
 
         Object[] args = new Object[size];
-        var reader = new BinaryTupleReader(size * 3, readBinaryUnsafe());
+        var reader = new BinaryTupleReader(size * 2, readBinaryUnsafe());
 
         for (int i = 0; i < size; i++) {
-            args[i] = ClientBinaryTupleUtils.readObject(reader, i * 3);
+            args[i] = ClientBinaryTupleUtils.readObject(reader, i * 2);
         }
 
         return args;
@@ -785,7 +785,7 @@ public class ClientMessageUnpacker implements AutoCloseable {
      *
      * @return Object array.
      */
-    public Object[] unpackObjectArrayFromBinaryTuple() {
+    public Object @Nullable [] unpackObjectArrayFromBinaryTuple() {
         assert refCnt > 0 : "Unpacker is closed";
 
         if (tryUnpackNil()) {
@@ -799,10 +799,10 @@ public class ClientMessageUnpacker implements AutoCloseable {
         }
 
         Object[] args = new Object[size];
-        var reader = new BinaryTupleReader(size * 3, readBinaryUnsafe());
+        var reader = new BinaryTupleReader(size * 2, readBinaryUnsafe());
 
         for (int i = 0; i < size; i++) {
-            args[i] = ClientBinaryTupleUtils.readObject(reader, i * 3);
+            args[i] = ClientBinaryTupleUtils.readObject(reader, i * 2);
         }
 
         return args;
@@ -813,14 +813,14 @@ public class ClientMessageUnpacker implements AutoCloseable {
      *
      * @return Object.
      */
-    public Object unpackObjectFromBinaryTuple() {
+    public @Nullable Object unpackObjectFromBinaryTuple() {
         assert refCnt > 0 : "Unpacker is closed";
 
         if (tryUnpackNil()) {
             return null;
         }
 
-        var reader = new BinaryTupleReader(3, readBinaryUnsafe());
+        var reader = new BinaryTupleReader(2, readBinaryUnsafe());
         return ClientBinaryTupleUtils.readObject(reader, 0);
     }
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/StreamerReceiverSerializer.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/StreamerReceiverSerializer.java
@@ -77,7 +77,7 @@ public class StreamerReceiverSerializer {
         Object[] receiverArgs = new Object[receiverArgsCount];
         for (int i = 0; i < receiverArgsCount; i++) {
             receiverArgs[i] = ClientBinaryTupleUtils.readObject(reader, readerIndex);
-            readerIndex += 3;
+            readerIndex += 2;
         }
 
         List<Object> items = ClientBinaryTupleUtils.readCollectionFromBinaryTuple(reader, readerIndex);

--- a/modules/platforms/cpp/ignite/client/detail/compute/compute_impl.cpp
+++ b/modules/platforms/cpp/ignite/client/detail/compute/compute_impl.cpp
@@ -35,7 +35,7 @@ void write_primitives_as_binary_tuple(protocol::writer &writer, const std::vecto
 
     writer.write(args_num);
 
-    binary_tuple_builder args_builder{args_num * 3};
+    binary_tuple_builder args_builder{args_num * 2};
 
     args_builder.start();
     for (const auto &arg : args) {
@@ -59,11 +59,10 @@ void write_primitives_as_binary_tuple(protocol::writer &writer, const std::vecto
  */
 primitive read_primitive_from_binary_tuple(protocol::reader &reader) {
     auto tuple_data = reader.read_binary();
-    binary_tuple_parser parser(3, tuple_data);
+    binary_tuple_parser parser(2, tuple_data);
 
     auto typ = static_cast<ignite_type>(binary_tuple_parser::get_int32(parser.get_next()));
-    auto scale = binary_tuple_parser::get_int32(parser.get_next());
-    return protocol::read_next_column(parser, typ, scale);
+    return protocol::read_next_column(parser, typ);
 }
 
 /**

--- a/modules/platforms/cpp/ignite/client/detail/sql/result_set_impl.h
+++ b/modules/platforms/cpp/ignite/client/detail/sql/result_set_impl.h
@@ -291,7 +291,7 @@ private:
             binary_tuple_parser parser(std::int32_t(columns_cnt), tuple_data);
 
             for (const auto &column : meta.columns()) {
-                res.set(column.name(), protocol::read_next_column(parser, column.type(), column.scale()));
+                res.set(column.name(), protocol::read_next_column(parser, column.type()));
             }
             page.emplace_back(std::move(res));
         }

--- a/modules/platforms/cpp/ignite/client/detail/sql/sql_impl.cpp
+++ b/modules/platforms/cpp/ignite/client/detail/sql/sql_impl.cpp
@@ -72,7 +72,7 @@ void write_args(protocol::writer &writer, const std::vector<primitive> &args) {
 
     writer.write(args_num);
 
-    binary_tuple_builder args_builder{args_num * 3};
+    binary_tuple_builder args_builder{args_num * 2};
 
     args_builder.start();
     for (const auto &arg : args) {

--- a/modules/platforms/cpp/ignite/client/detail/utils.cpp
+++ b/modules/platforms/cpp/ignite/client/detail/utils.cpp
@@ -294,7 +294,7 @@ ignite_tuple read_tuple(protocol::reader &reader, const schema *sch, bool key_on
 
     for (std::int32_t i = 0; i < columns_cnt; ++i) {
         auto &column = sch->get_column(key_only, i);
-        res.set(column.name, protocol::read_next_column(parser, column.type, column.scale));
+        res.set(column.name, protocol::read_next_column(parser, column.type));
     }
     return res;
 }

--- a/modules/platforms/cpp/ignite/odbc/app/parameter.cpp
+++ b/modules/platforms/cpp/ignite/odbc/app/parameter.cpp
@@ -141,7 +141,7 @@ void parameter::claim(binary_tuple_builder &builder, int offset, SQLULEN idx) co
             big_decimal dec_value;
             buf.get_decimal(dec_value);
 
-            protocol::claim_type_and_scale(builder, ignite_type::DECIMAL, dec_value.get_scale());
+            protocol::claim_type_and_scale(builder, ignite_type::DECIMAL);
             builder.claim_number(dec_value);
             break;
         }
@@ -269,7 +269,7 @@ void parameter::append(binary_tuple_builder &builder, int offset, SQLULEN idx) c
             big_decimal dec_value;
             buf.get_decimal(dec_value);
 
-            protocol::append_type_and_scale(builder, ignite_type::DECIMAL, dec_value.get_scale());
+            protocol::append_type_and_scale(builder, ignite_type::DECIMAL);
             builder.append_number(dec_value);
             break;
         }

--- a/modules/platforms/cpp/ignite/odbc/app/parameter.cpp
+++ b/modules/platforms/cpp/ignite/odbc/app/parameter.cpp
@@ -47,70 +47,70 @@ void parameter::claim(binary_tuple_builder &builder, int offset, SQLULEN idx) co
         case SQL_CHAR:
         case SQL_VARCHAR:
         case SQL_LONGVARCHAR: {
-            protocol::claim_type_and_scale(builder, ignite_type::STRING);
+            protocol::claim_type(builder, ignite_type::STRING);
             builder.claim_varlen(buf.get_string(m_column_size));
             break;
         }
 
         case SQL_TINYINT: {
-            protocol::claim_type_and_scale(builder, ignite_type::INT8);
+            protocol::claim_type(builder, ignite_type::INT8);
             builder.claim_int8(buf.get_int8());
             break;
         }
 
         case SQL_SMALLINT: {
-            protocol::claim_type_and_scale(builder, ignite_type::INT16);
+            protocol::claim_type(builder, ignite_type::INT16);
             builder.claim_int16(buf.get_int16());
             break;
         }
 
         case SQL_INTEGER: {
-            protocol::claim_type_and_scale(builder, ignite_type::INT32);
+            protocol::claim_type(builder, ignite_type::INT32);
             builder.claim_int32(buf.get_int32());
             break;
         }
 
         case SQL_BIGINT: {
-            protocol::claim_type_and_scale(builder, ignite_type::INT64);
+            protocol::claim_type(builder, ignite_type::INT64);
             builder.claim_int64(buf.get_int64());
             break;
         }
 
         case SQL_FLOAT: {
-            protocol::claim_type_and_scale(builder, ignite_type::FLOAT);
+            protocol::claim_type(builder, ignite_type::FLOAT);
             builder.claim_float(buf.get_float());
             break;
         }
 
         case SQL_DOUBLE: {
-            protocol::claim_type_and_scale(builder, ignite_type::DOUBLE);
+            protocol::claim_type(builder, ignite_type::DOUBLE);
             builder.claim_double(buf.get_double());
             break;
         }
 
         case SQL_BIT: {
-            protocol::claim_type_and_scale(builder, ignite_type::BOOLEAN);
+            protocol::claim_type(builder, ignite_type::BOOLEAN);
             builder.claim_bool(buf.get_int8() != 0);
             break;
         }
 
         case SQL_TYPE_DATE:
         case SQL_DATE: {
-            protocol::claim_type_and_scale(builder, ignite_type::DATE);
+            protocol::claim_type(builder, ignite_type::DATE);
             builder.claim_date(buf.get_date());
             break;
         }
 
         case SQL_TYPE_TIMESTAMP:
         case SQL_TIMESTAMP: {
-            protocol::claim_type_and_scale(builder, ignite_type::DATETIME);
+            protocol::claim_type(builder, ignite_type::DATETIME);
             builder.claim_date_time(buf.get_date_time());
             break;
         }
 
         case SQL_TYPE_TIME:
         case SQL_TIME: {
-            protocol::claim_type_and_scale(builder, ignite_type::TIME);
+            protocol::claim_type(builder, ignite_type::TIME);
             builder.claim_time(buf.get_time());
             break;
         }
@@ -118,7 +118,7 @@ void parameter::claim(binary_tuple_builder &builder, int offset, SQLULEN idx) co
         case SQL_BINARY:
         case SQL_VARBINARY:
         case SQL_LONGVARBINARY: {
-            protocol::claim_type_and_scale(builder, ignite_type::BYTE_ARRAY);
+            protocol::claim_type(builder, ignite_type::BYTE_ARRAY);
 
             const application_data_buffer &const_buf = buf;
             const SQLLEN *res_len_ptr = const_buf.get_result_len();
@@ -131,7 +131,7 @@ void parameter::claim(binary_tuple_builder &builder, int offset, SQLULEN idx) co
         }
 
         case SQL_GUID: {
-            protocol::claim_type_and_scale(builder, ignite_type::UUID);
+            protocol::claim_type(builder, ignite_type::UUID);
             builder.claim_uuid(buf.get_uuid());
 
             break;
@@ -141,7 +141,7 @@ void parameter::claim(binary_tuple_builder &builder, int offset, SQLULEN idx) co
             big_decimal dec_value;
             buf.get_decimal(dec_value);
 
-            protocol::claim_type_and_scale(builder, ignite_type::DECIMAL);
+            protocol::claim_type(builder, ignite_type::DECIMAL);
             builder.claim_number(dec_value);
             break;
         }
@@ -175,70 +175,70 @@ void parameter::append(binary_tuple_builder &builder, int offset, SQLULEN idx) c
         case SQL_CHAR:
         case SQL_VARCHAR:
         case SQL_LONGVARCHAR: {
-            protocol::append_type_and_scale(builder, ignite_type::STRING);
+            protocol::append_type(builder, ignite_type::STRING);
             builder.append_varlen(buf.get_string(m_column_size));
             break;
         }
 
         case SQL_TINYINT: {
-            protocol::append_type_and_scale(builder, ignite_type::INT8);
+            protocol::append_type(builder, ignite_type::INT8);
             builder.append_int8(buf.get_int8());
             break;
         }
 
         case SQL_SMALLINT: {
-            protocol::append_type_and_scale(builder, ignite_type::INT16);
+            protocol::append_type(builder, ignite_type::INT16);
             builder.append_int16(buf.get_int16());
             break;
         }
 
         case SQL_INTEGER: {
-            protocol::append_type_and_scale(builder, ignite_type::INT32);
+            protocol::append_type(builder, ignite_type::INT32);
             builder.append_int32(buf.get_int32());
             break;
         }
 
         case SQL_BIGINT: {
-            protocol::append_type_and_scale(builder, ignite_type::INT64);
+            protocol::append_type(builder, ignite_type::INT64);
             builder.append_int64(buf.get_int64());
             break;
         }
 
         case SQL_FLOAT: {
-            protocol::append_type_and_scale(builder, ignite_type::FLOAT);
+            protocol::append_type(builder, ignite_type::FLOAT);
             builder.append_float(buf.get_float());
             break;
         }
 
         case SQL_DOUBLE: {
-            protocol::append_type_and_scale(builder, ignite_type::DOUBLE);
+            protocol::append_type(builder, ignite_type::DOUBLE);
             builder.append_double(buf.get_double());
             break;
         }
 
         case SQL_BIT: {
-            protocol::append_type_and_scale(builder, ignite_type::BOOLEAN);
+            protocol::append_type(builder, ignite_type::BOOLEAN);
             builder.append_bool(buf.get_int8() != 0);
             break;
         }
 
         case SQL_TYPE_DATE:
         case SQL_DATE: {
-            protocol::append_type_and_scale(builder, ignite_type::DATE);
+            protocol::append_type(builder, ignite_type::DATE);
             builder.append_date(buf.get_date());
             break;
         }
 
         case SQL_TYPE_TIMESTAMP:
         case SQL_TIMESTAMP: {
-            protocol::append_type_and_scale(builder, ignite_type::DATETIME);
+            protocol::append_type(builder, ignite_type::DATETIME);
             builder.append_date_time(buf.get_date_time());
             break;
         }
 
         case SQL_TYPE_TIME:
         case SQL_TIME: {
-            protocol::append_type_and_scale(builder, ignite_type::TIME);
+            protocol::append_type(builder, ignite_type::TIME);
             builder.append_time(buf.get_time());
             break;
         }
@@ -246,7 +246,7 @@ void parameter::append(binary_tuple_builder &builder, int offset, SQLULEN idx) c
         case SQL_BINARY:
         case SQL_VARBINARY:
         case SQL_LONGVARBINARY: {
-            protocol::append_type_and_scale(builder, ignite_type::BYTE_ARRAY);
+            protocol::append_type(builder, ignite_type::BYTE_ARRAY);
 
             const application_data_buffer &const_buf = buf;
             const SQLLEN *res_len_ptr = const_buf.get_result_len();
@@ -259,7 +259,7 @@ void parameter::append(binary_tuple_builder &builder, int offset, SQLULEN idx) c
         }
 
         case SQL_GUID: {
-            protocol::append_type_and_scale(builder, ignite_type::UUID);
+            protocol::append_type(builder, ignite_type::UUID);
             builder.append_uuid(buf.get_uuid());
 
             break;
@@ -269,7 +269,7 @@ void parameter::append(binary_tuple_builder &builder, int offset, SQLULEN idx) c
             big_decimal dec_value;
             buf.get_decimal(dec_value);
 
-            protocol::append_type_and_scale(builder, ignite_type::DECIMAL);
+            protocol::append_type(builder, ignite_type::DECIMAL);
             builder.append_number(dec_value);
             break;
         }

--- a/modules/platforms/cpp/ignite/odbc/app/parameter.cpp
+++ b/modules/platforms/cpp/ignite/odbc/app/parameter.cpp
@@ -26,7 +26,6 @@ namespace ignite {
 void parameter::claim(binary_tuple_builder &builder, int offset, SQLULEN idx) const {
     if (m_buffer.get_input_size() == SQL_NULL_DATA) {
         builder.claim_null(); // Type.
-        builder.claim_null(); // Scale.
         builder.claim_null(); // Value.
         return;
     }
@@ -154,7 +153,6 @@ void parameter::claim(binary_tuple_builder &builder, int offset, SQLULEN idx) co
 void parameter::append(binary_tuple_builder &builder, int offset, SQLULEN idx) const {
     if (m_buffer.get_input_size() == SQL_NULL_DATA) {
         builder.append_null(); // Type.
-        builder.append_null(); // Scale.
         builder.append_null(); // Value.
         return;
     }

--- a/modules/platforms/cpp/ignite/odbc/app/parameter_set.cpp
+++ b/modules/platforms/cpp/ignite/odbc/app/parameter_set.cpp
@@ -162,7 +162,7 @@ void parameter_set::write(protocol::writer &writer, SQLULEN begin, SQLULEN end, 
 
 void parameter_set::write_row(protocol::writer &writer, SQLULEN idx) const {
     auto args_num = calculate_row_len();
-    binary_tuple_builder row_builder{args_num * 3};
+    binary_tuple_builder row_builder{args_num * 2};
 
     row_builder.start();
 

--- a/modules/platforms/cpp/ignite/odbc/query/cursor.h
+++ b/modules/platforms/cpp/ignite/odbc/query/cursor.h
@@ -66,7 +66,7 @@ public:
         m_row.clear();
         for (size_t i = 0; i < columns_cnt; ++i) {
             auto &column = columns[i];
-            m_row.push_back(protocol::read_next_column(parser, column.get_data_type(), column.get_scale()));
+            m_row.push_back(protocol::read_next_column(parser, column.get_data_type()));
         }
 
         return true;

--- a/modules/platforms/cpp/ignite/protocol/utils.cpp
+++ b/modules/platforms/cpp/ignite/protocol/utils.cpp
@@ -309,7 +309,7 @@ void claim_primitive_with_type(binary_tuple_builder &builder, const primitive &v
         }
         case ignite_type::DECIMAL: {
             const auto &dec_value = value.get<big_decimal>();
-            claim_type(builder, ignite_type::DECIMAL));
+            claim_type(builder, ignite_type::DECIMAL);
             builder.claim_number(dec_value);
             break;
         }
@@ -468,7 +468,7 @@ void append_primitive_with_type(binary_tuple_builder &builder, const primitive &
     }
 }
 
-primitive read_next_column(binary_tuple_parser &parser, ignite_type typ, std::int32_t scale) {
+primitive read_next_column(binary_tuple_parser &parser, ignite_type typ) {
     auto val = parser.get_next();
     if (val.empty())
         return {};

--- a/modules/platforms/cpp/ignite/protocol/utils.cpp
+++ b/modules/platforms/cpp/ignite/protocol/utils.cpp
@@ -257,99 +257,99 @@ void claim_primitive_with_type(binary_tuple_builder &builder, const primitive &v
 
     switch (value.get_type()) {
         case ignite_type::BOOLEAN: {
-            claim_type_and_scale(builder, ignite_type::BOOLEAN);
+            claim_type(builder, ignite_type::BOOLEAN);
             builder.claim_bool(value.get<bool>());
             break;
         }
         case ignite_type::INT8: {
-            claim_type_and_scale(builder, ignite_type::INT8);
+            claim_type(builder, ignite_type::INT8);
             builder.claim_int8(value.get<std::int8_t>());
             break;
         }
         case ignite_type::INT16: {
-            claim_type_and_scale(builder, ignite_type::INT16);
+            claim_type(builder, ignite_type::INT16);
             builder.claim_int16(value.get<std::int16_t>());
             break;
         }
         case ignite_type::INT32: {
-            claim_type_and_scale(builder, ignite_type::INT32);
+            claim_type(builder, ignite_type::INT32);
             builder.claim_int32(value.get<std::int32_t>());
             break;
         }
         case ignite_type::INT64: {
-            claim_type_and_scale(builder, ignite_type::INT64);
+            claim_type(builder, ignite_type::INT64);
             builder.claim_int64(value.get<std::int64_t>());
             break;
         }
         case ignite_type::FLOAT: {
-            claim_type_and_scale(builder, ignite_type::FLOAT);
+            claim_type(builder, ignite_type::FLOAT);
             builder.claim_float(value.get<float>());
             break;
         }
         case ignite_type::DOUBLE: {
-            claim_type_and_scale(builder, ignite_type::DOUBLE);
+            claim_type(builder, ignite_type::DOUBLE);
             builder.claim_double(value.get<double>());
             break;
         }
         case ignite_type::UUID: {
-            claim_type_and_scale(builder, ignite_type::UUID);
+            claim_type(builder, ignite_type::UUID);
             builder.claim_uuid(value.get<uuid>());
             break;
         }
         case ignite_type::STRING: {
-            claim_type_and_scale(builder, ignite_type::STRING);
+            claim_type(builder, ignite_type::STRING);
             builder.claim_varlen(value.get<std::string>());
             break;
         }
         case ignite_type::BYTE_ARRAY: {
-            claim_type_and_scale(builder, ignite_type::BYTE_ARRAY);
+            claim_type(builder, ignite_type::BYTE_ARRAY);
             auto &data = value.get<std::vector<std::byte>>();
             builder.claim_varlen(data);
             break;
         }
         case ignite_type::DECIMAL: {
             const auto &dec_value = value.get<big_decimal>();
-            claim_type_and_scale(builder, ignite_type::DECIMAL));
+            claim_type(builder, ignite_type::DECIMAL));
             builder.claim_number(dec_value);
             break;
         }
         case ignite_type::NUMBER: {
-            claim_type_and_scale(builder, ignite_type::NUMBER);
+            claim_type(builder, ignite_type::NUMBER);
             builder.claim_number(value.get<big_integer>());
             break;
         }
         case ignite_type::DATE: {
-            claim_type_and_scale(builder, ignite_type::DATE);
+            claim_type(builder, ignite_type::DATE);
             builder.claim_date(value.get<ignite_date>());
             break;
         }
         case ignite_type::TIME: {
-            claim_type_and_scale(builder, ignite_type::TIME);
+            claim_type(builder, ignite_type::TIME);
             builder.claim_time(value.get<ignite_time>());
             break;
         }
         case ignite_type::DATETIME: {
-            claim_type_and_scale(builder, ignite_type::DATETIME);
+            claim_type(builder, ignite_type::DATETIME);
             builder.claim_date_time(value.get<ignite_date_time>());
             break;
         }
         case ignite_type::TIMESTAMP: {
-            claim_type_and_scale(builder, ignite_type::TIMESTAMP);
+            claim_type(builder, ignite_type::TIMESTAMP);
             builder.claim_timestamp(value.get<ignite_timestamp>());
             break;
         }
         case ignite_type::PERIOD: {
-            claim_type_and_scale(builder, ignite_type::PERIOD);
+            claim_type(builder, ignite_type::PERIOD);
             builder.claim_period(value.get<ignite_period>());
             break;
         }
         case ignite_type::DURATION: {
-            claim_type_and_scale(builder, ignite_type::DURATION);
+            claim_type(builder, ignite_type::DURATION);
             builder.claim_duration(value.get<ignite_duration>());
             break;
         }
         case ignite_type::BITMASK: {
-            claim_type_and_scale(builder, ignite_type::BITMASK);
+            claim_type(builder, ignite_type::BITMASK);
             builder.claim_varlen(value.get<bit_array>().get_raw());
             break;
         }
@@ -367,99 +367,99 @@ void append_primitive_with_type(binary_tuple_builder &builder, const primitive &
 
     switch (value.get_type()) {
         case ignite_type::BOOLEAN: {
-            append_type_and_scale(builder, ignite_type::BOOLEAN);
+            append_type(builder, ignite_type::BOOLEAN);
             builder.append_bool(value.get<bool>());
             break;
         }
         case ignite_type::INT8: {
-            append_type_and_scale(builder, ignite_type::INT8);
+            append_type(builder, ignite_type::INT8);
             builder.append_int8(value.get<std::int8_t>());
             break;
         }
         case ignite_type::INT16: {
-            append_type_and_scale(builder, ignite_type::INT16);
+            append_type(builder, ignite_type::INT16);
             builder.append_int16(value.get<std::int16_t>());
             break;
         }
         case ignite_type::INT32: {
-            append_type_and_scale(builder, ignite_type::INT32);
+            append_type(builder, ignite_type::INT32);
             builder.append_int32(value.get<std::int32_t>());
             break;
         }
         case ignite_type::INT64: {
-            append_type_and_scale(builder, ignite_type::INT64);
+            append_type(builder, ignite_type::INT64);
             builder.append_int64(value.get<std::int64_t>());
             break;
         }
         case ignite_type::FLOAT: {
-            append_type_and_scale(builder, ignite_type::FLOAT);
+            append_type(builder, ignite_type::FLOAT);
             builder.append_float(value.get<float>());
             break;
         }
         case ignite_type::DOUBLE: {
-            append_type_and_scale(builder, ignite_type::DOUBLE);
+            append_type(builder, ignite_type::DOUBLE);
             builder.append_double(value.get<double>());
             break;
         }
         case ignite_type::UUID: {
-            append_type_and_scale(builder, ignite_type::UUID);
+            append_type(builder, ignite_type::UUID);
             builder.append_uuid(value.get<uuid>());
             break;
         }
         case ignite_type::STRING: {
-            append_type_and_scale(builder, ignite_type::STRING);
+            append_type(builder, ignite_type::STRING);
             builder.append_varlen(value.get<std::string>());
             break;
         }
         case ignite_type::BYTE_ARRAY: {
-            append_type_and_scale(builder, ignite_type::BYTE_ARRAY);
+            append_type(builder, ignite_type::BYTE_ARRAY);
             auto &data = value.get<std::vector<std::byte>>();
             builder.append_varlen(data);
             break;
         }
         case ignite_type::DECIMAL: {
             const auto &dec_value = value.get<big_decimal>();
-            append_type_and_scale(builder, ignite_type::DECIMAL);
+            append_type(builder, ignite_type::DECIMAL);
             builder.append_number(dec_value);
             break;
         }
         case ignite_type::NUMBER: {
-            append_type_and_scale(builder, ignite_type::NUMBER);
+            append_type(builder, ignite_type::NUMBER);
             builder.append_number(value.get<big_integer>());
             break;
         }
         case ignite_type::DATE: {
-            append_type_and_scale(builder, ignite_type::DATE);
+            append_type(builder, ignite_type::DATE);
             builder.append_date(value.get<ignite_date>());
             break;
         }
         case ignite_type::TIME: {
-            append_type_and_scale(builder, ignite_type::TIME);
+            append_type(builder, ignite_type::TIME);
             builder.append_time(value.get<ignite_time>());
             break;
         }
         case ignite_type::DATETIME: {
-            append_type_and_scale(builder, ignite_type::DATETIME);
+            append_type(builder, ignite_type::DATETIME);
             builder.append_date_time(value.get<ignite_date_time>());
             break;
         }
         case ignite_type::TIMESTAMP: {
-            append_type_and_scale(builder, ignite_type::TIMESTAMP);
+            append_type(builder, ignite_type::TIMESTAMP);
             builder.append_timestamp(value.get<ignite_timestamp>());
             break;
         }
         case ignite_type::PERIOD: {
-            append_type_and_scale(builder, ignite_type::PERIOD);
+            append_type(builder, ignite_type::PERIOD);
             builder.append_period(value.get<ignite_period>());
             break;
         }
         case ignite_type::DURATION: {
-            append_type_and_scale(builder, ignite_type::DURATION);
+            append_type(builder, ignite_type::DURATION);
             builder.append_duration(value.get<ignite_duration>());
             break;
         }
         case ignite_type::BITMASK: {
-            append_type_and_scale(builder, ignite_type::BITMASK);
+            append_type(builder, ignite_type::BITMASK);
             builder.append_varlen(value.get<bit_array>().get_raw());
             break;
         }

--- a/modules/platforms/cpp/ignite/protocol/utils.cpp
+++ b/modules/platforms/cpp/ignite/protocol/utils.cpp
@@ -251,7 +251,6 @@ ignite_error read_error(reader &reader) {
 void claim_primitive_with_type(binary_tuple_builder &builder, const primitive &value) {
     if (value.is_null()) {
         builder.claim_null(); // Type.
-        builder.claim_null(); // Scale.
         builder.claim_null(); // Value.
         return;
     }
@@ -310,7 +309,7 @@ void claim_primitive_with_type(binary_tuple_builder &builder, const primitive &v
         }
         case ignite_type::DECIMAL: {
             const auto &dec_value = value.get<big_decimal>();
-            claim_type_and_scale(builder, ignite_type::DECIMAL, dec_value.get_scale());
+            claim_type_and_scale(builder, ignite_type::DECIMAL));
             builder.claim_number(dec_value);
             break;
         }
@@ -362,7 +361,6 @@ void claim_primitive_with_type(binary_tuple_builder &builder, const primitive &v
 void append_primitive_with_type(binary_tuple_builder &builder, const primitive &value) {
     if (value.is_null()) {
         builder.append_null(); // Type.
-        builder.append_null(); // Scale.
         builder.append_null(); // Value.
         return;
     }
@@ -421,7 +419,7 @@ void append_primitive_with_type(binary_tuple_builder &builder, const primitive &
         }
         case ignite_type::DECIMAL: {
             const auto &dec_value = value.get<big_decimal>();
-            append_type_and_scale(builder, ignite_type::DECIMAL, dec_value.get_scale());
+            append_type_and_scale(builder, ignite_type::DECIMAL);
             builder.append_number(dec_value);
             break;
         }
@@ -497,7 +495,7 @@ primitive read_next_column(binary_tuple_parser &parser, ignite_type typ, std::in
         case ignite_type::BYTE_ARRAY:
             return std::vector<std::byte>(binary_tuple_parser::get_varlen(val));
         case ignite_type::DECIMAL:
-            return binary_tuple_parser::get_decimal(val, scale);
+            return binary_tuple_parser::get_decimal(val);
         case ignite_type::NUMBER:
             return binary_tuple_parser::get_number(val);
         case ignite_type::DATE:

--- a/modules/platforms/cpp/ignite/protocol/utils.h
+++ b/modules/platforms/cpp/ignite/protocol/utils.h
@@ -270,6 +270,6 @@ void append_primitive_with_type(binary_tuple_builder &builder, const primitive &
  * @param scale Column scale.
  * @return Column value.
  */
-[[nodiscard]] primitive read_next_column(binary_tuple_parser &parser, ignite_type typ, std::int32_t scale);
+[[nodiscard]] primitive read_next_column(binary_tuple_parser &parser, ignite_type typ);
 
 } // namespace ignite::protocol

--- a/modules/platforms/cpp/ignite/protocol/utils.h
+++ b/modules/platforms/cpp/ignite/protocol/utils.h
@@ -231,11 +231,9 @@ template<>
  *
  * @param builder Tuple builder.
  * @param typ Type.
- * @param scale Scale.
  */
-inline void claim_type_and_scale(binary_tuple_builder &builder, ignite_type typ, std::int32_t scale = 0) {
+inline void claim_type_and_scale(binary_tuple_builder &builder, ignite_type typ) {
     builder.claim_int32(static_cast<std::int32_t>(typ));
-    builder.claim_int32(scale);
 }
 
 /**
@@ -243,11 +241,9 @@ inline void claim_type_and_scale(binary_tuple_builder &builder, ignite_type typ,
  *
  * @param builder Tuple builder.
  * @param typ Type.
- * @param scale Scale.
  */
-inline void append_type_and_scale(binary_tuple_builder &builder, ignite_type typ, std::int32_t scale = 0) {
+inline void append_type_and_scale(binary_tuple_builder &builder, ignite_type typ) {
     builder.append_int32(static_cast<std::int32_t>(typ));
-    builder.append_int32(scale);
 }
 
 /**

--- a/modules/platforms/cpp/ignite/protocol/utils.h
+++ b/modules/platforms/cpp/ignite/protocol/utils.h
@@ -232,7 +232,7 @@ template<>
  * @param builder Tuple builder.
  * @param typ Type.
  */
-inline void claim_type_and_scale(binary_tuple_builder &builder, ignite_type typ) {
+inline void claim_type(binary_tuple_builder &builder, ignite_type typ) {
     builder.claim_int32(static_cast<std::int32_t>(typ));
 }
 
@@ -242,7 +242,7 @@ inline void claim_type_and_scale(binary_tuple_builder &builder, ignite_type typ)
  * @param builder Tuple builder.
  * @param typ Type.
  */
-inline void append_type_and_scale(binary_tuple_builder &builder, ignite_type typ) {
+inline void append_type(binary_tuple_builder &builder, ignite_type typ) {
     builder.append_int32(static_cast<std::int32_t>(typ));
 }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -708,7 +708,7 @@ namespace Apache.Ignite.Tests
                 }.ToString()
                 : Node.Name;
 
-            using var builder = new BinaryTupleBuilder(3);
+            using var builder = new BinaryTupleBuilder(2);
             builder.AppendObjectWithType(resObj);
 
             var arrayBufferWriter = new PooledArrayBuffer();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -476,13 +476,12 @@ namespace Apache.Ignite.Tests
 
             for (int i = 0; i < propCount; i++)
             {
-                var idx = i * 4;
+                var idx = i * 3;
 
                 var name = propTuple.GetString(idx);
                 var type = (ColumnType)propTuple.GetInt(idx + 1);
-                var scale = propTuple.GetInt(idx + 2);
 
-                props[name] = propTuple.GetObject(idx + 3, type);
+                props[name] = propTuple.GetObject(idx + 2, type);
             }
 
             var sql = reader.ReadString();
@@ -587,13 +586,12 @@ namespace Apache.Ignite.Tests
 
             for (int i = 0; i < propCount; i++)
             {
-                var idx = i * 4;
+                var idx = i * 3;
 
                 var name = propTuple.GetString(idx);
                 var type = (ColumnType)propTuple.GetInt(idx + 1);
-                var scale = propTuple.GetInt(idx + 2);
 
-                props[name] = propTuple.GetObject(idx + 3, type);
+                props[name] = propTuple.GetObject(idx + 2, type);
             }
 
             var sql = reader.ReadString();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -482,7 +482,7 @@ namespace Apache.Ignite.Tests
                 var type = (ColumnType)propTuple.GetInt(idx + 1);
                 var scale = propTuple.GetInt(idx + 2);
 
-                props[name] = propTuple.GetObject(idx + 3, type, scale);
+                props[name] = propTuple.GetObject(idx + 3, type);
             }
 
             var sql = reader.ReadString();
@@ -593,7 +593,7 @@ namespace Apache.Ignite.Tests
                 var type = (ColumnType)propTuple.GetInt(idx + 1);
                 var scale = propTuple.GetInt(idx + 2);
 
-                props[name] = propTuple.GetObject(idx + 3, type, scale);
+                props[name] = propTuple.GetObject(idx + 3, type);
             }
 
             var sql = reader.ReadString();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/BinaryTuple/BinaryTupleTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/BinaryTuple/BinaryTupleTests.cs
@@ -460,7 +460,7 @@ namespace Apache.Ignite.Tests.Proto.BinaryTuple
             static void Test(decimal val, int scale, decimal? expected = null)
             {
                 var reader = BuildAndRead((ref BinaryTupleBuilder b) => b.AppendDecimal(val, scale));
-                var res = reader.GetDecimal(0, scale);
+                var res = reader.GetDecimal(0);
 
                 Assert.AreEqual(expected ?? val, res);
             }
@@ -469,10 +469,8 @@ namespace Apache.Ignite.Tests.Proto.BinaryTuple
         [Test]
         public void TestDecimalScaleOverflow()
         {
-            const int scale = 100;
-
             var ex = Assert.Throws<OverflowException>(
-                () => BuildAndRead((ref BinaryTupleBuilder b) => b.AppendBytes(new byte[] { 64, 64, 64 })).GetDecimal(0, scale));
+                () => BuildAndRead((ref BinaryTupleBuilder b) => b.AppendBytes(new byte[] { 64, 64, 64 })).GetDecimal(0));
 
             Assert.AreEqual("Value was either too large or too small for a Decimal.", ex!.Message);
         }
@@ -483,7 +481,7 @@ namespace Apache.Ignite.Tests.Proto.BinaryTuple
             var magnitude = Enumerable.Range(1, 100).Select(_ => (byte)250).ToArray();
 
             var ex = Assert.Throws<OverflowException>(
-                () => BuildAndRead((ref BinaryTupleBuilder b) => b.AppendBytes(magnitude)).GetDecimal(0, 0));
+                () => BuildAndRead((ref BinaryTupleBuilder b) => b.AppendBytes(magnitude)).GetDecimal(0));
 
             Assert.AreEqual("Value was either too large or too small for a Decimal.", ex!.Message);
         }
@@ -653,7 +651,7 @@ namespace Apache.Ignite.Tests.Proto.BinaryTuple
             Assert.IsNull(reader.GetLongNullable(0));
             Assert.IsNull(reader.GetDoubleNullable(0));
             Assert.IsNull(reader.GetFloatNullable(0));
-            Assert.IsNull(reader.GetDecimalNullable(0, 123));
+            Assert.IsNull(reader.GetDecimalNullable(0));
             Assert.IsNull(reader.GetNumberNullable(0));
             Assert.IsNull(reader.GetStringNullable(0));
             Assert.IsNull(reader.GetBitmaskNullable(0));
@@ -739,8 +737,8 @@ namespace Apache.Ignite.Tests.Proto.BinaryTuple
             Assert.IsNull(reader.GetGuidNullable(17));
             Assert.AreEqual(bitArray, reader.GetBitmaskNullable(18));
             Assert.IsNull(reader.GetBitmaskNullable(19));
-            Assert.AreEqual(1, reader.GetDecimalNullable(20, 3));
-            Assert.IsNull(reader.GetDecimalNullable(21, 3));
+            Assert.AreEqual(1, reader.GetDecimalNullable(20));
+            Assert.IsNull(reader.GetDecimalNullable(21));
             Assert.AreEqual((BigInteger)1, reader.GetNumberNullable(22));
             Assert.IsNull(reader.GetNumberNullable(23));
             Assert.AreEqual(date, reader.GetDateNullable(24));

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/BinaryTuple/BinaryTupleTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/BinaryTuple/BinaryTupleTests.cs
@@ -838,25 +838,25 @@ namespace Apache.Ignite.Tests.Proto.BinaryTuple
                     b.AppendObjectWithType(dateTime);
                     b.AppendObjectWithType(Instant.FromDateTimeUtc(utcNow));
                 },
-                17 * 3);
+                17 * 2);
 
             Assert.IsNull(reader.GetObject(0));
-            Assert.AreEqual(sbyte.MaxValue, reader.GetObject(3));
-            Assert.AreEqual(short.MaxValue, reader.GetObject(6));
-            Assert.AreEqual(int.MaxValue, reader.GetObject(9));
-            Assert.AreEqual(long.MaxValue, reader.GetObject(12));
-            Assert.AreEqual(float.MaxValue, reader.GetObject(15));
-            Assert.AreEqual(double.MaxValue, reader.GetObject(18));
-            Assert.AreEqual(decimal.One, reader.GetObject(21));
-            Assert.AreEqual(BigInteger.One, reader.GetObject(24));
-            Assert.AreEqual("foo", reader.GetObject(27));
-            Assert.AreEqual(bitArray, reader.GetObject(30));
-            Assert.AreEqual(guid, reader.GetObject(33));
-            Assert.AreEqual(bytes, reader.GetObject(36));
-            Assert.AreEqual(LocalTime.FromMinutesSinceMidnight(123), reader.GetObject(39));
-            Assert.AreEqual(date, reader.GetObject(42));
-            Assert.AreEqual(dateTime, reader.GetObject(45));
-            Assert.AreEqual(Instant.FromDateTimeUtc(utcNow), reader.GetObject(48));
+            Assert.AreEqual(sbyte.MaxValue, reader.GetObject(2));
+            Assert.AreEqual(short.MaxValue, reader.GetObject(4));
+            Assert.AreEqual(int.MaxValue, reader.GetObject(6));
+            Assert.AreEqual(long.MaxValue, reader.GetObject(8));
+            Assert.AreEqual(float.MaxValue, reader.GetObject(10));
+            Assert.AreEqual(double.MaxValue, reader.GetObject(12));
+            Assert.AreEqual(decimal.One, reader.GetObject(14));
+            Assert.AreEqual(BigInteger.One, reader.GetObject(16));
+            Assert.AreEqual("foo", reader.GetObject(18));
+            Assert.AreEqual(bitArray, reader.GetObject(20));
+            Assert.AreEqual(guid, reader.GetObject(22));
+            Assert.AreEqual(bytes, reader.GetObject(24));
+            Assert.AreEqual(LocalTime.FromMinutesSinceMidnight(123), reader.GetObject(26));
+            Assert.AreEqual(date, reader.GetObject(28));
+            Assert.AreEqual(dateTime, reader.GetObject(30));
+            Assert.AreEqual(Instant.FromDateTimeUtc(utcNow), reader.GetObject(32));
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/ColocationHashTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/ColocationHashTests.cs
@@ -211,8 +211,8 @@ public class ColocationHashTests : IgniteTestsBase
     private static (byte[] Bytes, int Hash) WriteAsBinaryTuple(IReadOnlyCollection<object> arr, int timePrecision, int timestampPrecision)
     {
         using var builder = new BinaryTupleBuilder(
-            numElements: arr.Count * 3,
-            hashedColumnsPredicate: new TestIndexProvider(x => x % 3 == 2 ? x / 3 : -1, arr.Count));
+            numElements: arr.Count * 2,
+            hashedColumnsPredicate: new TestIndexProvider(x => x % 2 == 1 ? x / 2 : -1, arr.Count));
 
         foreach (var obj in arr)
         {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/ResultSelector.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/ResultSelector.cs
@@ -359,11 +359,6 @@ internal static class ResultSelector
         il.Emit(OpCodes.Ldarg_1); // Reader.
         il.Emit(OpCodes.Ldc_I4, index); // Index.
 
-        if (col.Type == ColumnType.Decimal)
-        {
-            il.Emit(OpCodes.Ldc_I4, col.Scale);
-        }
-
         var colType = col.Type.ToClrType(col.Nullable);
         il.Emit(OpCodes.Call, BinaryTupleMethods.GetReadMethod(colType));
 
@@ -398,11 +393,6 @@ internal static class ResultSelector
         il.Emit(targetObj.LocalType.IsValueType ? OpCodes.Ldloca_S : OpCodes.Ldloc, targetObj); // res
         il.Emit(OpCodes.Ldarg_1); // Reader.
         il.Emit(OpCodes.Ldc_I4, colIndex); // Index.
-
-        if (col.Type == ColumnType.Decimal)
-        {
-            il.Emit(OpCodes.Ldc_I4, col.Scale);
-        }
 
         var colType = col.Type.ToClrType(col.Nullable);
         il.Emit(OpCodes.Call, BinaryTupleMethods.GetReadMethod(colType));

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleReader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleReader.cs
@@ -21,7 +21,6 @@ namespace Apache.Ignite.Internal.Proto.BinaryTuple
     using System.Buffers.Binary;
     using System.Collections;
     using System.Diagnostics;
-    using System.Diagnostics.CodeAnalysis;
     using System.Numerics;
     using Ignite.Sql;
     using NodaTime;
@@ -269,17 +268,15 @@ namespace Apache.Ignite.Internal.Proto.BinaryTuple
         /// Gets a decimal value.
         /// </summary>
         /// <param name="index">Index.</param>
-        /// <param name="scale">Decimal scale.</param>
         /// <returns>Value.</returns>
-        public decimal GetDecimal(int index, int scale) => GetDecimalNullable(index, scale) ?? ThrowNullElementException<decimal>(index);
+        public decimal GetDecimal(int index) => GetDecimalNullable(index) ?? ThrowNullElementException<decimal>(index);
 
         /// <summary>
         /// Gets a decimal value.
         /// </summary>
         /// <param name="index">Index.</param>
-        /// <param name="scale">Decimal scale.</param>
         /// <returns>Value.</returns>
-        public decimal? GetDecimalNullable(int index, int scale) => ReadDecimal(Seek(index), scale);
+        public decimal? GetDecimalNullable(int index) => ReadDecimal(Seek(index));
 
         /// <summary>
         /// Gets a number (big integer) value.
@@ -461,9 +458,8 @@ namespace Apache.Ignite.Internal.Proto.BinaryTuple
         /// </summary>
         /// <param name="index">Index.</param>
         /// <param name="columnType">Column type.</param>
-        /// <param name="scale">Column decimal scale.</param>
         /// <returns>Value.</returns>
-        public object? GetObject(int index, ColumnType columnType, int scale = 0) =>
+        public object? GetObject(int index, ColumnType columnType) =>
             columnType switch
             {
                 ColumnType.Null => null,
@@ -475,7 +471,7 @@ namespace Apache.Ignite.Internal.Proto.BinaryTuple
                 ColumnType.Double => GetDoubleNullable(index),
                 ColumnType.Uuid => GetGuidNullable(index),
                 ColumnType.String => GetStringNullable(index),
-                ColumnType.Decimal => GetDecimalNullable(index, scale),
+                ColumnType.Decimal => GetDecimalNullable(index),
                 ColumnType.ByteArray => GetBytesNullable(index),
                 ColumnType.Bitmask => GetBitmaskNullable(index),
                 ColumnType.Date => GetDateNullable(index),
@@ -502,9 +498,8 @@ namespace Apache.Ignite.Internal.Proto.BinaryTuple
             }
 
             var type = (ColumnType)GetInt(index);
-            var scale = GetInt(index + 1);
 
-            return GetObject(index + 2, type, scale);
+            return GetObject(index + 1, type);
         }
 
         private static LocalDate ReadDate(ReadOnlySpan<byte> span)
@@ -553,8 +548,7 @@ namespace Apache.Ignite.Internal.Proto.BinaryTuple
             return LocalTime.FromHourMinuteSecondNanosecond(hour, minute, second, nanos);
         }
 
-        [SuppressMessage("ReSharper", "UnusedParameter.Local", Justification = "Schema scale is not required for deserialization.")]
-        private static decimal? ReadDecimal(ReadOnlySpan<byte> span, int scale)
+        private static decimal? ReadDecimal(ReadOnlySpan<byte> span)
         {
             if (span.IsEmpty)
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MsgPack/MsgPackReader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MsgPack/MsgPackReader.cs
@@ -376,7 +376,7 @@ internal ref struct MsgPackReader
             return null;
         }
 
-        var tuple = new BinaryTupleReader(ReadBinary(), 3);
+        var tuple = new BinaryTupleReader(ReadBinary(), 2);
 
         return tuple.GetObject(0);
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MsgPack/MsgPackWriter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MsgPack/MsgPackWriter.cs
@@ -376,7 +376,7 @@ internal readonly ref struct MsgPackWriter
             return;
         }
 
-        using var builder = new BinaryTupleBuilder(col.Count * 3);
+        using var builder = new BinaryTupleBuilder(col.Count * 2);
 
         foreach (var obj in col)
         {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/Sql.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/Sql.cs
@@ -125,7 +125,7 @@ namespace Apache.Ignite.Internal.Sql
                 ColumnType.Int64 => reader.GetLong(idx),
                 ColumnType.Float => reader.GetFloat(idx),
                 ColumnType.Double => reader.GetDouble(idx),
-                ColumnType.Decimal => reader.GetDecimal(idx, col.Scale),
+                ColumnType.Decimal => reader.GetDecimal(idx),
                 ColumnType.Date => reader.GetDate(idx),
                 ColumnType.Time => reader.GetTime(idx),
                 ColumnType.Datetime => reader.GetDateTime(idx),

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
@@ -105,11 +105,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
                 il.Emit(OpCodes.Ldarg_0); // writer
                 il.Emit(OpCodes.Ldarg_2); // value
 
-                if (col.Type == ColumnType.Decimal)
-                {
-                    il.Emit(OpCodes.Ldc_I4, col.Scale);
-                }
-                else if (col.Type is ColumnType.Time or ColumnType.Datetime or ColumnType.Timestamp)
+                if (col.Type is ColumnType.Time or ColumnType.Datetime or ColumnType.Timestamp)
                 {
                     il.Emit(OpCodes.Ldc_I4, col.Precision);
                 }
@@ -403,11 +399,6 @@ namespace Apache.Ignite.Internal.Table.Serialization
             il.Emit(local.LocalType.IsValueType ? OpCodes.Ldloca_S : OpCodes.Ldloc, local); // res
             il.Emit(OpCodes.Ldarg_0); // reader
             il.Emit(OpCodes.Ldc_I4, elemIdx); // index
-
-            if (col.Type == ColumnType.Decimal)
-            {
-                il.Emit(OpCodes.Ldc_I4, col.Scale);
-            }
 
             il.Emit(OpCodes.Call, readMethod);
             il.Emit(OpCodes.Stfld, fieldInfo); // res.field = value

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
@@ -105,7 +105,11 @@ namespace Apache.Ignite.Internal.Table.Serialization
                 il.Emit(OpCodes.Ldarg_0); // writer
                 il.Emit(OpCodes.Ldarg_2); // value
 
-                if (col.Type is ColumnType.Time or ColumnType.Datetime or ColumnType.Timestamp)
+                if (col.Type == ColumnType.Decimal)
+                {
+                    il.Emit(OpCodes.Ldc_I4, col.Scale);
+                }
+                else if (col.Type is ColumnType.Time or ColumnType.Datetime or ColumnType.Timestamp)
                 {
                     il.Emit(OpCodes.Ldc_I4, col.Precision);
                 }
@@ -285,11 +289,6 @@ namespace Apache.Ignite.Internal.Table.Serialization
                 // Single column to primitive type mapping.
                 il.Emit(OpCodes.Ldarg_0); // reader
                 il.Emit(OpCodes.Ldc_I4_0); // index
-
-                if (schema.Columns[0] is { Type: ColumnType.Decimal } col)
-                {
-                    il.Emit(OpCodes.Ldc_I4, col.Scale);
-                }
 
                 il.Emit(OpCodes.Call, readMethod);
                 il.Emit(OpCodes.Ret);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TuplePairSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TuplePairSerializerHandler.cs
@@ -54,7 +54,7 @@ internal sealed class TuplePairSerializerHandler : IRecordSerializerHandler<KvPa
 
             foreach (var column in schema.KeyColumns)
             {
-                keyTuple[column.Name] = tupleReader.GetObject(column.KeyIndex, column.Type, column.Scale);
+                keyTuple[column.Name] = tupleReader.GetObject(column.KeyIndex, column.Type);
             }
 
             return new(keyTuple);
@@ -68,7 +68,7 @@ internal sealed class TuplePairSerializerHandler : IRecordSerializerHandler<KvPa
             foreach (var column in schema.Columns)
             {
                 var tuple = column.IsKey ? keyTuple : valTuple;
-                tuple[column.Name] = tupleReader.GetObject(column.SchemaIndex, column.Type, column.Scale);
+                tuple[column.Name] = tupleReader.GetObject(column.SchemaIndex, column.Type);
             }
 
             return new(keyTuple, valTuple);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TupleSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TupleSerializerHandler.cs
@@ -58,7 +58,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
 
             foreach (var column in columns)
             {
-                tuple[column.Name] = tupleReader.GetObject(column.GetBinaryTupleIndex(keyOnly), column.Type, column.Scale);
+                tuple[column.Name] = tupleReader.GetObject(column.GetBinaryTupleIndex(keyOnly), column.Type);
             }
 
             return tuple;
@@ -78,7 +78,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
             var tupleReader = new BinaryTupleReader(buf, columns.Length);
             var column = columns[index];
 
-            return tupleReader.GetObject(index, column.Type, column.Scale);
+            return tupleReader.GetObject(index, column.Type);
         }
 
         /// <inheritdoc/>

--- a/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbDataReader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Sql/IgniteDbDataReader.cs
@@ -207,11 +207,9 @@ public sealed class IgniteDbDataReader : DbDataReader, IDbColumnSchemaGenerator
     /// <inheritdoc/>
     public override decimal GetDecimal(int ordinal)
     {
-        var column = Metadata.Columns[ordinal];
+        ValidateColumnType(typeof(decimal), Metadata.Columns[ordinal]);
 
-        ValidateColumnType(typeof(decimal), column);
-
-        return GetReader().GetDecimal(ordinal, column.Scale);
+        return GetReader().GetDecimal(ordinal);
     }
 
     /// <inheritdoc/>

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -654,8 +654,10 @@ public class PlatformTestNodeRunner {
                         break;
 
                     case DECIMAL:
-                        columns.add(new Column(colName, NativeTypes.decimalOf(100, 50), false));
-                        tuple.set(colName, reader.decimalValue(valIdx, -1));
+                        BigDecimal decimalVal = reader.decimalValue(valIdx, -1);
+                        assert decimalVal != null;
+                        columns.add(new Column(colName, NativeTypes.decimalOf(100, decimalVal.scale()), false));
+                        tuple.set(colName, decimalVal);
                         break;
 
                     case STRING:

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -609,12 +609,11 @@ public class PlatformTestNodeRunner {
 
             List<Column> columns = new ArrayList<>(columnCount);
             var tuple = Tuple.create(columnCount);
-            var reader = new BinaryTupleReader(columnCount * 3, buf);
+            var reader = new BinaryTupleReader(columnCount * 2, buf);
 
             for (int i = 0; i < columnCount; i++) {
-                var type = ColumnTypeConverter.fromIdOrThrow(reader.intValue(i * 3));
-                var scale = reader.intValue(i * 3 + 1);
-                var valIdx = i * 3 + 2;
+                var type = ColumnTypeConverter.fromIdOrThrow(reader.intValue(i * 2));
+                var valIdx = i * 2 + 1;
 
                 String colName = "col" + i;
 
@@ -655,8 +654,8 @@ public class PlatformTestNodeRunner {
                         break;
 
                     case DECIMAL:
-                        columns.add(new Column(colName, NativeTypes.decimalOf(100, scale), false));
-                        tuple.set(colName, reader.decimalValue(valIdx, scale));
+                        columns.add(new Column(colName, NativeTypes.decimalOf(100, 50), false));
+                        tuple.set(colName, reader.decimalValue(valIdx, -1));
                         break;
 
                     case STRING:


### PR DESCRIPTION
[IGNITE-21745](https://issues.apache.org/jira/browse/IGNITE-21745) #3493 adds decimal scale as part of the binary tuple payload. We no longed need to send it separately in `ClientBinaryTupleUtils#appendTypeAndScale`.