### PR TITLE
IGNITE-22851 Move raft client's update configuration process into replicas

### DIFF
--- a/modules/partition-replicator/src/main/java/org/apache/ignite/internal/partition/replicator/PartitionReplicaLifecycleManager.java
+++ b/modules/partition-replicator/src/main/java/org/apache/ignite/internal/partition/replicator/PartitionReplicaLifecycleManager.java
@@ -802,7 +802,7 @@ public class PartitionReplicaLifecycleManager implements IgniteComponent {
 
             // Update raft client peers and learners according to the actual assignments.
             return replicaMgr.replica(zonePartitionId)
-                    .thenAccept(replica -> replica.updateConfiguration(fromAssignments(stableAssignments)));
+                    .thenAccept(replica -> replica.updatePeersAndLearners(fromAssignments(stableAssignments)));
         }));
     }
 
@@ -976,7 +976,7 @@ public class PartitionReplicaLifecycleManager implements IgniteComponent {
                             : union(pendingAssignmentsNodes, stableAssignments.nodes());
 
                     replicaMgr.replica(replicaGrpId)
-                            .thenAccept(replica -> replica.updateConfiguration(fromAssignments(newAssignments)));
+                            .thenAccept(replica -> replica.updatePeersAndLearners(fromAssignments(newAssignments)));
                 }), ioExecutor);
     }
 

--- a/modules/partition-replicator/src/main/java/org/apache/ignite/internal/partition/replicator/PartitionReplicaLifecycleManager.java
+++ b/modules/partition-replicator/src/main/java/org/apache/ignite/internal/partition/replicator/PartitionReplicaLifecycleManager.java
@@ -802,8 +802,7 @@ public class PartitionReplicaLifecycleManager implements IgniteComponent {
 
             // Update raft client peers and learners according to the actual assignments.
             return replicaMgr.replica(zonePartitionId)
-                    .thenApply(Replica::raftClient)
-                    .thenAccept(raftClient -> raftClient.updateConfiguration(fromAssignments(stableAssignments)));
+                    .thenAccept(replica -> replica.updateConfiguration(fromAssignments(stableAssignments)));
         }));
     }
 
@@ -977,8 +976,7 @@ public class PartitionReplicaLifecycleManager implements IgniteComponent {
                             : union(pendingAssignmentsNodes, stableAssignments.nodes());
 
                     replicaMgr.replica(replicaGrpId)
-                            .thenApply(Replica::raftClient)
-                            .thenAccept(raftClient -> raftClient.updateConfiguration(fromAssignments(newAssignments)));
+                            .thenAccept(replica -> replica.updateConfiguration(fromAssignments(newAssignments)));
                 }), ioExecutor);
     }
 

--- a/modules/replicator/src/main/java/org/apache/ignite/internal/replicator/Replica.java
+++ b/modules/replicator/src/main/java/org/apache/ignite/internal/replicator/Replica.java
@@ -20,6 +20,7 @@ package org.apache.ignite.internal.replicator;
 import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.internal.network.NetworkMessage;
 import org.apache.ignite.internal.placementdriver.message.PlacementDriverReplicaMessage;
+import org.apache.ignite.internal.raft.PeersAndLearners;
 import org.apache.ignite.internal.raft.client.TopologyAwareRaftGroupService;
 import org.apache.ignite.internal.replicator.listener.ReplicaListener;
 import org.apache.ignite.internal.replicator.message.ReplicaRequest;
@@ -73,4 +74,11 @@ public interface Replica {
      * Shutdowns the replica.
      */
     CompletableFuture<Void> shutdown();
+
+    /**
+     * Updates peers and learners lists in raft client.
+     *
+     * @param configuration Peers and learners configuration.
+     */
+    void updateConfiguration(PeersAndLearners configuration);
 }

--- a/modules/replicator/src/main/java/org/apache/ignite/internal/replicator/Replica.java
+++ b/modules/replicator/src/main/java/org/apache/ignite/internal/replicator/Replica.java
@@ -76,9 +76,9 @@ public interface Replica {
     CompletableFuture<Void> shutdown();
 
     /**
-     * Updates peers and learners lists in raft client.
+     * Updates local peers and learners.
      *
-     * @param configuration Peers and learners configuration.
+     * @param peersAndLearners Peers and learners.
      */
-    void updateConfiguration(PeersAndLearners configuration);
+    void updatePeersAndLearners(PeersAndLearners peersAndLearners);
 }

--- a/modules/replicator/src/main/java/org/apache/ignite/internal/replicator/ReplicaImpl.java
+++ b/modules/replicator/src/main/java/org/apache/ignite/internal/replicator/ReplicaImpl.java
@@ -41,6 +41,7 @@ import org.apache.ignite.internal.placementdriver.message.LeaseGrantedMessageRes
 import org.apache.ignite.internal.placementdriver.message.PlacementDriverMessagesFactory;
 import org.apache.ignite.internal.placementdriver.message.PlacementDriverReplicaMessage;
 import org.apache.ignite.internal.raft.Peer;
+import org.apache.ignite.internal.raft.PeersAndLearners;
 import org.apache.ignite.internal.raft.client.TopologyAwareRaftGroupService;
 import org.apache.ignite.internal.replicator.listener.ReplicaListener;
 import org.apache.ignite.internal.replicator.message.PrimaryReplicaChangeCommand;
