### PR TITLE
IGNITE-22794 .NET: Fix TestMicrosoftConsoleLogger flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
@@ -76,7 +76,8 @@ public class LoggingTests
     {
         var oldWriter = Console.Out;
         var writer = new StringWriter();
-        Console.SetOut(TextWriter.Synchronized(writer));
+        var textWriter = TextWriter.Synchronized(writer);
+        Console.SetOut(textWriter);
 
         try
         {
@@ -97,6 +98,7 @@ public class LoggingTests
         }
 
         // Prevent further writes before accessing the inner StringBuilder.
+        textWriter.Close();
         writer.Close();
         var log = writer.ToString();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
@@ -74,9 +74,9 @@ public class LoggingTests
     [Test]
     public async Task TestMicrosoftConsoleLogger()
     {
-        var oldWriter = Console.Out;
-        var writer = new StringWriter();
-        var textWriter = TextWriter.Synchronized(writer);
+        var oldTextWriter = Console.Out;
+        var stringWriter = new StringWriter();
+        var textWriter = TextWriter.Synchronized(stringWriter);
         Console.SetOut(textWriter);
 
         try
@@ -94,13 +94,13 @@ public class LoggingTests
         }
         finally
         {
-            Console.SetOut(oldWriter);
+            Console.SetOut(oldTextWriter);
         }
 
         // Prevent further writes before accessing the inner StringBuilder.
         textWriter.Close();
-        writer.Close();
-        var log = writer.ToString();
+        stringWriter.Close();
+        var log = stringWriter.ToString();
 
         StringAssert.Contains("dbug: Apache.Ignite.Internal.ClientSocket", log);
         StringAssert.Contains("Connection established", log);


### PR DESCRIPTION
Close synchronized writer to avoid race condition while accessing results.