### PR TITLE
IGNITE-22934 .NET: Fix tuple equality - ignore column order

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/BinaryTupleIgniteTupleAdapterTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/BinaryTupleIgniteTupleAdapterTests.cs
@@ -23,6 +23,7 @@ using Ignite.Sql;
 using Ignite.Table;
 using Internal.Proto.BinaryTuple;
 using Internal.Table;
+using NodaTime;
 using NUnit.Framework;
 
 /// <summary>
@@ -137,24 +138,23 @@ public class BinaryTupleIgniteTupleAdapterTests : IgniteTupleTests
 
         return new BinaryTupleIgniteTupleAdapter(buf, schema, keyOnly: false);
 
-        static ColumnType GetColumnType(object? obj)
-        {
-            if (obj == null || obj is string)
+        static ColumnType GetColumnType(object? obj) =>
+            obj switch
             {
-                return ColumnType.String;
-            }
-
-            if (obj is int)
-            {
-                return ColumnType.Int32;
-            }
-
-            if (obj is long)
-            {
-                return ColumnType.Int64;
-            }
-
-            throw new NotSupportedException("Unsupported type: " + obj.GetType());
-        }
+                null => ColumnType.String,
+                string => ColumnType.String,
+                int => ColumnType.Int32,
+                long => ColumnType.Int64,
+                short => ColumnType.Int16,
+                sbyte => ColumnType.Int8,
+                byte[] => ColumnType.ByteArray,
+                Guid => ColumnType.Uuid,
+                LocalDateTime => ColumnType.Datetime,
+                double => ColumnType.Double,
+                float => ColumnType.Float,
+                decimal => ColumnType.Decimal,
+                bool => ColumnType.Boolean,
+                _ => throw new NotSupportedException("Unsupported type: " + obj.GetType())
+            };
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
@@ -188,6 +188,8 @@ namespace Apache.Ignite.Tests.Table
             var tuple2 = GetRandomizedTuple();
 
             Assert.AreEqual(tuple1, tuple2);
+            Assert.AreEqual(tuple1.GetHashCode(), tuple2.GetHashCode());
+            Assert.AreNotEqual(tuple1.ToString(), tuple2.ToString());
 
             IgniteTuple GetRandomizedTuple() =>
                 data

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
@@ -163,8 +163,26 @@ namespace Apache.Ignite.Tests.Table
         [Test]
         public void TestTupleEqualityDifferentColumnOrder()
         {
-            var data = Enumerable.Range(1, 100)
-                .ToDictionary(x => $"col-{x}", x => Random.Shared.NextDouble());
+            var randomBytes = new byte[100];
+            Random.Shared.NextBytes(randomBytes);
+
+            var data = new Dictionary<string, object?>
+            {
+                { "nil", null },
+                { "int", Random.Shared.Next() },
+                { "short", (short)Random.Shared.Next() },
+                { "sbyte", (sbyte)Random.Shared.Next() },
+                { "long", Random.Shared.NextInt64() },
+                { "dbl", Random.Shared.NextDouble() },
+                { "flt", Random.Shared.NextSingle() },
+                { "bytes", randomBytes },
+                { "str", "s-" + Random.Shared.Next() },
+                { "guid", Guid.NewGuid() },
+                { "dt", DateTime.Now },
+                { "ts", TimeSpan.FromMilliseconds(Random.Shared.Next()) },
+                { "bool", Random.Shared.Next() % 2 == 0 },
+                { "dec", (decimal)Random.Shared.NextDouble() }
+            };
 
             var tuple1 = GetRandomizedTuple();
             var tuple2 = GetRandomizedTuple();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
@@ -21,6 +21,7 @@ namespace Apache.Ignite.Tests.Table
     using System.Collections.Generic;
     using System.Linq;
     using Ignite.Table;
+    using NodaTime;
     using NUnit.Framework;
 
     /// <summary>
@@ -178,14 +179,13 @@ namespace Apache.Ignite.Tests.Table
                 { "bytes", randomBytes },
                 { "str", "s-" + Random.Shared.Next() },
                 { "guid", Guid.NewGuid() },
-                { "dt", DateTime.Now },
-                { "ts", TimeSpan.FromMilliseconds(Random.Shared.Next()) },
+                { "dt", LocalDateTime.FromDateTime(DateTime.UtcNow) },
                 { "bool", Random.Shared.Next() % 2 == 0 },
                 { "dec", (decimal)Random.Shared.NextDouble() }
             };
 
-            var tuple1 = GetRandomizedTuple();
-            var tuple2 = GetRandomizedTuple();
+            var tuple1 = CreateTuple(GetRandomizedTuple());
+            var tuple2 = CreateTuple(GetRandomizedTuple());
 
             Assert.AreEqual(tuple1, tuple2);
             Assert.AreEqual(tuple1.GetHashCode(), tuple2.GetHashCode());

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/IgniteTupleTests.cs
@@ -137,9 +137,9 @@ namespace Apache.Ignite.Tests.Table
             var guid = Guid.NewGuid();
 
             var t1 = CreateTuple(new IgniteTuple(2) { ["k"] = 1, ["v"] = "2", ["v2"] = guid });
-            var t2 = CreateTuple(new IgniteTuple(3) { ["k"] = 1, ["v"] = "2", ["v2"] = guid });
+            var t2 = CreateTuple(new IgniteTuple(3) { ["K"] = 1, ["V"] = "2", ["V2"] = guid });
             var t3 = CreateTuple(new IgniteTuple(4) { ["k"] = 1, ["v"] = null, ["v2"] = guid });
-            var t4 = CreateTuple(new IgniteTuple(5) { ["v"] = "2", ["k"] = 1, ["v2"] = guid });
+            var t4 = CreateTuple(new IgniteTuple(5) { ["v"] = "2", ["k"] = 1, ["V2"] = guid });
             var t5 = CreateTuple(new IgniteTuple(6) { ["v"] = "2", ["k"] = 1, ["v2"] = guid, ["v3"] = 1 });
 
             Assert.AreEqual(t1, t2);
@@ -196,7 +196,12 @@ namespace Apache.Ignite.Tests.Table
                     .OrderBy(_ => Random.Shared.Next())
                     .Aggregate(new IgniteTuple(), (tuple, pair) =>
                     {
-                        tuple[pair.Key] = pair.Value;
+                        var name = Random.Shared.Next() % 2 == 0
+                            ? pair.Key.ToUpperInvariant()
+                            : pair.Key.ToLowerInvariant();
+
+                        tuple[name] = pair.Value;
+
                         return tuple;
                     });
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Table/IIgniteTuple.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Table/IIgniteTuple.cs
@@ -113,14 +113,16 @@ namespace Apache.Ignite.Table
                 return false;
             }
 
-            for (int i = 0; i < tuple1.FieldCount; i++)
+            for (int idx1 = 0; idx1 < tuple1.FieldCount; idx1++)
             {
-                if (tuple1.GetName(i) != tuple2.GetName(i))
+                var idx2 = tuple2.GetOrdinal(tuple1.GetName(idx1));
+
+                if (idx2 < 0)
                 {
                     return false;
                 }
 
-                if (!Equals(tuple1[i], tuple2[i]))
+                if (!Equals(tuple1[idx1], tuple2[idx2]))
                 {
                     return false;
                 }


### PR DESCRIPTION
Fix .NET `IIgniteTuple` equality logic to match Java - ignore column order in `Equals` and `GetHashCode`.