### PR TITLE
IGNITE-23177 .NET: Increase SQL decimal tests timeout

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
@@ -65,12 +65,13 @@ public partial class LinqTests
     }
 
     [Test]
+    [Timeout(45_000)] // TODO IGNITE-23170 Decimal handling is very slow
     public void TestCastToDecimalPrecision()
     {
         // ReSharper disable once RedundantCast
         var query = PocoIntView.AsQueryable()
+            .OrderByDescending(x => x.Val)
             .Select(x => (decimal?)x.Val / 33m)
-            .OrderByDescending(x => x)
             .Take(1);
 
         var res = query.ToList();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
@@ -26,7 +26,7 @@ using NUnit.Framework;
 public partial class LinqTests
 {
     [Test]
-    [Timeout(45_000)] // TODO IGNITE-23170 Decimal handling is very slow
+    [Timeout(90_000)] // TODO IGNITE-23170 Decimal handling is very slow
     public void TestProjectionWithCastIntoAnonymousType()
     {
         // BigInteger is not suppoerted by the SQL engine.
@@ -66,7 +66,7 @@ public partial class LinqTests
     }
 
     [Test]
-    [Timeout(45_000)] // TODO IGNITE-23170 Decimal handling is very slow
+    [Timeout(90_000)] // TODO IGNITE-23170 Decimal handling is very slow
     public void TestCastToDecimalPrecision()
     {
         // ReSharper disable once RedundantCast

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
@@ -26,6 +26,7 @@ using NUnit.Framework;
 public partial class LinqTests
 {
     [Test]
+    [Timeout(45_000)] // TODO IGNITE-23170 Decimal handling is very slow
     public void TestProjectionWithCastIntoAnonymousType()
     {
         // BigInteger is not suppoerted by the SQL engine.


### PR DESCRIPTION
Increase timeout from default 15s to 90s.

Decimal handling is very slow due to [IGNITE-23170](https://issues.apache.org/jira/browse/IGNITE-23170), will be fixed by [IGNITE-18922](https://issues.apache.org/jira/browse/IGNITE-18922)