### PR TITLE
IGNITE-22873: InvalidTypeException should not include a value in its error message

### DIFF
--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientBinaryTupleUtils.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientBinaryTupleUtils.java
@@ -448,7 +448,7 @@ public class ClientBinaryTupleUtils {
 
             // Exception message is similar to embedded mode - see o.a.i.i.schema.Column#validate
             String error = format(
-                    "Value type does not match expected {} but got {} in column '{}'",
+                    "Value type does not match. Expected {} but got {} in column '{}'",
                     expectedType.name(), actualType.name(), name
             );
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientBinaryTupleUtils.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientBinaryTupleUtils.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.client.proto;
 
+import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
 import static org.apache.ignite.lang.ErrorGroups.Client.PROTOCOL_ERR;
 
 import java.math.BigDecimal;
@@ -35,6 +36,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import org.apache.ignite.internal.binarytuple.BinaryTupleBuilder;
 import org.apache.ignite.internal.binarytuple.BinaryTupleReader;
+import org.apache.ignite.internal.type.NativeType;
+import org.apache.ignite.internal.type.NativeTypeSpec;
+import org.apache.ignite.internal.type.NativeTypes;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.marshalling.Marshaller;
 import org.apache.ignite.sql.ColumnType;
@@ -435,11 +439,20 @@ public class ClientBinaryTupleUtils {
                     throw new IllegalArgumentException("Unsupported type: " + type);
             }
         } catch (ClassCastException e) {
+            NativeType nativeType = NativeTypes.fromObject(v);
+            // A null is handled separately, so nativeType should not be null.
+            assert nativeType != null;
+
+            NativeTypeSpec actualType = nativeType.spec();
+            NativeTypeSpec expectedType = NativeTypeSpec.fromColumnType(type);
+
             // Exception message is similar to embedded mode - see o.a.i.i.schema.Column#validate
-            throw new IgniteException(PROTOCOL_ERR, "Column's type mismatch ["
-                    + "column=" + name
-                    + ", expectedType=" + type
-                    + ", actualType=" + v.getClass() + ']', e);
+            String error = format(
+                    "Value type does not match expected {} but got {} in column '{}'",
+                    expectedType.name(), actualType.name(), name
+            );
+
+            throw new IgniteException(PROTOCOL_ERR, error, e);
         }
     }
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientBinaryTupleUtils.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientBinaryTupleUtils.java
@@ -448,8 +448,8 @@ public class ClientBinaryTupleUtils {
 
             // Exception message is similar to embedded mode - see o.a.i.i.schema.Column#validate
             String error = format(
-                    "Value type does not match. Expected {} but got {} in column '{}'",
-                    expectedType.name(), actualType.name(), name
+                    "Value type does not match [column='{}', expected={}, actual={}]",
+                    name, expectedType.name(), actualType.name()
             );
 
             throw new IgniteException(PROTOCOL_ERR, error, e);

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientTableTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientTableTest.java
@@ -461,7 +461,7 @@ public class ClientTableTest extends AbstractClientTableTest {
         var tuple = Tuple.create().set("id", "str");
 
         var ex = assertThrows(IgniteException.class, () -> defaultTable().recordView().upsert(null, tuple));
-        assertEquals("Value type does not match. Expected INT64 but got STRING in column 'ID'", ex.getMessage());
+        assertEquals("Value type does not match [column='ID', expected=INT64, actual=STRING]", ex.getMessage());
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientTableTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientTableTest.java
@@ -461,7 +461,7 @@ public class ClientTableTest extends AbstractClientTableTest {
         var tuple = Tuple.create().set("id", "str");
 
         var ex = assertThrows(IgniteException.class, () -> defaultTable().recordView().upsert(null, tuple));
-        assertEquals("Value type does not match expected INT64 but got STRING in column 'ID'", ex.getMessage());
+        assertEquals("Value type does not match. Expected INT64 but got STRING in column 'ID'", ex.getMessage());
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientTableTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientTableTest.java
@@ -461,7 +461,7 @@ public class ClientTableTest extends AbstractClientTableTest {
         var tuple = Tuple.create().set("id", "str");
 
         var ex = assertThrows(IgniteException.class, () -> defaultTable().recordView().upsert(null, tuple));
-        assertEquals("Column's type mismatch [column=ID, expectedType=INT64, actualType=class java.lang.String]", ex.getMessage());
+        assertEquals("Value type does not match expected INT64 but got STRING in column 'ID'", ex.getMessage());
     }
 
     @Test

--- a/modules/core/src/main/java/org/apache/ignite/internal/type/DecimalNativeType.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/type/DecimalNativeType.java
@@ -17,6 +17,8 @@
 
 package org.apache.ignite.internal.type;
 
+import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
+
 import java.util.Objects;
 import org.apache.ignite.internal.tostring.S;
 
@@ -55,6 +57,12 @@ public class DecimalNativeType extends NativeType {
      */
     public int scale() {
         return scale;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String displayName() {
+        return format("{}({}, {})", super.displayName(), precision, scale);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/type/NativeType.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/type/NativeType.java
@@ -91,6 +91,7 @@ public class NativeType implements Comparable<NativeType> {
 
     /**
      * Return human readable name of this type.
+     *
      * @return Human readable name of this type.
      */
     public String displayName() {

--- a/modules/core/src/main/java/org/apache/ignite/internal/type/NativeType.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/type/NativeType.java
@@ -89,6 +89,14 @@ public class NativeType implements Comparable<NativeType> {
         return this != type && typeSpec != type.typeSpec;
     }
 
+    /**
+     * Return human readable name of this type.
+     * @return Human readable name of this type.
+     */
+    public String displayName() {
+        return typeSpec.asColumnType().name();
+    }
+
     /** {@inheritDoc} */
     @Override
     public boolean equals(Object o) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/type/NativeTypeSpec.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/type/NativeTypeSpec.java
@@ -333,8 +333,9 @@ public enum NativeTypeSpec {
      * Returns a {@link NativeTypeSpec} that corresponds to the given {@link ColumnType}.
      *
      * @param columnType Column type.
-     * @throws IllegalArgumentException if ColumnType is {@link ColumnType#NULL} or is not supported.
+     *
      * @return Native type.
+     * @throws IllegalArgumentException if ColumnType is {@link ColumnType#NULL} or is not supported.
      */
     public static NativeTypeSpec fromColumnType(ColumnType columnType) {
         switch (columnType) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/type/NativeTypeSpec.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/type/NativeTypeSpec.java
@@ -329,6 +329,51 @@ public enum NativeTypeSpec {
         return val != null ? fromClass(val.getClass()) : null;
     }
 
+    /**
+     * Returns a {@link NativeTypeSpec} that corresponds to the given {@link ColumnType}.
+     *
+     * @param columnType Column type.
+     * @throws IllegalArgumentException if ColumnType is {@link ColumnType#NULL} or is not supported.
+     * @return Native type.
+     */
+    public static NativeTypeSpec fromColumnType(ColumnType columnType) {
+        switch (columnType) {
+            case BOOLEAN:
+                return BOOLEAN;
+            case INT8:
+                return INT8;
+            case INT16:
+                return INT16;
+            case INT32:
+                return INT32;
+            case INT64:
+                return INT64;
+            case FLOAT:
+                return FLOAT;
+            case DOUBLE:
+                return DOUBLE;
+            case DECIMAL:
+                return DECIMAL;
+            case DATE:
+                return DATE;
+            case TIME:
+                return TIME;
+            case DATETIME:
+                return DATETIME;
+            case TIMESTAMP:
+                return TIMESTAMP;
+            case UUID:
+                return UUID;
+            case STRING:
+                return STRING;
+            case BYTE_ARRAY:
+                return BYTES;
+            case NULL:
+            default:
+                throw new IllegalArgumentException("No native type spec for column type: " + columnType);
+        }
+    }
+
     /** {@inheritDoc} */
     @Override
     public String toString() {

--- a/modules/core/src/main/java/org/apache/ignite/internal/type/TemporalNativeType.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/type/TemporalNativeType.java
@@ -17,6 +17,8 @@
 
 package org.apache.ignite.internal.type;
 
+import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
+
 import org.apache.ignite.internal.tostring.S;
 
 /**
@@ -85,6 +87,12 @@ public class TemporalNativeType extends NativeType {
      */
     public int precision() {
         return precision;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String displayName() {
+        return format("{}({})", super.displayName(), precision);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/type/VarlenNativeType.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/type/VarlenNativeType.java
@@ -17,6 +17,8 @@
 
 package org.apache.ignite.internal.type;
 
+import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
+
 import org.apache.ignite.internal.tostring.S;
 
 /**
@@ -38,9 +40,16 @@ public class VarlenNativeType extends NativeType {
         this.len = len;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean mismatch(NativeType type) {
         return super.mismatch(type) || len < ((VarlenNativeType) type).len;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String displayName() {
+        return format("{}({})", super.displayName(), len);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/type/NativeTypeSpecTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/type/NativeTypeSpecTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.ignite.sql.ColumnType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+
+/** NativeType spec tests. */
+public class NativeTypeSpecTest {
+
+    @ParameterizedTest
+    // TODO: https://issues.apache.org/jira/browse/IGNITE-15200: Include PERIOD and DURATION after interval type support is added.
+    @EnumSource(value = ColumnType.class, mode = Mode.EXCLUDE, names = {"NULL", "PERIOD", "DURATION"})
+    public void testFromColumnType(ColumnType columnType) {
+        NativeTypeSpec typeSpec = NativeTypeSpec.fromColumnType(columnType);
+        assertEquals(typeSpec.asColumnType(), columnType);
+    }
+
+    @Test
+    public void testFromColumnTypeNullVal() {
+        IllegalArgumentException err = assertThrows(IllegalArgumentException.class,
+                () -> NativeTypeSpec.fromColumnType(ColumnType.NULL));
+        assertEquals(err.getMessage(), "No native type spec for column type: NULL");
+    }
+
+    @Test
+    public void testFromColumnTypeNull() {
+        assertThrows(NullPointerException.class, () -> NativeTypeSpec.fromColumnType(null));
+    }
+}

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -247,8 +247,8 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
         // The validation done on a client side (for a thin client), and messages may differ between embedded clients and thin clients.
         // For an embedded client the message include type precision, but for a thin client it doesn't.
         Throwable ex = assertThrows(IgniteException.class, () -> tupleView.upsert(null, rec));
-        assertThat(ex.getMessage(), startsWith("Value type does not match expected STRING"));
-        assertThat(ex.getMessage(), endsWith("but got INT64 in column 'VAL'"));
+        assertThat(ex.getMessage(), startsWith("Value type does not match [column='VAL', expected=STRING"));
+        assertThat(ex.getMessage(), endsWith(", actual=INT64]"));
     }
 
     @Test
@@ -335,7 +335,7 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
                 () -> tupleView.put(null, Tuple.create().set("KEY", 1), Tuple.create().set("VAL", "1".repeat(20))),
                 IgniteException.class);
 
-        assertThat(ex.getMessage(), containsString("Value too long for type STRING(10) in column 'VAL'"));
+        assertThat(ex.getMessage(), containsString("Value too long [column='VAL', type=STRING(10)]"));
     }
 
     @Test

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMarshallingTest.java
@@ -243,6 +243,7 @@ public class ItThinClientMarshallingTest extends ItAbstractThinClientTest {
 
         Tuple rec = Tuple.create().set("KEY", 1).set("VAL", 1L);
 
+        // TODO: https://issues.apache.org/jira/browse/IGNITE-22965.
         // The validation done on a client side (for a thin client), and messages may differ between embedded clients and thin clients.
         // For an embedded client the message include type precision, but for a thin client it doesn't.
         Throwable ex = assertThrows(IgniteException.class, () -> tupleView.upsert(null, rec));

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/Column.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/Column.java
@@ -211,12 +211,12 @@ public class Column {
             boolean specMatches = objType.spec() == type.spec();
 
             if (specMatches &&  type instanceof VarlenNativeType) {
-                String error = format("Value too long for type {} in column '{}'", type.displayName(), name);
+                String error = format("Value too long [column='{}', type={}]", name, type.displayName());
                 throw new InvalidTypeException(error);
             } else {
                 String error = format(
-                        "Value type does not match. Expected {} but got {} in column '{}'",
-                        type.displayName(), objType.displayName(), name
+                        "Value type does not match [column='{}', expected={}, actual={}]",
+                        name, type.displayName(), objType.displayName()
                 );
                 throw new InvalidTypeException(error);
             }

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/Column.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/Column.java
@@ -215,7 +215,7 @@ public class Column {
                 throw new InvalidTypeException(error);
             } else {
                 String error = format(
-                        "Value type does not match expected {} but got {} in column '{}'",
+                        "Value type does not match. Expected {} but got {} in column '{}'",
                         type.displayName(), objType.displayName(), name
                 );
                 throw new InvalidTypeException(error);

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/Column.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/Column.java
@@ -23,6 +23,7 @@ import org.apache.ignite.internal.tostring.IgniteToStringExclude;
 import org.apache.ignite.internal.tostring.S;
 import org.apache.ignite.internal.type.NativeType;
 import org.apache.ignite.internal.type.NativeTypes;
+import org.apache.ignite.internal.type.VarlenNativeType;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -207,11 +208,18 @@ public class Column {
         NativeType objType = NativeTypes.fromObject(val);
 
         if (objType != null && type.mismatch(objType)) {
-            throw new InvalidTypeException("Column's type mismatch ["
-                    + "column=" + this
-                    + ", expectedType=" + type
-                    + ", actualType=" + objType
-                    + ", val=" + val + ']');
+            boolean specMatches = objType.spec() == type.spec();
+
+            if (specMatches &&  type instanceof VarlenNativeType) {
+                String error = format("Value too long for type {} in column '{}'", type.displayName(), name);
+                throw new InvalidTypeException(error);
+            } else {
+                String error = format(
+                        "Value type does not match expected {} but got {} in column '{}'",
+                        type.displayName(), objType.displayName(), name
+                );
+                throw new InvalidTypeException(error);
+            }
         }
     }
 
@@ -249,5 +257,15 @@ public class Column {
      */
     public static String nullConstraintViolationMessage(String columnName) {
         return format("Column '{}' does not allow NULLs", columnName);
+    }
+
+    /**
+     * Returns an error message for numeric field overflow error.
+     *
+     * @param columnName Column name.
+     * @return Error message.
+     */
+    public static String numericFieldOverflow(String columnName) {
+        return format("Numeric field overflow in column '{}'", columnName);
     }
 }

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/row/RowAssembler.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/row/RowAssembler.java
@@ -350,10 +350,9 @@ public class RowAssembler {
 
         DecimalNativeType type = (DecimalNativeType) col.type();
 
-        if (val.setScale(type.scale(), RoundingMode.HALF_UP).precision() > type.precision()) {
-            throw new SchemaMismatchException("Failed to set decimal value for column '" + col.name() + "' "
-                    + "(max precision exceeds allocated precision)"
-                    + " [decimal=" + val + ", max precision=" + type.precision() + "]");
+        BigDecimal scaled = val.setScale(type.scale(), RoundingMode.HALF_UP);
+        if (scaled.precision() > type.precision()) {
+            throw new SchemaMismatchException(Column.numericFieldOverflow(col.name()));
         }
 
         builder.appendDecimalNotNull(val, type.scale());

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/MutableRowTupleAdapterTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/MutableRowTupleAdapterTest.java
@@ -412,8 +412,12 @@ public class MutableRowTupleAdapterTest extends AbstractMutableTupleTest {
                 .set("string", "abcefghi")
                 .set("bytes", new byte[]{1, 2, 3, 4, 5});
 
-        assertThrowsWithCause(() -> marshaller.marshal(tuple1), InvalidTypeException.class, "Column's type mismatch");
-        assertThrowsWithCause(() -> marshaller.marshal(tuple2), InvalidTypeException.class, "Column's type mismatch");
+        assertThrowsWithCause(() -> marshaller.marshal(tuple1), InvalidTypeException.class,
+                "Value too long for type BYTE_ARRAY(5) in column 'BYTES'"
+        );
+        assertThrowsWithCause(() -> marshaller.marshal(tuple2), InvalidTypeException.class,
+                "Value too long for type STRING(5) in column 'STRING'"
+        );
 
         Tuple expected = Tuple.create().set("key", 1)
                 .set("string", "abc")
@@ -438,7 +442,7 @@ public class MutableRowTupleAdapterTest extends AbstractMutableTupleTest {
         Tuple tuple1 = Tuple.create().set("key", 1).set("decimal", new BigDecimal("123456.7"));
 
         assertThrowsWithCause(() -> marshaller.marshal(tuple1), SchemaMismatchException.class,
-                "Failed to set decimal value for column 'DECIMAL' (max precision exceeds allocated precision)");
+                "Numeric field overflow in column 'DECIMAL'");
     }
 
     @Test

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/MutableRowTupleAdapterTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/MutableRowTupleAdapterTest.java
@@ -413,10 +413,10 @@ public class MutableRowTupleAdapterTest extends AbstractMutableTupleTest {
                 .set("bytes", new byte[]{1, 2, 3, 4, 5});
 
         assertThrowsWithCause(() -> marshaller.marshal(tuple1), InvalidTypeException.class,
-                "Value too long for type BYTE_ARRAY(5) in column 'BYTES'"
+                "Value too long [column='BYTES', type=BYTE_ARRAY(5)]"
         );
         assertThrowsWithCause(() -> marshaller.marshal(tuple2), InvalidTypeException.class,
-                "Value too long for type STRING(5) in column 'STRING'"
+                "Value too long [column='STRING', type=STRING(5)]"
         );
 
         Tuple expected = Tuple.create().set("key", 1)

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/RecordBinaryViewOperationsTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/RecordBinaryViewOperationsTest.java
@@ -280,12 +280,12 @@ public class RecordBinaryViewOperationsTest extends TableKvOperationsTestBase {
         final Tuple tuple1 = new TestTupleBuilder().set("id", 1L).set("blob", new byte[]{0, 1, 2, 3}).set("val", 22L);
 
         assertThrowsWithCause(InvalidTypeException.class, () -> tbl.get(null, keyTuple0),
-                "Value type does not match. Expected INT64 but got INT32");
+                "Value type does not match [column='ID', expected=INT64, actual=INT32]");
         assertThrowsWithCause(SchemaMismatchException.class, () -> tbl.get(null, keyTuple1),
                 "Missed key column: ID");
 
-        String strTooLongErr = "Value too long for type STRING(3)";
-        String byteArrayTooLongErr = "Value too long for type BYTE_ARRAY(3)";
+        String strTooLongErr = "Value too long [column='STR', type=STRING(3)]";
+        String byteArrayTooLongErr = "Value too long [column='BLOB', type=BYTE_ARRAY(3)]";
 
         assertThrowsWithCause(InvalidTypeException.class, () -> tbl.replace(null, tuple0), strTooLongErr);
         assertThrowsWithCause(InvalidTypeException.class, () -> tbl.replace(null, tuple1), byteArrayTooLongErr);

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/RecordBinaryViewOperationsTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/RecordBinaryViewOperationsTest.java
@@ -280,7 +280,7 @@ public class RecordBinaryViewOperationsTest extends TableKvOperationsTestBase {
         final Tuple tuple1 = new TestTupleBuilder().set("id", 1L).set("blob", new byte[]{0, 1, 2, 3}).set("val", 22L);
 
         assertThrowsWithCause(InvalidTypeException.class, () -> tbl.get(null, keyTuple0),
-                "Value type does not match expected INT64 but got INT32");
+                "Value type does not match. Expected INT64 but got INT32");
         assertThrowsWithCause(SchemaMismatchException.class, () -> tbl.get(null, keyTuple1),
                 "Missed key column: ID");
 

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/RecordBinaryViewOperationsTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/RecordBinaryViewOperationsTest.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
@@ -50,8 +49,8 @@ import org.apache.ignite.internal.schema.marshaller.TupleMarshallerImpl;
 import org.apache.ignite.internal.table.distributed.replicator.InternalSchemaVersionMismatchException;
 import org.apache.ignite.internal.table.impl.DummySchemaManagerImpl;
 import org.apache.ignite.internal.table.impl.TestTupleBuilder;
+import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.internal.type.NativeTypes;
-import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.sql.IgniteSql;
 import org.apache.ignite.table.RecordView;
 import org.apache.ignite.table.Tuple;
@@ -280,17 +279,22 @@ public class RecordBinaryViewOperationsTest extends TableKvOperationsTestBase {
         final Tuple tuple0 = new TestTupleBuilder().set("id", 1L).set("str", "qweqweqwe").set("val", 11L);
         final Tuple tuple1 = new TestTupleBuilder().set("id", 1L).set("blob", new byte[]{0, 1, 2, 3}).set("val", 22L);
 
-        assertThrowsWithCause(InvalidTypeException.class, () -> tbl.get(null, keyTuple0));
-        assertThrowsWithCause(SchemaMismatchException.class, () -> tbl.get(null, keyTuple1));
+        assertThrowsWithCause(InvalidTypeException.class, () -> tbl.get(null, keyTuple0),
+                "Value type does not match expected INT64 but got INT32");
+        assertThrowsWithCause(SchemaMismatchException.class, () -> tbl.get(null, keyTuple1),
+                "Missed key column: ID");
 
-        assertThrowsWithCause(InvalidTypeException.class, () -> tbl.replace(null, tuple0));
-        assertThrowsWithCause(InvalidTypeException.class, () -> tbl.replace(null, tuple1));
+        String strTooLongErr = "Value too long for type STRING(3)";
+        String byteArrayTooLongErr = "Value too long for type BYTE_ARRAY(3)";
 
-        assertThrowsWithCause(InvalidTypeException.class, () -> tbl.insert(null, tuple0));
-        assertThrowsWithCause(InvalidTypeException.class, () -> tbl.insert(null, tuple1));
+        assertThrowsWithCause(InvalidTypeException.class, () -> tbl.replace(null, tuple0), strTooLongErr);
+        assertThrowsWithCause(InvalidTypeException.class, () -> tbl.replace(null, tuple1), byteArrayTooLongErr);
 
-        assertThrowsWithCause(InvalidTypeException.class, () -> tbl.replace(null, tuple0));
-        assertThrowsWithCause(InvalidTypeException.class, () -> tbl.replace(null, tuple1));
+        assertThrowsWithCause(InvalidTypeException.class, () -> tbl.insert(null, tuple0), strTooLongErr);
+        assertThrowsWithCause(InvalidTypeException.class, () -> tbl.insert(null, tuple1), byteArrayTooLongErr);
+
+        assertThrowsWithCause(InvalidTypeException.class, () -> tbl.replace(null, tuple0), strTooLongErr);
+        assertThrowsWithCause(InvalidTypeException.class, () -> tbl.replace(null, tuple1), byteArrayTooLongErr);
     }
 
     @Test
@@ -736,17 +740,7 @@ public class RecordBinaryViewOperationsTest extends TableKvOperationsTestBase {
         }
     }
 
-    private <T extends Throwable> void assertThrowsWithCause(Class<T> expectedType, Executable executable) {
-        Throwable ex = assertThrows(IgniteException.class, executable);
-
-        while (ex.getCause() != null) {
-            if (expectedType.isInstance(ex.getCause())) {
-                return;
-            }
-
-            ex = ex.getCause();
-        }
-
-        fail("Expected cause wasn't found.");
+    private <T extends Throwable> void assertThrowsWithCause(Class<T> expectedType, Executable executable, String message) {
+        IgniteTestUtils.assertThrowsWithCause(executable::execute, expectedType, message);
     }
 }

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/type/NumericTypesSerializerTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/type/NumericTypesSerializerTest.java
@@ -118,7 +118,6 @@ public class NumericTypesSerializerTest {
                 MarshallerException.class,
                 "Numeric field overflow"
         );
-        //  Failed to set decimal value for column 'DECIMALCOL' (max precision exceeds allocated precision) [decimal=12345678.9, max precision=9]
         assertThrowsWithCause(
                 () -> marshaller.marshal(badTup.set("decimalCol", new BigDecimal("12345678.9"))),
                 MarshallerException.class,

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/type/NumericTypesSerializerTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/type/NumericTypesSerializerTest.java
@@ -106,22 +106,23 @@ public class NumericTypesSerializerTest {
         assertThrowsWithCause(
                 () -> marshaller.marshal(badTup.set("decimalCol", new BigDecimal("123456789.0123"))),
                 MarshallerException.class,
-                "Failed to set decimal value for column"
+                "Numeric field overflow"
         );
         assertThrowsWithCause(
                 () -> marshaller.marshal(badTup.set("decimalCol", new BigDecimal("-1234567890123"))),
                 MarshallerException.class,
-                "Failed to set decimal value for column"
+                "Numeric field overflow"
         );
         assertThrowsWithCause(
                 () -> marshaller.marshal(badTup.set("decimalCol", new BigDecimal("1234567"))),
                 MarshallerException.class,
-                "Failed to set decimal value for column"
+                "Numeric field overflow"
         );
+        //  Failed to set decimal value for column 'DECIMALCOL' (max precision exceeds allocated precision) [decimal=12345678.9, max precision=9]
         assertThrowsWithCause(
                 () -> marshaller.marshal(badTup.set("decimalCol", new BigDecimal("12345678.9"))),
                 MarshallerException.class,
-                "Failed to set decimal value for column"
+                "Numeric field overflow"
         );
     }
 


### PR DESCRIPTION
Fixes error message for a column type mismatch error in KV/Record View APIs.

https://issues.apache.org/jira/browse/IGNITE-22873

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)