### PR TITLE
IGNITE-22772 Sql. Fix row type derivation for renaming in FROM clause

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1052,7 +1052,9 @@
     <inspection_tool class="SystemGetenv" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TestCaseInProductCode" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TestCaseWithConstructor" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="TestCaseWithNoTestMethods" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="TestCaseWithNoTestMethods" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoreSupers" value="true" />
+    </inspection_tool>
     <inspection_tool class="TestMethodInProductCode" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TestNGDataProvider" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TestOnlyProblems" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1052,9 +1052,7 @@
     <inspection_tool class="SystemGetenv" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TestCaseInProductCode" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TestCaseWithConstructor" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="TestCaseWithNoTestMethods" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="ignoreSupers" value="true" />
-    </inspection_tool>
+    <inspection_tool class="TestCaseWithNoTestMethods" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TestMethodInProductCode" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TestNGDataProvider" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TestOnlyProblems" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItMetadataTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItMetadataTest.java
@@ -30,7 +30,6 @@ import org.apache.ignite.sql.ColumnType;
 import org.apache.ignite.sql.ResultSet;
 import org.apache.ignite.sql.SqlRow;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -90,7 +89,6 @@ public class ItMetadataTest extends BaseSqlIntegrationTest {
     }
 
     @Test
-    @Disabled("IGNITE-22772")
     public void renameColumnsInFrom() {
         assertQuery("select NEW_PERSON.NEW_ID, NEW_NAME, NEW_persON.New_salary from person NEW_PERSON(NeW_Id, NeW_NaMe, New_SaLaRy)")
                 .columnNames("NEW_ID", "NEW_NAME", "NEW_SALARY").check();

--- a/modules/sql-engine/src/integrationTest/sql/basic_queries/rename_columns_in_from.test
+++ b/modules/sql-engine/src/integrationTest/sql/basic_queries/rename_columns_in_from.test
@@ -2,7 +2,6 @@
 # description: SQL feature E051-9 (Basic query specification. Rename columns in the FROM clause)
 # feature: E051-09
 # group: [basic_queries]
-# Ignore: https://issues.apache.org/jira/browse/IGNITE-22772
 
 statement ok
 CREATE TABLE tab ( A INT PRIMARY KEY, B INT )
@@ -68,13 +67,44 @@ SELECT X, Y FROM tab alias (X, Y) order by x -- no AS
 3	11
 
 # duplicate alias name
-statement error
+statement error: Duplicate name 'B' in column alias list
 SELECT alias.b, b FROM tab AS alias (b, b)
 
 # number of aliases is less than number of columns
-statement error
+statement error: List of column aliases must have same degree as table; table has 2 columns ('A', 'B'), whereas alias list has 1 columns
 SELECT alias.X FROM tab AS alias (X)
 
 # number of aliases is bigger than number of columns
-statement error
+statement error: List of column aliases must have same degree as table; table has 2 columns ('A', 'B'), whereas alias list has 3 columns
 SELECT alias.X FROM tab AS alias (X, Y, Z)
+
+statement ok
+CREATE TABLE another_table(val INT);
+
+statement ok
+INSERT INTO another_table VALUES(1)
+
+# system columns still can be referenced by old name after renaming
+query IIIIII
+SELECT
+  -- simple references
+  "__part" IS NOT NULL,
+  "__p_key" IS NOT NULL,
+  new_val,
+
+  -- qualified reference
+  t."__part" IS NOT NULL, 
+  t."__p_key" IS NOT NULL,
+  t.new_val
+  FROM another_table t (new_val)
+----
+true	true	1	true	true	1
+
+statement ok
+SELECT alias.X FROM (SELECT * FROM tab) AS alias (X, Y)
+
+statement error: List of column aliases must have same degree as table; table has 3 columns ('__part', 'A', 'B'), whereas alias list has 2 columns
+SELECT alias.X FROM (SELECT "__part", * FROM tab) AS alias (X, Y)
+
+statement ok
+SELECT alias.X FROM (SELECT "__part", * FROM tab) AS alias (X, Y, Z)

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/IgniteAliasNamespace.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/IgniteAliasNamespace.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.prepare;
+
+import static org.apache.calcite.util.Static.RESOURCE;
+
+import java.util.List;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.validate.AliasNamespace;
+import org.apache.calcite.sql.validate.SqlValidatorImpl;
+import org.apache.calcite.sql.validate.SqlValidatorNamespace;
+import org.apache.calcite.sql.validate.SqlValidatorTable;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.Util;
+import org.apache.calcite.util.mapping.Mapping;
+import org.apache.calcite.util.mapping.MappingType;
+import org.apache.calcite.util.mapping.Mappings;
+import org.apache.ignite.internal.sql.engine.schema.ColumnDescriptor;
+import org.apache.ignite.internal.sql.engine.schema.TableDescriptor;
+
+/**
+ * Alias namespace that properly handles `system` (aka {@link ColumnDescriptor#hidden() hidden}) columns during renaming.
+ */
+public class IgniteAliasNamespace extends AliasNamespace {
+    IgniteAliasNamespace(
+            SqlValidatorImpl validator, SqlCall call, SqlNode enclosingNode
+    ) {
+        super(validator, call, enclosingNode);
+    }
+
+    @Override
+    protected RelDataType validateImpl(RelDataType targetRowType) {
+        List<SqlNode> operands = call.getOperandList();
+
+        if (operands.size() == 2) {
+            return super.validateImpl(targetRowType);
+        }
+
+        // Alias is 'AS t (c0, ..., cN)'
+        SqlValidatorNamespace childNs = validator.getNamespace(operands.get(0));
+
+        assert childNs != null : "Alias in FROM list must have a namespace";
+
+        SqlValidatorTable table = childNs.getTable();
+
+        if (table == null) {
+            // Not all namespaces derived from a table (for example, the one derived from sub-query).
+            // In this case let's fallback to original validation, because logic below is meant to
+            // handle `system` columns which belongs solely to the IgniteTable.
+            return super.validateImpl(targetRowType);
+        }
+
+        List<SqlNode> columnNames = Util.skip(operands, 2);
+        List<String> nameList = SqlIdentifier.simpleNames(columnNames);
+
+        int i = Util.firstDuplicate(nameList);
+        if (i >= 0) {
+            SqlIdentifier id = (SqlIdentifier) columnNames.get(i);
+            throw validator.newValidationError(id,
+                    RESOURCE.aliasListDuplicate(id.getSimple()));
+        }
+
+        TableDescriptor descriptor = table.unwrap(TableDescriptor.class);
+
+        assert descriptor != null;
+
+        RelDataType rowTypeSansHidden = descriptor.rowTypeSansHidden();
+        // At the moment, only system columns are hidden, and user must provide
+        // aliases for all non-system columns.
+        if (columnNames.size() != rowTypeSansHidden.getFieldList().size()) {
+            // Position error over all column names
+            SqlNode node = operands.size() == 3
+                    ? operands.get(2)
+                    : new SqlNodeList(columnNames, SqlParserPos.sum(columnNames));
+
+            throw validator.newValidationError(node,
+                    RESOURCE.aliasListDegree(rowTypeSansHidden.getFieldCount(),
+                            getString(rowTypeSansHidden), columnNames.size()));
+        }
+
+        // Although this may look like proper way to address `system` columns, in fact it's not:
+        //     1) Calcite has different notion of `system` columns. First of all, all implementations
+        //     of namespace just propagate call to getRowType() method. Second, system columns are
+        //     registered only when converter meets LogicalJoin.
+        //
+        //     2) Row type returned from this method will be used to resolve columns. Thus, if we skip
+        //     `system` columns validator won't be able to resolve any reference of such columns (given
+        //     that they are registered only in case of joins)
+        RelDataType rowType = childNs.getRowTypeSansSystemColumns();
+
+        assert rowType != null;
+
+        int fieldsCount = rowType.getFieldCount();
+        Mapping mapping = Mappings.create(MappingType.PARTIAL_FUNCTION, fieldsCount, nameList.size());
+        int idx = 0;
+        for (ColumnDescriptor column : descriptor) {
+            if (!column.hidden()) {
+                mapping.set(column.logicalIndex(), idx++);
+            }
+        }
+
+        RelDataType aliasedType = validator.getTypeFactory().builder()
+                .addAll(
+                        Util.transform(
+                                rowType.getFieldList(),
+                                f -> {
+                                    int index = mapping.getTargetOpt(f.getIndex());
+                                    String name = index == -1 ? f.getName() : nameList.get(index);
+
+                                    return Pair.of(name, f.getType());
+                                }
+                        )
+                )
+                .kind(rowType.getStructKind())
+                .build();
+
+        return validator.getTypeFactory()
+                .createTypeWithNullability(aliasedType, rowType.isNullable());
+    }
+
+    @SuppressWarnings("MethodOverridesInaccessibleMethodOfSuper")
+    private static String getString(RelDataType rowType) {
+        StringBuilder buf = new StringBuilder();
+        buf.append('(');
+        for (RelDataTypeField field : rowType.getFieldList()) {
+            if (field.getIndex() > 0) {
+                buf.append(", ");
+            }
+            buf.append('\'');
+            buf.append(field.getName());
+            buf.append('\'');
+        }
+        buf.append(')');
+        return buf.toString();
+    }
+}

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/IgniteAliasNamespace.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/IgniteAliasNamespace.java
@@ -105,8 +105,8 @@ public class IgniteAliasNamespace extends AliasNamespace {
         //     registered only when converter meets LogicalJoin.
         //
         //     2) Row type returned from this method will be used to resolve columns. Thus, if we skip
-        //     `system` columns validator won't be able to resolve any reference of such columns (given
-        //     that they are registered only in case of joins)
+        //     `system` columns, validator won't be able to resolve any reference of such columns (given
+        //     that they are registered only in case of joins).
         RelDataType rowType = childNs.getRowTypeSansSystemColumns();
 
         assert rowType != null;

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/TableDescriptor.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/TableDescriptor.java
@@ -41,6 +41,9 @@ public interface TableDescriptor extends InitializerExpressionFactory, Iterable<
      */
     RelDataType rowType(IgniteTypeFactory factory, @Nullable ImmutableBitSet usedColumns);
 
+    /** Returns type of the row excluding all {@link ColumnDescriptor#hidden() hidden} columns. */
+    RelDataType rowTypeSansHidden();
+
     /**
      * Returns column descriptor for given field name.
      *

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/TableDescriptorImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/TableDescriptorImpl.java
@@ -55,6 +55,7 @@ public class TableDescriptorImpl extends NullInitializerExpressionFactory implem
     private final IgniteDistribution distribution;
 
     private final RelDataType rowType;
+    private final RelDataType rowTypeSansHidden;
 
     /**
      * Constructor.
@@ -69,15 +70,24 @@ public class TableDescriptorImpl extends NullInitializerExpressionFactory implem
 
         IgniteTypeFactory factory = Commons.typeFactory();
         RelDataTypeFactory.Builder typeBuilder = new RelDataTypeFactory.Builder(factory);
+        RelDataTypeFactory.Builder typeSansHiddenBuilder = new RelDataTypeFactory.Builder(factory);
 
         for (ColumnDescriptor descriptor : columnDescriptors) {
-            typeBuilder.add(descriptor.name(), deriveLogicalType(factory, descriptor));
+            RelDataType columnType = deriveLogicalType(factory, descriptor);
+
+            typeBuilder.add(descriptor.name(), columnType);
+
+            if (!descriptor.hidden()) {
+                typeSansHiddenBuilder.add(descriptor.name(), columnType);
+            }
+
             descriptorsMap.put(descriptor.name(), descriptor);
         }
 
         this.descriptors = columnDescriptors.toArray(DUMMY);
         this.descriptorsMap = descriptorsMap;
         this.rowType = typeBuilder.build();
+        this.rowTypeSansHidden = typeSansHiddenBuilder.build();
     }
 
     @Override
@@ -153,6 +163,11 @@ public class TableDescriptorImpl extends NullInitializerExpressionFactory implem
 
             return builder.build();
         }
+    }
+
+    @Override
+    public RelDataType rowTypeSansHidden() {
+        return rowTypeSansHidden;
     }
 
     /** {@inheritDoc} */

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/AbstractPlannerTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/AbstractPlannerTest.java
@@ -826,6 +826,11 @@ public abstract class AbstractPlannerTest extends IgniteAbstractTest {
             return rowType;
         }
 
+        @Override
+        public RelDataType rowTypeSansHidden() {
+            return rowType;
+        }
+
         /** {@inheritDoc} */
         @Override
         public ColumnDescriptor columnDescriptor(String fieldName) {

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/CorrelatedSubqueryPlannerTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/CorrelatedSubqueryPlannerTest.java
@@ -59,7 +59,7 @@ public class CorrelatedSubqueryPlannerTest extends AbstractPlannerTest {
      * @throws Exception In case of any unexpected error.
      */
     @Test
-    @Disabled("IGNITE-22772")
+    @Disabled("IGNITE-22853")
     public void test() throws Exception {
         IgniteSchema schema = createSchema(createTestTable("A", "B", "C", "D", "E"));
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22772

This patch introduces proper handling of system/hidden columns during column renaming in `FROM` clause (`SELECT * FROM my_table AS new_name(new_c1, new_c2, ...)`). Provided solution has one limitation: it's impossible to rename system columns directly. But this limitation has workaround: table may be replaced with sub-select explicitly mentioning system columns in SELECT clause (see last test case in `rename_columns_in_from.test`). 

-------------
Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)