### PR TITLE
IGNITE-21595 .NET: Update dependencies

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Apache.Ignite.Benchmarks.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Apache.Ignite.Benchmarks.csproj
@@ -26,7 +26,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
     </ItemGroup>
 
     <ItemGroup>

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/Serialization/SerializerHandlerReadBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Table/Serialization/SerializerHandlerReadBenchmarks.cs
@@ -79,9 +79,9 @@ namespace Apache.Ignite.Benchmarks.Table.Serialization
             var reader = new MsgPackReader(SerializedData);
             var res = TupleSerializerHandler.Instance.Read(ref reader, Schema);
 
-            Consumer.Consume(res[0]);
-            Consumer.Consume(res[1]);
-            Consumer.Consume(res[2]);
+            Consumer.Consume(res[0]!);
+            Consumer.Consume(res[1]!);
+            Consumer.Consume(res[2]!);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/Apache.Ignite.Internal.Generators.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/Apache.Ignite.Internal.Generators.csproj
@@ -21,12 +21,13 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     </PropertyGroup>
     
     <ItemGroup>
         <!-- Source Generators -->
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Internal.Generators
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.IO;
     using System.Linq;
@@ -32,6 +33,10 @@ namespace Apache.Ignite.Internal.Generators
     /// Generates exception classes from Java exceptions.
     /// </summary>
     [Generator]
+    [SuppressMessage(
+        "MicrosoftCodeAnalysisCorrectness",
+        "RS1035:Do not use APIs banned for analyzers",
+        Justification = "IO is required to read Java code.")]
     public sealed class ExceptionsGenerator : JavaToCsharpGeneratorBase
     {
         /// <inheritdoc/>
@@ -151,7 +156,7 @@ namespace Apache.Ignite.Internal.Generators
             }
 
             var xmlDoc = javaDocMatch.Groups[1].Value
-                .Replace(Environment.NewLine, " ")
+                .Replace("\r\n", " ")
                 .Replace('\n', ' ')
                 .Replace(" * ", " ");
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Apache.Ignite.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Apache.Ignite.Tests.csproj
@@ -34,7 +34,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 
         <!-- Test-only dependency to use as a reference implementation. -->
-        <PackageReference Include="MessagePack" Version="[2.1.90,)" />
+        <PackageReference Include="MessagePack" Version="2.5.171" />
     </ItemGroup>
 
     <ItemGroup>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Apache.Ignite.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Apache.Ignite.Tests.csproj
@@ -31,7 +31,7 @@
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
         <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
 
         <!-- Test-only dependency to use as a reference implementation. -->
         <PackageReference Include="MessagePack" Version="2.5.171" />

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ConsoleLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ConsoleLogger.cs
@@ -74,7 +74,9 @@ public class ConsoleLogger : ILogger, ILoggerFactory
 
     public bool IsEnabled(LogLevel logLevel) => logLevel >= _minLevel;
 
