### PR TITLE
IGNITE-23142 Docker compose example doesn't save config

### DIFF
--- a/modules/runner/src/main/java/org/apache/ignite/internal/configuration/storage/LocalFileConfigurationStorage.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/configuration/storage/LocalFileConfigurationStorage.java
@@ -298,6 +298,7 @@ public class LocalFileConfigurationStorage implements ConfigurationStorage {
                     StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING
             );
         } catch (IOException e) {
+            LOG.error("Failed to write values to config file.", e);
             throw new NodeConfigWriteException(
                     "Failed to write values to config file.", e);
         }

--- a/packaging/docker/docker-compose.yml
+++ b/packaging/docker/docker-compose.yml
@@ -19,9 +19,9 @@ name: ignite3
 
 x-ignite-def:
   &ignite-def
-  image: apacheignite/ignite3:${IGNITE3_VERSION:-latest}
-  volumes:
-    - ./cluster.conf:/opt/ignite/etc/ignite-config.conf
+  image: ignite3-node
+  build:
+    dockerfile: node.Dockerfile
 
 services:
   node1:

--- a/packaging/docker/docker-compose.yml
+++ b/packaging/docker/docker-compose.yml
@@ -19,9 +19,10 @@ name: ignite3
 
 x-ignite-def:
   &ignite-def
-  image: ignite3-node
-  build:
-    dockerfile: node.Dockerfile
+  image: apacheignite/ignite3:${IGNITE3_VERSION:-latest}
+  configs:
+    - source: node_config
+      target: /opt/ignite/etc/ignite-config.conf
 
 services:
   node1:
@@ -42,3 +43,7 @@ services:
     ports:
       - 10302:10300
       - 10802:10800
+
+configs:
+  node_config:
+    content: ignite.network { port = 3344, nodeFinder.netClusterNodes = ["node1:3344","node2:3344", "node3:3344"]}

--- a/packaging/docker/node.Dockerfile
+++ b/packaging/docker/node.Dockerfile
@@ -1,3 +1,0 @@
-FROM apacheignite/ignite3
-
-COPY ./cluster.conf /opt/ignite/etc/ignite-config.conf

--- a/packaging/docker/node.Dockerfile
+++ b/packaging/docker/node.Dockerfile
@@ -1,0 +1,3 @@
+FROM apacheignite/ignite3
+
+COPY ./cluster.conf /opt/ignite/etc/ignite-config.conf


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23142

Issue is fixed by providing a config with text content. Requires Docker Compose version 2.23.1.
Logging is also added to help debug these issues.