### PR TITLE
IGNITE-22774 Remove `raftClient` map from `ItTxTestCluster`

### DIFF
--- a/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItTxDistributedTestSingleNodeCollocated.java
+++ b/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItTxDistributedTestSingleNodeCollocated.java
@@ -17,8 +17,6 @@
 
 package org.apache.ignite.distributed;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 

--- a/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItTxDistributedTestSingleNodeCollocated.java
+++ b/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItTxDistributedTestSingleNodeCollocated.java
@@ -46,15 +46,6 @@ public class ItTxDistributedTestSingleNodeCollocated extends ItTxAbstractDistrib
     @Override
     public void before() throws Exception {
         super.before();
-
-        assertSame(
-                txTestCluster.raftClients.get(ACC_TABLE_NAME).get(0).clusterService(),
-                txTestCluster.getLeader(ACC_TABLE_NAME).service()
-        );
-        assertSame(
-                txTestCluster.raftClients.get(CUST_TABLE_NAME).get(0).clusterService(),
-                txTestCluster.getLeader(CUST_TABLE_NAME).service()
-        );
     }
 }
 

--- a/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItTxDistributedTestThreeNodesThreeReplicasCollocated.java
+++ b/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItTxDistributedTestThreeNodesThreeReplicasCollocated.java
@@ -18,7 +18,6 @@
 package org.apache.ignite.distributed;
 
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.waitForCondition;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.UUID;

--- a/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItTxDistributedTestThreeNodesThreeReplicasCollocated.java
+++ b/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItTxDistributedTestThreeNodesThreeReplicasCollocated.java
@@ -50,11 +50,6 @@ public class ItTxDistributedTestThreeNodesThreeReplicasCollocated extends ItTxDi
     @BeforeEach
     @Override public void before() throws Exception {
         super.before();
-
-        assertSame(
-                txTestCluster.raftClients.get(ACC_TABLE_NAME).get(0).clusterService(),
-                txTestCluster.getLeader(ACC_TABLE_NAME).service()
-        );
     }
 
     @Test

--- a/modules/table/src/testFixtures/java/org/apache/ignite/distributed/ItTxTestCluster.java
+++ b/modules/table/src/testFixtures/java/org/apache/ignite/distributed/ItTxTestCluster.java
@@ -857,7 +857,6 @@ public class ItTxTestCluster {
             assertThat(client.stopAsync(new ComponentContext()), willCompleteSuccessfully());
         }
 
-
         if (executor != null) {
             IgniteUtils.shutdownAndAwaitTermination(executor, 10, TimeUnit.SECONDS);
         }

--- a/modules/table/src/testFixtures/java/org/apache/ignite/distributed/ItTxTestCluster.java
+++ b/modules/table/src/testFixtures/java/org/apache/ignite/distributed/ItTxTestCluster.java
@@ -857,6 +857,7 @@ public class ItTxTestCluster {
             assertThat(client.stopAsync(new ComponentContext()), willCompleteSuccessfully());
         }
 
+
         if (executor != null) {
             IgniteUtils.shutdownAndAwaitTermination(executor, 10, TimeUnit.SECONDS);
         }
@@ -914,27 +915,6 @@ public class ItTxTestCluster {
 
         if (clientTxManager != null) {
             assertThat(clientTxManager.stopAsync(new ComponentContext()), willCompleteSuccessfully());
-        }
-
-        Set<TablePartitionId> grpIds = tables.values()
-                .stream()
-                .map(table -> new TablePartitionId(table.tableId(), 0))
-                .collect(toSet());
-
-        for (String consistentId : clusterServices.keySet()) {
-            ReplicaManager replicaManager = replicaManagers.get(consistentId);
-
-            if (replicaManager == null) {
-                continue;
-            }
-
-            grpIds.forEach(id -> {
-                try {
-                    replicaManager.stopReplica(id);
-                } catch (NodeStoppingException e) {
-                    throw new AssertionError(e);
-                }
-            });
         }
     }
 

--- a/modules/table/src/testFixtures/java/org/apache/ignite/distributed/ItTxTestCluster.java
+++ b/modules/table/src/testFixtures/java/org/apache/ignite/distributed/ItTxTestCluster.java
@@ -101,8 +101,10 @@ import org.apache.ignite.internal.raft.client.TopologyAwareRaftGroupServiceFacto
 import org.apache.ignite.internal.raft.configuration.RaftConfiguration;
 import org.apache.ignite.internal.raft.service.RaftGroupService;
 import org.apache.ignite.internal.raft.storage.impl.VolatileLogStorageFactoryCreator;
+import org.apache.ignite.internal.replicator.Replica;
 import org.apache.ignite.internal.replicator.ReplicaManager;
 import org.apache.ignite.internal.replicator.ReplicaService;
+import org.apache.ignite.internal.replicator.ReplicationGroupId;
 import org.apache.ignite.internal.replicator.TablePartitionId;
 import org.apache.ignite.internal.replicator.configuration.ReplicationConfiguration;
 import org.apache.ignite.internal.replicator.listener.ReplicaListener;
