### PR TITLE
IGNITE-22903 Handle BecomeMetastorageLeaderMessage

### DIFF
--- a/modules/metastorage/build.gradle
+++ b/modules/metastorage/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation project(':ignite-network-api')
     implementation project(':ignite-vault')
     implementation project(':ignite-raft-api')
+    implementation project(':ignite-raft')
     implementation project(':ignite-replicator')
     implementation project(':ignite-api')
     implementation project(':ignite-core')

--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.metastorage.impl;
+
+import static java.util.concurrent.CompletableFuture.allOf;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.ignite.internal.testframework.IgniteTestUtils.waitForCondition;
+import static org.apache.ignite.internal.testframework.matchers.CompletableFutureExceptionMatcher.willTimeoutIn;
+import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willCompleteSuccessfully;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.apache.ignite.internal.configuration.testframework.ConfigurationExtension;
+import org.apache.ignite.internal.hlc.HybridTimestamp;
+import org.apache.ignite.internal.lang.ByteArray;
+import org.apache.ignite.internal.lang.NodeStoppingException;
+import org.apache.ignite.internal.metastorage.server.time.ClusterTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ConfigurationExtension.class)
+class ItMetaStorageMaintenanceTest extends ItMetaStorageMultipleNodesAbstractTest {
+    @Test
+    void becomeLonelyLeaderMakesNodeLeaderForcefully() throws Exception {
+        start3VotingNodes();
+
+        Node node0 = nodes.get(0);
+
+        // Metastorage works.
+        assertThatMetastorageHasMajority(node0);
+
+        // Stop the majority.
+        stopAllNodesBut0();
+
+        // Metastorage does not work anymore.
+        assertThatMetastorageHasNoMajority(node0);
+
+        assertThat(node0.metaStorageManager.becomeLonelyLeader(true), willCompleteSuccessfully());
+
+        assertThatMetastorageHasMajority(node0);
+    }
+
+    private void start3VotingNodes() throws NodeStoppingException {
+        Node node0 = startNode();
+        Node node1 = startNode();
+        Node node2 = startNode();
+
+        node0.cmgManager.initCluster(List.of(node0.name(), node1.name(), node2.name()), List.of(node0.name()), "test");
+
+        assertThat(
+                allOf(node0.cmgManager.onJoinReady(), node1.cmgManager.onJoinReady(), node2.cmgManager.onJoinReady()),
+                willCompleteSuccessfully()
+        );
+
+        node0.waitWatches();
+        node1.waitWatches();
+        node2.waitWatches();
+    }
+
+    private static void assertThatMetastorageHasNoMajority(Node node0) {
+        assertThat(node0.metaStorageManager.get(new ByteArray("abc")), willTimeoutIn(1, SECONDS));
+    }
+
+    private static void assertThatMetastorageHasMajority(Node node0) {
+        assertThat(node0.metaStorageManager.get(new ByteArray("abc")), willCompleteSuccessfully());
+    }
+
+    private void stopAllNodesBut0() {
+        for (int i = 1; i < nodes.size(); i++) {
+            Node node = nodes.get(i);
+            node.clusterService.beforeNodeStop();
+            assertThat(node.clusterService.stopAsync(), willCompleteSuccessfully());
+        }
+    }
+
+    @Test
+    void becomeLonelyLeaderStopsLearnerManagementIfPauseRequested() throws Exception {
+        start3VotingNodes();
+
+        Node node0 = nodes.get(0);
+
+        // Stop the majority.
+        stopAllNodesBut0();
+
+        assertThat(node0.metaStorageManager.becomeLonelyLeader(true), willCompleteSuccessfully());
+
+        Node node3 = startNode();
+
+        assertFalse(
+                waitForCondition(() -> learnersAt(node0).contains(node3.name()), SECONDS.toMillis(3)),
+                "The leader still manages learners"
+        );
+    }
+
+    @Test
+    void becomeLonelyLeaderContinuesLearnerManagementIfPauseNotRequested() throws Exception {
+        start3VotingNodes();
+
+        Node node0 = nodes.get(0);
+
+        // Stop the majority.
+        stopAllNodesBut0();
+
+        assertThat(node0.metaStorageManager.becomeLonelyLeader(false), willCompleteSuccessfully());
+
+        Node node3 = startNode();
+
+        assertTrue(
+                waitForCondition(() -> learnersAt(node0).contains(node3.name()), SECONDS.toMillis(10)),
+                "The leader does not manage learners"
+        );
+    }
+
+    private static Set<String> learnersAt(Node node0) {
+        CompletableFuture<Set<String>> future = node0.getMetaStorageLearners();
+
+        assertThat(future, willCompleteSuccessfully());
+
+        return future.join();
+    }
+
+    @Test
+    void becomeLonelyLeaderStopsIdleSafeTimePropagationIfPauseRequested() throws Exception {
+        enableIdleSafeTimeSync();
+        start3VotingNodes();
+
+        Node node0 = nodes.get(0);
+
+        // Stop the majority.
+        stopAllNodesBut0();
+
+        assertThat(node0.metaStorageManager.becomeLonelyLeader(true), willCompleteSuccessfully());
+
+        ClusterTime clusterTime0 = node0.metaStorageManager.clusterTime();
+        HybridTimestamp timeBeforeOp = clusterTime0.currentSafeTime();
+
+        assertFalse(
+                waitForCondition(() -> clusterTime0.currentSafeTime().longValue() > timeBeforeOp.longValue(), SECONDS.toMillis(2)),
+                "The leader still propagates safetime"
+        );
+    }
+
+    @Test
+    void becomeLonelyLeaderKeepsIdleSafeTimePropagationIfPauseNotRequested() throws Exception {
+        enableIdleSafeTimeSync();
+        start3VotingNodes();
+
+        Node node0 = nodes.get(0);
+
+        // Stop the majority.
+        stopAllNodesBut0();
+
+        assertThat(node0.metaStorageManager.becomeLonelyLeader(false), willCompleteSuccessfully());
+
+        ClusterTime clusterTime0 = node0.metaStorageManager.clusterTime();
+        HybridTimestamp timeBeforeOp = clusterTime0.currentSafeTime();
+
+        assertTrue(
+                waitForCondition(() -> clusterTime0.currentSafeTime().longValue() > timeBeforeOp.longValue(), SECONDS.toMillis(10)),
+                "The leader does not propagate safetime"
+        );
+    }
+}

--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
@@ -105,6 +105,7 @@ class ItMetaStorageMaintenanceTest extends ItMetaStorageMultipleNodesAbstractTes
 
         Node node3 = startNode();
 