-    public IDisposable BeginScope<TState>(TState state) => new DisposeAction(() => { });
+    public IDisposable BeginScope<TState>(TState state)
+        where TState : notnull
+        => new DisposeAction(() => { });
 
     public void Dispose()
     {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ListLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ListLogger.cs
@@ -69,7 +69,9 @@ namespace Apache.Ignite.Tests
         /** <inheritdoc /> */
         public bool IsEnabled(LogLevel logLevel) => EnabledLevels.Contains(logLevel);
 
-        public IDisposable BeginScope<TState>(TState state) => throw new NotImplementedException();
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull
+            => throw new NotImplementedException();
 
         [SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible", Justification = "Tests.")]
         public record Entry(string Message, LogLevel Level, string? Category, Exception? Exception);

--- a/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="all" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" PrivateAssets="all" />
     <PackageReference Include="NodaTime" Version="[3.*,)" />
     <PackageReference Include="Remotion.Linq" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[6.*,)" />

--- a/modules/platforms/dotnet/Apache.Ignite/Compute/JobTarget.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Compute/JobTarget.cs
@@ -78,10 +78,24 @@ public static class JobTarget
         return new ColocatedTarget<TKey>(tableName, key);
     }
 
+    /// <summary>
+    /// Single node job target.
+    /// </summary>
+    /// <param name="Data">Cluster node.</param>
     internal sealed record SingleNodeTarget(IClusterNode Data) : IJobTarget<IClusterNode>;
 
+    /// <summary>
+    /// Any node job target.
+    /// </summary>
+    /// <param name="Data">Nodes.</param>
     internal sealed record AnyNodeTarget(IEnumerable<IClusterNode> Data) : IJobTarget<IEnumerable<IClusterNode>>;
 
+    /// <summary>
+    /// Colocated job target.
+    /// </summary>
+    /// <param name="TableName">Table name.</param>
+    /// <param name="Data">Key.</param>
+    /// <typeparam name="TKey">Key type.</typeparam>
     internal sealed record ColocatedTarget<TKey>(string TableName, TKey Data) : IJobTarget<TKey>
         where TKey : notnull;
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Network/ConnectionInfo.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Network/ConnectionInfo.cs
@@ -19,4 +19,9 @@ namespace Apache.Ignite.Internal.Network;
 
 using Ignite.Network;
 
+/// <summary>
+/// Connection info.
+/// </summary>
+/// <param name="Node">Node.</param>
+/// <param name="SslInfo">SSL info.</param>
 internal sealed record ConnectionInfo(IClusterNode Node, ISslInfo? SslInfo) : IConnectionInfo;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Network/SslInfo.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Network/SslInfo.cs
@@ -21,6 +21,15 @@ using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using Ignite.Network;
 
+/// <summary>
+/// SSL info.
+/// </summary>
+/// <param name="TargetHostName">Target host name.</param>
+/// <param name="NegotiatedCipherSuiteName">Negotiated cipher suite name.</param>
+/// <param name="IsMutuallyAuthenticated">Whether client and server are mutually authenticated.</param>
+/// <param name="LocalCertificate">Local certificate.</param>
+/// <param name="RemoteCertificate">Remote certificate.</param>
+/// <param name="SslProtocol">SSL protocol.</param>
 internal sealed record SslInfo(
     string TargetHostName,
     string NegotiatedCipherSuiteName,

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ColumnMetadata.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ColumnMetadata.cs
@@ -15,10 +15,18 @@
  * limitations under the License.
  */
 
-namespace Apache.Ignite.Internal.Sql
-{
-    using Ignite.Sql;
+namespace Apache.Ignite.Internal.Sql;
 
-    internal sealed record ColumnMetadata(string Name, ColumnType Type, int Precision, int Scale, bool Nullable, IColumnOrigin? Origin)
-        : IColumnMetadata;
-}
+using Ignite.Sql;
+
+/// <summary>
+/// Column metadata.
+/// </summary>
+/// <param name="Name">Name.</param>
+/// <param name="Type">Type.</param>
+/// <param name="Precision">Precision, or -1 when not applicable to the current column type.</param>
+/// <param name="Scale">Scale.</param>
+/// <param name="Nullable">Whether column is nullable.</param>
+/// <param name="Origin">Origin.</param>
+internal sealed record ColumnMetadata(string Name, ColumnType Type, int Precision, int Scale, bool Nullable, IColumnOrigin? Origin)
+    : IColumnMetadata;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ColumnOrigin.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ColumnOrigin.cs
@@ -15,9 +15,14 @@
  * limitations under the License.
  */
 
-namespace Apache.Ignite.Internal.Sql
-{
-    using Ignite.Sql;
+namespace Apache.Ignite.Internal.Sql;
 
-    internal sealed record ColumnOrigin(string ColumnName, string SchemaName, string TableName) : IColumnOrigin;
-}
+using Ignite.Sql;
+
+/// <summary>
+/// Column origin.
+/// </summary>
+/// <param name="ColumnName">Column name.</param>
+/// <param name="SchemaName">Schema name.</param>
+/// <param name="TableName">Table name.</param>
+internal sealed record ColumnOrigin(string ColumnName, string SchemaName, string TableName) : IColumnOrigin;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSetMetadata.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSetMetadata.cs
@@ -21,6 +21,10 @@ namespace Apache.Ignite.Internal.Sql
     using Common;
     using Ignite.Sql;
 
+    /// <summary>
+    /// Result set metadata.
+    /// </summary>
+    /// <param name="Columns">Columns.</param>
     internal sealed record ResultSetMetadata(IReadOnlyList<IColumnMetadata> Columns) : IResultSetMetadata
     {
         /** Column index by name. Initialized on first access. */

--- a/modules/platforms/dotnet/Apache.Ignite/Table/ReceiverDescriptor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/ReceiverDescriptor.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Table;
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Compute;
 
 /// <summary>
@@ -37,6 +38,7 @@ public sealed record ReceiverDescriptor<TArg>(
 /// <param name="DeploymentUnits">Deployment units.</param>
 /// <typeparam name="TArg">Argument type.</typeparam>
 /// <typeparam name="TResult">Result type.</typeparam>
+[SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Reviewed.")]
 public sealed record ReceiverDescriptor<TArg, TResult>(
     string ReceiverClassName,
     IEnumerable<DeploymentUnit>? DeploymentUnits = null);

--- a/modules/platforms/dotnet/Directory.Build.props
+++ b/modules/platforms/dotnet/Directory.Build.props
@@ -42,7 +42,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0"/>
-        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="all"/>
+        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
**Build-only** dependencies:
* StyleCop.Analyzers `1.2.0-beta.435` -> `1.2.0-beta.556`
* Microsoft.CodeAnalysis.Analyzers `3.3.3` -> `3.3.4`
* JetBrains.Annotations `2023.3.0` -> `2024.2.0`

**Test-only** dependencies:
* Microsoft.Extensions.Logging.Console `6.0.0` -> `8.0.0`
* MessagePack `2.1.90` -> `2.5.171`
* BenchmarkDotNet `0.13.1` -> `0.13.12`

Runtime dependencies are not affected.