### PR TITLE
IGNITE-22413 Jdbc. Reduce amount of roundtrips on statement execution

### DIFF
--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcBatchExecuteResult.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcBatchExecuteResult.java
@@ -73,8 +73,6 @@ public class JdbcBatchExecuteResult extends Response {
         Objects.requireNonNull(updateCnts);
 
         this.updateCnts = updateCnts;
-
-        hasResults = true;
     }
 
     /**

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcColumnMeta.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcColumnMeta.java
@@ -155,8 +155,6 @@ public class JdbcColumnMeta extends Response {
         this.dataTypeCls = javaTypeName;
         this.precision = precision;
         this.scale = scale;
-
-        hasResults = true;
     }
 
     /**
@@ -263,7 +261,7 @@ public class JdbcColumnMeta extends Response {
     public void writeBinary(ClientMessagePacker packer) {
         super.writeBinary(packer);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 
@@ -285,7 +283,7 @@ public class JdbcColumnMeta extends Response {
     public void readBinary(ClientMessageUnpacker unpacker) {
         super.readBinary(unpacker);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcConnectResult.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcConnectResult.java
@@ -50,8 +50,6 @@ public class JdbcConnectResult extends Response {
      */
     public JdbcConnectResult(long connectionId) {
         this.connectionId = connectionId;
-
-        this.hasResults = true;
     }
 
     /** Returns an identifier of the connection. */