+        // Make sure the leader does not manage learners (as we requested it to pause secondary duties).
         assertFalse(
                 waitForCondition(() -> learnersAt(node0).contains(node3.name()), SECONDS.toMillis(3)),
                 "The leader still manages learners"

--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
@@ -155,6 +155,7 @@ class ItMetaStorageMaintenanceTest extends ItMetaStorageMultipleNodesAbstractTes
         ClusterTime clusterTime0 = node0.metaStorageManager.clusterTime();
         HybridTimestamp timeBeforeOp = clusterTime0.currentSafeTime();
 
+        // Make sure the leader does not propagate Metastorage SafeTime (as we requested it to pause secondary duties).
         assertFalse(
                 waitForCondition(() -> clusterTime0.currentSafeTime().longValue() > timeBeforeOp.longValue(), SECONDS.toMillis(2)),
                 "The leader still propagates safetime"
@@ -176,6 +177,7 @@ class ItMetaStorageMaintenanceTest extends ItMetaStorageMultipleNodesAbstractTes
         ClusterTime clusterTime0 = node0.metaStorageManager.clusterTime();
         HybridTimestamp timeBeforeOp = clusterTime0.currentSafeTime();
 
+        // Make sure the leader propagates Metastorage SafeTime (as we requested it NOT to pause secondary duties).
         assertTrue(
                 waitForCondition(() -> clusterTime0.currentSafeTime().longValue() > timeBeforeOp.longValue(), SECONDS.toMillis(10)),
                 "The leader does not propagate safetime"

--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
@@ -59,6 +59,11 @@ class ItMetaStorageMaintenanceTest extends ItMetaStorageMultipleNodesAbstractTes
         assertThatMetastorageHasMajority(node0);
     }
 
+    /**
+     * Starts 3 voting Raft nodes. 'Voting' here is opposed to a 'learner' node which does not vote.
+     *
+     * @throws NodeStoppingException If a node is being stopped.
+     */
     private void start3VotingNodes() throws NodeStoppingException {
         Node node0 = startNode();
         Node node1 = startNode();

--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
@@ -49,7 +49,7 @@ class ItMetaStorageMaintenanceTest extends ItMetaStorageMultipleNodesAbstractTes
         assertThatMetastorageHasMajority(node0);
 
         // Stop the majority.
-        stopAllNodesBut0();
+        stopAllNodesExcept0();
 
         // Metastorage does not work anymore.
         assertThatMetastorageHasNoMajority(node0);
@@ -84,7 +84,7 @@ class ItMetaStorageMaintenanceTest extends ItMetaStorageMultipleNodesAbstractTes
         assertThat(node0.metaStorageManager.get(new ByteArray("abc")), willCompleteSuccessfully());
     }
 
-    private void stopAllNodesBut0() {
+    private void stopAllNodesExcept0() {
         for (int i = 1; i < nodes.size(); i++) {
             Node node = nodes.get(i);
             node.clusterService.beforeNodeStop();
@@ -99,7 +99,7 @@ class ItMetaStorageMaintenanceTest extends ItMetaStorageMultipleNodesAbstractTes
         Node node0 = nodes.get(0);
 
         // Stop the majority.
-        stopAllNodesBut0();
+        stopAllNodesExcept0();
 
         assertThat(node0.metaStorageManager.becomeLonelyLeader(true), willCompleteSuccessfully());
 
@@ -118,7 +118,7 @@ class ItMetaStorageMaintenanceTest extends ItMetaStorageMultipleNodesAbstractTes
         Node node0 = nodes.get(0);
 
         // Stop the majority.
-        stopAllNodesBut0();
+        stopAllNodesExcept0();
 
         assertThat(node0.metaStorageManager.becomeLonelyLeader(false), willCompleteSuccessfully());
 
@@ -146,7 +146,7 @@ class ItMetaStorageMaintenanceTest extends ItMetaStorageMultipleNodesAbstractTes
         Node node0 = nodes.get(0);
 
         // Stop the majority.
-        stopAllNodesBut0();
+        stopAllNodesExcept0();
 
         assertThat(node0.metaStorageManager.becomeLonelyLeader(true), willCompleteSuccessfully());
 
@@ -167,7 +167,7 @@ class ItMetaStorageMaintenanceTest extends ItMetaStorageMultipleNodesAbstractTes
         Node node0 = nodes.get(0);
 
         // Stop the majority.
-        stopAllNodesBut0();
+        stopAllNodesExcept0();
 
         assertThat(node0.metaStorageManager.becomeLonelyLeader(false), willCompleteSuccessfully());
 

--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
@@ -125,6 +125,7 @@ class ItMetaStorageMaintenanceTest extends ItMetaStorageMultipleNodesAbstractTes
 
         Node node3 = startNode();
 
+        // Make sure the leader manages learners (as we requested it NOT to pause secondary duties).
         assertTrue(
                 waitForCondition(() -> learnersAt(node0).contains(node3.name()), SECONDS.toMillis(10)),
                 "The leader does not manage learners"

--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMultipleNodesAbstractTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMultipleNodesAbstractTest.java
@@ -17,34 +17,19 @@
 
 package org.apache.ignite.internal.metastorage.impl;
 
-import static java.util.concurrent.CompletableFuture.allOf;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toSet;
-import static org.apache.ignite.internal.metastorage.dsl.Conditions.notExists;
-import static org.apache.ignite.internal.metastorage.dsl.Conditions.revision;
-import static org.apache.ignite.internal.metastorage.dsl.Operations.noop;
-import static org.apache.ignite.internal.metastorage.dsl.Operations.put;
-import static org.apache.ignite.internal.testframework.IgniteTestUtils.waitForCondition;
-import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willBe;
 import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willCompleteSuccessfully;
-import static org.apache.ignite.internal.util.CompletableFutures.nullCompletedFuture;
 import static org.apache.ignite.internal.util.IgniteUtils.closeAll;
 import static org.apache.ignite.internal.util.IgniteUtils.startAsync;
 import static org.apache.ignite.internal.util.IgniteUtils.stopAsync;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.apache.ignite.internal.cluster.management.ClusterIdHolder;
 import org.apache.ignite.internal.cluster.management.ClusterInitializer;
@@ -65,19 +50,11 @@ import org.apache.ignite.internal.failure.FailureProcessor;
 import org.apache.ignite.internal.failure.NoOpFailureProcessor;
 import org.apache.ignite.internal.hlc.HybridClock;
 import org.apache.ignite.internal.hlc.HybridClockImpl;
-import org.apache.ignite.internal.hlc.HybridTimestamp;
-import org.apache.ignite.internal.lang.ByteArray;
-import org.apache.ignite.internal.lang.NodeStoppingException;
 import org.apache.ignite.internal.manager.ComponentContext;
 import org.apache.ignite.internal.manager.IgniteComponent;
-import org.apache.ignite.internal.metastorage.Entry;
-import org.apache.ignite.internal.metastorage.EntryEvent;
-import org.apache.ignite.internal.metastorage.WatchEvent;
-import org.apache.ignite.internal.metastorage.WatchListener;
 import org.apache.ignite.internal.metastorage.configuration.MetaStorageConfiguration;
 import org.apache.ignite.internal.metastorage.server.KeyValueStorage;
-import org.apache.ignite.internal.metastorage.server.time.ClusterTime;
-import org.apache.ignite.internal.metastorage.server.time.ClusterTimeImpl;
+import org.apache.ignite.internal.metastorage.server.SimpleInMemoryKeyValueStorage;
 import org.apache.ignite.internal.metrics.NoOpMetricManager;
 import org.apache.ignite.internal.network.ClusterService;
 import org.apache.ignite.internal.network.ConstantClusterIdSupplier;
@@ -89,51 +66,51 @@ import org.apache.ignite.internal.raft.RaftGroupOptionsConfigurer;
 import org.apache.ignite.internal.raft.TestLozaFactory;
 import org.apache.ignite.internal.raft.client.TopologyAwareRaftGroupServiceFactory;
 import org.apache.ignite.internal.raft.configuration.RaftConfiguration;
-import org.apache.ignite.internal.raft.service.RaftGroupService;
 import org.apache.ignite.internal.raft.storage.LogStorageFactory;
 import org.apache.ignite.internal.raft.util.SharedLogStorageFactoryUtils;
 import org.apache.ignite.internal.storage.configurations.StorageConfiguration;
 import org.apache.ignite.internal.testframework.IgniteAbstractTest;
 import org.apache.ignite.internal.vault.VaultManager;
 import org.apache.ignite.internal.vault.inmemory.InMemoryVaultService;
-import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.NetworkAddress;
 import org.apache.ignite.raft.jraft.rpc.impl.RaftGroupEventsClientListener;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * Tests for scenarios when Meta Storage nodes join and leave a cluster.
+ * Tests for scenarios in which multiple Meta Storage nodes participate.
  */
 @ExtendWith(ConfigurationExtension.class)
-public abstract class ItMetaStorageMultipleNodesAbstractTest extends IgniteAbstractTest {
-    private static final long AWAIT_TIMEOUT = TimeUnit.SECONDS.toMillis(10);
+abstract class ItMetaStorageMultipleNodesAbstractTest extends IgniteAbstractTest {
+    static final long AWAIT_TIMEOUT = SECONDS.toMillis(10);
 
     @InjectConfiguration
-    private static RaftConfiguration raftConfiguration;
+    private RaftConfiguration raftConfiguration;
 
     @InjectConfiguration
-    private static NodeAttributesConfiguration nodeAttributes;
+    private NodeAttributesConfiguration nodeAttributes;
 
     @InjectConfiguration
-    private static StorageConfiguration storageConfiguration;
+    private StorageConfiguration storageConfiguration;
 
     /**
      * Large interval to effectively disable idle safe time propagation.
      */
     @InjectConfiguration("mock.idleSyncTimeInterval=1000000")
-    private static MetaStorageConfiguration metaStorageConfiguration;
+    private MetaStorageConfiguration metaStorageConfiguration;
 
-    public abstract KeyValueStorage createStorage(String nodeName, Path path);
+    private TestInfo testInfo;
 
-    private class Node {
+    KeyValueStorage createStorage(String nodeName, Path path) {
+        return new SimpleInMemoryKeyValueStorage(nodeName);
+    }
+
+    class Node {
         private final VaultManager vaultManager;
 
-        private final ClusterService clusterService;
+        final ClusterService clusterService;
 
         private final Loza raftManager;
 
@@ -145,9 +122,9 @@ public abstract class ItMetaStorageMultipleNodesAbstractTest extends IgniteAbstr
 
         private final ClusterStateStorage clusterStateStorage = new TestClusterStateStorage();
 
-        private final ClusterManagementGroupManager cmgManager;
+        final ClusterManagementGroupManager cmgManager;
 
-        private final MetaStorageManagerImpl metaStorageManager;
+        final MetaStorageManagerImpl metaStorageManager;
 
         /** The future have to be complete after the node start and all Meta storage watches are deployd. */
         private final CompletableFuture<Void> deployWatchesFut;
@@ -301,9 +278,9 @@ public abstract class ItMetaStorageMultipleNodesAbstractTest extends IgniteAbstr
         }
     }
 
-    private final List<Node> nodes = new ArrayList<>();
+    final List<Node> nodes = new ArrayList<>();
 
-    private Node startNode(TestInfo testInfo) {
+    final Node startNode() {
         var nodeFinder = new StaticNodeFinder(List.of(new NetworkAddress("localhost", 10_000)));
 
         ClusterService clusterService = ClusterServiceTestUtils.clusterService(testInfo, 10_000 + nodes.size(), nodeFinder);
@@ -317,371 +294,19 @@ public abstract class ItMetaStorageMultipleNodesAbstractTest extends IgniteAbstr
         return node;
     }
 
+    @BeforeEach
+    void saveTestInfo(TestInfo testInfo) {
+        this.testInfo = testInfo;
+    }
+
     @AfterEach
     void tearDown() throws Exception {
         closeAll(nodes.parallelStream().map(node -> node::stop));
     }
 
-    /**
-     * Tests that an incoming node gets registered as a Learner and receives Meta Storage updates.
-     */
-    @Test
-    void testLearnerJoin(TestInfo testInfo) throws NodeStoppingException {
-        Node firstNode = startNode(testInfo);
-
-        firstNode.cmgManager.initCluster(List.of(firstNode.name()), List.of(firstNode.name()), "test");
-
-        firstNode.waitWatches();
-
-        var key = new ByteArray("foo");
-        byte[] value = "bar".getBytes(StandardCharsets.UTF_8);
-
-        CompletableFuture<Boolean> invokeFuture = firstNode.metaStorageManager.invoke(notExists(key), put(key, value), noop());
-
-        assertThat(invokeFuture, willBe(true));
-
-        Node secondNode = startNode(testInfo);
-
-        secondNode.waitWatches();
-
-        // Check that reading remote data works correctly.
-        assertThat(secondNode.metaStorageManager.get(key).thenApply(Entry::value), willBe(value));
-
-        // Check that the new node will receive events.
-        var awaitFuture = new CompletableFuture<EntryEvent>();
-
-        secondNode.metaStorageManager.registerExactWatch(key, new WatchListener() {
-            @Override
-            public CompletableFuture<Void> onUpdate(WatchEvent event) {
-                // Skip the first update event, because it's not guaranteed to arrive here (insert may have happened before the watch was
-                // registered).
-                if (event.revision() != 1) {
-                    awaitFuture.complete(event.entryEvent());
-                }
-
-                return nullCompletedFuture();
-            }
-
-            @Override
-            public void onError(Throwable e) {
-                awaitFuture.completeExceptionally(e);
-            }
-        });
-
-        byte[] newValue = "baz".getBytes(StandardCharsets.UTF_8);
-
-        invokeFuture = firstNode.metaStorageManager.invoke(revision(key).eq(1), put(key, newValue), noop());
-
-        assertThat(invokeFuture, willBe(true));
-
-        var expectedEntryEvent = new EntryEvent(
-                new EntryImpl(key.bytes(), value, 1, 1),
-                new EntryImpl(key.bytes(), newValue, 2, 3)
-        );
-
-        assertThat(awaitFuture, willBe(expectedEntryEvent));
-
-        // Check that the second node has been registered as a learner.
-        assertThat(firstNode.getMetaStorageLearners(), willBe(Set.of(secondNode.name())));
-    }
-
-    /**
-     * Tests a case when a node leaves the physical topology without entering the logical topology.
-     */
-    @Test
-    void testLearnerLeavePhysicalTopology(TestInfo testInfo) throws Exception {
-        Node firstNode = startNode(testInfo);
-        Node secondNode = startNode(testInfo);
-
-        firstNode.cmgManager.initCluster(List.of(firstNode.name()), List.of(firstNode.name()), "test");
-
-        firstNode.waitWatches();
-        secondNode.waitWatches();
-
-        // Try reading some data to make sure that Raft has been configured correctly.
-        assertThat(secondNode.metaStorageManager.get(new ByteArray("test")).thenApply(Entry::value), willBe(nullValue()));
-
-        // Check that the second node has been registered as a learner.
-        assertTrue(waitForCondition(() -> firstNode.getMetaStorageLearners().join().equals(Set.of(secondNode.name())), AWAIT_TIMEOUT));
-
-        // Stop the second node.
-        secondNode.stop();
-
-        nodes.remove(1);
-
-        assertTrue(waitForCondition(() -> firstNode.getMetaStorageLearners().join().isEmpty(), AWAIT_TIMEOUT));
-    }
-
-    /**
-     * Tests a case when a node leaves the physical topology without entering the logical topology.
-     */
-    @Test
-    void testLearnerLeaveLogicalTopology(TestInfo testInfo) throws Exception {
-        Node firstNode = startNode(testInfo);
-        Node secondNode = startNode(testInfo);
-
-        firstNode.cmgManager.initCluster(List.of(firstNode.name()), List.of(firstNode.name()), "test");
-
-        assertThat(allOf(firstNode.cmgManager.onJoinReady(), secondNode.cmgManager.onJoinReady()), willCompleteSuccessfully());
-
-        firstNode.waitWatches();
-        secondNode.waitWatches();
-
-        CompletableFuture<Set<String>> logicalTopologyNodes = firstNode.cmgManager
-                .logicalTopology()
-                .thenApply(logicalTopology -> logicalTopology.nodes().stream().map(ClusterNode::name).collect(toSet()));
-
-        assertThat(logicalTopologyNodes, willBe(Set.of(firstNode.name(), secondNode.name())));
-
-        // Try reading some data to make sure that Raft has been configured correctly.
-        assertThat(secondNode.metaStorageManager.get(new ByteArray("test")).thenApply(Entry::value), willBe(nullValue()));
-
-        // Check that the second node has been registered as a learner.
-        assertTrue(waitForCondition(() -> firstNode.getMetaStorageLearners().join().equals(Set.of(secondNode.name())), AWAIT_TIMEOUT));
-
-        // Stop the second node.
-        secondNode.stop();
-
-        nodes.remove(1);
-
-        assertTrue(waitForCondition(() -> firstNode.getMetaStorageLearners().join().isEmpty(), AWAIT_TIMEOUT));
-    }
-
-    /**
-     * Tests that safe time is propagated from the leader to the follower/learner.
-     */
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void testSafeTimePropagation(boolean useFollower, TestInfo testInfo) throws Exception {
-        Node firstNode = startNode(testInfo);
-        Node secondNode = startNode(testInfo);
-
-        List<String> followers = new ArrayList<>();
-        followers.add(firstNode.name());
-
-        if (useFollower) {
-            followers.add(secondNode.name());
-        }
-
-        firstNode.cmgManager.initCluster(followers, List.of(firstNode.name()), "test");
-
-        ClusterTimeImpl firstNodeTime = (ClusterTimeImpl) firstNode.metaStorageManager.clusterTime();
-        ClusterTimeImpl secondNodeTime = (ClusterTimeImpl) secondNode.metaStorageManager.clusterTime();
-
-        assertThat(allOf(firstNode.cmgManager.onJoinReady(), secondNode.cmgManager.onJoinReady()), willCompleteSuccessfully());
-
-        firstNode.waitWatches();
-        secondNode.waitWatches();
-
-        CompletableFuture<Void> watchCompletedFuture = new CompletableFuture<>();
-        CountDownLatch watchCalledLatch = new CountDownLatch(1);
-
-        ByteArray testKey = ByteArray.fromString("test-key");
-
-        // Register watch listener, so that we can control safe time propagation.
-        // Safe time can only be propagated when all of the listeners completed their futures successfully.
-        secondNode.metaStorageManager.registerExactWatch(testKey, new WatchListener() {
-            @Override
-            public CompletableFuture<Void> onUpdate(WatchEvent event) {
-                watchCalledLatch.countDown();
-
-                return watchCompletedFuture;
-            }
-
-            @Override
-            public void onError(Throwable e) {
-                // No-op.
-            }
-        });
-
-        HybridTimestamp timeBeforeOp = firstNodeTime.currentSafeTime();
-
-        // Try putting data from both nodes, because any of them can be a leader.
-        assertThat(
-                firstNode.metaStorageManager.put(testKey, new byte[]{0, 1, 2, 3}),
-                willCompleteSuccessfully()
-        );
-
-        // Ensure watch listener is called.
-        assertTrue(watchCalledLatch.await(AWAIT_TIMEOUT, TimeUnit.MILLISECONDS));
-
-        // Wait until leader's safe time is propagated.
-        assertTrue(waitForCondition(() -> firstNodeTime.currentSafeTime().compareTo(timeBeforeOp) > 0, AWAIT_TIMEOUT));
-
-        // Safe time must not be propagated to the second node at this moment.
-        assertThat(firstNodeTime.currentSafeTime(), greaterThan(secondNodeTime.currentSafeTime()));
-
-        // Finish watch listener notification process.
-        watchCompletedFuture.complete(null);
-
-        // After that in the nearest future safe time must be propagated.
-        assertTrue(waitForCondition(() -> {
-            HybridTimestamp sf1 = firstNodeTime.currentSafeTime();
-            HybridTimestamp sf2 = secondNodeTime.currentSafeTime();
-
-            return sf1.equals(sf2);
-        }, AWAIT_TIMEOUT));
-
-        assertThat(
-                secondNode.metaStorageManager.put(ByteArray.fromString("test-key-2"), new byte[]{0, 1, 2, 3}),
-                willCompleteSuccessfully()
-        );
-
-        assertTrue(waitForCondition(() -> {
-            HybridTimestamp sf1 = firstNodeTime.currentSafeTime();
-            HybridTimestamp sf2 = secondNodeTime.currentSafeTime();
-
-            return sf1.equals(sf2);
-        }, AWAIT_TIMEOUT));
-    }
-
-    /**
-     * Tests that safe time is propagated after leader was changed.
-     */
-    @Test
-    void testSafeTimePropagationLeaderTransferred(TestInfo testInfo) throws Exception {
-        Node firstNode = startNode(testInfo);
-        Node secondNode = startNode(testInfo);
-
-        List<String> followers = List.of(firstNode.name(), secondNode.name());
-
-        firstNode.cmgManager.initCluster(followers, List.of(firstNode.name()), "test");
-
-        ClusterTimeImpl firstNodeTime = (ClusterTimeImpl) firstNode.metaStorageManager.clusterTime();
-        ClusterTimeImpl secondNodeTime = (ClusterTimeImpl) secondNode.metaStorageManager.clusterTime();
-
-        assertThat(allOf(firstNode.cmgManager.onJoinReady(), secondNode.cmgManager.onJoinReady()), willCompleteSuccessfully());
-
-        firstNode.waitWatches();
-        secondNode.waitWatches();
-
-        assertThat(
-                firstNode.metaStorageManager.put(ByteArray.fromString("test-key"), new byte[]{0, 1, 2, 3}),
-                willCompleteSuccessfully()
-        );
-
-        assertTrue(waitForCondition(() -> {
-            HybridTimestamp sf1 = firstNodeTime.currentSafeTime();
-            HybridTimestamp sf2 = secondNodeTime.currentSafeTime();
-
-            return sf1.equals(sf2);
-        }, AWAIT_TIMEOUT));
-
-        // Change leader and check if propagation still works.
-        Node prevLeader = transferLeadership(firstNode, secondNode);
-
-        assertThat(
-                prevLeader.metaStorageManager.put(ByteArray.fromString("test-key-2"), new byte[]{0, 1, 2, 3}),
-                willCompleteSuccessfully()
-        );
-
-        assertTrue(waitForCondition(() -> {
-            HybridTimestamp sf1 = firstNodeTime.currentSafeTime();
-            HybridTimestamp sf2 = secondNodeTime.currentSafeTime();
-
-            return sf1.equals(sf2);
-        }, AWAIT_TIMEOUT));
-    }
-
-    /**
-     * Tests that safe time is propagated from the leader even if the Meta Storage is idle.
-     */
-    @Test
-    void testIdleSafeTimePropagation(TestInfo testInfo) throws Exception {
-        // Enable idle safe time sync.
+    final void enableIdleSafeTimeSync() {
         CompletableFuture<Void> updateIdleSyncTimeIntervalFuture = metaStorageConfiguration.idleSyncTimeInterval().update(100L);
 
         assertThat(updateIdleSyncTimeIntervalFuture, willCompleteSuccessfully());
-
-        Node firstNode = startNode(testInfo);
-        Node secondNode = startNode(testInfo);
-
-        firstNode.cmgManager.initCluster(List.of(firstNode.name()), List.of(firstNode.name()), "test");
-
-        assertThat(firstNode.cmgManager.onJoinReady(), willCompleteSuccessfully());
-        assertThat(secondNode.cmgManager.onJoinReady(), willCompleteSuccessfully());
-
-        firstNode.waitWatches();
-        secondNode.waitWatches();
-
-        ClusterTime firstNodeTime = firstNode.metaStorageManager.clusterTime();
-        ClusterTime secondNodeTime = secondNode.metaStorageManager.clusterTime();
-
-        HybridTimestamp now = firstNodeTime.now();
-
-        assertThat(firstNodeTime.waitFor(now), willCompleteSuccessfully());
-        assertThat(secondNodeTime.waitFor(now), willCompleteSuccessfully());
-    }
-
-    /**
-     * Tests that safe time is propagated after leader was changed and the Meta Storage is idle.
-     */
-    @Test
-    void testIdleSafeTimePropagationLeaderTransferred(TestInfo testInfo) throws Exception {
-        // Enable idle safe time sync.
-        CompletableFuture<Void> updateIdleSyncTimeIntervalFuture = metaStorageConfiguration.idleSyncTimeInterval().update(100L);
-
-        assertThat(updateIdleSyncTimeIntervalFuture, willCompleteSuccessfully());
-
-        Node firstNode = startNode(testInfo);
-        Node secondNode = startNode(testInfo);
-
-        firstNode.cmgManager.initCluster(List.of(firstNode.name(), secondNode.name()), List.of(firstNode.name()), "test");
-
-        assertThat(firstNode.cmgManager.onJoinReady(), willCompleteSuccessfully());
-        assertThat(secondNode.cmgManager.onJoinReady(), willCompleteSuccessfully());
-
-        firstNode.waitWatches();
-        secondNode.waitWatches();
-
-        ClusterTime firstNodeTime = firstNode.metaStorageManager.clusterTime();
-        ClusterTime secondNodeTime = secondNode.metaStorageManager.clusterTime();
-
-        Node leader = transferLeadership(firstNode, secondNode);
-
-        HybridTimestamp now = leader.metaStorageManager.clusterTime().now();
-
-        assertThat(firstNodeTime.waitFor(now), willCompleteSuccessfully());
-        assertThat(secondNodeTime.waitFor(now), willCompleteSuccessfully());
-
-        leader = transferLeadership(firstNode, secondNode);
-
-        now = leader.metaStorageManager.clusterTime().now();
-
-        assertThat(firstNodeTime.waitFor(now), willCompleteSuccessfully());
-        assertThat(secondNodeTime.waitFor(now), willCompleteSuccessfully());
-    }
-
-    private Node transferLeadership(Node firstNode, Node secondNode) {
-        RaftGroupService svc = getMetastorageService(firstNode);
-
-        CompletableFuture<Node> future = svc.refreshLeader()
-                .thenCompose(v -> {
-                    Peer leader = svc.leader();
-
-                    assertThat(leader, is(notNullValue()));
-
-                    Peer newLeader = svc.peers().stream()
-                            .filter(p -> !p.equals(leader))
-                            .findFirst()
-                            .orElseThrow();
-
-                    Node newLeaderNode = newLeader.consistentId().equals(firstNode.name()) ? firstNode : secondNode;
-
-                    return svc.transferLeadership(newLeader).thenApply(unused -> newLeaderNode);
-                });
-
-        assertThat(future, willCompleteSuccessfully());
-
-        return future.join();
-    }
-
-    private RaftGroupService getMetastorageService(Node node) {
-        CompletableFuture<RaftGroupService> future = node.metaStorageManager.metaStorageService()
-                .thenApply(MetaStorageServiceImpl::raftGroupService);
-
-        assertThat(future, willCompleteSuccessfully());
-
-        return future.join();
     }
 }

--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMultipleNodesRocksDbTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMultipleNodesRocksDbTest.java
@@ -22,8 +22,8 @@ import org.apache.ignite.internal.failure.NoOpFailureProcessor;
 import org.apache.ignite.internal.metastorage.server.KeyValueStorage;
 import org.apache.ignite.internal.metastorage.server.persistence.RocksDbKeyValueStorage;
 
-/** {@link ItMetaStorageMultipleNodesAbstractTest} with {@link RocksDbKeyValueStorage} implementation. */
-public class ItMetaStorageMultipleNodesRocksDbTest extends ItMetaStorageMultipleNodesAbstractTest {
+/** {@link ItMetaStorageMultipleNodesVsStorageTest} with {@link RocksDbKeyValueStorage} implementation. */
+public class ItMetaStorageMultipleNodesRocksDbTest extends ItMetaStorageMultipleNodesVsStorageTest {
     @Override
     public KeyValueStorage createStorage(String nodeName, Path path) {
         return new RocksDbKeyValueStorage(nodeName, path.resolve("ms"), new NoOpFailureProcessor());

--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMultipleNodesSimpleStorageTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMultipleNodesSimpleStorageTest.java
@@ -21,8 +21,8 @@ import java.nio.file.Path;
 import org.apache.ignite.internal.metastorage.server.KeyValueStorage;
 import org.apache.ignite.internal.metastorage.server.SimpleInMemoryKeyValueStorage;
 
-/** {@link ItMetaStorageMultipleNodesAbstractTest} with {@link SimpleInMemoryKeyValueStorage} implementation. */
-public class ItMetaStorageMultipleNodesSimpleStorageTest extends ItMetaStorageMultipleNodesAbstractTest {
+/** {@link ItMetaStorageMultipleNodesVsStorageTest} with {@link SimpleInMemoryKeyValueStorage} implementation. */
+public class ItMetaStorageMultipleNodesSimpleStorageTest extends ItMetaStorageMultipleNodesVsStorageTest {
     @Override
     public KeyValueStorage createStorage(String nodeName, Path path) {
         return new SimpleInMemoryKeyValueStorage(nodeName);

--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMultipleNodesVsStorageTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMultipleNodesVsStorageTest.java
@@ -1,0 +1,428 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.metastorage.impl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.CompletableFuture.allOf;
+import static java.util.stream.Collectors.toSet;
+import static org.apache.ignite.internal.metastorage.dsl.Conditions.notExists;
+import static org.apache.ignite.internal.metastorage.dsl.Conditions.revision;
+import static org.apache.ignite.internal.metastorage.dsl.Operations.noop;
+import static org.apache.ignite.internal.metastorage.dsl.Operations.put;
+import static org.apache.ignite.internal.testframework.IgniteTestUtils.waitForCondition;
+import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willBe;
+import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willCompleteSuccessfully;
+import static org.apache.ignite.internal.util.CompletableFutures.nullCompletedFuture;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.ignite.internal.configuration.testframework.ConfigurationExtension;
+import org.apache.ignite.internal.hlc.HybridTimestamp;
+import org.apache.ignite.internal.lang.ByteArray;
+import org.apache.ignite.internal.lang.NodeStoppingException;
+import org.apache.ignite.internal.metastorage.Entry;
+import org.apache.ignite.internal.metastorage.EntryEvent;
+import org.apache.ignite.internal.metastorage.WatchEvent;
+import org.apache.ignite.internal.metastorage.WatchListener;
+import org.apache.ignite.internal.metastorage.server.KeyValueStorage;
+import org.apache.ignite.internal.metastorage.server.time.ClusterTime;
+import org.apache.ignite.internal.metastorage.server.time.ClusterTimeImpl;
+import org.apache.ignite.internal.raft.Peer;
+import org.apache.ignite.internal.raft.service.RaftGroupService;
+import org.apache.ignite.network.ClusterNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for scenarios when Meta Storage nodes join and leave a cluster.
+ */
+@ExtendWith(ConfigurationExtension.class)
+abstract class ItMetaStorageMultipleNodesVsStorageTest extends ItMetaStorageMultipleNodesAbstractTest {
+    @Override
+    abstract KeyValueStorage createStorage(String nodeName, Path path);
+
+    /**
+     * Tests that an incoming node gets registered as a Learner and receives Meta Storage updates.
+     */
+    @Test
+    void testLearnerJoin() throws NodeStoppingException {
+        Node firstNode = startNode();
+
+        firstNode.cmgManager.initCluster(List.of(firstNode.name()), List.of(firstNode.name()), "test");
+
+        firstNode.waitWatches();
+
+        var key = new ByteArray("foo");
+        byte[] value = "bar".getBytes(UTF_8);
+
+        CompletableFuture<Boolean> invokeFuture = firstNode.metaStorageManager.invoke(notExists(key), put(key, value), noop());
+
+        assertThat(invokeFuture, willBe(true));
+
+        Node secondNode = startNode();
+
+        secondNode.waitWatches();
+
+        // Check that reading remote data works correctly.
+        assertThat(secondNode.metaStorageManager.get(key).thenApply(Entry::value), willBe(value));
+
+        // Check that the new node will receive events.
+        var awaitFuture = new CompletableFuture<EntryEvent>();
+
+        secondNode.metaStorageManager.registerExactWatch(key, new WatchListener() {
+            @Override
+            public CompletableFuture<Void> onUpdate(WatchEvent event) {
+                // Skip the first update event, because it's not guaranteed to arrive here (insert may have happened before the watch was
+                // registered).
+                if (event.revision() != 1) {
+                    awaitFuture.complete(event.entryEvent());
+                }
+
+                return nullCompletedFuture();
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                awaitFuture.completeExceptionally(e);
+            }
+        });
+
+        byte[] newValue = "baz".getBytes(UTF_8);
+
+        invokeFuture = firstNode.metaStorageManager.invoke(revision(key).eq(1), put(key, newValue), noop());
+
+        assertThat(invokeFuture, willBe(true));
+
+        var expectedEntryEvent = new EntryEvent(
+                new EntryImpl(key.bytes(), value, 1, 1),
+                new EntryImpl(key.bytes(), newValue, 2, 3)
+        );
+
+        assertThat(awaitFuture, willBe(expectedEntryEvent));
+
+        // Check that the second node has been registered as a learner.
+        assertThat(firstNode.getMetaStorageLearners(), willBe(Set.of(secondNode.name())));
+    }
+
+    /**
+     * Tests a case when a node leaves the physical topology without entering the logical topology.
+     */
+    @Test
+    void testLearnerLeavePhysicalTopology() throws Exception {
+        Node firstNode = startNode();
+        Node secondNode = startNode();
+
+        firstNode.cmgManager.initCluster(List.of(firstNode.name()), List.of(firstNode.name()), "test");
+
+        firstNode.waitWatches();
+        secondNode.waitWatches();
+
+        // Try reading some data to make sure that Raft has been configured correctly.
+        assertThat(secondNode.metaStorageManager.get(new ByteArray("test")).thenApply(Entry::value), willBe(nullValue()));
+
+        // Check that the second node has been registered as a learner.
+        assertTrue(waitForCondition(() -> firstNode.getMetaStorageLearners().join().equals(Set.of(secondNode.name())), AWAIT_TIMEOUT));
+
+        // Stop the second node.
+        secondNode.stop();
+
+        nodes.remove(1);
+
+        assertTrue(waitForCondition(() -> firstNode.getMetaStorageLearners().join().isEmpty(), AWAIT_TIMEOUT));
+    }
+
+    /**
+     * Tests a case when a node leaves the physical topology without entering the logical topology.
+     */
+    @Test
+    void testLearnerLeaveLogicalTopology() throws Exception {
+        Node firstNode = startNode();
+        Node secondNode = startNode();
+
+        firstNode.cmgManager.initCluster(List.of(firstNode.name()), List.of(firstNode.name()), "test");
+
+        assertThat(allOf(firstNode.cmgManager.onJoinReady(), secondNode.cmgManager.onJoinReady()), willCompleteSuccessfully());
+
+        firstNode.waitWatches();
+        secondNode.waitWatches();
+
+        CompletableFuture<Set<String>> logicalTopologyNodes = firstNode.cmgManager
+                .logicalTopology()
+                .thenApply(logicalTopology -> logicalTopology.nodes().stream().map(ClusterNode::name).collect(toSet()));
+
+        assertThat(logicalTopologyNodes, willBe(Set.of(firstNode.name(), secondNode.name())));
+
+        // Try reading some data to make sure that Raft has been configured correctly.
+        assertThat(secondNode.metaStorageManager.get(new ByteArray("test")).thenApply(Entry::value), willBe(nullValue()));
+
+        // Check that the second node has been registered as a learner.
+        assertTrue(waitForCondition(() -> firstNode.getMetaStorageLearners().join().equals(Set.of(secondNode.name())), AWAIT_TIMEOUT));
+
+        // Stop the second node.
+        secondNode.stop();
+
+        nodes.remove(1);
+
+        assertTrue(waitForCondition(() -> firstNode.getMetaStorageLearners().join().isEmpty(), AWAIT_TIMEOUT));
+    }
+
+    /**
+     * Tests that safe time is propagated from the leader to the follower/learner.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testSafeTimePropagation(boolean useFollower) throws Exception {
+        Node firstNode = startNode();
+        Node secondNode = startNode();
+
+        List<String> followers = new ArrayList<>();
+        followers.add(firstNode.name());
+
+        if (useFollower) {
+            followers.add(secondNode.name());
+        }
+
+        firstNode.cmgManager.initCluster(followers, List.of(firstNode.name()), "test");
+
+        ClusterTimeImpl firstNodeTime = (ClusterTimeImpl) firstNode.metaStorageManager.clusterTime();
+        ClusterTimeImpl secondNodeTime = (ClusterTimeImpl) secondNode.metaStorageManager.clusterTime();
+
+        assertThat(allOf(firstNode.cmgManager.onJoinReady(), secondNode.cmgManager.onJoinReady()), willCompleteSuccessfully());
+
+        firstNode.waitWatches();
+        secondNode.waitWatches();
+
+        CompletableFuture<Void> watchCompletedFuture = new CompletableFuture<>();
+        CountDownLatch watchCalledLatch = new CountDownLatch(1);
+
+        ByteArray testKey = ByteArray.fromString("test-key");
+
+        // Register watch listener, so that we can control safe time propagation.
+        // Safe time can only be propagated when all of the listeners completed their futures successfully.
+        secondNode.metaStorageManager.registerExactWatch(testKey, new WatchListener() {
+            @Override
+            public CompletableFuture<Void> onUpdate(WatchEvent event) {
+                watchCalledLatch.countDown();
+
+                return watchCompletedFuture;
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                // No-op.
+            }
+        });
+
+        HybridTimestamp timeBeforeOp = firstNodeTime.currentSafeTime();
+
+        // Try putting data from both nodes, because any of them can be a leader.
+        assertThat(
+                firstNode.metaStorageManager.put(testKey, new byte[]{0, 1, 2, 3}),
+                willCompleteSuccessfully()
+        );
+
+        // Ensure watch listener is called.
+        assertTrue(watchCalledLatch.await(AWAIT_TIMEOUT, TimeUnit.MILLISECONDS));
+
+        // Wait until leader's safe time is propagated.
+        assertTrue(waitForCondition(() -> firstNodeTime.currentSafeTime().compareTo(timeBeforeOp) > 0, AWAIT_TIMEOUT));
+
+        // Safe time must not be propagated to the second node at this moment.
+        assertThat(firstNodeTime.currentSafeTime(), greaterThan(secondNodeTime.currentSafeTime()));
+
+        // Finish watch listener notification process.
+        watchCompletedFuture.complete(null);
+
+        // After that in the nearest future safe time must be propagated.
+        assertTrue(waitForCondition(() -> {
+            HybridTimestamp sf1 = firstNodeTime.currentSafeTime();
+            HybridTimestamp sf2 = secondNodeTime.currentSafeTime();
+
+            return sf1.equals(sf2);
+        }, AWAIT_TIMEOUT));
+
+        assertThat(
+                secondNode.metaStorageManager.put(ByteArray.fromString("test-key-2"), new byte[]{0, 1, 2, 3}),
+                willCompleteSuccessfully()
+        );
+
+        assertTrue(waitForCondition(() -> {
+            HybridTimestamp sf1 = firstNodeTime.currentSafeTime();
+            HybridTimestamp sf2 = secondNodeTime.currentSafeTime();
+
+            return sf1.equals(sf2);
+        }, AWAIT_TIMEOUT));
+    }
+
+    /**
+     * Tests that safe time is propagated after leader was changed.
+     */
+    @Test
+    void testSafeTimePropagationLeaderTransferred() throws Exception {
+        Node firstNode = startNode();
+        Node secondNode = startNode();
+
+        List<String> followers = List.of(firstNode.name(), secondNode.name());
+
+        firstNode.cmgManager.initCluster(followers, List.of(firstNode.name()), "test");
+
+        ClusterTimeImpl firstNodeTime = (ClusterTimeImpl) firstNode.metaStorageManager.clusterTime();
+        ClusterTimeImpl secondNodeTime = (ClusterTimeImpl) secondNode.metaStorageManager.clusterTime();
+
+        assertThat(allOf(firstNode.cmgManager.onJoinReady(), secondNode.cmgManager.onJoinReady()), willCompleteSuccessfully());
+
+        firstNode.waitWatches();
+        secondNode.waitWatches();
+
+        assertThat(
+                firstNode.metaStorageManager.put(ByteArray.fromString("test-key"), new byte[]{0, 1, 2, 3}),
+                willCompleteSuccessfully()
+        );
+
+        assertTrue(waitForCondition(() -> {
+            HybridTimestamp sf1 = firstNodeTime.currentSafeTime();
+            HybridTimestamp sf2 = secondNodeTime.currentSafeTime();
+
+            return sf1.equals(sf2);
+        }, AWAIT_TIMEOUT));
+
+        // Change leader and check if propagation still works.
+        Node prevLeader = transferLeadership(firstNode, secondNode);
+
+        assertThat(
+                prevLeader.metaStorageManager.put(ByteArray.fromString("test-key-2"), new byte[]{0, 1, 2, 3}),
+                willCompleteSuccessfully()
+        );
+
+        assertTrue(waitForCondition(() -> {
+            HybridTimestamp sf1 = firstNodeTime.currentSafeTime();
+            HybridTimestamp sf2 = secondNodeTime.currentSafeTime();
+
+            return sf1.equals(sf2);
+        }, AWAIT_TIMEOUT));
+    }
+
+    /**
+     * Tests that safe time is propagated from the leader even if the Meta Storage is idle.
+     */
+    @Test
+    void testIdleSafeTimePropagation() throws Exception {
+        enableIdleSafeTimeSync();
+
+        Node firstNode = startNode();
+        Node secondNode = startNode();
+
+        firstNode.cmgManager.initCluster(List.of(firstNode.name()), List.of(firstNode.name()), "test");
+
+        assertThat(firstNode.cmgManager.onJoinReady(), willCompleteSuccessfully());
+        assertThat(secondNode.cmgManager.onJoinReady(), willCompleteSuccessfully());
+
+        firstNode.waitWatches();
+        secondNode.waitWatches();
+
+        ClusterTime firstNodeTime = firstNode.metaStorageManager.clusterTime();
+        ClusterTime secondNodeTime = secondNode.metaStorageManager.clusterTime();
+
+        HybridTimestamp now = firstNodeTime.now();
+
+        assertThat(firstNodeTime.waitFor(now), willCompleteSuccessfully());
+        assertThat(secondNodeTime.waitFor(now), willCompleteSuccessfully());
+    }
+
+    /**
+     * Tests that safe time is propagated after leader was changed and the Meta Storage is idle.
+     */
+    @Test
+    void testIdleSafeTimePropagationLeaderTransferred() throws Exception {
+        enableIdleSafeTimeSync();
+
+        Node firstNode = startNode();
+        Node secondNode = startNode();
+
+        firstNode.cmgManager.initCluster(List.of(firstNode.name(), secondNode.name()), List.of(firstNode.name()), "test");
+
+        assertThat(firstNode.cmgManager.onJoinReady(), willCompleteSuccessfully());
+        assertThat(secondNode.cmgManager.onJoinReady(), willCompleteSuccessfully());
+
+        firstNode.waitWatches();
+        secondNode.waitWatches();
+
+        ClusterTime firstNodeTime = firstNode.metaStorageManager.clusterTime();
+        ClusterTime secondNodeTime = secondNode.metaStorageManager.clusterTime();
+
+        Node leader = transferLeadership(firstNode, secondNode);
+
+        HybridTimestamp now = leader.metaStorageManager.clusterTime().now();
+
+        assertThat(firstNodeTime.waitFor(now), willCompleteSuccessfully());
+        assertThat(secondNodeTime.waitFor(now), willCompleteSuccessfully());
+
+        leader = transferLeadership(firstNode, secondNode);
+
+        now = leader.metaStorageManager.clusterTime().now();
+
+        assertThat(firstNodeTime.waitFor(now), willCompleteSuccessfully());
+        assertThat(secondNodeTime.waitFor(now), willCompleteSuccessfully());
+    }
+
+    private Node transferLeadership(Node firstNode, Node secondNode) {
+        RaftGroupService svc = getMetastorageService(firstNode);
+
+        CompletableFuture<Node> future = svc.refreshLeader()
+                .thenCompose(v -> {
+                    Peer leader = svc.leader();
+
+                    assertThat(leader, is(notNullValue()));
+
+                    Peer newLeader = svc.peers().stream()
+                            .filter(p -> !p.equals(leader))
+                            .findFirst()
+                            .orElseThrow();
+
+                    Node newLeaderNode = newLeader.consistentId().equals(firstNode.name()) ? firstNode : secondNode;
+
+                    return svc.transferLeadership(newLeader).thenApply(unused -> newLeaderNode);
+                });
+
+        assertThat(future, willCompleteSuccessfully());
+
+        return future.join();
+    }
+
+    private RaftGroupService getMetastorageService(Node node) {
+        CompletableFuture<RaftGroupService> future = node.metaStorageManager.metaStorageService()
+                .thenApply(MetaStorageServiceImpl::raftGroupService);
+
+        assertThat(future, willCompleteSuccessfully());
+
+        return future.join();
+    }
+}

--- a/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/impl/MetaStorageLeaderElectionListener.java
+++ b/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/impl/MetaStorageLeaderElectionListener.java
@@ -204,12 +204,6 @@ public class MetaStorageLeaderElectionListener implements LeaderElectionListener
      * Executes the given action if the current node is the Meta Storage leader.
      */
     private void execute(Action action) {
-        if (leaderSecondaryDutiesPaused.getAsBoolean()) {
-            LOG.info("Skipping Meta Storage configuration update because the leader's secondary duties are paused");
-
-            return;
-        }
-
         if (!busyLock.enterBusy()) {
             LOG.info("Skipping Meta Storage configuration update because the node is stopping");
 
@@ -217,6 +211,12 @@ public class MetaStorageLeaderElectionListener implements LeaderElectionListener
         }
 
         try {
+            if (leaderSecondaryDutiesPaused.getAsBoolean()) {
+                LOG.info("Skipping Meta Storage configuration update because the leader's secondary duties are paused");
+
+                return;
+            }
+
             synchronized (serializationFutureMux) {
                 // We are definitely not a leader if the serialization future has not been initialized.
                 if (serializationFuture == null) {

--- a/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/impl/MetaStorageLeaderElectionListener.java
+++ b/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/impl/MetaStorageLeaderElectionListener.java
@@ -81,6 +81,13 @@ public class MetaStorageLeaderElectionListener implements LeaderElectionListener
 
     private final List<ElectionListener> electionListeners;
 
+    /**
+     * Becomes {@code true} when the node, even being formally a leader, should not perform secondary leader duties (these are managing
+     * learners and propagating idle safe time through Metastorage).
+     *
+     * <p>The flag is raised when we appoint a node as a leader forcefully via resetPeers(). The flag gets cleared when first non-forced
+     * configuration update comes after forcing leadership.
+     */
     private final BooleanSupplier leaderSecondaryDutiesPaused;
 
     /**

--- a/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/impl/MetastorageGroupMaintenance.java
+++ b/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/impl/MetastorageGroupMaintenance.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.metastorage.impl;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.ignite.internal.raft.IndexWithTerm;
+
+/**
+ * Entry point for tasks related to maintenance of the Metastorage Raft group.
+ */
+public interface MetastorageGroupMaintenance {
+    /**
+     * Returns a future that will be completed with information about index and term of the Metastorage Raft group.
+     *
+     * <p>This method is special in the following regard: it can be called before the component gets started. The returned
+     * future will be completed after the component start.
+     */
+    CompletableFuture<IndexWithTerm> raftNodeIndex();
+
+    /**
+     * Makes this node a leader of the Metastorage group (with the voting set containing of just this node).
+     *
+     * @param pauseLeaderSecondaryDuties Whether leader secondary duties (managing learners, propagating idle safe time) should be paused.
+     * @return Future which completes when this node becomes a leader.
+     */
+    CompletableFuture<Void> becomeLonelyLeader(boolean pauseLeaderSecondaryDuties);
+}

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
@@ -699,7 +699,7 @@ public class IgniteImpl implements Ignite {
                 clusterSvc.messagingService(),
                 vaultMgr,
                 restarter,
-                metaStorageMgr::raftNodeIndex
+                metaStorageMgr
         );
 
         SchemaSynchronizationConfiguration schemaSyncConfig = clusterConfigRegistry

--- a/modules/system-disaster-recovery-api/src/main/java/org/apache/ignite/internal/disaster/system/message/BecomeMetastorageLeaderMessage.java
+++ b/modules/system-disaster-recovery-api/src/main/java/org/apache/ignite/internal/disaster/system/message/BecomeMetastorageLeaderMessage.java
@@ -17,30 +17,14 @@
 
 package org.apache.ignite.internal.disaster.system.message;
 
-import org.apache.ignite.internal.network.annotations.MessageGroup;
+import org.apache.ignite.internal.network.NetworkMessage;
+import org.apache.ignite.internal.network.annotations.Transferable;
 
 /**
- * Message Group for disaster recovery of system groups.
+ * A command to make a node become a Metastorage Raft group leader.
  */
-@MessageGroup(groupType = 15, groupName = "SystemDisasterRecoveryMessages")
-public class SystemDisasterRecoveryMessageGroup {
-    /**
-     * Message type for {@link ResetClusterMessage}.
-     */
-    public static final short RESET_CLUSTER = 1;
-
-    /**
-     * Message type for {@link MetastorageIndexTermRequestMessage}.
-     */
-    public static final short METASTORAGE_INDEX_TERM_REQUEST = 2;
-
-    /**
-     * Message type for {@link MetastorageIndexTermResponseMessage}.
-     */
-    public static final short METASTORAGE_INDEX_TERM_RESPONSE = 3;
-
-    /**
-     * Message type for {@link BecomeMetastorageLeaderMessage}.
-     */
-    public static final short BECOME_METASTORAGE_LEADER = 4;
+@Transferable(SystemDisasterRecoveryMessageGroup.BECOME_METASTORAGE_LEADER)
+public interface BecomeMetastorageLeaderMessage extends NetworkMessage {
+    /** Whether leader secondary duties (managing learners, propagating idle safe time) should be paused. */
+    boolean pauseLeaderSecondaryDuties();
 }

--- a/modules/system-disaster-recovery/build.gradle
+++ b/modules/system-disaster-recovery/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation project(':ignite-vault')
     implementation project(':ignite-cluster-management')
     implementation project(':ignite-raft-api')
+    implementation project(':ignite-metastorage')
     implementation libs.jetbrains.annotations
 
     testImplementation libs.hamcrest.core

--- a/modules/system-disaster-recovery/src/main/java/org/apache/ignite/internal/disaster/system/SystemDisasterRecoveryManagerImpl.java
+++ b/modules/system-disaster-recovery/src/main/java/org/apache/ignite/internal/disaster/system/SystemDisasterRecoveryManagerImpl.java
@@ -373,7 +373,9 @@ public class SystemDisasterRecoveryManagerImpl implements SystemDisasterRecovery
     private static String findAnyFailedNodeName(Map<String, CompletableFuture<NetworkMessage>> responseFutures) {
         return responseFutures.entrySet().stream()
                 .filter(entry -> entry.getValue().isCompletedExceptionally())
-                .findAny().orElseThrow().getKey();
+                .findAny()
+                .orElseThrow(() -> new AssertionError("At least one failed future must be present"))
+                .getKey();
     }
 
     @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22903

When BecomeMetastorageLeaderMessage is received:

 * make the current node the leader of the Metastorage group by forcing the voting members set to only consist of the current node
 * stop managing learners and propagating safe-time if requested by the message (useful as an optimization to avoid 2-step configuration change when the target MG voting set consists of just 1 node)