### PR TITLE
IGNITE-23078 Fix flaky test CatalogCompactionRunnerSelfTest.mustNotPerformWhenAssignmentNodeIsMissing.

### DIFF
--- a/modules/catalog-compaction/src/test/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunnerSelfTest.java
+++ b/modules/catalog-compaction/src/test/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunnerSelfTest.java
@@ -275,9 +275,11 @@ public class CatalogCompactionRunnerSelfTest extends AbstractCatalogCompactionTe
 
             compactor.triggerCompaction(clockService.now());
             assertThat(compactor.lastRunFuture(), willCompleteSuccessfully());
-            waitForCondition(() -> catalogManager.earliestCatalogVersion() != 0, 1_000);
 
-            assertThat(catalogManager.earliestCatalogVersion(), is(catalog.version() - 1));
+            int expectedEarliestVersion = catalog.version() - 1;
+
+            waitForCondition(() -> catalogManager.earliestCatalogVersion() == expectedEarliestVersion, 1_000);
+            assertThat(catalogManager.earliestCatalogVersion(), is(expectedEarliestVersion));
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23078

The test runs compaction and expects that the earliest version of catalog will change from 0 to N at once.

But versions are stored in `ConcurrentSkipListMap`, when we trim the catalog we clear the head of this map.

And while trimming this map we can observe an earliest version between 0 and N, which looks valid and shouldn't be a problem.

Therefore, the test has been fixed to wait for the required version (ver == N), instead non zero version (ver != 0).