### PR TITLE
IGNITE-22986 Close storage after RAFT

### DIFF
--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/server/raft/ItMetaStorageRaftGroupTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/server/raft/ItMetaStorageRaftGroupTest.java
@@ -199,18 +199,6 @@ public class ItMetaStorageRaftGroupTest extends IgniteAbstractTest {
     public void afterTest() {
         ComponentContext componentContext = new ComponentContext();
 
-        if (logStorageFactory3 != null) {
-            assertThat(logStorageFactory3.stopAsync(componentContext), willCompleteSuccessfully());
-        }
-
-        if (logStorageFactory2 != null) {
-            assertThat(logStorageFactory2.stopAsync(componentContext), willCompleteSuccessfully());
-        }
-
-        if (logStorageFactory1 != null) {
-            assertThat(logStorageFactory1.stopAsync(componentContext), willCompleteSuccessfully());
-        }
-
         if (metaStorageRaftSrv3 != null) {
             metaStorageRaftSrv3.stopRaftNodes(MetastorageGroupId.INSTANCE);
             assertThat(metaStorageRaftSrv3.stopAsync(componentContext), willCompleteSuccessfully());
@@ -227,6 +215,18 @@ public class ItMetaStorageRaftGroupTest extends IgniteAbstractTest {
             metaStorageRaftSrv1.stopRaftNodes(MetastorageGroupId.INSTANCE);
             assertThat(metaStorageRaftSrv1.stopAsync(componentContext), willCompleteSuccessfully());
             metaStorageRaftGrpSvc1.shutdown();
+        }
+
+        if (logStorageFactory3 != null) {
+            assertThat(logStorageFactory3.stopAsync(componentContext), willCompleteSuccessfully());
+        }
+
+        if (logStorageFactory2 != null) {
+            assertThat(logStorageFactory2.stopAsync(componentContext), willCompleteSuccessfully());
+        }
+
+        if (logStorageFactory1 != null) {
+            assertThat(logStorageFactory1.stopAsync(componentContext), willCompleteSuccessfully());
         }
 
         IgniteUtils.shutdownAndAwaitTermination(executor, 10, TimeUnit.SECONDS);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22986

Storage was closed before RAFT server and a running thread was trying to access the already closed RocksDB storage, which resulted in a crash.