### PR TITLE
IGNITE-22984 Java thin: Add endpoint info to connection errors

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConnectionException.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConnectionException.java
@@ -79,7 +79,7 @@ public class IgniteClientConnectionException extends IgniteException {
         return endpoint;
     }
 
-    private static @NotNull String getMessage(String msg, String endpoint) {
+    private static @NotNull String getMessage(String msg, @Nullable String endpoint) {
         return endpoint == null || endpoint.isEmpty() ? msg : msg + " [endpoint=" + endpoint + "]";
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConnectionException.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConnectionException.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.client;
 
 import org.apache.ignite.lang.IgniteException;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -28,7 +29,7 @@ public class IgniteClientConnectionException extends IgniteException {
     private static final long serialVersionUID = 0L;
 
     /** The endpoint that caused the exception. */
-    private final String endpoint;
+    private final @Nullable String endpoint;
 
     /**
      * Constructs a new exception with the specified cause and detail message.
@@ -37,8 +38,8 @@ public class IgniteClientConnectionException extends IgniteException {
      * @param msg   the detail message.
      * @param cause the cause.
      */
-    public IgniteClientConnectionException(int code, String msg, String endpoint, @Nullable Throwable cause) {
-        super(code, msg, cause);
+    public IgniteClientConnectionException(int code, String msg, @Nullable String endpoint, @Nullable Throwable cause) {
+        super(code, getMessage(msg, endpoint), cause);
 
         this.endpoint = endpoint;
     }
@@ -49,7 +50,7 @@ public class IgniteClientConnectionException extends IgniteException {
      * @param code  the error code.
      * @param msg   the detail message.
      */
-    public IgniteClientConnectionException(int code, String msg, String endpoint) {
+    public IgniteClientConnectionException(int code, String msg, @Nullable String endpoint) {
         this(code, msg, endpoint, null);
     }
 
@@ -58,7 +59,11 @@ public class IgniteClientConnectionException extends IgniteException {
      *
      * @return the endpoint that caused the exception.
      */
-    public String endpoint() {
+    public @Nullable String endpoint() {
         return endpoint;
+    }
+
+    private static @NotNull String getMessage(String msg, String endpoint) {
+        return endpoint == null || endpoint.isEmpty() ? msg : msg + " [endpoint=" + endpoint + "]";
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConnectionException.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConnectionException.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.client;
 
+import java.util.UUID;
 import org.apache.ignite.lang.IgniteException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -38,6 +39,20 @@ public class IgniteClientConnectionException extends IgniteException {
      * @param msg   the detail message.
      * @param cause the cause.
      */
+    public IgniteClientConnectionException(UUID traceId, int code, String msg, @Nullable Throwable cause) {
+        super(traceId, code, msg, cause);
+
+        this.endpoint = null;
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and detail message.
+     *
+     * @param code the error code.
+     * @param msg the detail message.
+     * @param endpoint the endpoint.
+     * @param cause the cause.
+     */
     public IgniteClientConnectionException(int code, String msg, @Nullable String endpoint, @Nullable Throwable cause) {
         super(code, getMessage(msg, endpoint), cause);
 
@@ -47,8 +62,9 @@ public class IgniteClientConnectionException extends IgniteException {
     /**
      * Constructs a new exception with the specified detail message.
      *
-     * @param code  the error code.
-     * @param msg   the detail message.
+     * @param code the error code.
+     * @param msg the detail message.
+     * @param endpoint the endpoint.
      */
     public IgniteClientConnectionException(int code, String msg, @Nullable String endpoint) {
         this(code, msg, endpoint, null);

--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConnectionException.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConnectionException.java
@@ -27,6 +27,9 @@ public class IgniteClientConnectionException extends IgniteException {
     /** Serial version uid. */
     private static final long serialVersionUID = 0L;
 
+    /** The endpoint that caused the exception. */
+    private final String endpoint;
+
     /**
      * Constructs a new exception with the specified cause and detail message.
      *
@@ -34,8 +37,10 @@ public class IgniteClientConnectionException extends IgniteException {
      * @param msg   the detail message.
      * @param cause the cause.
      */
-    public IgniteClientConnectionException(int code, String msg, @Nullable Throwable cause) {
+    public IgniteClientConnectionException(int code, String msg, String endpoint, @Nullable Throwable cause) {
         super(code, msg, cause);
+
+        this.endpoint = endpoint;
     }
 
     /**
@@ -44,7 +49,16 @@ public class IgniteClientConnectionException extends IgniteException {
      * @param code  the error code.
      * @param msg   the detail message.
      */
-    public IgniteClientConnectionException(int code, String msg) {
-        super(code, msg);
+    public IgniteClientConnectionException(int code, String msg, String endpoint) {
+        this(code, msg, endpoint, null);
+    }
+
+    /**
+     * Returns the endpoint that caused the exception.
+     *
+     * @return the endpoint that caused the exception.
+     */
+    public String endpoint() {
+        return endpoint;
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConnectionException.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClientConnectionException.java
@@ -19,7 +19,6 @@ package org.apache.ignite.client;
 
 import java.util.UUID;
 import org.apache.ignite.lang.IgniteException;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -79,7 +78,7 @@ public class IgniteClientConnectionException extends IgniteException {
         return endpoint;
     }
 
-    private static @NotNull String getMessage(String msg, @Nullable String endpoint) {
+    private static String getMessage(String msg, @Nullable String endpoint) {
         return endpoint == null || endpoint.isEmpty() ? msg : msg + " [endpoint=" + endpoint + "]";
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientChannel.java
@@ -74,6 +74,13 @@ public interface ClientChannel extends AutoCloseable {
     ProtocolContext protocolContext();
 
     /**
+     * Returns endpoint.
+     *
+     * @return Endpoint.
+     */
+    String endpoint();
+
+    /**
      * Send heartbeat request.
      *
      * @param payloadWriter Payload writer or {@code null} for no payload.

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ReliableChannel.java
@@ -582,7 +582,7 @@ public final class ReliableChannel implements AutoCloseable {
 
     private CompletableFuture<ClientChannel> getCurChannelAsync() {
         if (closed) {
-            return CompletableFuture.failedFuture(new IgniteClientConnectionException(CONNECTION_ERR, "ReliableChannel is closed"));
+            return CompletableFuture.failedFuture(new IgniteClientConnectionException(CONNECTION_ERR, "ReliableChannel is closed", null));
         }
 
         curChannelsGuard.readLock().lock();
@@ -829,8 +829,8 @@ public final class ReliableChannel implements AutoCloseable {
                 }
 
                 if (!ignoreThrottling && applyReconnectionThrottling()) {
-                    return CompletableFuture.failedFuture(
-                            new IgniteClientConnectionException(CONNECTION_ERR, "Reconnect is not allowed due to applied throttling"));
+                    return CompletableFuture.failedFuture(new IgniteClientConnectionException(
+                            CONNECTION_ERR, "Reconnect is not allowed due to applied throttling", null));
                 }
 
                 CompletableFuture<ClientChannel> createFut = chFactory.create(
@@ -852,7 +852,8 @@ public final class ReliableChannel implements AutoCloseable {
 
                         throw new IgniteClientConnectionException(
                                 CLUSTER_ID_MISMATCH_ERR,
-                                "Cluster ID mismatch: expected=" + oldClusterId + ", actual=" + ch.protocolContext().clusterId());
+                                "Cluster ID mismatch: expected=" + oldClusterId + ", actual=" + ch.protocolContext().clusterId(),
+                                ch.endpoint());
                     }
 
                     ClusterNode newNode = ch.protocolContext().clusterNode();

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/io/netty/NettyClientConnectionMultiplexer.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/io/netty/NettyClientConnectionMultiplexer.java
@@ -193,6 +193,7 @@ public class NettyClientConnectionMultiplexer implements ClientConnectionMultipl
                 var err = new IgniteClientConnectionException(
                         Client.CONNECTION_ERR,
                         "Client failed to connect: " + cause.getMessage(),
+                        addr.toString(),
                         cause);
 
                 fut.completeExceptionally(err);

--- a/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -78,7 +78,7 @@ public class ConnectionTest extends AbstractClientTest {
 
         // It does not seem possible to verify that it's a 'Connection refused' exception because with different
         // user locales the message differs, so let's just check that the message ends with the known suffix.
-        assertThat(errMsg, endsWith(": /127.0.0.1:47500"));
+        assertThat(errMsg, endsWith(" [endpoint=127.0.0.1:47500]"));
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -145,7 +145,7 @@ public class ConnectionTest extends AbstractClientTest {
             assertThrowsWithCause(
                     clientBuilder::build,
                     IgniteClientConnectionException.class,
-                    "Handshake timeout"
+                    "Handshake timeout [endpoint=127.0.0.1:" + testServer.port() + "]"
             );
 
             testServer.enableClientRequestHandling();

--- a/modules/client/src/test/java/org/apache/ignite/internal/client/RepeatedFinishClientTransactionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/internal/client/RepeatedFinishClientTransactionTest.java
@@ -203,6 +203,11 @@ public class RepeatedFinishClientTransactionTest extends BaseIgniteAbstractTest 
         }
 
         @Override
+        public String endpoint() {
+            return "test";
+        }
+
+        @Override
         public void close() {
             // No-op.
         }


### PR DESCRIPTION
* Add `IgniteClientConnectionException#endpoint` so that there is a mandatory constructor parameter
* Add endpoint to the exception message
* Propagate endpoints from call sites