### PR TITLE
IGNITE-22160: Sql. Usability of error message in case of numeric overflow

### DIFF
--- a/modules/sql-engine/src/integrationTest/sql/cast/test_cast_decimal.test
+++ b/modules/sql-engine/src/integrationTest/sql/cast/test_cast_decimal.test
@@ -17,12 +17,38 @@ SELECT CAST('1e2' AS DECIMAL);
 100
 
 # overflow
-statement error
+
+statement error: Numeric field overflow. A field with precision 5, scale 0 must round to an absolute value less than 10^5.
 SELECT CAST(1e20 AS DECIMAL(5));
 
-# overflow
-statement error
+statement error: Numeric field overflow. A field with precision 5, scale 0 must round to an absolute value less than 10^5.
 SELECT CAST(-1e20 AS DECIMAL(5));
+
+statement error: Numeric field overflow. A field with precision 3, scale 5 must round to an absolute value less than 10^-2.
+SELECT 0.3::DECIMAL(3, 5);
+
+statement error: Numeric field overflow. A field with precision 3, scale 3 must round to an absolute value less than 1.
+SELECT -1::DECIMAL(3, 3);
+
+# the first cast produces must report an error
+statement error: Numeric field overflow. A field with precision 3, scale 0 must round to an absolute value less than 10^3.
+SELECT 9999999::DECIMAL(3)::DECIMAL(4, 2);
+
+for val in ['10000', 10000::SMALLINT, 10000::INT, 10000::BIGINT, 10000::REAL, 10000::FLOAT, 10000::DOUBLE, 10000::DECIMAL, 10000::DECIMAL(10)]
+
+statement error: Numeric field overflow. A field with precision 4, scale 2 must round to an absolute value less than 10^2.
+SELECT ${val}::DECIMAL(4, 2);
+
+statement error: Numeric field overflow. A field with precision 2, scale 4 must round to an absolute value less than 10^-2.
+SELECT ${val}::DECIMAL(2, 4);
+
+statement error: Numeric field overflow. A field with precision 2, scale 2 must round to an absolute value less than 1.
+SELECT ${val}::DECIMAL(2, 2);
+
+statement error: Numeric field overflow. A field with precision 3, scale 0 must round to an absolute value less than 10^3.
+SELECT ${val}::DECIMAL(3);
+
+endfor
 
 for val in [100::TINYINT, 100::SMALLINT, 100::INT, 100::BIGINT, 100::DECIMAL, 100::DECIMAL(3)]
 

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/exp/IgniteSqlFunctions.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/exp/IgniteSqlFunctions.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.sql.engine.exec.exp;
 
 import static org.apache.calcite.runtime.SqlFunctions.charLength;
+import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
 import static org.apache.ignite.internal.sql.engine.prepare.IgniteSqlValidator.NUMERIC_FIELD_OVERFLOW_ERROR;
 import static org.apache.ignite.lang.ErrorGroups.Sql.RUNTIME_ERR;
 
@@ -368,13 +369,13 @@ public class IgniteSqlFunctions {
         BigDecimal dec = convertToBigDecimal(value);
 
         if (scale > precision) {
-            throw new SqlException(RUNTIME_ERR, NUMERIC_FIELD_OVERFLOW_ERROR);
+            throw numericOverflowError(precision, scale);
         } else {
             int currentSignificantDigits = dec.precision() - dec.scale();
             int expectedSignificantDigits = precision - scale;
 
             if (currentSignificantDigits > expectedSignificantDigits) {
-                throw new SqlException(RUNTIME_ERR, NUMERIC_FIELD_OVERFLOW_ERROR);
+                throw numericOverflowError(precision, scale);
             }
         }
 
@@ -394,7 +395,7 @@ public class IgniteSqlFunctions {
         int numPrecision = Math.min(num0.precision(), scale);
 
         if (numPrecision > precision) {
-            throw new SqlException(RUNTIME_ERR, NUMERIC_FIELD_OVERFLOW_ERROR);
+            throw numericOverflowError(precision, scale);
         }
 
         return num.setScale(scale, roundingMode);
@@ -415,6 +416,22 @@ public class IgniteSqlFunctions {
         }
 
         return dec;
+    }
+
+    private static SqlException numericOverflowError(int precision, int scale) {
+        String maxVal;
+
+        if (precision == scale) {
+            maxVal = "1";
+        } else {
+            maxVal = format("10^{}", precision - scale);
+        }
+
+        String detail = format("A field with precision {}, scale {} must round to an absolute value less than {}.",
+                precision, scale, maxVal
+        );
+
+        throw new SqlException(RUNTIME_ERR, NUMERIC_FIELD_OVERFLOW_ERROR + ". " + detail);
     }
 
     /** CAST(VARCHAR AS VARBINARY). */


### PR DESCRIPTION
Updates numeric overflow error message to `Numeric field overflow. A field with precision 5, scale 0 must round to an absolute value less than 10^5.`

https://issues.apache.org/jira/browse/IGNITE-22160

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)