### PR TITLE
IGNITE-22642 Add internal heartbeat API to Java and .NET clients

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientChannel.java
@@ -76,9 +76,11 @@ public interface ClientChannel extends AutoCloseable {
     /**
      * Send heartbeat request.
      *
+     * @param payloadWriter Payload writer or {@code null} for no payload.
+     *     Heartbeat request payload is ignored by the server, but can be used for benchmarking.
      * @return Future for the operation.
      */
-    default CompletableFuture<Void> heartbeatAsync() {
-        return serviceAsync(ClientOp.HEARTBEAT, null, null, false);
+    default CompletableFuture<Void> heartbeatAsync(@Nullable PayloadWriter payloadWriter) {
+        return serviceAsync(ClientOp.HEARTBEAT, payloadWriter, null, false);
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientChannel.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.client;
 
 import java.util.concurrent.CompletableFuture;
+import org.apache.ignite.internal.client.proto.ClientOp;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -71,4 +72,13 @@ public interface ClientChannel extends AutoCloseable {
      * @return Protocol context.
      */
     ProtocolContext protocolContext();
+
+    /**
+     * Send heartbeat request.
+     *
+     * @return Future for the operation.
+     */
+    default CompletableFuture<Void> heartbeatAsync() {
+        return serviceAsync(ClientOp.HEARTBEAT, null, null, false);
+    }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -201,6 +201,29 @@ public final class ReliableChannel implements AutoCloseable {
     }
 
     /**
+     * Gets active client channels.
+     *
+     * @return List of connected channels.
+     */
+    public List<ClientChannel> channels() {
+        List<ClientChannel> res = new ArrayList<>(channels.size());
+
+        for (var holder : nodeChannelsByName.values()) {
+            var chFut = holder.chFut;
+
+            if (chFut != null) {
+                ClientChannel ch = ClientFutureUtils.getNowSafe(chFut);
+
+                if (ch != null && !ch.closed()) {
+                    res.add(ch);
+                }
+            }
+        }
+
+        return res;
+    }
+
+    /**
      * Sends request and handles response asynchronously.
      *
      * @param opCode        Operation code.

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpIgniteClient.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpIgniteClient.java
@@ -253,6 +253,15 @@ public class TcpIgniteClient implements IgniteClient {
     }
 
     /**
+     * Returns the underlying channel.
+     *
+     * @return Channel.
+     */
+    public ReliableChannel channel() {
+        return ch;
+    }
+
+    /**
      * Sends ClientMessage request to server side asynchronously and returns result future.
      *
      * @param opCode Operation code.

--- a/modules/client/src/test/java/org/apache/ignite/client/ObservableTimestampPropagationTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ObservableTimestampPropagationTest.java
@@ -29,10 +29,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.ignite.client.fakes.FakeIgnite;
 import org.apache.ignite.internal.TestHybridClock;
 import org.apache.ignite.internal.client.ReliableChannel;
+import org.apache.ignite.internal.client.TcpIgniteClient;
 import org.apache.ignite.internal.client.tx.ClientLazyTransaction;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
-import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.sql.Statement;
 import org.apache.ignite.sql.async.AsyncResultSet;
 import org.apache.ignite.tx.TransactionOptions;
@@ -71,7 +71,7 @@ public class ObservableTimestampPropagationTest extends BaseIgniteAbstractTest {
     @Test
     @SuppressWarnings("resource")
     public void testClientPropagatesLatestKnownHybridTimestamp() {
-        ReliableChannel ch = IgniteTestUtils.getFieldValue(client, "ch");
+        ReliableChannel ch = ((TcpIgniteClient) client).channel();
         TransactionOptions roOpts = new TransactionOptions().readOnly(true);
 
         // +2 because logical time is incremented on every call to nowLong - for replica tracker and for handshake.

--- a/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/PartitionAwarenessTest.java
@@ -42,6 +42,7 @@ import org.apache.ignite.compute.IgniteCompute;
 import org.apache.ignite.compute.JobDescriptor;
 import org.apache.ignite.compute.JobTarget;
 import org.apache.ignite.internal.client.ReliableChannel;
+import org.apache.ignite.internal.client.TcpIgniteClient;
 import org.apache.ignite.internal.client.tx.ClientLazyTransaction;
 import org.apache.ignite.internal.hlc.HybridClockImpl;
 import org.apache.ignite.internal.streamer.SimplePublisher;
@@ -179,7 +180,7 @@ public class PartitionAwarenessTest extends AbstractClientTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testClientReceivesPartitionAssignmentUpdates(boolean useHeartbeat) throws InterruptedException {
-        ReliableChannel ch = IgniteTestUtils.getFieldValue(client2, "ch");
+        ReliableChannel ch = ((TcpIgniteClient) client2).channel();
 
         // Check default assignment.
         RecordView<Tuple> recordView = defaultTable().recordView();

--- a/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
@@ -33,10 +33,10 @@ import org.apache.ignite.client.fakes.FakeIgniteTables;
 import org.apache.ignite.internal.client.ClientUtils;
 import org.apache.ignite.internal.client.IgniteClientConfigurationImpl;
 import org.apache.ignite.internal.client.RetryPolicyContextImpl;
+import org.apache.ignite.internal.client.TcpIgniteClient;
 import org.apache.ignite.internal.client.proto.ClientOp;
 import org.apache.ignite.internal.client.tx.ClientLazyTransaction;
 import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
-import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.lang.LoggerFactory;
 import org.apache.ignite.table.RecordView;
@@ -104,7 +104,7 @@ public class RetryPolicyTest extends BaseIgniteAbstractTest {
 
         try (var client = getClient(plc)) {
             Transaction tx = client.transactions().begin();
-            ClientLazyTransaction.ensureStarted(tx, IgniteTestUtils.getFieldValue(client, "ch"), null).join();
+            ClientLazyTransaction.ensureStarted(tx, ((TcpIgniteClient) client).channel(), null).join();
 
             assertThrows(IgniteClientConnectionException.class, tx::commit);
             assertEquals(0, plc.invocations.size());
@@ -167,7 +167,7 @@ public class RetryPolicyTest extends BaseIgniteAbstractTest {
         try (var client = getClient(plc)) {
             RecordView<Tuple> recView = client.tables().table("t").recordView();
             Transaction tx = client.transactions().begin();
-            ClientLazyTransaction.ensureStarted(tx, IgniteTestUtils.getFieldValue(client, "ch"), null).join();
+            ClientLazyTransaction.ensureStarted(tx, ((TcpIgniteClient) client).channel(), null).join();
 
             var ex = assertThrows(IgniteException.class, () -> recView.get(tx, Tuple.create().set("id", 1)));
             assertThat(ex.getMessage(), containsString("Transaction context has been lost due to connection errors."));

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteClientTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteClientTests.cs
@@ -19,6 +19,8 @@ namespace Apache.Ignite.Tests
 {
     using System.Linq;
     using System.Threading.Tasks;
+    using Internal;
+    using Internal.Buffers;
     using NUnit.Framework;
 
     /// <summary>
@@ -61,6 +63,24 @@ namespace Apache.Ignite.Tests
                            $"Address = {address} }} ] }}";
 
             Assert.AreEqual(expected, client.ToString());
+        }
+
+        [Test]
+        public async Task TestHeartbeat()
+        {
+            using var client = await IgniteClient.StartAsync(GetConfig());
+            IgniteClientInternal clientInternal = (IgniteClientInternal)client;
+
+            var sockets = clientInternal.Socket.GetSockets().ToList();
+
+            var payload = new PooledArrayBuffer();
+            payload.MessageWriter.Write("foo bar baz");
+
+            foreach (var socket in sockets)
+            {
+                await socket.HeartbeatAsync();
+                await socket.HeartbeatAsync(payload);
+            }
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteClientTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteClientTests.cs
@@ -73,7 +73,7 @@ namespace Apache.Ignite.Tests
 
             var sockets = clientInternal.Socket.GetSockets().ToList();
 
-            var payload = new PooledArrayBuffer();
+            using var payload = new PooledArrayBuffer();
             payload.MessageWriter.Write("foo bar baz");
 
             foreach (var socket in sockets)

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -338,7 +338,7 @@ public class MetricsTests
             RetryPolicy = new RetryNonePolicy()
         };
 
-    private static Guid? GetClientId(IIgniteClient? client) => client?.GetFieldValue<ClientFailoverSocket>("_socket").ClientId;
+    private static Guid? GetClientId(IIgniteClient? client) => ((IgniteClientInternal?)client)?.Socket.ClientId;
 
     private void AssertMetric(string name, int value, int timeoutMs = 1000) =>
         _listener.AssertMetric(name, value, timeoutMs);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/TestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/TestUtils.cs
@@ -106,7 +106,7 @@ namespace Apache.Ignite.Tests
         internal static async Task ForceLazyTxStart(ITransaction tx, IIgnite client, PreferredNode preferredNode = default) =>
             await LazyTransaction.EnsureStartedAsync(
                 tx,
-                client.GetFieldValue<ClientFailoverSocket>("_socket"),
+                ((IgniteClientInternal)client).Socket,
                 preferredNode);
 
         private static FieldInfo GetNonPublicField(object obj, string fieldName)

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Transactions/TransactionsTests.cs
@@ -296,7 +296,7 @@ namespace Apache.Ignite.Tests.Transactions
         public async Task TestObservableTimestampIsInitializedFromHandshake()
         {
             using var client = await IgniteClient.StartAsync(new() { Endpoints = { "127.0.0.1:" + ServerPort } });
-            var observableTimestamp = client.GetFieldValue<ClientFailoverSocket>("_socket").ObservableTimestamp;
+            var observableTimestamp = ((IgniteClientInternal)client).Socket.ObservableTimestamp;
 
             Assert.Greater(observableTimestamp, 0);
         }
@@ -313,7 +313,7 @@ namespace Apache.Ignite.Tests.Transactions
 
             Assert.AreEqual(
                 server.ObservableTimestamp,
-                client.GetFieldValue<ClientFailoverSocket>("_socket").ObservableTimestamp,
+                ((IgniteClientInternal)client).Socket.ObservableTimestamp,
                 "Handshake should initialize observable timestamp");
 
             server.ObservableTimestamp = 123;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -316,6 +316,25 @@ namespace Apache.Ignite.Internal
         }
 
         /// <summary>
+        /// Gets active sockets.
+        /// </summary>
+        /// <returns>Active sockets.</returns>
+        internal IEnumerable<ClientSocket> GetSockets()
+        {
+            var res = new List<ClientSocket>(_endpoints.Count);
+
+            foreach (var endpoint in _endpoints)
+            {
+                if (endpoint.Socket is { IsDisposed: false })
+                {
+                    res.Add(endpoint.Socket);
+                }
+            }
+
+            return res;
+        }
+
+        /// <summary>
         /// Gets a socket. Reconnects if necessary.
         /// </summary>
         /// <param name="preferredNode">Preferred node.</param>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/IgniteClientInternal.cs
@@ -18,9 +18,7 @@
 namespace Apache.Ignite.Internal
 {
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
-    using System.Net;
     using System.Threading.Tasks;
     using Common;
     using Ignite.Compute;
@@ -37,16 +35,13 @@ namespace Apache.Ignite.Internal
     /// </summary>
     internal sealed class IgniteClientInternal : IIgniteClient
     {
-        /** Underlying connection. */
-        private readonly ClientFailoverSocket _socket;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="IgniteClientInternal"/> class.
         /// </summary>
         /// <param name="socket">Socket.</param>
         public IgniteClientInternal(ClientFailoverSocket socket)
         {
-            _socket = socket;
+            Socket = socket;
 
             var sql = new Sql.Sql(socket);
             var tables = new Tables(socket, sql);
@@ -59,7 +54,7 @@ namespace Apache.Ignite.Internal
 
         /// <inheritdoc/>
         public IgniteClientConfiguration Configuration =>
-            new(_socket.Configuration); // Defensive copy.
+            new(Socket.Configuration); // Defensive copy.
 
         /// <inheritdoc/>
         public ITables Tables { get; }
@@ -73,10 +68,15 @@ namespace Apache.Ignite.Internal
         /// <inheritdoc/>
         public ISql Sql { get; }
 
+        /// <summary>
+        /// Gets the underlying socket.
+        /// </summary>
+        internal ClientFailoverSocket Socket { get; }
+
         /// <inheritdoc/>
         public async Task<IList<IClusterNode>> GetClusterNodesAsync()
         {
-            using var resBuf = await _socket.DoOutInOpAsync(ClientOp.ClusterGetNodes).ConfigureAwait(false);
+            using var resBuf = await Socket.DoOutInOpAsync(ClientOp.ClusterGetNodes).ConfigureAwait(false);
 
             return Read();
 
@@ -96,13 +96,10 @@ namespace Apache.Ignite.Internal
         }
 
         /// <inheritdoc/>
-        public IList<IConnectionInfo> GetConnections() => _socket.GetConnections();
+        public IList<IConnectionInfo> GetConnections() => Socket.GetConnections();
 
         /// <inheritdoc/>
-        public void Dispose()
-        {
-            _socket.Dispose();
-        }
+        public void Dispose() => Socket.Dispose();
 
         /// <inheritdoc/>
         public override string ToString() =>

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
@@ -100,10 +100,12 @@ public class ItThinClientConnectionTest extends ItAbstractThinClientTest {
     }
 
     @Test
-    void testHeartbeatInternalApi() {
+    void testHeartbeat() {
         var client = (TcpIgniteClient) client();
 
         List<ClientChannel> channels = client.channel().channels();
+
+        assertEquals(2, channels.size());
 
         for (var channel : channels) {
             channel.heartbeatAsync(null).join();

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -108,8 +109,11 @@ public class ItThinClientConnectionTest extends ItAbstractThinClientTest {
         assertEquals(2, channels.size());
 
         for (var channel : channels) {
+            assertFalse(channel.closed());
+
             channel.heartbeatAsync(null).join();
             channel.heartbeatAsync(w -> w.out().packString("foo-bar")).join();
+            channel.heartbeatAsync(w -> w.out().writePayload(new byte[]{1, 2, 3})).join();
         }
     }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.internal.client.ClientChannel;
 import org.apache.ignite.internal.client.TcpIgniteClient;
 import org.apache.ignite.internal.testframework.WorkDirectoryExtension;
 import org.apache.ignite.lang.IgniteException;
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * Tests thin client connecting to a real server node.
  */
+@SuppressWarnings("resource")
 @ExtendWith(WorkDirectoryExtension.class)
 public class ItThinClientConnectionTest extends ItAbstractThinClientTest {
     /**
@@ -95,5 +97,17 @@ public class ItThinClientConnectionTest extends ItAbstractThinClientTest {
     @Test
     void clusterName() {
         assertThat(((TcpIgniteClient) client()).clusterName(), is("cluster"));
+    }
+
+    @Test
+    void testHeartbeatInternalApi() {
+        var client = (TcpIgniteClient) client();
+
+        List<ClientChannel> channels = client.channel().channels();
+
+        for (var channel : channels) {
+            channel.heartbeatAsync(null).join();
+            channel.heartbeatAsync(w -> w.out().packString("foo-bar")).join();
+        }
     }
 }


### PR DESCRIPTION
Add internal heartbeat API with optional payload for benchmarking to Java and .NET clients.