### PR TITLE
IGNITE-22941 Improve performance of TupleMarshaller

### DIFF
--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtil.java
@@ -56,7 +56,9 @@ public final class MarshallerUtil {
 
             case STRING:
                 CharSequence chars = (CharSequence) val;
-                return chars.length() == 0 ? 1 : utf8EncodedLength(chars);
+                int length = chars.length();
+
+                return length == 0 ? 1 : length /* optimistically assume string value contains only ASCII symbols */;
 
             case DECIMAL:
                 return sizeInBytes((BigDecimal) val);
@@ -85,34 +87,6 @@ public final class MarshallerUtil {
      * Stub.
      */
     private MarshallerUtil() {
-    }
-
-    /**
-     * Calculates encoded string length.
-     *
-     * @param seq Char sequence.
-     * @return Encoded string length.
-     * @implNote This implementation is not tolerant to malformed char sequences.
-     */
-    public static int utf8EncodedLength(CharSequence seq) {
-        int cnt = 0;
-
-        for (int i = 0, len = seq.length(); i < len; i++) {
-            char ch = seq.charAt(i);
-
-            if (ch <= 0x7F) {
-                cnt++;
-            } else if (ch <= 0x7FF) {
-                cnt += 2;
-            } else if (Character.isHighSurrogate(ch)) {
-                cnt += 4;
-                ++i;
-            } else {
-                cnt += 3;
-            }
-        }
-
-        return cnt;
     }
 
     /**

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/row/RowAssembler.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/row/RowAssembler.java
@@ -69,6 +69,17 @@ public class RowAssembler {
     }
 
     /**
+     * Creates a builder.
+     *
+     * @param schema Schema descriptor.
+     * @param totalValueSize Total estimated length of non-NULL values, -1 if not known.
+     * @param exactEstimate Whether the total size is exact estimate or approximate.
+     */
+    public RowAssembler(SchemaDescriptor schema, int totalValueSize, boolean exactEstimate) {
+        this(schema.version(), schema.columns(), totalValueSize, exactEstimate);
+    }
+
+    /**
      * Create a builder.
      *
      * @param schemaVersion Version of the schema.

--- a/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtilTest.java
+++ b/modules/schema/src/test/java/org/apache/ignite/internal/schema/marshaller/MarshallerUtilTest.java
@@ -55,9 +55,11 @@ public class MarshallerUtilTest extends BaseIgniteAbstractTest {
                 Arguments.of("", NativeTypes.STRING, 1),
                 Arguments.of("1", NativeTypes.STRING, 1),
                 Arguments.of("abc", NativeTypes.STRING, 3),
-                Arguments.of(new String(new byte[]{-36, -128}, StandardCharsets.UTF_8), NativeTypes.STRING, 2),
-                Arguments.of(new String(new byte[]{-30, -104, -128}, StandardCharsets.UTF_8), NativeTypes.STRING, 3),
-                Arguments.of(new String(new byte[]{97, -36, -128, -30, -104, -128}, StandardCharsets.UTF_8), NativeTypes.STRING, 6),
+                // although following string consists of 2-bytes character, optimistic size estimation assumes
+                // that every character occupies exactly one byte
+                Arguments.of(new String(new byte[]{-36, -128}, StandardCharsets.UTF_8), NativeTypes.STRING, 1),
+                Arguments.of(new String(new byte[]{-30, -104, -128}, StandardCharsets.UTF_8), NativeTypes.STRING, 1),
+                Arguments.of(new String(new byte[]{97, -36, -128, -30, -104, -128}, StandardCharsets.UTF_8), NativeTypes.STRING, 3),
                 // decimal
                 Arguments.of(BigDecimal.ONE, NativeTypes.decimalOf(12, 1), 3),
                 Arguments.of(BigDecimal.valueOf(123456789), NativeTypes.decimalOf(12, 3), 6)

--- a/modules/table/src/test/java/org/apache/ignite/internal/benchmarks/TupleMarshallerFixlenOnlyBenchmark.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/benchmarks/TupleMarshallerFixlenOnlyBenchmark.java
@@ -48,8 +48,8 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  * Serializer benchmark.
  */
 @State(Scope.Benchmark)
-@Warmup(iterations = 1, time = 15)
-@Measurement(iterations = 1, time = 30)
+@Warmup(iterations = 20, time = 1)
+@Measurement(iterations = 10, time = 1)
 @BenchmarkMode({Mode.AverageTime})
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Fork(jvmArgs = "-Djava.lang.invoke.stringConcat=BC_SB" /* Workaround for Java 9+ */, value = 1)
@@ -97,9 +97,9 @@ public class TupleMarshallerFixlenOnlyBenchmark {
 
         schema = new SchemaDescriptor(
                 42,
-                new Column[]{new Column("key", NativeTypes.INT64, false)},
+                new Column[]{new Column("KEY", NativeTypes.INT64, false)},
                 IntStream.range(0, fieldsCount).boxed()
-                        .map(i -> new Column("col" + i, NativeTypes.INT64, nullable))
+                        .map(i -> new Column("COL" + i, NativeTypes.INT64, nullable))
                         .toArray(Column[]::new)
         );
 

--- a/modules/table/src/test/java/org/apache/ignite/internal/benchmarks/TupleMarshallerVarlenOnlyBenchmark.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/benchmarks/TupleMarshallerVarlenOnlyBenchmark.java
@@ -53,13 +53,18 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  * Serializer benchmark.
  */
 @State(Scope.Benchmark)
-@Warmup(iterations = 1, time = 15)
-@Measurement(iterations = 1, time = 30)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 20, time = 1)
 @BenchmarkMode({Mode.AverageTime})
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Fork(jvmArgs = "-Djava.lang.invoke.stringConcat=BC_SB" /* Workaround for Java 9+ */, value = 1)
 @SuppressWarnings("InstanceVariableMayNotBeInitialized")
 public class TupleMarshallerVarlenOnlyBenchmark {
+    /** Type of the generated payload. */
+    public enum Type {
+        BYTES, PREDEFINED_STRING, RANDOM_STRING
+    }
+
     /** Random. */
     private Random rnd;
 
@@ -78,9 +83,12 @@ public class TupleMarshallerVarlenOnlyBenchmark {
     //    @Param({"true", "false"})
     public boolean nullable = true;
 
+    @Param({"a", "ж", "我"})
+    public String character;
+
     /** Column types. */
-    @Param({"string", "bytes"})
-    public String type;
+    @Param({"PREDEFINED_STRING"})
+    public Type type;
 
     /** Schema descriptor. */
     private SchemaDescriptor schema;
@@ -105,30 +113,41 @@ public class TupleMarshallerVarlenOnlyBenchmark {
     @Setup
     public void init() {
         final long seed = System.currentTimeMillis();
-        final boolean useString = "string".equals(type);
 
         rnd = new Random(seed);
 
         schema = new SchemaDescriptor(
                 42,
-                new Column[]{new Column("key", INT64, false, DefaultValueProvider.constantProvider(0L))},
+                new Column[]{new Column("KEY", INT64, false, DefaultValueProvider.constantProvider(0L))},
                 IntStream.range(0, fieldsCount).boxed()
-                        .map(i -> new Column("col" + i, useString ? STRING : BYTES, nullable))
+                        .map(i -> new Column("COL" + i, type == Type.BYTES ? BYTES : STRING, nullable))
                         .toArray(Column[]::new)
         );
 
         marshaller = new TupleMarshallerImpl(schema);
 
-        if (useString) {
-            final byte[] data = new byte[dataSize / fieldsCount];
+        switch (type) {
+            case RANDOM_STRING: {
+                final byte[] data = new byte[dataSize / fieldsCount];
 
-            for (int i = 0; i < data.length; i++) {
-                data[i] = (byte) (rnd.nextInt() & 0x7F);
+                for (int i = 0; i < data.length; i++) {
+                    data[i] = (byte) (rnd.nextInt() & 0x7F);
+                }
+
+                val = new String(data, StandardCharsets.ISO_8859_1); // Latin1 string.
+
+                break;
             }
+            case PREDEFINED_STRING: {
+                val = character.repeat(dataSize / fieldsCount / character.getBytes(StandardCharsets.UTF_8).length);
 
-            val = new String(data, StandardCharsets.ISO_8859_1); // Latin1 string.
-        } else {
-            rnd.nextBytes((byte[]) (val = new byte[dataSize / fieldsCount]));
+                break;
+            }
+            case BYTES: {
+                rnd.nextBytes((byte[]) (val = new byte[dataSize / fieldsCount]));
+                break;
+            }
+            default: throw new IllegalStateException("Unknown type " + type);
         }
     }
 

--- a/modules/table/src/test/java/org/apache/ignite/internal/schema/marshaller/TupleMarshallerStatisticsTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/schema/marshaller/TupleMarshallerStatisticsTest.java
@@ -31,6 +31,7 @@ import org.apache.ignite.internal.binarytuple.BinaryTupleCommon;
 import org.apache.ignite.internal.catalog.commands.CatalogUtils;
 import org.apache.ignite.internal.schema.Column;
 import org.apache.ignite.internal.schema.SchemaDescriptor;
+import org.apache.ignite.internal.schema.marshaller.TupleMarshallerImpl.TuplePart;
 import org.apache.ignite.internal.schema.marshaller.TupleMarshallerImpl.ValuesWithStatistics;
 import org.apache.ignite.internal.table.impl.TestTupleBuilder;
 import org.apache.ignite.internal.type.NativeTypes;
@@ -63,7 +64,7 @@ public class TupleMarshallerStatisticsTest {
         assertThat(sizeInBytes(hugeScaledDecimal), is(greaterThan(16384)));
 
         ValuesWithStatistics statistics = new ValuesWithStatistics();
-        marshaller.gatherStatistics(schema.keyColumns(), tuple, statistics);
+        marshaller.gatherStatistics(TuplePart.KEY, tuple, statistics);
         assertThat(statistics.estimatedValueSize(), is(3));
         BigDecimal compactedValue = (BigDecimal) statistics.value("KEY");
         assertNotNull(compactedValue);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22941

```
Benchmark                                   (character)  (dataSize)  (fieldsCount)             (type)  Mode  Cnt          Before           After  Units
TupleMarshallerVarlenOnlyBenchmark.measure            a         250              2  PREDEFINED_STRING  avgt   20   0.706 ± 0.001   0.397 ± 0.001  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            a         250             10  PREDEFINED_STRING  avgt   20   1.649 ± 0.005   1.207 ± 0.004  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            a         250            100  PREDEFINED_STRING  avgt   20  13.485 ± 0.043  13.022 ± 0.018  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            a       64000              2  PREDEFINED_STRING  avgt   20  72.666 ± 0.301   4.390 ± 0.010  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            a       64000             10  PREDEFINED_STRING  avgt   20  73.900 ± 0.096   6.178 ± 0.051  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            a       64000            100  PREDEFINED_STRING  avgt   20  86.879 ± 0.652  16.665 ± 0.038  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            ж         250              2  PREDEFINED_STRING  avgt   20   0.615 ± 0.001   0.449 ± 0.001  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            ж         250             10  PREDEFINED_STRING  avgt   20   1.706 ± 0.006   1.330 ± 0.001  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            ж         250            100  PREDEFINED_STRING  avgt   20  17.213 ± 0.044  13.142 ± 0.044  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            ж       64000              2  PREDEFINED_STRING  avgt   20  53.123 ± 0.166  19.661 ± 0.023  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            ж       64000             10  PREDEFINED_STRING  avgt   20  54.188 ± 0.146  19.566 ± 0.024  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            ж       64000            100  PREDEFINED_STRING  avgt   20  64.661 ± 0.096  31.082 ± 0.033  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            我         250              2  PREDEFINED_STRING  avgt   20   0.634 ± 0.001  0.466 ± 0.001  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            我         250             10  PREDEFINED_STRING  avgt   20   1.702 ± 0.005  1.521 ± 0.008  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            我         250            100  PREDEFINED_STRING  avgt   20  12.295 ± 0.019  12.510 ± 0.019  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            我       64000              2  PREDEFINED_STRING  avgt   20  50.638 ± 0.347  28.550 ± 0.091  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            我       64000             10  PREDEFINED_STRING  avgt   20  50.891 ± 0.077  25.950 ± 0.223  us/op
TupleMarshallerVarlenOnlyBenchmark.measure            我       64000            100  PREDEFINED_STRING  avgt   20  62.798 ± 0.176  37.169 ± 0.023  us/op



Benchmark                                   (fieldsCount)  (nullable)  Mode  Cnt          Before           After  Units
TupleMarshallerFixlenOnlyBenchmark.measure              1        true  avgt   10   0.279 ± 0.003   0.262 ± 0.001  us/op
TupleMarshallerFixlenOnlyBenchmark.measure             10        true  avgt   10   1.192 ± 0.004   1.171 ± 0.005  us/op
TupleMarshallerFixlenOnlyBenchmark.measure            100        true  avgt   10  10.842 ± 0.066  10.392 ± 0.089  us/op



Benchmark                 (clusterSize)  (fsync)  (partitionCount)  Mode  Cnt          Before           After  Units
InsertBenchmark.kvInsert              1    false                25  avgt   20  68.338 ± 5.490  64.695 ± 4.713  us/op
```


-------------
Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)