### PR TITLE
IGNITE-22048 .NET: Add Gradle task to run tests

### DIFF
--- a/modules/platforms/build.gradle
+++ b/modules/platforms/build.gradle
@@ -161,6 +161,7 @@ tasks.register('dotnetTest', Exec) {
     workingDir "$rootDir/modules/platforms/dotnet"
 
     // Do not require external server, it will be started as part of tests.
+    // Alternatively, start PlatformTestNodeRunner manually before executing this task.
     environment("IGNITE_DOTNET_REQUIRE_EXTERNAL_SERVER", "false")
 
     commandLine "dotnet", "test", "Apache.Ignite.Tests", "--logger", "console;verbosity=normal"

--- a/modules/platforms/build.gradle
+++ b/modules/platforms/build.gradle
@@ -157,6 +157,12 @@ tasks.register('signArtifacts', Sign) {
     sign zipCppClient
 }
 
+tasks.register('dotnetTest', Exec) {
+    workingDir "$rootDir/modules/platforms/dotnet"
+
+    commandLine "dotnet", "test", "Apache.Ignite.Tests", "--logger", "console;verbosity=normal"
+}
+
 configurations {
     platformsRelease {
         canBeConsumed = true

--- a/modules/platforms/build.gradle
+++ b/modules/platforms/build.gradle
@@ -160,6 +160,9 @@ tasks.register('signArtifacts', Sign) {
 tasks.register('dotnetTest', Exec) {
     workingDir "$rootDir/modules/platforms/dotnet"
 
+    // Do not require external server, it will be started as part of tests.
+    environment("IGNITE_DOTNET_REQUIRE_EXTERNAL_SERVER", "false")
+
     commandLine "dotnet", "test", "Apache.Ignite.Tests", "--logger", "console;verbosity=normal"
 }
 


### PR DESCRIPTION
* Add Gradle task to run .NET tests: `./gradlew dotnetTest`
* If any test fails, the task fails
* Starts test cluster automatically, unless already started (e.g. you can debug Java side of things by running `PlatformTestNodeRunner` under a debugger, then starting `dotnetTest`)