### PR TITLE
IGNITE-22622 PartitionReplicaLifecycleManager must use weakStart/weaskStop approach

### DIFF
--- a/modules/partition-replicator/src/integrationTest/java/org/apache/ignite/internal/partition/replicator/ItReplicaLifecycleTest.java
+++ b/modules/partition-replicator/src/integrationTest/java/org/apache/ignite/internal/partition/replicator/ItReplicaLifecycleTest.java
@@ -353,7 +353,7 @@ public class ItReplicaLifecycleTest extends BaseIgniteAbstractTest {
     }
 
     @Test
-    //@Disabled("https://issues.apache.org/jira/browse/IGNITE-22928")
+    @Disabled("https://issues.apache.org/jira/browse/IGNITE-22928")
     public void testZoneReplicaListener(TestInfo testInfo) throws Exception {
         startNodes(testInfo, 3);
 
@@ -362,9 +362,9 @@ public class ItReplicaLifecycleTest extends BaseIgniteAbstractTest {
 
         Node node = getNode(replicaAssignment.consistentId());
 
-//        placementDriver.setPrimary(node.clusterService.topologyService().localMember());
+        placementDriver.setPrimary(node.clusterService.topologyService().localMember());
 
-        createZone(node, "test_zone", 1, 3);
+        createZone(node, "test_zone", 1, 1);
         int zoneId = DistributionZonesTestUtil.getZoneId(node.catalogManager, "test_zone", node.hybridClock.nowLong());
 
         long key = 1;

--- a/modules/partition-replicator/src/integrationTest/java/org/apache/ignite/internal/partition/replicator/ItReplicaLifecycleTest.java
+++ b/modules/partition-replicator/src/integrationTest/java/org/apache/ignite/internal/partition/replicator/ItReplicaLifecycleTest.java
@@ -122,7 +122,6 @@ import org.apache.ignite.internal.metastorage.impl.MetaStorageManagerImpl;
 import org.apache.ignite.internal.metastorage.server.KeyValueStorage;
 import org.apache.ignite.internal.metastorage.server.SimpleInMemoryKeyValueStorage;
 import org.apache.ignite.internal.metrics.NoOpMetricManager;
-import org.apache.ignite.internal.network.ClusterNodeImpl;
 import org.apache.ignite.internal.network.ClusterService;
 import org.apache.ignite.internal.network.StaticNodeFinder;
 import org.apache.ignite.internal.network.configuration.NetworkConfiguration;
@@ -183,7 +182,6 @@ import org.apache.ignite.internal.tx.message.TxMessageGroup;
 import org.apache.ignite.internal.tx.message.WriteIntentSwitchReplicaRequest;
 import org.apache.ignite.internal.tx.test.TestLocalRwTxCounter;
 import org.apache.ignite.internal.vault.VaultManager;
-import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.NetworkAddress;
 import org.apache.ignite.raft.jraft.rpc.impl.RaftGroupEventsClientListener;
 import org.apache.ignite.sql.IgniteSql;
@@ -311,7 +309,7 @@ public class ItReplicaLifecycleTest extends BaseIgniteAbstractTest {
 
         node0.cmgManager.initCluster(List.of(node0.name), List.of(node0.name), "cluster");
 
-        placementDriver.setPrimary(node0.toClusterNode());
+        placementDriver.setPrimary(node0.clusterService.topologyService().localMember());
 
         nodes.values().forEach(Node::waitWatches);
 
@@ -355,7 +353,7 @@ public class ItReplicaLifecycleTest extends BaseIgniteAbstractTest {
     }
 
     @Test
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-22928")
+    //@Disabled("https://issues.apache.org/jira/browse/IGNITE-22928")
     public void testZoneReplicaListener(TestInfo testInfo) throws Exception {
         startNodes(testInfo, 3);
 
@@ -364,9 +362,9 @@ public class ItReplicaLifecycleTest extends BaseIgniteAbstractTest {
 
         Node node = getNode(replicaAssignment.consistentId());
 
-        placementDriver.setPrimary(node.clusterService.topologyService().localMember());
+//        placementDriver.setPrimary(node.clusterService.topologyService().localMember());
 
-        createZone(node, "test_zone", 1, 1);
+        createZone(node, "test_zone", 1, 3);
         int zoneId = DistributionZonesTestUtil.getZoneId(node.catalogManager, "test_zone", node.hybridClock.nowLong());
 
         long key = 1;
@@ -1324,10 +1322,6 @@ public class ItReplicaLifecycleTest extends BaseIgniteAbstractTest {
 
             nodeCfgGenerator.close();
             clusterCfgGenerator.close();
-        }
-
-        ClusterNode toClusterNode() {
-            return new ClusterNodeImpl(name, name, networkAddress);
         }
     }
 

--- a/modules/partition-replicator/src/main/java/org/apache/ignite/internal/partition/replicator/PartitionReplicaLifecycleManager.java
+++ b/modules/partition-replicator/src/main/java/org/apache/ignite/internal/partition/replicator/PartitionReplicaLifecycleManager.java
@@ -435,10 +435,10 @@ public class PartitionReplicaLifecycleManager implements IgniteComponent {
                 distributionZoneMgr
         );
 
-        replicationGroupIds.add(replicaGrpId);
-
         Supplier<CompletableFuture<Boolean>> startReplicaSupplier = () -> {
             try {
+                replicationGroupIds.add(replicaGrpId);
+
                 return replicaMgr.startReplica(
                         replicaGrpId,
                         (raftClient) -> new ZonePartitionReplicaListener(
@@ -633,7 +633,6 @@ public class PartitionReplicaLifecycleManager implements IgniteComponent {
     public boolean hasLocalPartition(ZonePartitionId zonePartitionId) {
         return replicationGroupIds.contains(zonePartitionId);
     }
-
 
     /**
      * Creates meta storage listener for pending assignments updates.


### PR DESCRIPTION
JIRA Ticket: [IGNITE-22622 | PartitionReplicaLifecycleManager must use weakStart/weaskStop approach](https://issues.apache.org/jira/browse/IGNITE-22622)

## The goal

The main goal of the ticket is to wrap start and stop zone replicas inside of `PartitionReplicaLifecycleManager` processes with weak start/stop.

## The reason

Weak start and stop are saving us from replicas deletion while a replica may was primary.

## The solution

Inside `PartitionReplicaLifecycleManager` all entries of `startReplica` and `stopReplica` are wrapped with `weakStartReplica` and `weakStopReplica` respectively.

Also there was fixed an issue in related test: before the fix zeroth node is registered as cluster node with consistent and local identifiers that are node name. Local name is UUID and the described code is a mistake.

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)