@@ -827,6 +829,15 @@ public class ItTxTestCluster {
         };
     }
 
+    protected RaftGroupService getRaftClientForGroup(ReplicationGroupId groupId) {
+        int partId = 0;
+
+        return replicaManagers.get(extractConsistentId(cluster.get(partId)))
+                .replica(groupId)
+                .thenApply(Replica::raftClient)
+                .join();
+    }
+
     protected Peer getLeaderId(String tableName) {
         int partId = 0;
 
@@ -922,7 +933,7 @@ public class ItTxTestCluster {
                 try {
                     replicaManager.stopReplica(id);
                 } catch (NodeStoppingException e) {
-                    // no-op
+                    throw new AssertionError(e);
                 }
             });
         }

--- a/modules/table/src/testFixtures/java/org/apache/ignite/distributed/ItTxTestCluster.java
+++ b/modules/table/src/testFixtures/java/org/apache/ignite/distributed/ItTxTestCluster.java
@@ -829,13 +829,12 @@ public class ItTxTestCluster {
         };
     }
 
-    protected RaftGroupService getRaftClientForGroup(ReplicationGroupId groupId) {
+    private CompletableFuture<RaftGroupService> getRaftClientForGroup(ReplicationGroupId groupId) {
         int partId = 0;
 
         return replicaManagers.get(extractConsistentId(cluster.get(partId)))
                 .replica(groupId)
-                .thenApply(Replica::raftClient)
-                .join();
+                .thenApply(Replica::raftClient);
     }
 
     protected Peer getLeaderId(String tableName) {

--- a/modules/table/src/testFixtures/java/org/apache/ignite/distributed/ItTxTestCluster.java
+++ b/modules/table/src/testFixtures/java/org/apache/ignite/distributed/ItTxTestCluster.java
@@ -159,7 +159,6 @@ import org.apache.ignite.internal.tx.test.TestLocalRwTxCounter;
 import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.Lazy;
 import org.apache.ignite.internal.util.PendingComparableValuesTracker;
-import org.apache.ignite.lang.ErrorGroups.Table;
 import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.NetworkAddress;
 import org.apache.ignite.raft.jraft.RaftMessagesFactory;
@@ -719,18 +718,16 @@ public class ItTxTestCluster {
                         schemaManager
                 );
 
-                CompletableFuture<Void> partitionReadyFuture = replicaManagers.get(assignment)
-                        .startReplica(
-                                RaftGroupEventsListener.noopLsnr,
-                                partitionListener,
-                                false,
-                                null,
-                                createReplicaListener,
-                                storageIndexTracker,
-                                grpId,
-                                configuration
-                        )
-                        .thenAccept(unused -> { });
+                CompletableFuture<?> partitionReadyFuture = replicaManagers.get(assignment).startReplica(
+                        RaftGroupEventsListener.noopLsnr,
+                        partitionListener,
+                        false,
+                        null,
+                        createReplicaListener,
+                        storageIndexTracker,
+                        grpId,
+                        configuration
+                );
 
                 partitionReadyFutures.add(partitionReadyFuture);
             }

--- a/modules/table/src/testFixtures/java/org/apache/ignite/distributed/ItTxTestCluster.java
+++ b/modules/table/src/testFixtures/java/org/apache/ignite/distributed/ItTxTestCluster.java
@@ -101,7 +101,6 @@ import org.apache.ignite.internal.raft.client.TopologyAwareRaftGroupServiceFacto
 import org.apache.ignite.internal.raft.configuration.RaftConfiguration;
 import org.apache.ignite.internal.raft.service.RaftGroupService;
 import org.apache.ignite.internal.raft.storage.impl.VolatileLogStorageFactoryCreator;
-import org.apache.ignite.internal.replicator.Replica;
 import org.apache.ignite.internal.replicator.ReplicaManager;
 import org.apache.ignite.internal.replicator.ReplicaService;
 import org.apache.ignite.internal.replicator.TablePartitionId;
@@ -160,6 +159,7 @@ import org.apache.ignite.internal.tx.test.TestLocalRwTxCounter;
 import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.Lazy;
 import org.apache.ignite.internal.util.PendingComparableValuesTracker;
+import org.apache.ignite.lang.ErrorGroups.Table;
 import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.NetworkAddress;
 import org.apache.ignite.raft.jraft.RaftMessagesFactory;
@@ -231,8 +231,7 @@ public class ItTxTestCluster {
 
     protected TransactionStateResolver clientTxStateResolver;
 
-    // TODO: should be removed in https://issues.apache.org/jira/browse/IGNITE-22774
-    protected Map<String, List<RaftGroupService>> raftClients = new HashMap<>();
+    protected Map<String, TableImpl> tables = new HashMap<>();
 
     protected Map<String, TxStateStorage> txStateStorages;
 
@@ -613,6 +612,8 @@ public class ItTxTestCluster {
                 pkCatalogIndexDescriptor.id()
         );
 
+        tables.put(tableName, table);
+
         for (int p = 0; p < assignments.size(); p++) {
             Set<String> partAssignments = assignments.get(p);
 
@@ -733,26 +734,9 @@ public class ItTxTestCluster {
 
                 partitionReadyFutures.add(partitionReadyFuture);
             }
-
-            // waiting for started replicas otherwise we would have NPE on {@link Replica#replica} call below
-            allOf(partitionReadyFutures.toArray(new CompletableFuture[0])).join();
-
-            // TODO: should be removed in https://issues.apache.org/jira/browse/IGNITE-22774
-            CompletableFuture<RaftGroupService> txExecutionRaftClient =  replicaManagers.get(extractConsistentId(cluster.get(0)))
-                        .replica(grpId)
-                        .thenApply(Replica::raftClient)
-                        .thenApply(RaftGroupService::leader)
-                        .thenApply(Peer::consistentId)
-                        .thenApply(replicaManagers::get)
-                        .thenCompose(rm -> rm.replica(grpId))
-                        .thenApply(Replica::raftClient);
-
-            partitionReadyFutures.add(txExecutionRaftClient.thenAccept(leaderClient -> clients.put(grpId.partitionId(), leaderClient)));
         }
 
         allOf(partitionReadyFutures.toArray(new CompletableFuture[0])).join();
-
-        raftClients.computeIfAbsent(tableName, t -> new ArrayList<>()).addAll(clients.values());
 
         return table;
     }
@@ -846,28 +830,13 @@ public class ItTxTestCluster {
         };
     }
 
