### PR TITLE
IGNITE-22644 .NET: Add JobDescriptor.Marshaller

### DIFF
--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/executor/ComputeExecutorImpl.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/executor/ComputeExecutorImpl.java
@@ -128,7 +128,7 @@ public class ComputeExecutorImpl implements ComputeExecutor {
     }
 
     private static <T> @Nullable T unmarshallOrNotIfNull(@Nullable Marshaller<T, byte[]> marshaller, Object input) {
-        if (marshaller == null) {
+        if (marshaller == null || input == null) {
             return (T) input;
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Apache.Ignite.Benchmarks.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Apache.Ignite.Benchmarks.csproj
@@ -23,6 +23,7 @@
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>Apache.Ignite.Benchmarks.snk</AssemblyOriginatorKeyFile>
         <ServerGarbageCollection>true</ServerGarbageCollection>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -846,7 +846,7 @@ namespace Apache.Ignite.Tests.Compute
                 ResultMarshaller = bytes => JsonSerializer.Deserialize<MyResult>(bytes.Span)!
             };
 
-            var arg = new MyArg(1, "foo", true, new Nested(Guid.NewGuid(), 1.234m));
+            var arg = new MyArg(1, "foo", new Nested(Guid.NewGuid(), 1.234m));
 
             var exec = await Client.Compute.SubmitAsync(await GetNodeAsync(1), job, arg);
             MyResult res = await exec.GetResultAsync();
@@ -881,7 +881,7 @@ namespace Apache.Ignite.Tests.Compute
 
         private record Nested(Guid Id, decimal Price);
 
-        private record MyArg(int Id, string Name, bool Flag, Nested Nested);
+        private record MyArg(int Id, string Name, Nested Nested);
 
         private record MyResult(string Data, Nested Nested);
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -848,7 +848,7 @@ namespace Apache.Ignite.Tests.Compute
 
             var job = new JobDescriptor<MyArg, MyResult>(PlatformTestNodeRunner + "$JsonMarshallerJob")
             {
-                ArgMarshaller = arg => JsonSerializer.SerializeToUtf8Bytes(arg, jsonOpts),
+                ArgMarshaller = (arg, writer) => JsonSerializer.Serialize(new Utf8JsonWriter(writer), arg, jsonOpts),
                 ResultMarshaller = bytes => JsonSerializer.Deserialize<MyResult>(bytes!.Value.Span, jsonOpts)!
             };
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -871,8 +871,13 @@ namespace Apache.Ignite.Tests.Compute
             var exec = await Client.Compute.SubmitAsync(await GetNodeAsync(1), job, arg);
             Nested res = await exec.GetResultAsync();
 
+            var nullExec = await Client.Compute.SubmitAsync(await GetNodeAsync(1), job, null!);
+            Nested nullRes = await nullExec.GetResultAsync();
+
             Assert.AreEqual(arg.Id, res.Id);
             Assert.AreEqual(arg.Price + 1, res.Price);
+
+            Assert.IsNull(nullRes);
         }
 
         private static async Task AssertJobStatus<T>(IJobExecution<T> jobExecution, JobStatus status, Instant beforeStart)

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -838,7 +838,7 @@ namespace Apache.Ignite.Tests.Compute
         }
 
         [Test]
