### PR TITLE
IGNITE-22883 Send all cluster IDs to thin client on connection

### DIFF
--- a/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/TestServer.java
+++ b/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/TestServer.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.client.handler.configuration.ClientConnectorConfiguration;
 import org.apache.ignite.internal.catalog.CatalogService;
@@ -119,6 +120,8 @@ public class TestServer {
         Mockito.when(clusterService.topologyService().localMember().id()).thenReturn("id");
         Mockito.when(clusterService.topologyService().localMember().name()).thenReturn("consistent-id");
 
+        ClusterTag clusterTag = ClusterTag.randomClusterTag(msgFactory, "Test Server");
+
         var module = new ClientHandlerModule(
                 mock(QueryProcessor.class),
                 mock(IgniteTablesInternal.class),
@@ -126,7 +129,7 @@ public class TestServer {
                 mock(IgniteComputeInternal.class),
                 clusterService,
                 bootstrapFactory,
-                () -> CompletableFuture.completedFuture(ClusterTag.randomClusterTag(msgFactory, "Test Server")),
+                () -> CompletableFuture.completedFuture(new ClusterInfo(clusterTag, List.of(clusterTag.clusterId()))),
                 mock(MetricManagerImpl.class),
                 metrics,
                 authenticationManager,

--- a/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/TestServer.java
+++ b/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/TestServer.java
@@ -23,7 +23,6 @@ import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.client.handler.configuration.ClientConnectorConfiguration;
 import org.apache.ignite.internal.catalog.CatalogService;
 import org.apache.ignite.internal.cluster.management.ClusterTag;
@@ -129,7 +128,7 @@ public class TestServer {
                 mock(IgniteComputeInternal.class),
                 clusterService,
                 bootstrapFactory,
-                () -> CompletableFuture.completedFuture(new ClusterInfo(clusterTag, List.of(clusterTag.clusterId()))),
+                () -> new ClusterInfo(clusterTag, List.of(clusterTag.clusterId())),
                 mock(MetricManagerImpl.class),
                 metrics,
                 authenticationManager,

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -38,6 +38,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import javax.net.ssl.SSLException;
 import org.apache.ignite.client.handler.configuration.ClientConnectorView;
 import org.apache.ignite.client.handler.requests.cluster.ClientClusterGetNodesRequest;
@@ -182,7 +183,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
     private final JdbcQueryCursorHandler jdbcQueryCursorHandler;
 
     /** Cluster ID. */
-    private final CompletableFuture<ClusterInfo> clusterInfoFuture;
+    private final Supplier<ClusterInfo> clusterInfoSupplier;
 
     /** Metrics. */
     private final ClientHandlerMetricSource metrics;
@@ -219,7 +220,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
      * @param configuration Configuration.
      * @param compute Compute.
      * @param clusterService Cluster.
-     * @param clusterInfoFuture Cluster info.
+     * @param clusterInfoSupplier Cluster info supplier.
      * @param metrics Metrics.
      * @param authenticationManager Authentication manager.
      * @param clockService Clock service.
@@ -231,7 +232,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
             ClientConnectorView configuration,
             IgniteComputeInternal compute,
             ClusterService clusterService,
-            CompletableFuture<ClusterInfo> clusterInfoFuture,
+            Supplier<ClusterInfo> clusterInfoSupplier,
             ClientHandlerMetricSource metrics,
             AuthenticationManager authenticationManager,
             ClockService clockService,
@@ -246,7 +247,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
         assert configuration != null;
         assert compute != null;
         assert clusterService != null;
-        assert clusterInfoFuture != null;
+        assert clusterInfoSupplier != null;
         assert metrics != null;
         assert authenticationManager != null;
         assert clockService != null;
@@ -260,7 +261,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
         this.compute = compute;
         this.clusterService = clusterService;
         this.queryProcessor = processor;
-        this.clusterInfoFuture = clusterInfoFuture;
+        this.clusterInfoSupplier = clusterInfoSupplier;
         this.metrics = metrics;
         this.authenticationManager = authenticationManager;
         this.clockService = clockService;
@@ -418,7 +419,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
         packer.packString(localMember.id());
         packer.packString(localMember.name());
 
-        ClusterInfo clusterInfo = clusterInfoFuture.join();
+        ClusterInfo clusterInfo = clusterInfoSupplier.get();
 
         // Cluster ID history, from the oldest to the newest (cluster ID can change during CMG/MG repair).
         packer.packInt(clusterInfo.idHistory().size());

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClusterInfo.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClusterInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client.handler;
+
+import java.util.List;
+import java.util.UUID;
+import org.apache.ignite.internal.cluster.management.ClusterTag;
+
+/**
+ * Information about the cluster.
+ */
+public class ClusterInfo {
+    private final ClusterTag tag;
+    private final List<UUID> idHistory;
+
+    /**
+     * Constructor.
+     */
+    public ClusterInfo(ClusterTag tag, List<UUID> idHistory) {
+        this.tag = tag;
+        this.idHistory = List.copyOf(idHistory);
+    }
+
+    /** Returns cluster name. */
+    public String name() {
+        return tag.clusterName();
+    }
+
+    /** Returns history of cluster IDs (oldest to newest). Last element is the current ID. Contains at least one element. */
+    public List<UUID> idHistory() {
+        return idHistory;
+    }
+}

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClusterInfo.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClusterInfo.java
@@ -33,7 +33,7 @@ public class ClusterInfo {
      */
     public ClusterInfo(ClusterTag tag, List<UUID> idHistory) {
         this.tag = tag;
-        this.idHistory = List.copyOf(idHistory);
+        this.idHistory = idHistory;
     }
 
     /** Returns cluster name. */

--- a/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
@@ -222,7 +222,7 @@ public class TestClientHandlerModule implements IgniteComponent {
                                         configuration,
                                         compute,
                                         clusterService,
-                                        CompletableFuture.completedFuture(clusterInfo),
+                                        () -> clusterInfo,
                                         metrics,
                                         authenticationManager,
                                         clockService,

--- a/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
@@ -40,11 +40,11 @@ import org.apache.ignite.client.fakes.FakeInternalTable;
 import org.apache.ignite.client.handler.ClientHandlerMetricSource;
 import org.apache.ignite.client.handler.ClientInboundMessageHandler;
 import org.apache.ignite.client.handler.ClientPrimaryReplicaTracker;
+import org.apache.ignite.client.handler.ClusterInfo;
 import org.apache.ignite.client.handler.FakeCatalogService;
 import org.apache.ignite.client.handler.configuration.ClientConnectorConfiguration;
 import org.apache.ignite.internal.catalog.CatalogService;
 import org.apache.ignite.internal.client.proto.ClientMessageDecoder;
-import org.apache.ignite.internal.cluster.management.ClusterTag;
 import org.apache.ignite.internal.compute.IgniteComputeInternal;
 import org.apache.ignite.internal.hlc.HybridClock;
 import org.apache.ignite.internal.hlc.TestClockService;
@@ -81,7 +81,7 @@ public class TestClientHandlerModule implements IgniteComponent {
     private final IgniteComputeInternal compute;
 
     /** Cluster id. */
-    private final ClusterTag clusterTag;
+    private final ClusterInfo clusterInfo;
 
     /** Metrics. */
     private final ClientHandlerMetricSource metrics;
@@ -112,7 +112,7 @@ public class TestClientHandlerModule implements IgniteComponent {
      * @param shouldDropConnection Connection drop condition.
      * @param responseDelay Response delay, in milliseconds.
      * @param clusterService Cluster service.
-     * @param clusterTag Cluster tag.
+     * @param clusterInfo Cluster info.
      * @param metrics Metrics.
      * @param authenticationManager Authentication manager.
      * @param clock Clock.
@@ -125,7 +125,7 @@ public class TestClientHandlerModule implements IgniteComponent {
             Function<Integer, Boolean> shouldDropConnection,
             @Nullable Function<Integer, Integer> responseDelay,
             ClusterService clusterService,
-            ClusterTag clusterTag,
+            ClusterInfo clusterInfo,
             ClientHandlerMetricSource metrics,
             AuthenticationManager authenticationManager,
             HybridClock clock,
@@ -141,7 +141,7 @@ public class TestClientHandlerModule implements IgniteComponent {
         this.responseDelay = responseDelay;
         this.clusterService = clusterService;
         this.compute = (IgniteComputeInternal) ignite.compute();
-        this.clusterTag = clusterTag;
+        this.clusterInfo = clusterInfo;
         this.metrics = metrics;
         this.authenticationManager = authenticationManager;
         this.clock = clock;
@@ -222,7 +222,7 @@ public class TestClientHandlerModule implements IgniteComponent {
                                         configuration,
                                         compute,
                                         clusterService,
-                                        CompletableFuture.completedFuture(clusterTag),
+                                        CompletableFuture.completedFuture(clusterInfo),
                                         metrics,
                                         authenticationManager,
                                         clockService,

--- a/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
@@ -34,7 +34,6 @@ import java.net.SocketAddress;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.client.fakes.FakeIgnite;
@@ -252,7 +251,7 @@ public class TestServer implements AutoCloseable {
                         (IgniteComputeInternal) ignite.compute(),
                         clusterService,
                         bootstrapFactory,
-                        () -> CompletableFuture.completedFuture(clusterInfo),
+                        () -> clusterInfo,
                         mock(MetricManagerImpl.class),
                         metrics,
                         authenticationManager,

--- a/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
@@ -41,6 +41,7 @@ import org.apache.ignite.client.fakes.FakeIgnite;
 import org.apache.ignite.client.fakes.FakeInternalTable;
 import org.apache.ignite.client.handler.ClientHandlerMetricSource;
 import org.apache.ignite.client.handler.ClientHandlerModule;
+import org.apache.ignite.client.handler.ClusterInfo;
 import org.apache.ignite.client.handler.DummyAuthenticationManager;
 import org.apache.ignite.client.handler.FakeCatalogService;
 import org.apache.ignite.client.handler.FakePlacementDriver;
@@ -229,6 +230,7 @@ public class TestServer implements AutoCloseable {
                 .clusterName("Test Server")
                 .clusterId(clusterId)
                 .build();
+        ClusterInfo clusterInfo = new ClusterInfo(tag, List.of(tag.clusterId()));
 
         module = shouldDropConnection != null
                 ? new TestClientHandlerModule(
@@ -237,7 +239,7 @@ public class TestServer implements AutoCloseable {
                 shouldDropConnection,
                 responseDelay,
                 clusterService,
-                tag,
+                clusterInfo,
                 metrics,
                 authenticationManager,
                 clock,
@@ -250,7 +252,7 @@ public class TestServer implements AutoCloseable {
                         (IgniteComputeInternal) ignite.compute(),
                         clusterService,
                         bootstrapFactory,
-                        () -> CompletableFuture.completedFuture(tag),
+                        () -> CompletableFuture.completedFuture(clusterInfo),
                         mock(MetricManagerImpl.class),
                         metrics,
                         authenticationManager,

--- a/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/ClusterState.java
+++ b/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/ClusterState.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.cluster.management;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -76,4 +77,21 @@ public interface ClusterState extends NetworkMessage, Serializable {
      */
     @Nullable
     List<UUID> formerClusterIds();
+
+    /**
+     * Returns history of cluster IDs (oldest to newest). Last element is the current ID. Contains at least one element.
+     */
+    default List<UUID> clusterIdHistory() {
+        List<UUID> formerClusterIds = formerClusterIds();
+        UUID currentClusterId = clusterTag().clusterId();
+
+        if (formerClusterIds == null) {
+            return List.of(currentClusterId);
+        }
+
+        List<UUID> history = new ArrayList<>(formerClusterIds);
+        history.add(currentClusterId);
+
+        return history;
+    }
 }

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
@@ -57,6 +57,7 @@ import org.apache.ignite.IgniteServer;
 import org.apache.ignite.catalog.IgniteCatalog;
 import org.apache.ignite.client.handler.ClientHandlerMetricSource;
 import org.apache.ignite.client.handler.ClientHandlerModule;
+import org.apache.ignite.client.handler.ClusterInfo;
 import org.apache.ignite.client.handler.configuration.ClientConnectorConfiguration;
 import org.apache.ignite.client.handler.configuration.ClientConnectorExtensionConfiguration;
 import org.apache.ignite.compute.IgniteCompute;
@@ -71,7 +72,6 @@ import org.apache.ignite.internal.catalog.sql.IgniteCatalogSqlImpl;
 import org.apache.ignite.internal.catalog.storage.UpdateLogImpl;
 import org.apache.ignite.internal.cluster.management.ClusterInitializer;
 import org.apache.ignite.internal.cluster.management.ClusterManagementGroupManager;
-import org.apache.ignite.internal.cluster.management.ClusterState;
 import org.apache.ignite.internal.cluster.management.NodeAttributesCollector;
 import org.apache.ignite.internal.cluster.management.configuration.NodeAttributesExtensionConfiguration;
 import org.apache.ignite.internal.cluster.management.raft.ClusterStateStorage;
@@ -1054,7 +1054,8 @@ public class IgniteImpl implements Ignite {
                 compute,
                 clusterSvc,
                 nettyBootstrapFactory,
-                () -> cmgMgr.clusterState().thenApply(ClusterState::clusterTag),
+                () -> cmgMgr.clusterState()
+                        .thenApply(clusterState -> new ClusterInfo(clusterState.clusterTag(), clusterState.clusterIdHistory())),
                 metricManager,
                 new ClientHandlerMetricSource(),
                 authenticationManager,

--- a/modules/system-disaster-recovery/build.gradle
+++ b/modules/system-disaster-recovery/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     integrationTestImplementation project(':ignite-cluster-management')
     integrationTestImplementation project(':ignite-vault')
     integrationTestImplementation project(':ignite-network-api')
+    integrationTestImplementation project(':ignite-client')
     integrationTestImplementation testFixtures(project(':ignite-core'))
     integrationTestImplementation testFixtures(project(':ignite-api'))
     integrationTestImplementation testFixtures(project(':ignite-runner'))

--- a/modules/system-disaster-recovery/src/main/java/org/apache/ignite/internal/disaster/system/SystemDisasterRecoveryStorage.java
+++ b/modules/system-disaster-recovery/src/main/java/org/apache/ignite/internal/disaster/system/SystemDisasterRecoveryStorage.java
@@ -53,7 +53,8 @@ public class SystemDisasterRecoveryStorage implements ClusterResetStorage {
         vault.remove(RESET_CLUSTER_MESSAGE_VAULT_KEY);
     }
 
-    @Nullable ClusterState readClusterState() {
+    /** Reads cluster state. */
+    public @Nullable ClusterState readClusterState() {
         return readFromVault(CLUSTER_STATE_VAULT_KEY);
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22883

Whole history of cluster IDs is passed the client handler so it can pass it to clients when they connect to allow them do cluster ID validation, but support cluster ID change (due to CMG repair).