### PR TITLE
IGNITE-23204 .NET: LINQ: Limit decimal scale to 30

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
@@ -26,7 +26,6 @@ using NUnit.Framework;
 public partial class LinqTests
 {
     [Test]
-    [Timeout(90_000)] // TODO IGNITE-23170 Decimal handling is very slow
     public void TestProjectionWithCastIntoAnonymousType()
     {
         // BigInteger is not suppoerted by the SQL engine.
@@ -39,7 +38,7 @@ public partial class LinqTests
                 Long = (long?)x.Val,
                 Float = (float?)x.Val / 1000,
                 Double = (double?)x.Val / 2000,
-                Decimal0 = (decimal?)x.Val / 200m
+                Decimal0 = (decimal?)(x.Val / 200m)
             })
             .OrderByDescending(x => x.Long)
             .Take(1);
@@ -59,7 +58,7 @@ public partial class LinqTests
             "cast(_T0.VAL as bigint) as LONG, " +
             "(cast(_T0.VAL as real) / ?) as FLOAT, " +
             "(cast(_T0.VAL as double) / ?) as DOUBLE, " +
-            "(cast(_T0.VAL as decimal(60, 30)) / ?) as DECIMAL0 " +
+            "cast((cast(_T0.VAL as decimal(60, 30)) / ?) as decimal(60, 30)) as DECIMAL0 " +
             "from PUBLIC.TBL_INT32 as _T0 " +
             "order by cast(_T0.VAL as bigint) desc",
             query.ToString());

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
@@ -66,13 +66,12 @@ public partial class LinqTests
     }
 
     [Test]
-    [Timeout(90_000)] // TODO IGNITE-23170 Decimal handling is very slow
     public void TestCastToDecimalPrecision()
     {
         // ReSharper disable once RedundantCast
         var query = PocoIntView.AsQueryable()
             .OrderByDescending(x => x.Val)
-            .Select(x => (decimal?)x.Val / 33m)
+            .Select(x => (decimal?)(x.Val / 33m))
             .Take(1);
 
         var res = query.ToList();
@@ -81,7 +80,7 @@ public partial class LinqTests
         // Assert.AreEqual(900m / 33m, res[0]);
         Assert.AreEqual(27.27272727272727m, res[0]);
 
-        StringAssert.Contains("(cast(_T0.VAL as decimal(60, 30)) / ?)", query.ToString());
+        StringAssert.Contains("select cast((cast(_T0.VAL as decimal(60, 30)) / ?) as decimal(60, 30))", query.ToString());
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Cast.cs
@@ -59,7 +59,7 @@ public partial class LinqTests
             "cast(_T0.VAL as bigint) as LONG, " +
             "(cast(_T0.VAL as real) / ?) as FLOAT, " +
             "(cast(_T0.VAL as double) / ?) as DOUBLE, " +
-            "(cast(_T0.VAL as decimal(30)) / ?) as DECIMAL0 " +
+            "(cast(_T0.VAL as decimal(60, 30)) / ?) as DECIMAL0 " +
             "from PUBLIC.TBL_INT32 as _T0 " +
             "order by cast(_T0.VAL as bigint) desc",
             query.ToString());
@@ -81,7 +81,7 @@ public partial class LinqTests
         // Assert.AreEqual(900m / 33m, res[0]);
         Assert.AreEqual(27.27272727272727m, res[0]);
 
-        StringAssert.Contains("(cast(_T0.VAL as decimal(30)) / ?)", query.ToString());
+        StringAssert.Contains("(cast(_T0.VAL as decimal(60, 30)) / ?)", query.ToString());
     }
 
     [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
@@ -516,10 +516,10 @@ namespace Apache.Ignite.Tests.Sql
         [Test]
         public async Task TestCustomDecimalScale()
         {
-            await using var resultSet = await Client.Sql.ExecuteAsync(null, "select (cast(10 as decimal(20, 10)) / ?)", 3m);
+            await using var resultSet = await Client.Sql.ExecuteAsync(null, "select cast((10 / ?) as decimal(20, 5))", 3m);
             IIgniteTuple res = await resultSet.SingleAsync();
 
-            Assert.AreEqual(3.333333333333333m, res[0]);
+            Assert.AreEqual(3.33333m, res[0]);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -482,7 +482,9 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
             else if ((Nullable.GetUnderlyingType(expression.Type) ?? expression.Type) == typeof(decimal))
             {
                 // .NET decimal has 28-29 digit precision, Ignite CatalogUtils.MAX_DECIMAL_PRECISION = Short.MAX_VALUE = 32767.
-                // Use 30 to avoid rounding errors, but not greater to avoid performance issues.
+                // Use (precision, scale) = (60, 30) to avoid rounding errors, but not greater to avoid performance issues.
+                // If we do not specify the scale, SQL engine will use MAX_DECIMAL_SCALE = 32767,
+                // causing unnecessary data transfer and CPU usage for conversion.
                 ResultBuilder.Append(" as decimal(60, 30))");
             }
             else

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -483,7 +483,7 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
             {
                 // .NET decimal has 28-29 digit precision, Ignite CatalogUtils.MAX_DECIMAL_PRECISION = Short.MAX_VALUE = 32767.
                 // Use 30 to avoid rounding errors, but not greater to avoid performance issues.
-                ResultBuilder.Append(" as decimal(30))");
+                ResultBuilder.Append(" as decimal(60, 30))");
             }
             else
             {


### PR DESCRIPTION
Limit decimal scale to 30 when performing a cast in generated SQL - .NET `decimal` has 28-29 digit precision and can't represent bigger scales.

Default scale is 32767, which causes performance issues ([IGNITE-23170](https://issues.apache.org/jira/browse/IGNITE-23170)).

With this fix, `TestCastToDecimalPrecision` and other decimal SQL tests now run in milliseconds instead of minutes.