### PR TITLE
IGNITE-22751 .NET: Enable NuGet audit

### DIFF
--- a/modules/platforms/dotnet/Directory.Build.props
+++ b/modules/platforms/dotnet/Directory.Build.props
@@ -36,8 +36,8 @@
         <Description>.NET client for Apache Ignite. Ignite is a distributed database for high-performance computing with in-memory speed.</Description>
 
         <NuGetAudit>true</NuGetAudit>
-        <NuGetAuditMode>all</NuGetAuditMode>
-        <NuGetAuditLevel>low</NuGetAuditLevel>
+        <NuGetAuditMode>all</NuGetAuditMode> <!-- Direct and transitive dependencies -->
+        <NuGetAuditLevel>low</NuGetAuditLevel> <!-- Fail on low+ severity issues -->
     </PropertyGroup>
 
     <ItemGroup>

--- a/modules/platforms/dotnet/Directory.Build.props
+++ b/modules/platforms/dotnet/Directory.Build.props
@@ -34,6 +34,10 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <PackageTags>Apache;Ignite;In-Memory;Distributed;Computing;SQL;NoSQL;Database;</PackageTags>
         <Description>.NET client for Apache Ignite. Ignite is a distributed database for high-performance computing with in-memory speed.</Description>
+
+        <NuGetAudit>true</NuGetAudit>
+        <NuGetAuditMode>all</NuGetAuditMode>
+        <NuGetAuditLevel>low</NuGetAuditLevel>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Build will fail if a security vulnerability is detected in any package in the dependency graph (direct or transitive).