### PR TITLE
IGNITE-22540 .NET: Add ReceiverDescriptor to Data Streamer

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/PartitionAwarenessTests.cs
@@ -128,8 +128,7 @@ public class PartitionAwarenessTests
                 new[] { 1 }.ToAsyncEnumerable(),
                 keySelector: x => x,
                 payloadSelector: x => x.ToString(),
-                units: Array.Empty<DeploymentUnit>(),
-                receiverClassName: "x"),
+                new("x")),
             ClientOp.StreamerWithReceiverBatchSend);
 
     [Test]
@@ -144,7 +143,7 @@ public class PartitionAwarenessTests
         var options = new DataStreamerOptions { PageSize = 1 };
         var data = producer.Reader.ReadAllAsync();
         var streamerTask = withReceiver
-            ? recordView.StreamDataAsync(data, x => x, x => x.ToString(), Array.Empty<DeploymentUnit>(), "x", null, options)
+            ? recordView.StreamDataAsync(data, x => x, x => x.ToString(), new("x"), null, options)
             : recordView.StreamDataAsync(data, options);
 
         Func<ITransaction?, Task> action = async _ =>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/DataStreamerTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/DataStreamerTests.cs
@@ -314,7 +314,7 @@ public class DataStreamerTests : IgniteTestsBase
 
         if (withReceiver)
         {
-            await table!.RecordBinaryView.StreamDataAsync<IIgniteTuple, string>(
+            await table!.RecordBinaryView.StreamDataAsync(
                 GetFakeServerData(count),
                 keySelector: t => t,
                 payloadSelector: t => t[0]!.ToString()!,
@@ -375,7 +375,7 @@ public class DataStreamerTests : IgniteTestsBase
     [Test]
     public async Task TestWithReceiverRecordBinaryView()
     {
-        await TupleView.StreamDataAsync<int, string>(
+        await TupleView.StreamDataAsync(
             Enumerable.Range(0, Count).ToAsyncEnumerable(),
             keySelector: x => GetTuple(x),
             payloadSelector: x => $"{x}-value{x * 10}",
@@ -423,7 +423,7 @@ public class DataStreamerTests : IgniteTestsBase
     [Test]
     public async Task TestWithReceiverRecordView()
     {
-        await PocoView.StreamDataAsync<int, string>(
+        await PocoView.StreamDataAsync(
             Enumerable.Range(0, Count).ToAsyncEnumerable(),
             keySelector: x => GetPoco(x),
             payloadSelector: x => $"{x}-value{x * 10}",
@@ -471,7 +471,7 @@ public class DataStreamerTests : IgniteTestsBase
     [Test]
     public async Task TestWithReceiverKeyValueBinaryView()
     {
-        await Table.KeyValueBinaryView.StreamDataAsync<int, string>(
+        await Table.KeyValueBinaryView.StreamDataAsync(
             Enumerable.Range(0, Count).ToAsyncEnumerable(),
             keySelector: x => new KeyValuePair<IIgniteTuple, IIgniteTuple>(GetTuple(x), new IgniteTuple()),
             payloadSelector: x => $"{x}-value{x * 10}",
@@ -517,7 +517,7 @@ public class DataStreamerTests : IgniteTestsBase
     [Test]
     public async Task TestWithReceiverKeyValueView()
     {
-        await Table.GetKeyValueView<long, Poco>().StreamDataAsync<int, string>(
+        await Table.GetKeyValueView<long, Poco>().StreamDataAsync(
             Enumerable.Range(0, Count).ToAsyncEnumerable(),
             keySelector: x => new KeyValuePair<long, Poco>(x, null!),
             payloadSelector: x => $"{x}-value{x * 10}",
@@ -536,7 +536,7 @@ public class DataStreamerTests : IgniteTestsBase
     [Test]
     public async Task TestWithReceiverResultsKeyValueView()
     {
-        IAsyncEnumerable<string> results = Table.GetKeyValueView<long, Poco>().StreamDataAsync<int, string, string>(
+        IAsyncEnumerable<string> results = Table.GetKeyValueView<long, Poco>().StreamDataAsync(
             Enumerable.Range(0, Count).ToAsyncEnumerable(),
             keySelector: x => new KeyValuePair<long, Poco>(x, null!),
             payloadSelector: x => $"{x}-value{x * 10}",

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
@@ -24,7 +24,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Apache.Ignite.Transactions;
 using Common;
-using Ignite.Compute;
 using Ignite.Sql;
 using Ignite.Table;
 using Linq;
@@ -188,8 +187,7 @@ internal sealed class KeyValueView<TK, TV> : IKeyValueView<TK, TV>
         IAsyncEnumerable<TSource> data,
         Func<TSource, KeyValuePair<TK, TV>> keySelector,
         Func<TSource, TPayload> payloadSelector,
-        IEnumerable<DeploymentUnit> units,
-        string receiverClassName,
+        ReceiverDescriptor receiver,
         ICollection<object>? receiverArgs,
         DataStreamerOptions? options,
         CancellationToken cancellationToken = default)
@@ -198,8 +196,7 @@ internal sealed class KeyValueView<TK, TV> : IKeyValueView<TK, TV>
             data,
             src => ToKv(keySelector(src)),
             payloadSelector,
-            units,
-            receiverClassName,
+            receiver,
             receiverArgs,
             options,
             cancellationToken);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/KeyValueView.cs
@@ -169,18 +169,16 @@ internal sealed class KeyValueView<TK, TV> : IKeyValueView<TK, TV>
         IAsyncEnumerable<TSource> data,
         Func<TSource, KeyValuePair<TK, TV>> keySelector,
         Func<TSource, TPayload> payloadSelector,
-        IEnumerable<DeploymentUnit> units,
-        string receiverClassName,
+        ReceiverDescriptor<TResult> receiver,
         ICollection<object>? receiverArgs,
         DataStreamerOptions? options,
         CancellationToken cancellationToken = default)
         where TPayload : notnull =>
-        _recordView.StreamDataAsync<TSource, TPayload, TResult>(
+        _recordView.StreamDataAsync(
             data,
             src => ToKv(keySelector(src)),
             payloadSelector,
-            units,
-            receiverClassName,
+            receiver,
             receiverArgs,
             options,
             cancellationToken);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -398,8 +398,7 @@ namespace Apache.Ignite.Internal.Table
             IAsyncEnumerable<TSource> data,
             Func<TSource, T> keySelector,
             Func<TSource, TPayload> payloadSelector,
-            IEnumerable<DeploymentUnit> units,
-            string receiverClassName,
+            ReceiverDescriptor receiver,
             ICollection<object>? receiverArgs,
             DataStreamerOptions? options,
             CancellationToken cancellationToken = default)
@@ -413,8 +412,8 @@ namespace Apache.Ignite.Internal.Table
                 keyWriter: _ser.Handler,
                 options ?? DataStreamerOptions.Default,
                 resultChannel: null,
-                units,
-                receiverClassName,
+                receiver.DeploymentUnits ?? Array.Empty<DeploymentUnit>(),
+                receiver.ReceiverClassName,
                 receiverArgs,
                 cancellationToken).ConfigureAwait(false);
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -312,8 +312,7 @@ namespace Apache.Ignite.Internal.Table
             IAsyncEnumerable<TSource> data,
             Func<TSource, T> keySelector,
             Func<TSource, TPayload> payloadSelector,
-            IEnumerable<DeploymentUnit> units,
-            string receiverClassName,
+            ReceiverDescriptor<TResult> receiver,
             ICollection<object>? receiverArgs,
             DataStreamerOptions? options,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -380,8 +379,8 @@ namespace Apache.Ignite.Internal.Table
                         keyWriter: _ser.Handler,
                         options,
                         resultChannel,
-                        units,
-                        receiverClassName,
+                        receiver.DeploymentUnits ?? Array.Empty<DeploymentUnit>(),
+                        receiver.ReceiverClassName,
                         receiverArgs,
                         cancellationToken).ConfigureAwait(false);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IDataStreamerTarget.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IDataStreamerTarget.cs
@@ -22,7 +22,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Compute;
 using Internal.Common;
 
 /// <summary>
@@ -103,8 +102,7 @@ public interface IDataStreamerTarget<T>
     /// <param name="data">Data.</param>
     /// <param name="keySelector">Key selector.</param>
     /// <param name="payloadSelector">Payload selector.</param>
-    /// <param name="units">Deployment units. Can be empty.</param>
-    /// <param name="receiverClassName">Java class name of the streamer receiver to execute on the server.</param>
+    /// <param name="receiver">Receiver descriptor.</param>
     /// <param name="receiverArgs">Receiver args.</param>
     /// <param name="options">Streamer options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -115,8 +113,7 @@ public interface IDataStreamerTarget<T>
         IAsyncEnumerable<TSource> data,
         Func<TSource, T> keySelector,
         Func<TSource, TPayload> payloadSelector,
-        IEnumerable<DeploymentUnit> units,
-        string receiverClassName,
+        ReceiverDescriptor receiver,
         ICollection<object>? receiverArgs = null,
         DataStreamerOptions? options = null,
         CancellationToken cancellationToken = default)

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IDataStreamerTarget.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IDataStreamerTarget.cs
@@ -74,8 +74,7 @@ public interface IDataStreamerTarget<T>
     /// <param name="data">Data.</param>
     /// <param name="keySelector">Key selector.</param>
     /// <param name="payloadSelector">Payload selector.</param>
-    /// <param name="units">Deployment units. Can be empty.</param>
-    /// <param name="receiverClassName">Java class name of the streamer receiver to execute on the server.</param>
+    /// <param name="receiver">Streamer receiver descriptor.</param>
     /// <param name="receiverArgs">Receiver args.</param>
     /// <param name="options">Streamer options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -92,8 +91,7 @@ public interface IDataStreamerTarget<T>
         IAsyncEnumerable<TSource> data,
         Func<TSource, T> keySelector,
         Func<TSource, TPayload> payloadSelector,
-        IEnumerable<DeploymentUnit> units,
-        string receiverClassName,
+        ReceiverDescriptor<TResult> receiver,
         ICollection<object>? receiverArgs = null,
         DataStreamerOptions? options = null,
         CancellationToken cancellationToken = default)

--- a/modules/platforms/dotnet/Apache.Ignite/Table/ReceiverDescriptor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/ReceiverDescriptor.cs
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Table;
+
+using System;
+using System.Collections.Generic;
+using Compute;
+
+/// <summary>
+/// Stream receiver descriptor.
+/// </summary>
+/// <param name="ReceiverClassName">Java class name of the streamer receiver to execute.</param>
+/// <param name="DeploymentUnits">Deployment units.</param>
+/// <typeparam name="TResult">Result type.</typeparam>
+public sealed record ReceiverDescriptor<TResult>(
+    string ReceiverClassName,
+    IEnumerable<DeploymentUnit>? DeploymentUnits = null)
+{
+    /// <summary>
+    /// Gets the result type.
+    /// </summary>
+    public Type ResultType => typeof(TResult);
+}

--- a/modules/platforms/dotnet/Apache.Ignite/Table/ReceiverDescriptor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/ReceiverDescriptor.cs
@@ -26,10 +26,12 @@ using Compute;
 /// </summary>
 /// <param name="ReceiverClassName">Java class name of the streamer receiver to execute.</param>
 /// <param name="DeploymentUnits">Deployment units.</param>
+/// <param name="IgnoreResults">Whether to ignore results returned by the receiver (don't send them back to the client).</param>
 /// <typeparam name="TResult">Result type.</typeparam>
 public sealed record ReceiverDescriptor<TResult>(
     string ReceiverClassName,
-    IEnumerable<DeploymentUnit>? DeploymentUnits = null)
+    IEnumerable<DeploymentUnit>? DeploymentUnits = null,
+    bool IgnoreResults = false)
 {
     /// <summary>
     /// Gets the result type.

--- a/modules/platforms/dotnet/Apache.Ignite/Table/ReceiverDescriptor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/ReceiverDescriptor.cs
@@ -22,16 +22,23 @@ using System.Collections.Generic;
 using Compute;
 
 /// <summary>
-/// Stream receiver descriptor.
+/// Stream receiver descriptor without results. If the specified receiver returns results, they will be discarded on the server.
 /// </summary>
 /// <param name="ReceiverClassName">Java class name of the streamer receiver to execute.</param>
 /// <param name="DeploymentUnits">Deployment units.</param>
-/// <param name="IgnoreResults">Whether to ignore results returned by the receiver (don't send them back to the client).</param>
+public sealed record ReceiverDescriptor(
+    string ReceiverClassName,
+    IEnumerable<DeploymentUnit>? DeploymentUnits = null);
+
+/// <summary>
+/// Stream receiver descriptor with result type.
+/// </summary>
+/// <param name="ReceiverClassName">Java class name of the streamer receiver to execute.</param>
+/// <param name="DeploymentUnits">Deployment units.</param>
 /// <typeparam name="TResult">Result type.</typeparam>
 public sealed record ReceiverDescriptor<TResult>(
     string ReceiverClassName,
-    IEnumerable<DeploymentUnit>? DeploymentUnits = null,
-    bool IgnoreResults = false)
+    IEnumerable<DeploymentUnit>? DeploymentUnits = null)
 {
     /// <summary>
     /// Gets the result type.


### PR DESCRIPTION
Similar to #3971, add `ReceiverDescriptor` to .NET.

* Non-generic class for receiver without results
* Generic class for receiver with results

This also removes the need for the user to specify generic arguments. Before: `view.StreamDataAsync<SourceClass, PayloadClass, ResultClass>(...)`, after `view.StreamDataAsync(...)` - type arguments are inferred by the compiler from the receiver class.