### PR TITLE
IGNITE-22422 C++ Fix compute_test.all_arg_types flakiness

### DIFF
--- a/modules/platforms/cpp/tests/client-test/compute_test.cpp
+++ b/modules/platforms/cpp/tests/client-test/compute_test.cpp
@@ -241,7 +241,12 @@ TEST_F(compute_test, all_arg_types) {
 
     check_argument<float>(0.123456f);
     check_argument<float>(std::numeric_limits<float>::max(), "3.4028235E38");
-    check_argument<float>(std::numeric_limits<float>::min(), "1.17549435E-38");
+    try {
+        check_argument<float>(std::numeric_limits<float>::min(), "1.17549435E-38");
+    }
+    catch (ignite_error&) {
+        check_argument<float>(std::numeric_limits<float>::min(), "1.1754944E-38");
+    }
 
     check_argument<double>(0.987654);
     check_argument<double>(std::numeric_limits<double>::max(), "1.7976931348623157E308");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22422

It looks like on newer JDK versions string representation of the floats varies a little. Check both variants.