@@ -305,5 +306,11 @@ public class ReplicaImpl implements Replica {
     public CompletableFuture<Void> shutdown() {
         listener.onShutdown();
         return raftClient.unsubscribeLeader();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateConfiguration(PeersAndLearners configuration) {
+        raftClient.updateConfiguration(configuration);
     }
 }

--- a/modules/replicator/src/main/java/org/apache/ignite/internal/replicator/ReplicaImpl.java
+++ b/modules/replicator/src/main/java/org/apache/ignite/internal/replicator/ReplicaImpl.java
@@ -310,7 +310,7 @@ public class ReplicaImpl implements Replica {
 
     /** {@inheritDoc} */
     @Override
-    public void updateConfiguration(PeersAndLearners configuration) {
-        raftClient.updateConfiguration(configuration);
+    public void updatePeersAndLearners(PeersAndLearners peersAndLearners) {
+        raftClient.updateConfiguration(peersAndLearners);
     }
 }

--- a/modules/replicator/src/main/java/org/apache/ignite/internal/replicator/ZonePartitionReplicaImpl.java
+++ b/modules/replicator/src/main/java/org/apache/ignite/internal/replicator/ZonePartitionReplicaImpl.java
@@ -22,6 +22,7 @@ import static org.apache.ignite.internal.util.CompletableFutures.nullCompletedFu
 import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.internal.network.NetworkMessage;
 import org.apache.ignite.internal.placementdriver.message.PlacementDriverReplicaMessage;
+import org.apache.ignite.internal.raft.PeersAndLearners;
 import org.apache.ignite.internal.raft.client.TopologyAwareRaftGroupService;
 import org.apache.ignite.internal.replicator.listener.ReplicaListener;
 import org.apache.ignite.internal.replicator.message.ReplicaRequest;
@@ -81,5 +82,11 @@ public class ZonePartitionReplicaImpl implements Replica {
     @Override
     public CompletableFuture<Void> shutdown() {
         return nullCompletedFuture();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateConfiguration(PeersAndLearners configuration) {
+        raftClient.updateConfiguration(configuration);
     }
 }

--- a/modules/replicator/src/main/java/org/apache/ignite/internal/replicator/ZonePartitionReplicaImpl.java
+++ b/modules/replicator/src/main/java/org/apache/ignite/internal/replicator/ZonePartitionReplicaImpl.java
@@ -86,7 +86,7 @@ public class ZonePartitionReplicaImpl implements Replica {
 
     /** {@inheritDoc} */
     @Override
-    public void updateConfiguration(PeersAndLearners configuration) {
-        raftClient.updateConfiguration(configuration);
+    public void updatePeersAndLearners(PeersAndLearners peersAndLearners) {
+        raftClient.updateConfiguration(peersAndLearners);
     }
 }

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
@@ -2112,7 +2112,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
                             : union(pendingAssignmentsNodes, stableAssignments.nodes());
 
                     replicaMgr.replica(replicaGrpId)
-                            .thenAccept(replica -> replica.updateConfiguration(fromAssignments(newAssignments)));
+                            .thenAccept(replica -> replica.updatePeersAndLearners(fromAssignments(newAssignments)));
                 }), ioExecutor);
     }
 
@@ -2445,7 +2445,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
 
             // Update raft client peers and learners according to the actual assignments.
             return replicaMgr.replica(tablePartitionId)
-                    .thenAccept(replica -> replica.updateConfiguration(fromAssignments(stableAssignments)));
+                    .thenAccept(replica -> replica.updatePeersAndLearners(fromAssignments(stableAssignments)));
         }));
     }
 

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/TableManager.java
@@ -2112,8 +2112,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
                             : union(pendingAssignmentsNodes, stableAssignments.nodes());
 
                     replicaMgr.replica(replicaGrpId)
-                            .thenApply(Replica::raftClient)
-                            .thenAccept(raftClient -> raftClient.updateConfiguration(fromAssignments(newAssignments)));
+                            .thenAccept(replica -> replica.updateConfiguration(fromAssignments(newAssignments)));
                 }), ioExecutor);
     }
 
@@ -2446,8 +2445,7 @@ public class TableManager implements IgniteTablesInternal, IgniteComponent {
 
             // Update raft client peers and learners according to the actual assignments.
             return replicaMgr.replica(tablePartitionId)
-                    .thenApply(Replica::raftClient)
-                    .thenAccept(raftClient -> raftClient.updateConfiguration(fromAssignments(stableAssignments)));
+                    .thenAccept(replica -> replica.updateConfiguration(fromAssignments(stableAssignments)));
         }));
     }
 


### PR DESCRIPTION
JIRA Ticket: [IGNITE-22851 | Move raft client's update configuration process into replicas](https://issues.apache.org/jira/browse/IGNITE-22851)

## The goal

The main goal is to remove all calls `RaftGroupService#updateConfiguration` from `TableManager`.

## The reason

There should no any raft client usages inside `TableManager`.

## The solution

1. Method Replica#updateConfiguration is introduced.
2. All calls like `raftClient -> raftClient.updateConfiguration(...)` are replaced with `replica -> replica.updateConfiguration(...)`

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)