### PR TITLE
IGNITE-22185 DistributionZoneCausalityDataNodesTest.testEmptyDataNode…

### DIFF
--- a/modules/distribution-zones/src/test/java/org/apache/ignite/internal/distributionzones/causalitydatanodes/DistributionZoneCausalityDataNodesTest.java
+++ b/modules/distribution-zones/src/test/java/org/apache/ignite/internal/distributionzones/causalitydatanodes/DistributionZoneCausalityDataNodesTest.java
@@ -599,7 +599,6 @@ public class DistributionZoneCausalityDataNodesTest extends BaseDistributionZone
      */
     @ParameterizedTest
     @MethodSource("provideArgumentsOfDifferentTimersValue")
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-22185")
     void testEmptyDataNodesOnZoneCreationBeforeTopologyEventAndZoneInitialisation(int scaleUp, int scaleDown) {
         CountDownLatch latch = new CountDownLatch(1);
 


### PR DESCRIPTION
…sOnZoneCreationBeforeTopologyEventAndZoneInitialisation became flaky on the main

https://issues.apache.org/jira/browse/IGNITE-22185