### PR TITLE
IGNITE-22791 Fix marshaller spelling

### DIFF
--- a/docs/_docs/developers-guide/clients/cpp.adoc
+++ b/docs/_docs/developers-guide/clients/cpp.adoc
@@ -244,7 +244,7 @@ There are limitations to user types that can be used for such a mapping. Some li
 - Fields should be mapped to Ignite types;
 - All fields in user type should either be mapped to Table column or explicitly excluded;
 - All columns from Table should be mapped to some field in the user type;
-- *C++ only*: User has to provide marshaling functions explicitly as there is no reflection to generate them based on user type structure.
+- *C++ only*: User has to provide marshalling functions explicitly as there is no reflection to generate them based on user type structure.
 
 === Usage Examples
 

--- a/modules/table/src/test/java/org/apache/ignite/internal/benchmarks/UpdateCommandsMarshallingMicroBenchmark.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/benchmarks/UpdateCommandsMarshallingMicroBenchmark.java
@@ -62,7 +62,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-public class UpdateCommandsMarshalingMicroBenchmark {
+public class UpdateCommandsMarshallingMicroBenchmark {
     private static final PartitionReplicationMessagesFactory PARTITION_REPLICATION_MESSAGES_FACTORY =
             new PartitionReplicationMessagesFactory();
 
@@ -151,7 +151,7 @@ public class UpdateCommandsMarshalingMicroBenchmark {
     public static void main(String[] args) throws Exception {
         Options build = new OptionsBuilder()
                 // .addProfiler("gc")
-                .include(UpdateCommandsMarshalingMicroBenchmark.class.getName() + ".*").build();
+                .include(UpdateCommandsMarshallingMicroBenchmark.class.getName() + ".*").build();
 
         new Runner(build).run();
     }


### PR DESCRIPTION
`Marshaller` and `marshalling` should be spelled with 2 `l`s.

Most places were fixed in #4100.

https://issues.apache.org/jira/browse/IGNITE-22791