-    /**
-     * Returns a raft manager for a group.
-     * TODO: should be removed in https://issues.apache.org/jira/browse/IGNITE-22774
-     *
-     * @param tableName Table name.
-     * @return Raft manager hosting a leader for group.
-     */
-    protected Loza getLeader(String tableName) {
-        var services = raftClients.get(tableName);
-
-        Peer leader = services.get(0).leader();
-
-        assertNotNull(leader);
-
-        return raftServers.get(leader.consistentId());
-    }
-
     protected Peer getLeaderId(String tableName) {
-        // TODO: should be rewritten in https://issues.apache.org/jira/browse/IGNITE-22774
-        var services = raftClients.get(tableName);
+        int partId = 0;
 
-        return services.get(0).leader();
+        return replicaManagers.get(extractConsistentId(cluster.get(partId)))
+                .replica(new TablePartitionId(tables.get(tableName).tableId(), partId))
+                .thenApply(replica -> replica.raftClient().leader())
+                .join();
     }
 
     /**
@@ -940,11 +909,25 @@ public class ItTxTestCluster {
             assertThat(clientTxManager.stopAsync(new ComponentContext()), willCompleteSuccessfully());
         }
 
-        // TODO: should be removed in https://issues.apache.org/jira/browse/IGNITE-22774
-        for (Map.Entry<String, List<RaftGroupService>> e : raftClients.entrySet()) {
-            for (RaftGroupService svc : e.getValue()) {
-                svc.shutdown();
+        Set<TablePartitionId> grpIds = tables.values()
+                .stream()
+                .map(table -> new TablePartitionId(table.tableId(), 0))
+                .collect(toSet());
+
+        for (String consistentId : clusterServices.keySet()) {
+            ReplicaManager replicaManager = replicaManagers.get(consistentId);
+
+            if (replicaManager == null) {
+                continue;
             }
+
+            grpIds.forEach(id -> {
+                try {
+                    replicaManager.stopReplica(id);
+                } catch (NodeStoppingException e) {
+                    // no-op
+                }
+            });
         }
     }
 


### PR DESCRIPTION
JIRA Ticket: [IGNITE-22774 | Remove raftClient map from ItTxTestCluster](https://issues.apache.org/jira/browse/IGNITE-22774)

## The goal

The goal is to remove `raftClient` from `ItTxTestCluster`.

## The reason

All raft-clients are created inside replicas through `ReplicaManager#startReplica`, and most of usages of `raftClient` are effectively useless

## The solution

1. The map `raftClients` is removed.
2. `getLeader` and related assertions are removed. 
3. `getLeaderId` method is rewritten as following:
```java
int partId = 0;

return replicaManagers.get(extractConsistentId(cluster.get(partId)))
                .replica(new TablePartitionId(tables.get(tableName).tableId(), partId))
                .thenApply(replica -> replica.raftClient().leader())
                .join();
```
4. Replicas are stopped instead of raft-clients from the map as following:
```java
for (String consistentId : clusterServices.keySet()) {
    ReplicaManager replicaManager = replicaManagers.get(consistentId);

    if (replicaManager == null) {
        continue;
    }

    grpIds.forEach(id -> {
        try {
            replicaManager.stopReplica(id);
        } catch (NodeStoppingException e) {
            // no-op
        }
    });
}
```
5. Extra map for tables is introduced because we need to get `tableId` in `getLeaderId`.

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)