### PR TITLE
IGNITE-22995 Fix compute broadcast hanging test

### DIFF
--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/ComputeJobFailover.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/ComputeJobFailover.java
@@ -136,7 +136,7 @@ class ComputeJobFailover<R> {
     }
 
     private JobExecution<R> launchJobOn(ClusterNode runningWorkerNode) {
-        if (runningWorkerNode.equals(topologyService.localMember())) {
+        if (runningWorkerNode.id().equals(topologyService.localMember().id())) {
             return computeComponent.executeLocally(
                     jobContext.executionOptions(), jobContext.units(), jobContext.jobClassName(), jobContext.arg()
             );

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeImpl.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeImpl.java
@@ -276,7 +276,7 @@ public class IgniteComputeImpl implements IgniteComputeInternal, StreamerReceive
     }
 
     private boolean isLocal(ClusterNode targetNode) {
-        return targetNode.equals(topologyService.localMember());
+        return targetNode.id().equals(topologyService.localMember().id());
     }
 
     @Override

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/messaging/ComputeMessaging.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/messaging/ComputeMessaging.java
@@ -457,7 +457,7 @@ public class ComputeMessaging {
         ClusterNode localMember = topologyService.localMember();
         CompletableFuture<?>[] futures = topologyService.allMembers()
                 .stream()
-                .filter(node -> !node.equals(localMember))
+                .filter(node -> !node.id().equals(localMember.id()))
                 .map(node -> request.apply(node)
                         .thenAccept(response -> {
                             if (response != null) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22995 

The reason why this test can hang is that when we execute broadcast job in the embedded mode on the same node that has been used as an entry point to the job call (for example, call job from node 1 and on node 1,2) -- then we failed to detect local node because of the wrong usage of ClientNode.equals method.

