### PR TITLE
IGNITE-22451: Sql. An insert may cause specific later updates to fail. Affects only char/varchar

### DIFF
--- a/modules/sql-engine/src/integrationTest/sql/types/char/test_implicit_cast.test
+++ b/modules/sql-engine/src/integrationTest/sql/types/char/test_implicit_cast.test
@@ -129,8 +129,5 @@ INSERT INTO tmp (c5) VALUES('a'::CHAR(5));
 statement ok
 INSERT INTO tmp (c5) VALUES('a'::CHAR(3));
 
-# https://issues.apache.org/jira/browse/IGNITE-22451 
-# Error: Row has not been fully built. Index: 2, fields: 3
-skipif ignite3
 statement ok
 UPDATE tmp SET c5=c5::CHAR(6)

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/TypeUtilsTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/TypeUtilsTest.java
@@ -129,7 +129,7 @@ public class TypeUtilsTest extends BaseIgniteAbstractTest {
                     .build();
 
             Object[] input = {"12345    ", null};
-            Object[] expected = {"12345", null};
+            Object[] expected = {"12345 ", null};
 
             expectOutputRow(rowType, input, expected);
         }
@@ -192,7 +192,11 @@ public class TypeUtilsTest extends BaseIgniteAbstractTest {
 
             Object[] input = {"123", "12345 6"};
 
-            assertThrowsSqlException(Sql.STMT_VALIDATION_ERR, "", () -> buildTrimmedRow(rowType, input));
+            assertThrowsSqlException(
+                    Sql.STMT_VALIDATION_ERR, 
+                    "Value too long for type: VARCHAR(6)", 
+                    () -> buildTrimmedRow(rowType, input)
+            );
         }
     }
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/TypeUtilsTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/TypeUtilsTest.java
@@ -112,12 +112,24 @@ public class TypeUtilsTest extends BaseIgniteAbstractTest {
 
         {
             RelDataType rowType = typeFactory.builder()
-                    .add("c2", typeFactory.createSqlType(SqlTypeName.INTEGER))
                     .add("c1", typeFactory.createSqlType(SqlTypeName.VARCHAR, 6))
+                    .add("c2", typeFactory.createSqlType(SqlTypeName.VARCHAR, 5))
                     .build();
 
             Object[] input = {null, "12345    "};
             Object[] expected = {null, "12345 "};
+
+            expectOutputRow(rowType, input, expected);
+        }
+
+        {
+            RelDataType rowType = typeFactory.builder()
+                    .add("c1", typeFactory.createSqlType(SqlTypeName.VARCHAR, 6))
+                    .add("c2", typeFactory.createSqlType(SqlTypeName.VARCHAR, 5))
+                    .build();
+
+            Object[] input = {"12345    ", null};
+            Object[] expected = {"12345 ", null};
 
             expectOutputRow(rowType, input, expected);
         }
@@ -137,12 +149,37 @@ public class TypeUtilsTest extends BaseIgniteAbstractTest {
         {
             RelDataType rowType = typeFactory.builder()
                     .add("c1", typeFactory.createSqlType(SqlTypeName.VARCHAR, 6))
+                    .add("c2", typeFactory.createSqlType(SqlTypeName.VARCHAR, 7))
+                    .add("c3", typeFactory.createSqlType(SqlTypeName.VARCHAR, 3))
+                    .build();
+
+            Object[] input = {"12345    ", null, "123 "};
+            Object[] expected = {"12345 ", null, "123"};
+
+            expectOutputRow(rowType, input, expected);
+        }
+
+        {
+            RelDataType rowType = typeFactory.builder()
+                    .add("c1", typeFactory.createSqlType(SqlTypeName.VARCHAR, 6))
                     .add("c2", typeFactory.createSqlType(SqlTypeName.INTEGER))
                     .add("c3", typeFactory.createSqlType(SqlTypeName.VARCHAR, 3))
                     .build();
 
             Object[] input = {"12345    ", null, "123 "};
             Object[] expected = {"12345 ", null, "123"};
+
+            expectOutputRow(rowType, input, expected);
+        }
+
+
+        {
+            RelDataType rowType = typeFactory.builder()
+                    .add("c1", typeFactory.createSqlType(SqlTypeName.INTEGER))
+                    .build();
+
+            Object[] input = {2};
+            Object[] expected = {2};
 
             expectOutputRow(rowType, input, expected);
         }

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/TypeUtilsTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/TypeUtilsTest.java
@@ -117,7 +117,7 @@ public class TypeUtilsTest extends BaseIgniteAbstractTest {
                     .build();
 
             Object[] input = {null, "12345    "};
-            Object[] expected = {null, "12345 "};
+            Object[] expected = {null, "12345"};
 
             expectOutputRow(rowType, input, expected);
         }
@@ -129,7 +129,7 @@ public class TypeUtilsTest extends BaseIgniteAbstractTest {
                     .build();
 
             Object[] input = {"12345    ", null};
-            Object[] expected = {"12345 ", null};
+            Object[] expected = {"12345", null};
 
             expectOutputRow(rowType, input, expected);
         }


### PR DESCRIPTION
Fixes a bug in `TypeUtils` that incorrectly skips `NULL` values.

https://issues.apache.org/jira/browse/IGNITE-22451

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)