### PR TITLE
IGNITE-23180 Fix fsync setting for RocksDbSharedLogStorage

### DIFF
--- a/modules/raft/src/main/java/org/apache/ignite/internal/raft/storage/impl/DefaultLogStorageFactory.java
+++ b/modules/raft/src/main/java/org/apache/ignite/internal/raft/storage/impl/DefaultLogStorageFactory.java
@@ -58,6 +58,7 @@ import org.rocksdb.Priority;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
 import org.rocksdb.util.SizeUnit;
 
 /** Implementation of the {@link LogStorageFactory} that creates {@link RocksDbSharedLogStorage}s. */
@@ -78,6 +79,9 @@ public class DefaultLogStorageFactory implements LogStorageFactory {
 
     /** Database options. */
     private DBOptions dbOptions;
+
+    /** Write options to use in writes to database. */
+    private WriteOptions writeOptions;
 
     /** Configuration column family handle. */
     private ColumnFamilyHandle confHandle;
@@ -116,6 +120,7 @@ public class DefaultLogStorageFactory implements LogStorageFactory {
      * @param factoryName Name of the log factory, will be used in logs.
      * @param nodeName Node name.
      * @param logPath Function to get path to the log storage.
+     * @param fsync If should fsync after each write to database.
      */
     public DefaultLogStorageFactory(String factoryName, String nodeName, Path logPath, boolean fsync) {
         this.factoryName = factoryName;
@@ -149,6 +154,8 @@ public class DefaultLogStorageFactory implements LogStorageFactory {
         List<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>();
 
         this.dbOptions = createDbOptions();
+
+        this.writeOptions = new WriteOptions().setSync(dbOptions.useFsync());
 
         this.cfOption = createColumnFamilyOptions();
 
@@ -210,12 +217,11 @@ public class DefaultLogStorageFactory implements LogStorageFactory {
         RocksUtils.closeAll(closables);
     }
 
-    /** {@inheritDoc} */
     @Override
     public LogStorage createLogStorage(String groupId, RaftOptions raftOptions) {
         assert raftOptions.isSync() == dbOptions.useFsync() : "Sync options must be the same";
 
-        return new RocksDbSharedLogStorage(this, db, confHandle, dataHandle, groupId, raftOptions, executorService);
+        return new RocksDbSharedLogStorage(this, db, confHandle, dataHandle, groupId, writeOptions, executorService);
     }
 
     @Override

--- a/modules/raft/src/main/java/org/apache/ignite/internal/raft/storage/impl/DefaultLogStorageFactory.java
+++ b/modules/raft/src/main/java/org/apache/ignite/internal/raft/storage/impl/DefaultLogStorageFactory.java
@@ -213,6 +213,7 @@ public class DefaultLogStorageFactory implements LogStorageFactory {
         closables.add(dbOptions);
         closables.add(cfOption);
         closables.add(flushListener);
+        closables.add(writeOptions);
 
         RocksUtils.closeAll(closables);
     }

--- a/modules/raft/src/main/java/org/apache/ignite/internal/raft/storage/impl/RocksDbSharedLogStorage.java
+++ b/modules/raft/src/main/java/org/apache/ignite/internal/raft/storage/impl/RocksDbSharedLogStorage.java
@@ -42,7 +42,6 @@ import org.apache.ignite.raft.jraft.entity.LogId;
 import org.apache.ignite.raft.jraft.entity.codec.LogEntryDecoder;
 import org.apache.ignite.raft.jraft.entity.codec.LogEntryEncoder;
 import org.apache.ignite.raft.jraft.option.LogStorageOptions;
-import org.apache.ignite.raft.jraft.option.RaftOptions;
 import org.apache.ignite.raft.jraft.storage.LogStorage;
 import org.apache.ignite.raft.jraft.util.BytesUtil;
 import org.apache.ignite.raft.jraft.util.Describer;
@@ -144,7 +143,7 @@ public class RocksDbSharedLogStorage implements LogStorage, Describer {
             ColumnFamilyHandle confHandle,
             ColumnFamilyHandle dataHandle,
             String groupId,
-            RaftOptions raftOptions,
+            WriteOptions writeOptions,
             Executor executor
     ) {
         Requires.requireNonNull(db);
@@ -170,8 +169,7 @@ public class RocksDbSharedLogStorage implements LogStorage, Describer {
         this.groupEndPrefix = groupEndPrefix(groupId);
         this.groupStartBound = new Slice(groupStartPrefix);
         this.groupEndBound = new Slice(groupEndPrefix);
-
-        this.writeOptions = new WriteOptions();
+        this.writeOptions = writeOptions;
     }
 
     /**

--- a/modules/raft/src/main/java/org/apache/ignite/internal/raft/storage/impl/RocksDbSharedLogStorage.java
+++ b/modules/raft/src/main/java/org/apache/ignite/internal/raft/storage/impl/RocksDbSharedLogStorage.java
@@ -94,7 +94,7 @@ public class RocksDbSharedLogStorage implements LogStorage, Describer {
     /** Shared data column family handle. */
     private final ColumnFamilyHandle dataHandle;
 
-    /** Write options. */
+    /** Shared write options. */
     private final WriteOptions writeOptions;
 
     /** Start prefix. */
@@ -662,7 +662,6 @@ public class RocksDbSharedLogStorage implements LogStorage, Describer {
      * Called upon closing the storage.
      */
     protected void onShutdown() {
-        writeOptions.close();
         groupEndBound.close();
         groupStartBound.close();
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23180

What was done: 
set fsync in writeOptions (if it's not set, then fsync=false is used regardless of DBOptions), moved writeOptions creation to factory

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)