### PR TITLE
IGNITE-22761 Disable WAL in RocksDB used to spill volatile Raft logs on disk

### DIFF
--- a/modules/raft/src/main/java/org/apache/ignite/raft/jraft/storage/impl/RocksDbSpillout.java
+++ b/modules/raft/src/main/java/org/apache/ignite/raft/jraft/storage/impl/RocksDbSpillout.java
@@ -144,6 +144,7 @@ public class RocksDbSpillout implements Logs {
         this.groupEndBound = new Slice(groupEndPrefix);
 
         this.writeOptions = new WriteOptions();
+        this.writeOptions.setDisableWAL(true);
         this.writeOptions.setSync(false);
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22761