-        public async Task TestJsonMarshaller()
+        public async Task TestNestedObjectsWithJsonMarshaller()
         {
             var jsonOpts = new JsonSerializerOptions
             {
@@ -857,7 +857,7 @@ namespace Apache.Ignite.Tests.Compute
             var exec = await Client.Compute.SubmitAsync(await GetNodeAsync(1), job, arg);
             MyResult res = await exec.GetResultAsync();
 
-            Assert.AreEqual("bar", res.Data);
+            Assert.AreEqual("foo_1", res.Data);
             Assert.AreEqual(arg.Nested, res.Nested);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -23,6 +23,7 @@ namespace Apache.Ignite.Tests.Compute
     using System.Globalization;
     using System.Linq;
     using System.Net;
+    using System.Text.Json;
     using System.Threading.Tasks;
     using Ignite.Compute;
     using Ignite.Table;
@@ -841,6 +842,8 @@ namespace Apache.Ignite.Tests.Compute
         {
             var job = new JobDescriptor<MyArg, MyResult>(ItThinClientComputeTest + "$JsonMarshallerJob")
             {
+                ArgMarshaller = arg => JsonSerializer.SerializeToUtf8Bytes(arg),
+                ResultMarshaller = bytes => JsonSerializer.Deserialize<MyResult>(bytes.Span)!
             };
 
             var arg = new MyArg(1, "foo", true, new Nested(Guid.NewGuid(), 1.234m));

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -23,14 +23,13 @@ namespace Apache.Ignite.Tests.Compute
     using System.Globalization;
     using System.Linq;
     using System.Net;
-    using System.Text.Json;
     using System.Threading.Tasks;
     using Ignite.Compute;
+    using Ignite.Marshalling;
     using Ignite.Table;
     using Internal.Compute;
     using Internal.Network;
     using Internal.Proto;
-    using Marshalling;
     using Network;
     using NodaTime;
     using NUnit.Framework;

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -849,7 +849,7 @@ namespace Apache.Ignite.Tests.Compute
             var job = new JobDescriptor<MyArg, MyResult>(PlatformTestNodeRunner + "$JsonMarshallerJob")
             {
                 ArgMarshaller = arg => JsonSerializer.SerializeToUtf8Bytes(arg, jsonOpts),
-                ResultMarshaller = bytes => JsonSerializer.Deserialize<MyResult>(bytes.Span, jsonOpts)!
+                ResultMarshaller = bytes => JsonSerializer.Deserialize<MyResult>(bytes!.Value.Span, jsonOpts)!
             };
 
             var arg = new MyArg(1, "foo", new Nested(Guid.NewGuid(), 1.234m));

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -840,10 +840,16 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestJsonMarshaller()
         {
+            var jsonOpts = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                PropertyNameCaseInsensitive = true
+            };
+
             var job = new JobDescriptor<MyArg, MyResult>(PlatformTestNodeRunner + "$JsonMarshallerJob")
             {
-                ArgMarshaller = arg => JsonSerializer.SerializeToUtf8Bytes(arg),
-                ResultMarshaller = bytes => JsonSerializer.Deserialize<MyResult>(bytes.Span)!
+                ArgMarshaller = arg => JsonSerializer.SerializeToUtf8Bytes(arg, jsonOpts),
+                ResultMarshaller = bytes => JsonSerializer.Deserialize<MyResult>(bytes.Span, jsonOpts)!
             };
 
             var arg = new MyArg(1, "foo", new Nested(Guid.NewGuid(), 1.234m));

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -840,7 +840,7 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestJsonMarshaller()
         {
-            var job = new JobDescriptor<MyArg, MyResult>(ItThinClientComputeTest + "$JsonMarshallerJob")
+            var job = new JobDescriptor<MyArg, MyResult>(PlatformTestNodeRunner + "$JsonMarshallerJob")
             {
                 ArgMarshaller = arg => JsonSerializer.SerializeToUtf8Bytes(arg),
                 ResultMarshaller = bytes => JsonSerializer.Deserialize<MyResult>(bytes.Span)!

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -30,6 +30,7 @@ namespace Apache.Ignite.Tests.Compute
     using Internal.Compute;
     using Internal.Network;
     using Internal.Proto;
+    using Marshalling;
     using Network;
     using NodaTime;
     using NUnit.Framework;
@@ -840,16 +841,10 @@ namespace Apache.Ignite.Tests.Compute
         [Test]
         public async Task TestNestedObjectsWithJsonMarshaller()
         {
-            var jsonOpts = new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                PropertyNameCaseInsensitive = true
-            };
-
             var job = new JobDescriptor<MyArg, MyResult>(PlatformTestNodeRunner + "$JsonMarshallerJob")
             {
-                ArgMarshaller = (arg, writer) => JsonSerializer.Serialize(new Utf8JsonWriter(writer), arg, jsonOpts),
-                ResultMarshaller = bytes => JsonSerializer.Deserialize<MyResult>(bytes!.Value.Span, jsonOpts)!
+                ArgMarshaller = new JsonMarshaller<MyArg>(),
+                ResultMarshaller = new JsonMarshaller<MyResult>()
             };
 
             var arg = new MyArg(1, "foo", new Nested(Guid.NewGuid(), 1.234m));

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Marshalling/JsonMarshallerTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Marshalling/JsonMarshallerTests.cs
@@ -30,4 +30,12 @@ public class JsonMarshallerTests
     {
         Assert.Fail("TODO");
     }
+
+    [Test]
+    public void TestToString()
+    {
+        Assert.AreEqual(
+            "JsonMarshaller`1[Int32] { Options = System.Text.Json.JsonSerializerOptions }",
+            new JsonMarshaller<int>().ToString());
+    }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Marshalling/JsonMarshallerTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Marshalling/JsonMarshallerTests.cs
@@ -17,6 +17,8 @@
 
 namespace Apache.Ignite.Tests.Marshalling;
 
+using System.Buffers;
+using System.Text;
 using Ignite.Marshalling;
 using NUnit.Framework;
 
@@ -28,7 +30,17 @@ public class JsonMarshallerTests
     [Test]
     public void TestMarshalUnmarshal()
     {
-        Assert.Fail("TODO");
+        var marshaller = new JsonMarshaller<Poco>();
+        var poco = new Poco(42, "foo");
+
+        var writer = new ArrayBufferWriter<byte>();
+        marshaller.Marshal(poco, writer);
+
+        var bytes = writer.WrittenSpan.ToArray();
+        var result = marshaller.Unmarshal(bytes);
+
+        Assert.AreEqual(poco, result);
+        Assert.AreEqual("{\"id\":42,\"name\":\"foo\"}", Encoding.UTF8.GetString(bytes));
     }
 
     [Test]
@@ -38,4 +50,6 @@ public class JsonMarshallerTests
             "JsonMarshaller`1[Int32] { Options = System.Text.Json.JsonSerializerOptions }",
             new JsonMarshaller<int>().ToString());
     }
+
+    private record Poco(int Id, string Name);
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Marshalling/JsonMarshallerTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Marshalling/JsonMarshallerTests.cs
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Tests.Marshalling;
+
+using Ignite.Marshalling;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests for <see cref="JsonMarshaller{T}"/>.
+/// </summary>
+public class JsonMarshallerTests
+{
+    [Test]
+    public void TestMarshalUnmarshal()
+    {
+        Assert.Fail("TODO");
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/BinaryTuple/BinaryTupleTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/BinaryTuple/BinaryTupleTests.cs
@@ -401,6 +401,24 @@ namespace Apache.Ignite.Tests.Proto.BinaryTuple
         }
 
         [Test]
+        public void TestBytesBufferWriter([Values(0, 1, 123, 65537)] int count)
+        {
+            var bytes = Enumerable.Range(1, count).Select(x => (byte)x).ToArray();
+
+            var reader = BuildAndRead((ref BinaryTupleBuilder b) => b.AppendBytes(
+                (writer, arg) =>
+                {
+                    arg.CopyTo(writer.GetSpan(arg.Length));
+                    writer.Advance(arg.Length);
+                },
+                bytes));
+
+            var res = reader.GetBytesSpan(0).ToArray();
+
+            CollectionAssert.AreEqual(bytes, res);
+        }
+
+        [Test]
         public void TestDecimal()
         {
             Test(0, 3);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/BinaryTuple/BinaryTupleTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Proto/BinaryTuple/BinaryTupleTests.cs
@@ -381,10 +381,28 @@ namespace Apache.Ignite.Tests.Proto.BinaryTuple
         }
 
         [Test]
-        public void TestVarlenEmptyByte()
+        public void TestVarlenEmptyByte([Values(1, 2, 123)] int count)
         {
-            var bytes = new[] { BinaryTupleCommon.VarlenEmptyByte };
+            var bytes = Enumerable.Repeat(BinaryTupleCommon.VarlenEmptyByte, count).ToArray();
             var reader = BuildAndRead((ref BinaryTupleBuilder b) => b.AppendBytes(bytes));
+            var res = reader.GetBytes(0);
+
+            CollectionAssert.AreEqual(bytes, res);
+        }
+
+        [Test]
+        public void TestVarlenEmptyByteBufferWriter([Values(1, 2, 123)] int count)
+        {
+            var bytes = Enumerable.Repeat(BinaryTupleCommon.VarlenEmptyByte, count).ToArray();
+
+            var reader = BuildAndRead((ref BinaryTupleBuilder b) => b.AppendBytes(
+                (writer, arg) =>
+                {
+                    arg.CopyTo(writer.GetSpan(arg.Length));
+                    writer.Advance(arg.Length);
+                },
+                bytes));
+
             var res = reader.GetBytes(0);
 
             CollectionAssert.AreEqual(bytes, res);

--- a/modules/platforms/dotnet/Apache.Ignite/Compute/JobDescriptor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Compute/JobDescriptor.cs
@@ -34,5 +34,5 @@ public sealed record JobDescriptor<TArg, TResult>(
     string JobClassName,
     IEnumerable<DeploymentUnit>? DeploymentUnits = null,
     JobExecutionOptions? Options = null,
-    Func<TArg, Memory<byte>>? ArgMarshaller = null,
+    Func<TArg, Memory<byte>>? ArgMarshaller = null, // TODO: This forces the user to allocate?
     Func<Memory<byte>, TResult>? ResultMarshaller = null);

--- a/modules/platforms/dotnet/Apache.Ignite/Compute/JobDescriptor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Compute/JobDescriptor.cs
@@ -34,5 +34,5 @@ public sealed record JobDescriptor<TArg, TResult>(
     string JobClassName,
     IEnumerable<DeploymentUnit>? DeploymentUnits = null,
     JobExecutionOptions? Options = null,
-    Func<TArg, Memory<byte>>? ArgMarshaller = null, // TODO: This forces the user to allocate?
-    Func<Memory<byte>, TResult>? ResultMarshaller = null);
+    Func<TArg, Memory<byte>?>? ArgMarshaller = null, // TODO: This forces the user to allocate?
+    Func<Memory<byte>?, TResult>? ResultMarshaller = null);

--- a/modules/platforms/dotnet/Apache.Ignite/Compute/JobDescriptor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Compute/JobDescriptor.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Compute;
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 
 /// <summary>
@@ -34,5 +35,5 @@ public sealed record JobDescriptor<TArg, TResult>(
     string JobClassName,
     IEnumerable<DeploymentUnit>? DeploymentUnits = null,
     JobExecutionOptions? Options = null,
-    Func<TArg, Memory<byte>?>? ArgMarshaller = null, // TODO: This forces the user to allocate?
+    Action<TArg, IBufferWriter<byte>>? ArgMarshaller = null, // TODO: This forces the user to allocate?
     Func<Memory<byte>?, TResult>? ResultMarshaller = null);

--- a/modules/platforms/dotnet/Apache.Ignite/Compute/JobDescriptor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Compute/JobDescriptor.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Compute;
 
+using System;
 using System.Collections.Generic;
 
 /// <summary>
@@ -25,9 +26,13 @@ using System.Collections.Generic;
 /// <param name="JobClassName">Java class name of the job to execute.</param>
 /// <param name="DeploymentUnits">Deployment units.</param>
 /// <param name="Options">Options.</param>
+/// <param name="ArgMarshaller">Argument marshaller (serializer).</param>
+/// <param name="ResultMarshaller">Result marshaller (deserializer).</param>
 /// <typeparam name="TArg">Argument type.</typeparam>
 /// <typeparam name="TResult">Result type.</typeparam>
 public sealed record JobDescriptor<TArg, TResult>(
     string JobClassName,
     IEnumerable<DeploymentUnit>? DeploymentUnits = null,
-    JobExecutionOptions? Options = null);
+    JobExecutionOptions? Options = null,
+    Func<TArg, Memory<byte>>? ArgMarshaller = null,
+    Func<Memory<byte>, TResult>? ResultMarshaller = null);

--- a/modules/platforms/dotnet/Apache.Ignite/Compute/JobDescriptor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Compute/JobDescriptor.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Compute;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using Marshalling;
 
 /// <summary>
 /// Compute job descriptor.
@@ -35,5 +36,5 @@ public sealed record JobDescriptor<TArg, TResult>(
     string JobClassName,
     IEnumerable<DeploymentUnit>? DeploymentUnits = null,
     JobExecutionOptions? Options = null,
-    Action<TArg, IBufferWriter<byte>>? ArgMarshaller = null, // TODO: This forces the user to allocate?
-    Func<Memory<byte>?, TResult>? ResultMarshaller = null);
+    IMarshaller<TArg>? ArgMarshaller = null,
+    IMarshaller<TResult>? ResultMarshaller = null);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Internal.Buffers
 {
     using System;
+    using System.Buffers;
     using System.Buffers.Binary;
     using System.Diagnostics;
     using System.IO;
@@ -26,7 +27,7 @@ namespace Apache.Ignite.Internal.Buffers
     /// <summary>
     /// Pooled buffer with additional logic to prepend messages with size and other data (opcode, request id).
     /// </summary>
-    internal sealed class PooledArrayBuffer : IDisposable
+    internal sealed class PooledArrayBuffer : IDisposable, IBufferWriter<byte>
     {
         /** Prefix size. */
         private readonly int _prefixSize;
@@ -116,15 +117,18 @@ namespace Apache.Ignite.Internal.Buffers
             Offset = 0;
         }
 
-        /// <summary>
-        /// Gets a span for writing.
-        /// </summary>
-        /// <param name="size">Size.</param>
-        /// <returns>Span for writing.</returns>
-        public Span<byte> GetSpan(int size)
+        /// <inheritdoc/>
+        public Memory<byte> GetMemory(int sizeHint = 0)
         {
-            CheckAndResizeBuffer(size);
-            return _buffer.AsSpan(_index, size);
+            CheckAndResizeBuffer(sizeHint);
+            return _buffer.AsMemory(_index);
+        }
+
+        /// <inheritdoc/>
+        public Span<byte> GetSpan(int sizeHint)
+        {
+            CheckAndResizeBuffer(sizeHint);
+            return _buffer.AsSpan(_index);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -386,7 +386,7 @@ namespace Apache.Ignite.Internal.Compute
                     ClientOp.ComputeExecute, writer, PreferredNode.FromName(node.Name), expectNotifications: true)
                 .ConfigureAwait(false);
 
-            return GetJobExecution<TResult>(res, readSchema: false);
+            return GetJobExecution<TResult>(res, readSchema: false, jobDescriptor.ResultMarshaller);
 
             void Write()
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -395,7 +395,7 @@ namespace Apache.Ignite.Internal.Compute
                 w.Write(options.Priority);
                 w.Write(options.MaxRetries);
 
-                w.WriteObjectAsBinaryTuple(arg);
+                w.WriteObjectAsBinaryTuple(arg, jobDescriptor.ArgMarshaller);
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -306,7 +306,10 @@ namespace Apache.Ignite.Internal.Compute
             return new TaskState(id, status, createTime.GetValueOrDefault(), startTime, endTime);
         }
 
-        private IJobExecution<T> GetJobExecution<T>(PooledBuffer computeExecuteResult, bool readSchema)
+        private IJobExecution<T> GetJobExecution<T>(
+            PooledBuffer computeExecuteResult,
+            bool readSchema,
+            Func<Memory<byte>?, T>? marshaller)
         {
             var reader = computeExecuteResult.GetReader();
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -95,7 +95,6 @@ namespace Apache.Ignite.Internal.Compute
 
             foreach (var node in nodes)
             {
-                // TODO: Remove array allocation.
                 Task<IJobExecution<TResult>> task = ExecuteOnNodes(new[] { node }, jobDescriptor, arg);
                 res[node] = task;
             }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -29,6 +29,7 @@ namespace Apache.Ignite.Internal.Compute
     using Ignite.Compute;
     using Ignite.Network;
     using Ignite.Table;
+    using Marshalling;
     using Proto;
     using Proto.MsgPack;
     using Table;
@@ -303,7 +304,7 @@ namespace Apache.Ignite.Internal.Compute
         private IJobExecution<T> GetJobExecution<T>(
             PooledBuffer computeExecuteResult,
             bool readSchema,
-            Func<Memory<byte>?, T>? marshaller)
+            IMarshaller<T>? marshaller)
         {
             var reader = computeExecuteResult.GetReader();
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleBuilder.cs
@@ -1390,7 +1390,7 @@ namespace Apache.Ignite.Internal.Proto.BinaryTuple
 
         private Span<byte> GetSpan(int size)
         {
-            var span = _buffer.GetSpan(size);
+            var span = _buffer.GetSpan(size)[..size];
 
             _buffer.Advance(size);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleBuilder.cs
@@ -83,7 +83,7 @@ namespace Apache.Ignite.Internal.Proto.BinaryTuple
 
             _valueBase = _entryBase + _entrySize * numElements;
 
-            _buffer.GetSpan(size: _valueBase)[.._valueBase].Clear();
+            _buffer.GetSpan(sizeHint: _valueBase)[.._valueBase].Clear();
             _buffer.Advance(_valueBase);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleBuilder.cs
@@ -448,6 +448,14 @@ namespace Apache.Ignite.Internal.Proto.BinaryTuple
             action(_buffer, arg);
 
             var length = _buffer.Position - oldPos;
+
+            if (length == 0)
+            {
+                GetSpan(1)[0] = BinaryTupleCommon.VarlenEmptyByte;
+                OnWrite();
+                return;
+            }
+
             var writtenSpan = _buffer.GetWrittenMemory().Span.Slice(oldPos, length);
 
             if (length > 0 && writtenSpan[0] == BinaryTupleCommon.VarlenEmptyByte)

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleBuilder.cs
@@ -471,8 +471,8 @@ namespace Apache.Ignite.Internal.Proto.BinaryTuple
                     // 2. Extend the buffer.
                     _buffer.GetSpanAndAdvance(1);
 
-                    // 3. Copy back.
-                    var newWrittenSpan = _buffer.GetWrittenMemory().Span.Slice(oldPos + 1, length + 1);
+                    // 3. Copy back, skipping existing VarlenEmptyByte at the beginning.
+                    var newWrittenSpan = _buffer.GetWrittenMemory().Span.Slice(oldPos + 1, length);
                     temp.AsSpan(0, length).CopyTo(newWrittenSpan);
                 }
                 finally

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleBuilder.cs
@@ -423,7 +423,7 @@ namespace Apache.Ignite.Internal.Proto.BinaryTuple
         /// Appends bytes.
         /// </summary>
         /// <param name="value">Value.</param>
-        public void AppendBytes(Span<byte> value)
+        public void AppendBytes(ReadOnlySpan<byte> value)
         {
             if (GetHashOrder() is { } hashOrder)
             {
@@ -1164,7 +1164,7 @@ namespace Apache.Ignite.Internal.Proto.BinaryTuple
 
         private void PutDouble(double value) => PutLong(BitConverter.DoubleToInt64Bits(value));
 
-        private void PutBytes(Span<byte> bytes)
+        private void PutBytes(ReadOnlySpan<byte> bytes)
         {
             if (bytes.Length == 0)
             {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/HashUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/HashUtils.cs
@@ -103,7 +103,7 @@ internal static class HashUtils
     /// </summary>
     /// <param name="data">Input data.</param>
     /// <returns>Resulting hash.</returns>
-    public static int Hash32(Span<byte> data) => data.IsEmpty ? 0 : Hash32Internal(data, 0);
+    public static int Hash32(ReadOnlySpan<byte> data) => data.IsEmpty ? 0 : Hash32Internal(data, 0);
 
     /// <summary>
     /// Generates 32-bit hash.
@@ -177,14 +177,14 @@ internal static class HashUtils
         }
     }
 
-    private static int Hash32Internal(Span<byte> data, ulong seed)
+    private static int Hash32Internal(ReadOnlySpan<byte> data, ulong seed)
     {
         var hash64 = Hash64Internal(data, seed);
 
         return (int)(hash64 ^ (hash64 >> 32));
     }
 
-    private static ulong Hash64Internal(Span<byte> data, ulong seed)
+    private static ulong Hash64Internal(ReadOnlySpan<byte> data, ulong seed)
     {
         unchecked
         {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MsgPack/MsgPackReader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MsgPack/MsgPackReader.cs
@@ -372,20 +372,16 @@ internal ref struct MsgPackReader
     /// <param name="marshaller">Optional marshaller.</param>
     /// <returns>Value.</returns>
     /// <typeparam name="T">Type of the value.</typeparam>
-    public T ReadObjectFromBinaryTuple<T>(Func<Memory<byte>?, T>? marshaller)
+    public T ReadObjectFromBinaryTuple<T>(IMarshaller<T>? marshaller)
     {
         var obj = ReadObjectFromBinaryTuple();
 
-        if (marshaller == null)
+        if (marshaller == null || obj == null)
         {
             return (T)obj!;
         }
 
-        if (obj == null)
-        {
-            return marshaller(null);
-        }
-
+        // TODO: Avoid allocating byte array, pass a span.
         if (obj is byte[] bytes)
         {
             return marshaller(bytes);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MsgPack/MsgPackReader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MsgPack/MsgPackReader.cs
@@ -381,10 +381,10 @@ internal ref struct MsgPackReader
             return (T)obj!;
         }
 
-        // TODO: Avoid allocating byte array, pass a span.
+        // TODO: Avoid allocating byte array, pass a span from BinaryTupleReader.
         if (obj is byte[] bytes)
         {
-            return marshaller(bytes);
+            return marshaller.Unmarshal(bytes);
         }
 
         throw new UnsupportedObjectTypeMarshallingException(

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MsgPack/MsgPackWriter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MsgPack/MsgPackWriter.cs
@@ -363,16 +363,21 @@ internal readonly ref struct MsgPackWriter
     /// <param name="obj">Object.</param>
     /// <param name="marshaller">Marshaller.</param>
     /// <typeparam name="T">Object type.</typeparam>
-    public void WriteObjectAsBinaryTuple<T>(T obj, Func<T, Memory<byte>>? marshaller)
+    public void WriteObjectAsBinaryTuple<T>(T obj, Func<T, Memory<byte>?>? marshaller)
     {
         if (marshaller != null)
         {
             var bytes = marshaller(obj);
+            if (bytes == null)
+            {
+                WriteNil();
+                return;
+            }
 
             using var builder = new BinaryTupleBuilder(3);
             builder.AppendInt((int)ColumnType.ByteArray);
             builder.AppendInt(0); // Scale.
-            builder.AppendBytes(bytes.Span);
+            builder.AppendBytes(bytes.Value.Span);
 
             Write(builder.Build().Span);
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MsgPack/MsgPackWriter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/MsgPack/MsgPackWriter.cs
@@ -379,14 +379,12 @@ internal readonly ref struct MsgPackWriter
             return;
         }
 
-        // TODO: Write directly to BinaryTupleBuilder - implement PooledArrayBufferWriter.
-        var bufferWriter = new ArrayBufferWriter<byte>();
-        marshaller.Marshal(obj, bufferWriter);
-
         using var builder = new BinaryTupleBuilder(3);
         builder.AppendInt((int)ColumnType.ByteArray);
         builder.AppendInt(0); // Scale.
-        builder.AppendBytes(bufferWriter.WrittenSpan);
+        builder.AppendBytes(
+            static (IBufferWriter<byte> writer, (T Obj, IMarshaller<T> Marshaller) arg) => arg.Marshaller.Marshal(arg.Obj, writer),
+            arg: (obj, marshaller));
 
         Write(builder.Build().Span);
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Marshalling/IMarshaller.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Marshalling/IMarshaller.cs
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Marshalling;
+
+using System;
+using System.Buffers;
+
+/// <summary>
+/// Ignite marshaller (serializer / deserializer).
+/// <para />
+/// Marshaller is used in APIs that require transferring custom objects over the wire, such as Compute arguments and results.
+/// </summary>
+/// <typeparam name="T">Object type.</typeparam>
+public interface IMarshaller<T>
+{
+    void Marshal(T obj, IBufferWriter<byte> writer);
+
+    T? Unmarshal(ReadOnlySpan<byte> data);
+}

--- a/modules/platforms/dotnet/Apache.Ignite/Marshalling/IMarshaller.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Marshalling/IMarshaller.cs
@@ -28,7 +28,17 @@ using System.Buffers;
 /// <typeparam name="T">Object type.</typeparam>
 public interface IMarshaller<T>
 {
+    /// <summary>
+    /// Marshals (serializes) the specified object into the provided writer.
+    /// </summary>
+    /// <param name="obj">Object. Not null - Ignite handles nulls separately and does not invoke the marshaller.</param>
+    /// <param name="writer">Writer.</param>
     void Marshal(T obj, IBufferWriter<byte> writer);
 
-    T? Unmarshal(ReadOnlySpan<byte> data);
+    /// <summary>
+    /// Unmarshals (deserializes) an object from the provided data.
+    /// </summary>
+    /// <param name="bytes">Serialized data.</param>
+    /// <returns>Deserialized object.</returns>
+    T Unmarshal(ReadOnlySpan<byte> bytes);
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Marshalling/JsonMarshaller.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Marshalling/JsonMarshaller.cs
@@ -60,4 +60,10 @@ public sealed class JsonMarshaller<T> : IMarshaller<T>
     /// <inheritdoc />
     public T Unmarshal(ReadOnlySpan<byte> bytes) =>
         JsonSerializer.Deserialize<T>(bytes, Options)!;
+
+    /// <inheritdoc />
+    public override string ToString() =>
+        new IgniteToStringBuilder(GetType())
+            .Append(Options)
+            .Build();
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Marshalling/JsonMarshaller.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Marshalling/JsonMarshaller.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Marshalling;
 using System;
 using System.Buffers;
 using System.Text.Json;
+using Internal.Common;
 
 /// <summary>
 /// JSON marshaller. Uses <see cref="System.Text.Json.JsonSerializer"/>.
@@ -49,6 +50,9 @@ public sealed class JsonMarshaller<T> : IMarshaller<T>
     /// <inheritdoc />
     public void Marshal(T obj, IBufferWriter<byte> writer)
     {
+        IgniteArgumentCheck.NotNull(obj);
+        IgniteArgumentCheck.NotNull(writer);
+
         using var utf8JsonWriter = new Utf8JsonWriter(writer);
         JsonSerializer.Serialize(utf8JsonWriter, obj, Options);
     }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -927,6 +927,10 @@ public class PlatformTestNodeRunner {
     private static class ToStringMarshallerJob implements ComputeJob<Nested, Nested> {
         @Override
         public @Nullable CompletableFuture<Nested> executeAsync(JobExecutionContext context, Nested arg) {
+            if (arg == null) {
+                return completedFuture(null);
+            }
+
             arg.price = arg.price.add(BigDecimal.ONE);
 
             return completedFuture(arg);
@@ -946,6 +950,10 @@ public class PlatformTestNodeRunner {
     private static class ToStringMarshaller implements Marshaller<Nested, byte[]> {
         @Override
         public byte[] marshal(Nested object) throws UnsupportedObjectTypeMarshallingException {
+            if (object == null) {
+                return null;
+            }
+
             var str = object.id + ":" + object.price;
 
             return str.getBytes(StandardCharsets.US_ASCII);
@@ -953,6 +961,10 @@ public class PlatformTestNodeRunner {
 
         @Override
         public @Nullable Nested unmarshal(byte[] raw) throws UnsupportedObjectTypeMarshallingException {
+            if (raw == null) {
+                return null;
+            }
+
             var str = new String(raw, StandardCharsets.US_ASCII);
             var parts = str.split(":");
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/PlatformTestNodeRunner.java
@@ -884,19 +884,19 @@ public class PlatformTestNodeRunner {
 
 
     private static class Nested {
-        UUID id;
-        BigDecimal price;
+        public UUID id;
+        public BigDecimal price;
     }
 
     private static class MyArg {
-        int id;
-        String name;
-        Nested nested;
+        public int id;
+        public String name;
+        public Nested nested;
     }
 
     private static class MyResult {
-        String data;
-        Nested nested;
+        public String data;
+        public Nested nested;
     }
 
     private static class JsonMarshallerJob implements ComputeJob<MyArg, MyResult> {


### PR DESCRIPTION
Public API changes:

* Add `IMarshaller<T>` interface
  * Unlike Java, we don't operate on `byte[]`, but use `IBufferWriter<byte>` and `ReadOnlySpan<byte>`, which allow reading/writing directly from/to underlying `BinaryTuple` without extra allocations and copying. 
    * Those APIs work directly and efficiently with modern serializers, such as `System.Text.Json`
* Add `JsonMarshaller` 
  * Unlike Java, we don't need a third-party library for JSON, so an out-of-the box implementation with good defaults and performance makes sense.
* Add `JobDescriptor.ArgMarshaller`, `JobDescriptor.ResultMarshaller`
