### PR TITLE
IGNITE-21974: Extend test coverage for SQL F221(Explicit defaults)

### DIFF
--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
@@ -175,7 +175,7 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
 
         values.add(values.get(0)); // add conflict entry from the first chunk
 
-        sql("CREATE TABLE test (id int primary key, val int default 1)");
+        sql("CREATE TABLE test (id int primary key, val int ult 1)");
 
         String insertStatement = "INSERT INTO test (id) VALUES " + values.stream()
                 .map(Object::toString)
@@ -603,9 +603,11 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
 
         var expectedMessage = "Column 'KEY' does not allow NULLs";
 
-        assertThrowsSqlException(Sql.CONSTRAINT_VIOLATION_ERR, expectedMessage, () -> sql("INSERT INTO tbl (key, val) VALUES (NULL,'AA')"));
+        assertThrowsSqlException(Sql.CONSTRAINT_VIOLATION_ERR,
+                expectedMessage,
+                () -> sql("INSERT INTO tbl (key, val) VALUES (NULL,'AA')"));
     }
-    
+
     // UPDATE set x = DEFAULT is not supported in parser
     @Disabled("https://issues.apache.org/jira/browse/IGNITE-21462")
     @Test
@@ -615,7 +617,7 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
             try {
                 sql(format("CREATE TABLE test (id INT PRIMARY KEY, val %s DEFAULT %s)", arg.sqlType, arg.sqlVal));
                 sql("INSERT INTO test (id, val) VALUES (1, NULL)");
-                
+
                 sql("UPDATE test SET val = DEFAULT WHERE id = 1");
                 assertQuery("SELECT val FROM test WHERE id = 1").returns(arg.expectedVal).check();
             } finally {

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
@@ -636,7 +636,7 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
                 sql("ALTER TABLE test ALTER COLUMN val DROP DEFAULT");
 
                 if (arg.sqlType.endsWith("NOT NULL")) {
-                    assertThrowsSqlException(Sql.STMT_VALIDATION_ERR, "Column 'VAL' does not allow NULL",
+                    assertThrowsSqlException(Sql.CONSTRAINT_VIOLATION_ERR, "Column 'VAL' does not allow NULL",
                             () -> sql("INSERT INTO test (id) VALUES (2)"));
                 } else {
                     sql("INSERT INTO test (id) VALUES (2)");

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
@@ -32,6 +32,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -486,7 +487,7 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
                 .returns(3)
                 .check();
 
-        var pkVals = sql("select \"__p_key\" from t").stream().map(row -> row.get(0)).collect(Collectors.toSet());
+        Set<?> pkVals = sql("select \"__p_key\" from t").stream().map(row -> row.get(0)).collect(Collectors.toSet());
 
         assertEquals(3, pkVals.size());
     }
@@ -571,7 +572,7 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
             sql(createStatement);
             sql("INSERT INTO test (id) VALUES (0)");
 
-            var expectedVals = args.stream()
+            List<Object> expectedVals = args.stream()
                     .map(a -> a.expectedVal)
                     .collect(Collectors.toList());
 
@@ -581,7 +582,7 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
                 columnEnumerationBuilder.append(", col_").append(i);
             }
 
-            var columnEnumeration = columnEnumerationBuilder.toString();
+            String columnEnumeration = columnEnumerationBuilder.toString();
 
             checkQueryResult("SELECT " + columnEnumeration + " FROM test", expectedVals);
 
@@ -626,7 +627,7 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
     @Test
     public void testDropDefault() {
         // SQL Standard 2016 feature F221 - Explicit defaults
-        for (var arg : defaultValueArgs().collect(Collectors.toList())) {
+        for (DefaultValueArg arg : defaultValueArgs().collect(Collectors.toList())) {
             try {
                 sql(format("CREATE TABLE test (id INT PRIMARY KEY, val {} DEFAULT {})", arg.sqlType, arg.sqlVal));
                 sql("INSERT INTO test (id) VALUES (1)");

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
@@ -175,7 +175,7 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
 
         values.add(values.get(0)); // add conflict entry from the first chunk
 
-        sql("CREATE TABLE test (id int primary key, val int ult 1)");
+        sql("CREATE TABLE test (id int primary key, val int default 1)");
 
         String insertStatement = "INSERT INTO test (id) VALUES " + values.stream()
                 .map(Object::toString)
@@ -603,7 +603,8 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
 
         var expectedMessage = "Column 'KEY' does not allow NULLs";
 
-        assertThrowsSqlException(Sql.CONSTRAINT_VIOLATION_ERR,
+        assertThrowsSqlException(
+                Sql.CONSTRAINT_VIOLATION_ERR,
                 expectedMessage,
                 () -> sql("INSERT INTO tbl (key, val) VALUES (NULL,'AA')"));
     }

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItDmlTest.java
@@ -492,9 +492,8 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
     }
 
     private static Stream<DefaultValueArg> defaultValueArgs() {
-        return Stream.of(
+        Stream<DefaultValueArg> vals = Stream.of(
                 new DefaultValueArg("BOOLEAN", "TRUE", Boolean.TRUE),
-                new DefaultValueArg("BOOLEAN NOT NULL", "TRUE", Boolean.TRUE),
 
                 new DefaultValueArg("BIGINT", "10", 10L),
                 new DefaultValueArg("INTEGER", "10", 10),
@@ -504,7 +503,6 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
                 new DefaultValueArg("FLOAT", "10.01", 10.01f),
                 new DefaultValueArg("DECIMAL(4, 2)", "10.01", new BigDecimal("10.01")),
                 new DefaultValueArg("VARCHAR", "'10'", "10"),
-                new DefaultValueArg("VARCHAR NOT NULL", "'10'", "10"),
                 new DefaultValueArg("VARCHAR(2)", "'10'", "10"),
 
                 // TODO: IGNITE-17373
@@ -523,11 +521,12 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
                 new DefaultValueArg("BINARY(3)", "x'010203'", new byte[]{1, 2, 3}),
                 new DefaultValueArg("VARBINARY", "x'010203'", new byte[]{1, 2, 3})
         );
+        return vals.flatMap(arg -> Stream.of(arg, new DefaultValueArg(arg.sqlType + " NOT NULL", arg.sqlVal, arg.expectedVal)));
     }
 
     @Test
     public void testInsertDefaultValue() {
-        // F221: Explicit defaults
+        // SQL Standard 2016 feature F221 - Explicit defaults
         checkDefaultValue(defaultValueArgs().collect(Collectors.toList()));
 
         checkWrongDefault("VARCHAR(1)", "10");
@@ -548,7 +547,7 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
 
     @Test
     public void testInsertDefaultNullValue() {
-        // F221: Explicit defaults
+        // SQL Standard 2016 feature F221 - Explicit defaults
         checkDefaultValue(defaultValueArgs()
                 .filter(a -> !a.sqlType.endsWith("NOT NULL"))
                 .map(a -> new DefaultValueArg(a.sqlType, "NULL", null))
@@ -598,7 +597,7 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
 
     @Test
     public void testCheckNullValueErrorMessageForColumnWithDefaultValue() {
-        // F221: Explicit defaults
+        // SQL Standard 2016 feature F221 - Explicit defaults
         sql("CREATE TABLE tbl(key int DEFAULT 9 primary key, val varchar)");
 
         var expectedMessage = "Column 'KEY' does not allow NULLs";
@@ -610,8 +609,8 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
     @Disabled("https://issues.apache.org/jira/browse/IGNITE-21462")
     @Test
     public void testUpdateAllowsDefault() {
-        // F221: Explicit defaults
-        for (var arg : defaultValueArgs().collect(Collectors.toList())) {
+        // SQL Standard 2016 feature F221 - Explicit defaults
+        for (DefaultValueArg arg : defaultValueArgs().collect(Collectors.toList())) {
             try {
                 sql(format("CREATE TABLE test (id INT PRIMARY KEY, val %s DEFAULT %s)", arg.sqlType, arg.sqlVal));
                 sql("INSERT INTO test (id, val) VALUES (1, NULL)");
@@ -626,7 +625,7 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
 
     @Test
     public void testDropDefault() {
-        // F221: Explicit defaults
+        // SQL Standard 2016 feature F221 - Explicit defaults
         for (var arg : defaultValueArgs().collect(Collectors.toList())) {
             try {
                 sql(format("CREATE TABLE test (id INT PRIMARY KEY, val {} DEFAULT {})", arg.sqlType, arg.sqlVal));
@@ -683,7 +682,7 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
 
     @Test
     public void testInsertMultipleDefaults() {
-        // F221: Explicit defaults
+        // SQL Standard 2016 feature F221 - Explicit defaults
         sql("CREATE TABLE integers(i INTEGER PRIMARY KEY, col1 INTEGER DEFAULT 200, col2 INTEGER DEFAULT 300)");
 
         sql("INSERT INTO integers (i) VALUES (0)");
@@ -712,7 +711,7 @@ public class ItDmlTest extends BaseSqlIntegrationTest {
     @Test
     @WithSystemProperty(key = "IMPLICIT_PK_ENABLED", value = "true")
     public void testInsertMultipleDefaultsWithImplicitPk() {
-        // F221: Explicit defaults
+        // SQL Standard 2016 feature F221 - Explicit defaults
         sql("CREATE TABLE integers(i INTEGER, j INTEGER DEFAULT 100)");
 
         sql("INSERT INTO integers VALUES (1, DEFAULT)");


### PR DESCRIPTION
Adds java tests for DROP default.

https://issues.apache.org/jira/browse/IGNITE-21974

--- 
Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)