@@ -64,7 +62,7 @@ public class JdbcConnectResult extends Response {
     public void writeBinary(ClientMessagePacker packer) {
         super.writeBinary(packer);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 
@@ -76,7 +74,7 @@ public class JdbcConnectResult extends Response {
     public void readBinary(ClientMessageUnpacker unpacker) {
         super.readBinary(unpacker);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcMetaColumnsResult.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcMetaColumnsResult.java
@@ -58,8 +58,6 @@ public class JdbcMetaColumnsResult extends Response {
         Objects.requireNonNull(meta);
 
         this.meta = new ArrayList<>(meta);
-
-        this.hasResults = true;
     }
 
     /**
@@ -76,7 +74,7 @@ public class JdbcMetaColumnsResult extends Response {
     public void writeBinary(ClientMessagePacker packer) {
         super.writeBinary(packer);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 
@@ -92,7 +90,7 @@ public class JdbcMetaColumnsResult extends Response {
     public void readBinary(ClientMessageUnpacker unpacker) {
         super.readBinary(unpacker);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcMetaPrimaryKeysResult.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcMetaPrimaryKeysResult.java
@@ -48,8 +48,6 @@ public class JdbcMetaPrimaryKeysResult extends Response {
         Objects.requireNonNull(meta);
 
         this.meta = new ArrayList<>(meta);
-
-        this.hasResults = true;
     }
 
     /** {@inheritDoc} */
@@ -57,7 +55,7 @@ public class JdbcMetaPrimaryKeysResult extends Response {
     public void writeBinary(ClientMessagePacker packer) {
         super.writeBinary(packer);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 
@@ -79,7 +77,7 @@ public class JdbcMetaPrimaryKeysResult extends Response {
     public void readBinary(ClientMessageUnpacker unpacker) {
         super.readBinary(unpacker);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcMetaSchemasResult.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcMetaSchemasResult.java
@@ -46,8 +46,6 @@ public class JdbcMetaSchemasResult extends Response {
         Objects.requireNonNull(schemas);
 
         this.schemas = schemas;
-
-        this.hasResults = true;
     }
 
     /** {@inheritDoc} */
@@ -55,7 +53,7 @@ public class JdbcMetaSchemasResult extends Response {
     public void writeBinary(ClientMessagePacker packer) {
         super.writeBinary(packer);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 
@@ -71,7 +69,7 @@ public class JdbcMetaSchemasResult extends Response {
     public void readBinary(ClientMessageUnpacker unpacker) {
         super.readBinary(unpacker);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcMetaTablesResult.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcMetaTablesResult.java
@@ -46,8 +46,6 @@ public class JdbcMetaTablesResult extends Response {
         Objects.requireNonNull(meta);
 
         this.meta = meta;
-
-        this.hasResults = true;
     }
 
     /** {@inheritDoc} */
@@ -55,7 +53,7 @@ public class JdbcMetaTablesResult extends Response {
     public void writeBinary(ClientMessagePacker packer) {
         super.writeBinary(packer);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 
@@ -71,7 +69,7 @@ public class JdbcMetaTablesResult extends Response {
     public void readBinary(ClientMessageUnpacker unpacker) {
         super.readBinary(unpacker);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcQueryCloseResult.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcQueryCloseResult.java
@@ -26,9 +26,7 @@ public class JdbcQueryCloseResult extends Response {
     /**
      * Default constructor is used for deserialization.
      */
-    public JdbcQueryCloseResult() {
-        hasResults = true;
-    }
+    public JdbcQueryCloseResult() { }
 
     /**
      * Constructor.

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcQueryFetchResult.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcQueryFetchResult.java
@@ -64,8 +64,6 @@ public class JdbcQueryFetchResult extends Response {
 
         this.rowTuples = rowTuples;
         this.last = last;
-
-        hasResults = true;
     }
 
     /**
@@ -91,7 +89,7 @@ public class JdbcQueryFetchResult extends Response {
     public void writeBinary(ClientMessagePacker packer) {
         super.writeBinary(packer);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 
@@ -109,7 +107,7 @@ public class JdbcQueryFetchResult extends Response {
     public void readBinary(ClientMessageUnpacker unpacker) {
         super.readBinary(unpacker);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcQuerySingleResult.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcQuerySingleResult.java
@@ -43,16 +43,16 @@ public class JdbcQuerySingleResult extends Response {
 
     // === Attributes of response with result set ===
 
-    /** Serialized query result rows. */
+    /** Serialized query result rows. Null only when result has no resultSet. */
     private @Nullable List<BinaryTupleReader> rowTuples;
 
     /** Flag indicating the query has un-fetched results. */
     private boolean hasMoreData;
 
-    /** Ordered list of types of columns in serialized rows. */
+    /** Ordered list of types of columns in serialized rows. Null only when result has no resultSet. */
     private @Nullable List<ColumnType> columnTypes;
 
-    /** Decimal scales in appearance order. Can be empty in case no any decimal columns. */
+    /** Decimal scales in appearance order. Can be empty in case no any decimal columns, or null when result has no resultSet. */
     private int @Nullable [] decimalScales;
 
     // === Attributes of response without result set ===
@@ -122,38 +122,22 @@ public class JdbcQuerySingleResult extends Response {
         this.hasNextResult = hasNextResult;
     }
 
-    /**
-     * Get the cursor id.
-     *
-     * @return Cursor ID.
-     */
+    /** Return id of the cursor in case it was registered on server, returns null otherwise. */
     public @Nullable Long cursorId() {
         return cursorId;
     }
 
-    /**
-     * Get the items.
-     *
-     * @return Serialized query result rows.
-     */
+    /** Return result rows in serialized form, return null if result has no result set. */
     public @Nullable List<BinaryTupleReader> items() {
         return rowTuples;
     }
 
-    /**
-     * Types of columns in serialized rows.
-     *
-     * @return Ordered list of types of columns in serialized rows.
-     */
+    /** Return types of columns in serialized rows if result has result set, return null otherwise. */
     public @Nullable List<ColumnType> columnTypes() {
         return columnTypes;
     }
 
-    /**
-     * Decimal scales.
-     *
-     * @return Decimal scales in appearance order in columns. Can be empty in case no any decimal columns.
-     */
+    /** Return decimal scales in appearance order in columns if result has result set, return null otherwise. */
     public int @Nullable [] decimalScales() {
         return decimalScales;
     }

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcQuerySingleResult.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcQuerySingleResult.java
@@ -25,41 +25,45 @@ import org.apache.ignite.internal.client.proto.ClientMessagePacker;
 import org.apache.ignite.internal.client.proto.ClientMessageUnpacker;
 import org.apache.ignite.internal.tostring.S;
 import org.apache.ignite.sql.ColumnType;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * JDBC query execute result.
  */
 public class JdbcQuerySingleResult extends Response {
-    /** Cursor ID. */
-    private Long cursorId;
+    // === Common attributes ===
+
+    /** Id of the cursor in case it was registered on server. */
+    private @Nullable Long cursorId;
+
+    private boolean hasResultSet;
+
+    /** Result is part of multi-statement query, there is at least one more result. */
+    private boolean hasNextResult;
+
+    // === Attributes of response with result set ===
 
     /** Serialized query result rows. */
-    private List<BinaryTupleReader> rowTuples;
+    private @Nullable List<BinaryTupleReader> rowTuples;
 
-    /** Flag indicating the query has no unfetched results. */
-    private boolean last;
-
-    /** Flag indicating the query is SELECT/EXPLAIN query. {@code false} for DML/DDL/TX queries. */
-    private boolean isQuery;
-
-    /** Update count. */
-    private long updateCnt;
+    /** Flag indicating the query has un-fetched results. */
+    private boolean hasMoreData;
 
     /** Ordered list of types of columns in serialized rows. */
-    private List<ColumnType> columnTypes;
+    private @Nullable List<ColumnType> columnTypes;
 
     /** Decimal scales in appearance order. Can be empty in case no any decimal columns. */
-    private int[] decimalScales;
+    private int @Nullable [] decimalScales;
 
-    /** {@code true} if results are available, {@code false} otherwise. */
-    private boolean resultsAvailable;
+    // === Attributes of response without result set ===
+
+    private long updateCnt = -1;
+
 
     /**
      * Constructor.
      */
-    public JdbcQuerySingleResult() {
-        resultsAvailable = false;
-    }
+    public JdbcQuerySingleResult() { }
 
     /**
      * Constructor.
@@ -69,23 +73,27 @@ public class JdbcQuerySingleResult extends Response {
      */
     public JdbcQuerySingleResult(int status, String err) {
         super(status, err);
-
-        resultsAvailable = false;
     }
 
     /**
      * Constructor.
      *
-     * @param cursorId Cursor ID.
+     * @param cursorId Id of the cursor in case it was registered on server.
      * @param rowTuples Serialized SQL result rows.
      * @param columnTypes Ordered list of types of columns in serialized rows.
      * @param decimalScales Decimal scales in appearance order.
-     * @param last     Flag indicates the query has no unfetched results.
+     * @param hasMoreData Flag indicates the query has un-fetched results.
+     * @param hasNextResult Flag indicates that current result is part of multi-statement query, there is at least one more result.
      */
-    public JdbcQuerySingleResult(long cursorId, List<BinaryTupleReader> rowTuples, List<ColumnType> columnTypes, int[] decimalScales,
-            boolean last) {
-        super();
-
+    @SuppressWarnings("NullableProblems")
+    public JdbcQuerySingleResult(
+            @Nullable Long cursorId,
+            List<BinaryTupleReader> rowTuples,
+            List<ColumnType> columnTypes,
+            int[] decimalScales,
+            boolean hasMoreData,
+            boolean hasNextResult
+    ) {
         Objects.requireNonNull(rowTuples);
 
         this.cursorId = cursorId;
@@ -93,11 +101,10 @@ public class JdbcQuerySingleResult extends Response {
         this.columnTypes = columnTypes;
         this.decimalScales = decimalScales;
 
-        this.last = last;
-        this.isQuery = true;
+        this.hasMoreData = hasMoreData;
+        this.hasNextResult = hasNextResult;
 
-        hasResults = true;
-        resultsAvailable = true;
+        hasResultSet = true;
 
         assert decimalScales != null;
     }
@@ -105,16 +112,14 @@ public class JdbcQuerySingleResult extends Response {
     /**
      * Constructor.
      *
+     * @param cursorId Id of the cursor in case it was registered on server.
      * @param updateCnt Update count for DML queries.
+     * @param hasNextResult Flag indicates that current result is part of multi-statement query, there is at least one more result.
      */
-    public JdbcQuerySingleResult(long cursorId, long updateCnt) {
-        super();
-
+    public JdbcQuerySingleResult(@Nullable Long cursorId, long updateCnt, boolean hasNextResult) {
         this.updateCnt = updateCnt;
         this.cursorId = cursorId;
-
-        hasResults = false;
-        resultsAvailable = true;
+        this.hasNextResult = hasNextResult;
     }
 
     /**
@@ -122,7 +127,7 @@ public class JdbcQuerySingleResult extends Response {
      *
      * @return Cursor ID.
      */
-    public Long cursorId() {
+    public @Nullable Long cursorId() {
         return cursorId;
     }
 
@@ -131,7 +136,7 @@ public class JdbcQuerySingleResult extends Response {
      *
      * @return Serialized query result rows.
      */
-    public List<BinaryTupleReader> items() {
+    public @Nullable List<BinaryTupleReader> items() {
         return rowTuples;
     }
 
@@ -140,7 +145,7 @@ public class JdbcQuerySingleResult extends Response {
      *
      * @return Ordered list of types of columns in serialized rows.
      */
-    public List<ColumnType> columnTypes() {
+    public @Nullable List<ColumnType> columnTypes() {
         return columnTypes;
     }
 
@@ -149,33 +154,24 @@ public class JdbcQuerySingleResult extends Response {
      *
      * @return Decimal scales in appearance order in columns. Can be empty in case no any decimal columns.
      */
-    public int[] decimalScales() {
+    public int @Nullable [] decimalScales() {
         return decimalScales;
     }
 
-    /**
-     * Get the last flag.
-     *
-     * @return Flag indicating the query has no unfetched results.
-     */
-    public boolean last() {
-        return last;
+    /** Returns {@code true} if there is more data available in current result set. */
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    public boolean hasMoreData() {
+        return hasMoreData;
     }
 
-    /**
-     * Get the isQuery flag.
-     *
-     * @return Flag indicating the query is SELECT query. {@code false} for DML/DDL queries.
-     */
-    public boolean isQuery() {
-        return isQuery;
+    /** Returns {@code true} if result contains rows. */
+    public boolean hasResultSet() {
+        return hasResultSet;
     }
 
-    /** Results availability flag.
-     * If no more results available, returns {@code false}
-     */
-    public boolean resultAvailable() {
-        return resultsAvailable;
+    /** Returns {@code true} if result is part of multi-statement query and there is at least one more result. */
+    public boolean hasNextResult() {
+        return hasNextResult;
     }
 
     /**
@@ -192,29 +188,30 @@ public class JdbcQuerySingleResult extends Response {
     public void writeBinary(ClientMessagePacker packer) {
         super.writeBinary(packer);
 
-        packer.packBoolean(resultsAvailable);
-        if (resultsAvailable) {
-            packer.packLong(updateCnt);
-
-            if (cursorId != null) {
-                packer.packLong(cursorId);
-            } else {
-                packer.packNil();
-            }
-        }
-
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 
-        packer.packBoolean(isQuery);
-        packer.packBoolean(last);
+        packer.packLongNullable(cursorId);
+        packer.packBoolean(hasResultSet);
+        packer.packBoolean(hasNextResult);
 
+        if (!hasResultSet) {
+            packer.packLong(updateCnt);
+
+            return;
+        }
+
+        assert decimalScales != null;
+        assert columnTypes != null;
+        assert rowTuples != null;
+
+        packer.packBoolean(hasMoreData);
         packer.packIntArray(decimalScales);
 
         packer.packInt(this.columnTypes.size());
-        for (int i = 0; i < this.columnTypes.size(); i++) {
-            packer.packInt(this.columnTypes.get(i).id());
+        for (ColumnType columnType : this.columnTypes) {
+            packer.packInt(columnType.id());
         }
 
         packer.packInt(rowTuples.size());
@@ -228,24 +225,27 @@ public class JdbcQuerySingleResult extends Response {
     @Override
     public void readBinary(ClientMessageUnpacker unpacker) {
         super.readBinary(unpacker);
-        resultsAvailable = unpacker.unpackBoolean();
-        if (resultsAvailable) {
-            updateCnt = unpacker.unpackLong();
 
-            if (unpacker.tryUnpackNil()) {
-                cursorId = null;
-            } else {
-                cursorId = unpacker.unpackLong();
-            }
-        }
-
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 
-        isQuery = unpacker.unpackBoolean();
-        last = unpacker.unpackBoolean();
+        if (unpacker.tryUnpackNil()) {
+            cursorId = null;
+        } else {
+            cursorId = unpacker.unpackLong();
+        }
 
+        hasResultSet = unpacker.unpackBoolean();
+        hasNextResult = unpacker.unpackBoolean();
+
+        if (!hasResultSet) {
+            updateCnt = unpacker.unpackLong();
+
+            return;
+        }
+
+        hasMoreData = unpacker.unpackBoolean();
         decimalScales = unpacker.unpackIntArray();
 
         int count = unpacker.unpackInt();

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcTableMeta.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcTableMeta.java
@@ -52,8 +52,6 @@ public class JdbcTableMeta extends Response {
         this.schemaName = schemaName;
         this.tblName = tblName;
         this.tblType = tblType;
-
-        this.hasResults = true;
     }
 
     /**
@@ -88,7 +86,7 @@ public class JdbcTableMeta extends Response {
     public void writeBinary(ClientMessagePacker packer) {
         super.writeBinary(packer);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 
@@ -102,7 +100,7 @@ public class JdbcTableMeta extends Response {
     public void readBinary(ClientMessageUnpacker unpacker) {
         super.readBinary(unpacker);
 
-        if (!hasResults) {
+        if (!success()) {
             return;
         }
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/Response.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/Response.java
@@ -65,7 +65,6 @@ public abstract class Response implements ClientMessage {
     /** {@inheritDoc} */
     @Override
     public void writeBinary(ClientMessagePacker packer) {
-        packer.packBoolean(hasResults);
         packer.packInt(status);
 
         if (StringUtil.isNullOrEmpty(err)) {
@@ -78,7 +77,6 @@ public abstract class Response implements ClientMessage {
     /** {@inheritDoc} */
     @Override
     public void readBinary(ClientMessageUnpacker unpacker) {
-        hasResults = unpacker.unpackBoolean();
         status = unpacker.unpackInt();
 
         if (!unpacker.tryUnpackNil()) {
@@ -127,8 +125,8 @@ public abstract class Response implements ClientMessage {
      *
      * @return Has results.
      */
-    public boolean hasResults() {
-        return hasResults;
+    public boolean success() {
+        return status == STATUS_SUCCESS;
     }
 
     /** {@inheritDoc} */

--- a/modules/client-handler/src/test/java/org/apache/ignite/client/handler/JdbcQueryEventHandlerImplTest.java
+++ b/modules/client-handler/src/test/java/org/apache/ignite/client/handler/JdbcQueryEventHandlerImplTest.java
@@ -107,7 +107,7 @@ class JdbcQueryEventHandlerImplTest extends BaseIgniteAbstractTest {
 
         assertThat(result, notNullValue());
         assertThat(result.status(), is(STATUS_FAILED));
-        assertThat(result.hasResults(), is(false));
+        assertThat(result.success(), is(false));
         assertThat(result.err(), containsString("Unable to connect"));
     }
 
@@ -137,7 +137,7 @@ class JdbcQueryEventHandlerImplTest extends BaseIgniteAbstractTest {
         JdbcBatchExecuteResult res = fut.get();
 
         assertThat(res.status(), is(STATUS_FAILED));
-        assertThat(res.hasResults(), is(false));
+        assertThat(res.success(), is(false));
         assertThat(res.err(), containsString("Connection is closed"));
     }
 
@@ -204,7 +204,7 @@ class JdbcQueryEventHandlerImplTest extends BaseIgniteAbstractTest {
 
         assertThat(result, notNullValue());
         assertThat(result.status(), is(STATUS_SUCCESS));
-        assertThat(result.hasResults(), is(true));
+        assertThat(result.success(), is(true));
 
         return result.connectionId();
     }

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcConnection.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcConnection.java
@@ -156,7 +156,7 @@ public class JdbcConnection implements Connection {
         try {
             JdbcConnectResult result = handler.connect(connProps.getConnectionTimeZone()).get();
 
-            if (!result.hasResults()) {
+            if (!result.success()) {
                 throw IgniteQueryErrorCode.createJdbcSqlException(result.err(), result.status());
             }
 

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcDatabaseMetadata.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcDatabaseMetadata.java
@@ -869,7 +869,7 @@ public class JdbcDatabaseMetadata implements DatabaseMetaData {
             JdbcMetaTablesResult res
                     = conn.handler().tablesMetaAsync(new JdbcMetaTablesRequest(schemaPtrn, tblNamePtrn, tblTypes)).get();
 
-            if (!res.hasResults()) {
+            if (!res.success()) {
                 throw IgniteQueryErrorCode.createJdbcSqlException(res.err(), res.status());
             }
 
@@ -912,7 +912,7 @@ public class JdbcDatabaseMetadata implements DatabaseMetaData {
         try {
             JdbcMetaSchemasResult res = conn.handler().schemasMetaAsync(new JdbcMetaSchemasRequest(schemaPtrn)).get();
 
-            if (!res.hasResults()) {
+            if (!res.success()) {
                 throw IgniteQueryErrorCode.createJdbcSqlException(res.err(), res.status());
             }
 
@@ -994,7 +994,7 @@ public class JdbcDatabaseMetadata implements DatabaseMetaData {
             JdbcMetaColumnsResult res = conn.handler().columnsMetaAsync(new JdbcMetaColumnsRequest(schemaPtrn, tblNamePtrn, colNamePtrn))
                     .get();
 
-            if (!res.hasResults()) {
+            if (!res.success()) {
                 throw IgniteQueryErrorCode.createJdbcSqlException(res.err(), res.status());
             }
 
@@ -1096,7 +1096,7 @@ public class JdbcDatabaseMetadata implements DatabaseMetaData {
         try {
             JdbcMetaPrimaryKeysResult res = conn.handler().primaryKeysMetaAsync(new JdbcMetaPrimaryKeysRequest(schema, tbl)).get();
 
-            if (!res.hasResults()) {
+            if (!res.success()) {
                 throw IgniteQueryErrorCode.createJdbcSqlException(res.err(), res.status());
             }
 

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcPreparedStatement.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcPreparedStatement.java
@@ -148,7 +148,7 @@ public class JdbcPreparedStatement extends JdbcStatement implements PreparedStat
         try {
             JdbcBatchExecuteResult res = conn.handler().batchPrepStatementAsync(conn.connectionId(), req).get();
 
-            if (!res.hasResults()) {
+            if (!res.success()) {
                 throw new BatchUpdateException(res.err(),
                         IgniteQueryErrorCode.codeToSqlState(res.getErrorCode()),
                         res.getErrorCode(),

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcQueryExecuteResponse.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcQueryExecuteResponse.java
@@ -71,12 +71,8 @@ public class JdbcQueryExecuteResponse extends Response {
 
     /** {@inheritDoc} */
     @Override
-    public boolean hasResults() {
-        return result.hasResults();
-    }
-
-    boolean hasResult() {
-        return result.resultAvailable();
+    public boolean success() {
+        return result.success();
     }
 
     /**

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcResultSet.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcResultSet.java
@@ -2143,6 +2143,8 @@ public class JdbcResultSet implements ResultSet {
         ensureHasCurrentRow();
 
         try {
+            assert curRow != null;
+
             Object val = curRow.get(colIdx - 1);
 
             wasNull = val == null;

--- a/modules/platforms/cpp/ignite/odbc/meta/table_meta.cpp
+++ b/modules/platforms/cpp/ignite/odbc/meta/table_meta.cpp
@@ -20,9 +20,6 @@
 namespace ignite {
 
 void table_meta::read(protocol::reader &reader) {
-    auto has_data = reader.read_bool();
-    assert(has_data);
-
     auto status = reader.read_int32();
     assert(status == 0);
 

--- a/modules/platforms/cpp/ignite/odbc/query/column_metadata_query.cpp
+++ b/modules/platforms/cpp/ignite/odbc/query/column_metadata_query.cpp
@@ -78,9 +78,6 @@ std::vector<odbc_column_meta> read_column_meta(protocol::reader &reader) {
     columns.reserve(size);
 
     for (std::int32_t column_idx = 0; column_idx < size; ++column_idx) {
-        auto has_data = reader.read_bool();
-        assert(has_data);
-
         auto status = reader.read_int32();
         assert(status == 0);
 
@@ -290,16 +287,13 @@ sql_result column_metadata_query::make_request_get_columns_meta() {
             });
 
         protocol::reader reader{response.get_bytes_view()};
-        m_has_result_set = reader.read_bool();
 
         auto status = reader.read_int32();
         auto err_msg = reader.read_string_nullable();
         if (err_msg)
             throw odbc_error(response_status_to_sql_state(status), *err_msg);
 
-        if (m_has_result_set) {
-            m_meta = read_column_meta(reader);
-        }
+        m_meta = read_column_meta(reader);
 
         m_executed = true;
     });

--- a/modules/platforms/cpp/ignite/odbc/query/primary_keys_query.cpp
+++ b/modules/platforms/cpp/ignite/odbc/query/primary_keys_query.cpp
@@ -130,15 +130,13 @@ sql_result primary_keys_query::make_request_get_primary_keys() {
             });
 
         protocol::reader reader{response.get_bytes_view()};
-        bool has_result_set = reader.read_bool();
 
         auto status = reader.read_int32();
         auto err_msg = reader.read_string_nullable();
         if (err_msg)
             throw odbc_error(response_status_to_sql_state(status), *err_msg);
 
-        if (has_result_set)
-            m_meta = read_key_meta(reader);
+        m_meta = read_key_meta(reader);
 
         m_executed = true;
     });

--- a/modules/platforms/cpp/ignite/odbc/query/table_metadata_query.cpp
+++ b/modules/platforms/cpp/ignite/odbc/query/table_metadata_query.cpp
@@ -192,16 +192,13 @@ sql_result table_metadata_query::make_request_get_tables_meta() {
             });
 
         protocol::reader reader{response.get_bytes_view()};
-        m_has_result_set = reader.read_bool();
-
+        
         auto status = reader.read_int32();
         auto err_msg = reader.read_string_nullable();
         if (err_msg)
             throw odbc_error(response_status_to_sql_state(status), *err_msg);
 
-        if (m_has_result_set) {
-            m_meta = read_table_meta_vector(reader);
-        }
+        m_meta = read_table_meta_vector(reader);
 
         m_executed = true;
     });


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22413

This patch addresses an issue when 2 additional *unnecessary* roundtrips were issued in JDBC driver on every consequent invocation of method `execute` on (Prepared-)Statement.

Below are results of benchmark runs on my laptop (MBP M3, 5 performance and 6 efficiency cores, 36GB):

```
Results before

Benchmark                   (clusterSize)  Mode  Cnt    Score   Error  Units
SelectBenchmark.jdbcGet                 1  avgt   20  145.237 ± 1.838  us/op
SelectBenchmark.sqlThinGet              1  avgt   20   60.506 ± 0.375  us/op


Results after 

Benchmark                   (clusterSize)  Mode  Cnt   Score   Error  Units
SelectBenchmark.jdbcGet                 1  avgt   20  84.314 ± 0.288  us/op
SelectBenchmark.sqlThinGet              1  avgt   20  60.785 ± 0.360  us/op
```

---------------------

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)