### PR TITLE
IGNITE-20869 Got rid of using CompletableFuture#orTimeout method on operations hot path

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -193,7 +193,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
                         heartbeatTimer = initHeartbeat(cfg.clientConfiguration().heartbeatInterval());
                     }
 
-                    new IgniteThread(timeoutWorker);
+                    new IgniteThread(timeoutWorker).start();
 
                     return this;
                 }, asyncContinuationExecutor);

--- a/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 import org.apache.ignite.client.IgniteClient.Builder;
 import org.apache.ignite.client.fakes.FakeIgnite;
 import org.apache.ignite.internal.testframework.IgniteTestUtils;
+import org.apache.ignite.internal.testframework.WithSystemProperty;
 import org.apache.ignite.lang.IgniteException;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -109,6 +110,7 @@ public class ConnectionTest extends AbstractClientTest {
 
     @SuppressWarnings("ThrowableNotThrown")
     @Test
+    @WithSystemProperty(key = "IGNITE_TIMEOUT_WORKER_SLEEP_INTERVAL", value = "10")
     public void testNoResponseFromServerWithinOperationTimeoutThrowsException() {
         Function<Integer, Integer> responseDelay = x -> x > 2 ? 100 : 0;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutObject.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutObject.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.future.timeout;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Timeout object.
+ * The class is a wrapper over the complete future.
+ */
+public class TimeoutObject {
+    /** End time (milliseconds since Unix epoch). */
+    private final long endTime;
+
+    /** Target future. */
+    private final CompletableFuture<?> fut;
+
+    /**
+     * Constructor.
+     *
+     * @param endTime End timestamp in milliseconds.
+     * @param fut Target future.
+     */
+    public TimeoutObject(long endTime, CompletableFuture<?> fut) {
+        this.endTime = endTime;
+        this.fut = fut;
+    }
+
+    /**
+     * Gets end timestamp.
+     *
+     * @return End timestamp in milliseconds.
+     */
+    public long endTime() {
+        return endTime;
+    }
+
+    /**
+     * Gets a target future.
+     *
+     * @return A future.
+     */
+    public CompletableFuture<?> future() {
+        return fut;
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutObject.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutObject.java
@@ -20,42 +20,21 @@ package org.apache.ignite.internal.future.timeout;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Timeout object.
- * The class is a wrapper over the complete future.
+ * Timeout object interface.
+ * It is used to limit a time to wait on the future compilation.
  */
-public class TimeoutObject<T extends CompletableFuture<?>> {
-    /** End time (milliseconds since Unix epoch). */
-    private final long endTime;
-
-    /** Target future. */
-    private final T fut;
-
-    /**
-     * Constructor.
-     *
-     * @param endTime End timestamp in milliseconds.
-     * @param fut Target future.
-     */
-    public TimeoutObject(long endTime, T fut) {
-        this.endTime = endTime;
-        this.fut = fut;
-    }
-
+public interface TimeoutObject<T extends CompletableFuture<?>> {
     /**
      * Gets end timestamp.
      *
      * @return End timestamp in milliseconds.
      */
-    public long endTime() {
-        return endTime;
-    }
+    long endTime();
 
     /**
      * Gets a target future.
      *
      * @return A future.
      */
-    public T future() {
-        return fut;
-    }
+    T future();
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutObject.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutObject.java
@@ -23,12 +23,12 @@ import java.util.concurrent.CompletableFuture;
  * Timeout object.
  * The class is a wrapper over the complete future.
  */
-public class TimeoutObject {
+public class TimeoutObject<T extends CompletableFuture<?>> {
     /** End time (milliseconds since Unix epoch). */
     private final long endTime;
 
     /** Target future. */
-    private final CompletableFuture<?> fut;
+    private final T fut;
 
     /**
      * Constructor.
@@ -36,7 +36,7 @@ public class TimeoutObject {
      * @param endTime End timestamp in milliseconds.
      * @param fut Target future.
      */
-    public TimeoutObject(long endTime, CompletableFuture<?> fut) {
+    public TimeoutObject(long endTime, T fut) {
         this.endTime = endTime;
         this.fut = fut;
     }
@@ -55,7 +55,7 @@ public class TimeoutObject {
      *
      * @return A future.
      */
-    public CompletableFuture<?> future() {
+    public T future() {
         return fut;
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutWorker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutWorker.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.future.timeout;
+
+import static org.apache.ignite.internal.lang.IgniteSystemProperties.getLong;
+import static org.apache.ignite.internal.util.FastTimestamps.coarseCurrentTimeMillis;
+
+import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeoutException;
+import org.apache.ignite.internal.lang.IgniteInternalException;
+import org.apache.ignite.internal.logger.IgniteLogger;
+import org.apache.ignite.internal.util.worker.IgniteWorker;
+
+/**
+ * Timeout object worker.
+ */
+public class TimeoutWorker extends IgniteWorker {
+    /** Worker sleep interval. */
+    private final long sleepInterval = getLong("IGNITE_TIMEOUT_WORKER_SLEEP_INTERVAL", 500);
+
+    /** Active operations. */
+    public final ConcurrentMap<Long, TimeoutObject> requestsMap;
+
+    /** True means removing object from the operation map on timeout. */
+    private final boolean removeOnTimeout;
+
+    /**
+     * Constructor.
+     *
+     * @param log Logger.
+     * @param igniteInstanceName Name of the Ignite instance this runnable is used in.
+     * @param name Worker name. Note that in general thread name and worker (runnable) name are two different things. The same
+     *         worker can be executed by multiple threads and therefore for logging and debugging purposes we separate the two.
+     * @param requestsMap Active operations.
+     * @param removeOnTimeout Remove operation from map.
+     */
+    public TimeoutWorker(
+            IgniteLogger log,
+            String igniteInstanceName,
+            String name,
+            ConcurrentMap<Long, TimeoutObject> requestsMap,
+            boolean removeOnTimeout
+    ) {
+        super(log, igniteInstanceName, name, null);
+
+        this.requestsMap = requestsMap;
+        this.removeOnTimeout = removeOnTimeout;
+    }
+
+    @Override
+    protected void body() {
+        try {
+            TimeoutObject timeoutObject;
+
+            while (!isCancelled()) {
+                long now = coarseCurrentTimeMillis();
+
+                for (Entry<Long, TimeoutObject> entry : requestsMap.entrySet()) {
+                    updateHeartbeat();
+
+                    timeoutObject = entry.getValue();
+
+                    assert timeoutObject != null : "Unexpected null in timeout operation map.";
+
+                    if (timeoutObject.endTime() > 0 && now > timeoutObject.endTime()) {
+                        CompletableFuture<?> fut = timeoutObject.future();
+
+                        if (!fut.isDone()) {
+                            fut.completeExceptionally(new TimeoutException());
+
+                            if (removeOnTimeout) {
+                                requestsMap.remove(entry.getKey(), timeoutObject);
+                            }
+                        }
+                    }
+                }
+
+                try {
+                    Thread.sleep(sleepInterval);
+                } catch (InterruptedException e) {
+                    log.info("The timeout worker was interrupted, probably the client is stopping.");
+                }
+
+                updateHeartbeat();
+            }
+
+        } catch (Throwable t) {
+            // TODO: IGNITE-23075 Call FH here.
+            throw new IgniteInternalException(t);
+        }
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutWorker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutWorker.java
@@ -36,7 +36,7 @@ public class TimeoutWorker extends IgniteWorker {
     private final long sleepInterval = getLong("IGNITE_TIMEOUT_WORKER_SLEEP_INTERVAL", 500);
 
     /** Active operations. */
-    public final ConcurrentMap<Long, TimeoutObject> requestsMap;
+    public final ConcurrentMap<Long, TimeoutObject<?>> requestsMap;
 
     /** True means removing object from the operation map on timeout. */
     private final boolean removeOnTimeout;
@@ -55,7 +55,7 @@ public class TimeoutWorker extends IgniteWorker {
             IgniteLogger log,
             String igniteInstanceName,
             String name,
-            ConcurrentMap<Long, TimeoutObject> requestsMap,
+            ConcurrentMap requestsMap,
             boolean removeOnTimeout
     ) {
         super(log, igniteInstanceName, name, null);
@@ -67,12 +67,12 @@ public class TimeoutWorker extends IgniteWorker {
     @Override
     protected void body() {
         try {
-            TimeoutObject timeoutObject;
+            TimeoutObject<?> timeoutObject;
 
             while (!isCancelled()) {
                 long now = coarseCurrentTimeMillis();
 
-                for (Entry<Long, TimeoutObject> entry : requestsMap.entrySet()) {
+                for (Entry<Long, TimeoutObject<?>> entry : requestsMap.entrySet()) {
                     updateHeartbeat();
 
                     timeoutObject = entry.getValue();

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/DefaultMessagingService.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/DefaultMessagingService.java
@@ -613,7 +613,7 @@ public class DefaultMessagingService extends AbstractMessagingService {
      * Starts the service.
      */
     public void start() {
-        new IgniteThread(timeoutWorker);
+        new IgniteThread(timeoutWorker).start();
 
         criticalWorkerRegistry.register(outboundExecutor);
 

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/DefaultMessagingService.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/DefaultMessagingService.java
@@ -106,7 +106,7 @@ public class DefaultMessagingService extends AbstractMessagingService {
     private volatile ConnectionManager connectionManager;
 
     /** Collection that maps correlation id to the future for an invocation request. */
-    private final ConcurrentMap<Long, TimeoutObject<CompletableFuture<NetworkMessage>>> requestsMap = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Long, TimeoutObjectImpl> requestsMap = new ConcurrentHashMap<>();
 
     /** Correlation id generator. */
     private final AtomicLong correlationIdGenerator = new AtomicLong();
@@ -300,7 +300,7 @@ public class DefaultMessagingService extends AbstractMessagingService {
 
         CompletableFuture<NetworkMessage> responseFuture = new CompletableFuture<>();
 
-        requestsMap.put(correlationId, new TimeoutObject<>(timeout > 0 ? coarseCurrentTimeMillis() + timeout : 0, responseFuture));
+        requestsMap.put(correlationId, new TimeoutObjectImpl(timeout > 0 ? coarseCurrentTimeMillis() + timeout : 0, responseFuture));
 
         InetSocketAddress recipientAddress = resolveRecipientAddress(recipient);
 
@@ -570,7 +570,7 @@ public class DefaultMessagingService extends AbstractMessagingService {
      * @param correlationId Request's correlation id.
      */
     private void onInvokeResponse(NetworkMessage response, Long correlationId) {
-        TimeoutObject<CompletableFuture<NetworkMessage>> responseFuture = requestsMap.remove(correlationId);
+        TimeoutObjectImpl responseFuture = requestsMap.remove(correlationId);
 
         if (responseFuture != null) {
             responseFuture.future().complete(response);
@@ -723,6 +723,38 @@ public class DefaultMessagingService extends AbstractMessagingService {
             for (CriticalWorker worker : registeredWorkers) {
                 workerRegistry.unregister(worker);
             }
+        }
+    }
+
+    /**
+     * Timeout object wrapper for the completable future.
+     */
+    private static class TimeoutObjectImpl implements TimeoutObject<CompletableFuture<NetworkMessage>> {
+        /** End time (milliseconds since Unix epoch). */
+        private final long endTime;
+
+        /** Target future. */
+        private final CompletableFuture<NetworkMessage> fut;
+
+        /**
+         * Constructor.
+         *
+         * @param endTime End timestamp in milliseconds.
+         * @param fut Target future.
+         */
+        public TimeoutObjectImpl(long endTime, CompletableFuture<NetworkMessage> fut) {
+            this.endTime = endTime;
+            this.fut = fut;
+        }
+
+        @Override
+        public long endTime() {
+            return endTime;
+        }
+
+        @Override
+        public CompletableFuture<NetworkMessage> future() {
+            return fut;
         }
     }
 

--- a/modules/raft/src/main/java/org/apache/ignite/raft/jraft/rpc/impl/IgniteRpcClient.java
+++ b/modules/raft/src/main/java/org/apache/ignite/raft/jraft/rpc/impl/IgniteRpcClient.java
@@ -120,6 +120,10 @@ public class IgniteRpcClient implements RpcClientEx {
 
                 blockedMsgs.add(msgData);
 
+                if (timeoutMs > 0) {
+                    fut.orTimeout(timeoutMs, TimeUnit.MILLISECONDS);
+                }
+
                 LOG.info("Blocked message to={} id={} msg={}", peerId.toString(), msgData[2], S.toString(request));
 
                 return fut;

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/FeatureTimeoutBenchmark.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/FeatureTimeoutBenchmark.java
@@ -85,6 +85,7 @@ public class FeatureTimeoutBenchmark {
         } else {
             requestsMap = new ConcurrentHashMap<>();
             timeoutWorker = new IgniteThread("benchmark", "timeout-worker", new TimeoutRunnable(requestsMap));
+            timeoutWorker.start();
         }
     }
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/FeatureTimeoutBenchmark.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/FeatureTimeoutBenchmark.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.benchmark;
+
+import static org.apache.ignite.internal.testframework.IgniteTestUtils.waitForCondition;
+import static org.apache.ignite.internal.util.FastTimestamps.coarseCurrentTimeMillis;
+
+import com.lmax.disruptor.dsl.Disruptor;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.ignite.internal.lang.IgniteInternalException;
+import org.apache.ignite.internal.thread.IgniteThread;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Feature timeout benchmark.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 10, time = 2)
+@Measurement(iterations = 20, time = 2)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class FeatureTimeoutBenchmark {
+    private static AtomicLong ID_GEN = new AtomicLong();
+
+    /** Active operation. */
+    public ConcurrentMap<Long, TimeoutObject> requestsMap;
+
+    private IgniteThread timeoutWorker;
+
+    private ArrayList<CompletableFuture<?>> futs;
+
+    private Disruptor<TimeoutObject> disruptor;
+
+    @Param({"false", "true"})
+    private boolean useFutureEmbeddedTimeout;
+
+    /**
+     * Prepare to start the benchmark.
+     */
+    @Setup
+    public void setUp() {
+        if (useFutureEmbeddedTimeout) {
+            futs = new ArrayList<>();
+        } else {
+            requestsMap = new ConcurrentHashMap<>();
+            timeoutWorker = new IgniteThread("benchmark", "timeout-worker", new TimeoutRunnable(requestsMap));
+        }
+    }
+
+    /**
+     * Closes resources.
+     */
+    @TearDown
+    public void tearDown() throws InterruptedException {
+        if (useFutureEmbeddedTimeout) {
+            for (CompletableFuture<?> fut : futs) {
+                if (!fut.isDone()) {
+                    try {
+                        fut.get(10, TimeUnit.SECONDS);
+                    } catch (ExecutionException e) {
+                        assert e.getCause() instanceof TimeoutException : "Unexpected exception type: " + e.getCause().getClass();
+                    } catch (TimeoutException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+
+            futs.clear();
+            futs = null;
+        } else {
+            assert waitForCondition(requestsMap::isEmpty, 10_000);
+
+            timeoutWorker.interrupt();
+            timeoutWorker = null;
+        }
+    }
+
+    /**
+     * Benchmark for KV upsert via embedded client.
+     */
+    @Benchmark
+    public void test() {
+        if (useFutureEmbeddedTimeout) {
+            for (int i = 0; i < 10; i++) {
+                var fut = new CompletableFuture<Void>();
+
+                futs.add(fut);
+
+                fut.orTimeout(10, TimeUnit.MILLISECONDS);
+            }
+        } else {
+            for (int i = 0; i < 10; i++) {
+                requestsMap.put(ID_GEN.incrementAndGet(), new TimeoutObject(
+                        System.currentTimeMillis() + 10,
+                        new CompletableFuture()
+                ));
+            }
+        }
+    }
+
+    /**
+     * Benchmark's entry point.
+     */
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(".*" + FeatureTimeoutBenchmark.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(opt).run();
+    }
+
+    /**
+     * Timeout object worker.
+     */
+    private static class TimeoutRunnable implements Runnable {
+        /** Active operation. */
+        public final ConcurrentMap<Long, TimeoutObject> requestsMap;
+
+        /**
+         * Constructor.
+         *
+         * @param requestsMap Active operations.
+         */
+        public TimeoutRunnable(ConcurrentMap<Long, TimeoutObject> requestsMap) {
+            this.requestsMap = requestsMap;
+        }
+
+        @Override
+        public void run() {
+            try {
+                TimeoutObject timeoutObject;
+
+                while (!Thread.currentThread().isInterrupted()) {
+                    Iterator<TimeoutObject> objs = requestsMap.values().iterator();
+
+                    while (objs.hasNext()) {
+                        timeoutObject = objs.next();
+
+                        assert timeoutObject != null : "Unexpected null on the timeout queue.";
+
+                        if (timeoutObject.getEndTime() > 0 && coarseCurrentTimeMillis() > timeoutObject.getEndTime()) {
+                            CompletableFuture<?> fut = timeoutObject.getFuture();
+
+                            if (!fut.isDone()) {
+                                fut.completeExceptionally(new TimeoutException());
+                            }
+
+                            objs.remove();
+                        }
+                    }
+
+                    Thread.sleep(200);
+                }
+            } catch (Throwable t) {
+                throw new IgniteInternalException(t);
+            }
+        }
+    }
+
+    /**
+     * Timeout object.
+     * The class is a wrapper over the complete future.
+     */
+    private static class TimeoutObject {
+        /** End time. */
+        private final long endTime;
+
+        /** Target future. */
+        private final CompletableFuture<?> fut;
+
+        /**
+         * Constructor.
+         *
+         * @param endTime End timestamp in milliseconds.
+         * @param fut Target future.
+         */
+        public TimeoutObject(long endTime, CompletableFuture<?> fut) {
+            this.endTime = endTime;
+            this.fut = fut;
+        }
+
+        /**
+         * Gets end timestamp.
+         *
+         * @return End timestamp in milliseconds.
+         */
+        public long getEndTime() {
+            return endTime;
+        }
+
+        /**
+         * Gets a target future.
+         *
+         * @return A future.
+         */
+        public CompletableFuture<?> getFuture() {
+            return fut;
+        }
+    }
+}

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/FutureTimeoutBenchmark.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/FutureTimeoutBenchmark.java
@@ -20,7 +20,6 @@ package org.apache.ignite.internal.benchmark;
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.waitForCondition;
 import static org.apache.ignite.internal.util.IgniteUtils.awaitForWorkersStop;
 
-import com.lmax.disruptor.dsl.Disruptor;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -58,8 +57,8 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  *
  * <p>Results on 11th Gen Intel® Core™ i7-1165G7 @ 2.80GHz, openjdk 11.0.24, Windows 10 Pro:
  * Benchmark                    (useFutureEmbeddedTimeout)  Mode  Cnt   Score    Error  Units
- * FutureTimeoutBenchmark.test                       false  avgt   20   0,875 ±  0,020  us/op
- * FutureTimeoutBenchmark.test                        true  avgt   20  28,409 ± 27,269  us/op
+ * FutureTimeoutBenchmark.test                       false  avgt   20   0,810 ±  0,112  us/op
+ * FutureTimeoutBenchmark.test                        true  avgt   20  30,261 ± 34,762  us/op
  */
 @State(Scope.Benchmark)
 @Fork(1)
@@ -72,13 +71,11 @@ public class FutureTimeoutBenchmark {
     private static AtomicLong ID_GEN = new AtomicLong();
 
     /** Active operations. */
-    public ConcurrentMap<Long, TimeoutObject> requestsMap;
+    public ConcurrentMap<Long, TimeoutObject<CompletableFuture<Void>>> requestsMap;
 
     private TimeoutWorker timeoutWorker;
 
     private ConcurrentMap<Long, CompletableFuture<?>> futs;
-
-    private Disruptor<TimeoutObject> disruptor;
 
     @Param({"false", "true"})
     private boolean useFutureEmbeddedTimeout;


### PR DESCRIPTION
**FeatureTimeoutBenchmark**
```
*  Results on 11th Gen Intel® Core™ i7-1165G7 @ 2.80GHz, openjdk 11.0.24, Windows 10 Pro:
 * Benchmark                     (useFutureEmbeddedTimeout)  Mode  Cnt   Score    Error  Units
 * FeatureTimeoutBenchmark.test                       false  avgt   20   1,501 ±  0,058  us/op
 * FeatureTimeoutBenchmark.test                        true  avgt   20  32,573 ± 47,598  us/op
```

https://issues.apache.org/jira/browse/IGNITE-20869