### PR TITLE
IGNITE-23206 Update term used for Metastorage idle SafeTime propagation on leadership refresh

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutWorker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutWorker.java
@@ -105,7 +105,7 @@ public class TimeoutWorker extends IgniteWorker {
                 try {
                     Thread.sleep(sleepInterval);
                 } catch (InterruptedException e) {
-                    log.info("The timeout worker was interrupted, probably the client is stopping.");
+                    log.info("The timeout worker was interrupted, probably the worker is stopping.");
                 }
 
                 updateHeartbeat();

--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.metastorage.impl;
 
 import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.ignite.internal.testframework.IgniteTestUtils.getFieldValue;
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.waitForCondition;
 import static org.apache.ignite.internal.testframework.matchers.CompletableFutureExceptionMatcher.willTimeoutIn;
 import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willCompleteSuccessfully;
@@ -33,7 +34,10 @@ import org.apache.ignite.internal.configuration.testframework.ConfigurationExten
 import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.apache.ignite.internal.lang.ByteArray;
 import org.apache.ignite.internal.lang.NodeStoppingException;
+import org.apache.ignite.internal.metastorage.server.SimpleInMemoryKeyValueStorage;
+import org.apache.ignite.internal.metastorage.server.WatchProcessor;
 import org.apache.ignite.internal.metastorage.server.time.ClusterTime;
+import org.apache.ignite.internal.util.ArrayUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -158,13 +162,31 @@ class ItMetaStorageMaintenanceTest extends ItMetaStorageMultipleNodesAbstractTes
         assertThat(node0.metaStorageManager.becomeLonelyLeader(true), willCompleteSuccessfully());
 
         ClusterTime clusterTime0 = node0.metaStorageManager.clusterTime();
-        HybridTimestamp timeBeforeOp = clusterTime0.currentSafeTime();
+
+        causeSafeTimeCommandsIssuedBeforePausingToBeApplied(node0);
+
 
         // Make sure the leader does not propagate Metastorage SafeTime (as we requested it to pause secondary duties).
+        HybridTimestamp timeAtStart = clusterTime0.currentSafeTime();
         assertFalse(
-                waitForCondition(() -> clusterTime0.currentSafeTime().longValue() > timeBeforeOp.longValue(), SECONDS.toMillis(2)),
-                "The leader still propagates safetime"
+                waitForCondition(() -> clusterTime0.currentSafeTime().longValue() > timeAtStart.longValue(), SECONDS.toMillis(2)),
+                () -> "The leader still propagates safetime " + clusterTime0.currentSafeTime()
         );
+    }
+
+    private static void causeSafeTimeCommandsIssuedBeforePausingToBeApplied(Node node) {
+        // We execute a PUT command and then wait for SafeTime to be advanced. This guarantees that idle SafeTime propagation
+        // commands before pausing idle SafeTime propagation get executed and we don't get a non-relevant test failure.
+        assertThat(node.metaStorageManager.put(new ByteArray("abc"), ArrayUtils.BYTE_EMPTY_ARRAY), willCompleteSuccessfully());
+
+        // TODO: IGNITE-15723 After a component factory is implemented, need to get rid of reflection here.
+        var storage = (SimpleInMemoryKeyValueStorage) getFieldValue(node.metaStorageManager, MetaStorageManagerImpl.class, "storage");
+        var watchProcessor = (WatchProcessor) getFieldValue(storage, SimpleInMemoryKeyValueStorage.class, "watchProcessor");
+
+        CompletableFuture<Void> notificationFuture = getFieldValue(watchProcessor, WatchProcessor.class, "notificationFuture");
+        if (notificationFuture != null) {
+            assertThat(notificationFuture, willCompleteSuccessfully());
+        }
     }
 
     @Test

--- a/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
+++ b/modules/metastorage/src/integrationTest/java/org/apache/ignite/internal/metastorage/impl/ItMetaStorageMaintenanceTest.java
@@ -165,7 +165,6 @@ class ItMetaStorageMaintenanceTest extends ItMetaStorageMultipleNodesAbstractTes
 
         causeSafeTimeCommandsIssuedBeforePausingToBeApplied(node0);
 
-
         // Make sure the leader does not propagate Metastorage SafeTime (as we requested it to pause secondary duties).
         HybridTimestamp timeAtStart = clusterTime0.currentSafeTime();
         assertFalse(

--- a/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/impl/MetaStorageLeaderElectionListener.java
+++ b/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/impl/MetaStorageLeaderElectionListener.java
@@ -127,41 +127,27 @@ public class MetaStorageLeaderElectionListener implements LeaderElectionListener
         synchronized (serializationFutureMux) {
             boolean weWerePreviousLeader = serializationFuture != null;
 
-            if (weWerePreviousLeader) {
-                if (weAreNewLeader) {
-                    LOG.info("Node leadership is refreshed, stopping Idle Safe Time scheduler to restart it with new term");
-                } else {
-                    LOG.info("Node has lost the leadership, stopping Idle Safe Time scheduler");
-                }
+            if (weWerePreviousLeader && !weAreNewLeader) {
+                LOG.info("Node has lost the leadership, stopping doing secondary duties");
 
-                // Stop SafeTime propagation even if we are still the leader as term used for propagation is to be refreshed.
+                thisNodeTerm = null;
+
                 clusterTime.stopSafeTimeScheduler();
 
-                if (!weAreNewLeader) {
-                    LOG.info("Node has lost the leadership, stopping learners management");
+                logicalTopologyService.removeEventListener(logicalTopologyEventListener);
 
-                    thisNodeTerm = null;
+                serializationFuture.cancel(false);
 
-                    logicalTopologyService.removeEventListener(logicalTopologyEventListener);
-
-                    serializationFuture.cancel(false);
-
-                    serializationFuture = null;
-                }
+                serializationFuture = null;
             }
 
             if (weAreNewLeader) {
-                // We are the new leader. This does not necessarily mean we weren't previous leader (one node might
-                // be a leader 2 times in a row at least as a result of Metastorage repair).
-                LOG.info("Node has been elected as the leader, starting secondary duties");
-
-                LOG.info("Starting Idle Safe Time scheduler");
-                startSafeTimeScheduler(term);
-
                 thisNodeTerm = term;
 
                 if (!weWerePreviousLeader) {
-                    LOG.info("Node has been elected as the leader (and it wasn't previous leader), so starting learners management");
+                    LOG.info("Node has been elected as the leader (and it wasn't previous leader), so starting doing secondary duties");
+
+                    startSafeTimeScheduler();
 
                     // The node was not previous leader, and it becomes a leader.
                     logicalTopologyService.addEventListener(logicalTopologyEventListener);
@@ -169,16 +155,18 @@ public class MetaStorageLeaderElectionListener implements LeaderElectionListener
                     // Update learner configuration (in case we missed some topology updates between elections).
                     serializationFuture = (serializationFuture == null ? nullCompletedFuture() : serializationFuture)
                             .thenCompose(unused -> updateLearnersIfSecondaryDutiesAreNotPaused(term));
+                } else {
+                    LOG.info("Node has been reelected as the leader");
                 }
             }
         }
     }
 
-    private void startSafeTimeScheduler(long term) {
+    private void startSafeTimeScheduler() {
         metaStorageSvcFut
                 .thenAcceptBoth(metaStorageConfigurationFuture, (service, metaStorageConfiguration) -> {
                     clusterTime.startSafeTimeScheduler(
-                            safeTime -> syncTimeIfSecondaryDutiesAreNotPaused(safeTime, term, service),
+                            safeTime -> syncTimeIfSecondaryDutiesAreNotPaused(safeTime, service),
                             metaStorageConfiguration
                     );
                 })
@@ -197,12 +185,14 @@ public class MetaStorageLeaderElectionListener implements LeaderElectionListener
         return metaStorageSvcFut.thenCompose(service -> resetLearners(service.raftGroupService(), term));
     }
 
-    private CompletableFuture<Void> syncTimeIfSecondaryDutiesAreNotPaused(
-            HybridTimestamp safeTime,
-            long term,
-            MetaStorageServiceImpl service
-    ) {
+    private CompletableFuture<Void> syncTimeIfSecondaryDutiesAreNotPaused(HybridTimestamp safeTime, MetaStorageServiceImpl service) {
         if (leaderSecondaryDutiesPaused.getAsBoolean()) {
+            return nullCompletedFuture();
+        }
+
+        Long term = thisNodeTerm;
+        if (term == null) {
+            // We seized to be a leader, do nothing.
             return nullCompletedFuture();
         }
 

--- a/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/server/raft/MetaStorageWriteHandler.java
+++ b/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/server/raft/MetaStorageWriteHandler.java
@@ -136,6 +136,10 @@ public class MetaStorageWriteHandler {
 
                     // Ignore the command if it has been sent by a stale leader.
                     if (clo.term() != syncTimeCommand.initiatorTerm()) {
+                        LOG.info("Sync time command closure term {}, initiator term {}, ignoring the command",
+                                clo.term(), syncTimeCommand.initiatorTerm()
+                        );
+
                         clo.result(null);
 
                         return;

--- a/modules/raft/src/main/java/org/apache/ignite/internal/raft/RaftGroupServiceImpl.java
+++ b/modules/raft/src/main/java/org/apache/ignite/internal/raft/RaftGroupServiceImpl.java
@@ -598,7 +598,8 @@ public class RaftGroupServiceImpl implements RaftGroupService {
                     .thenCompose(node -> cluster.messagingService().invoke(node, request, configuration.responseTimeout().value()))
                     .whenComplete((resp, err) -> {
                         if (LOG.isTraceEnabled()) {
-                            LOG.trace("sendWithRetry resp={} from={} to={} err={}",
+                            LOG.trace("sendWithRetry req={} resp={} from={} to={} err={}",
+                                    request,
                                     resp,
                                     cluster.topologyService().localMember().address(),
                                     peer.consistentId(),


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23206

 * If an elected leader is same as before, still update term used for Metastorage Idle SafeTime propagation
 * Fix a race condition in test which was giving false positives. That is, we now make sure that 'old' SafeTime advancements (made before pausing secondary duties) are waited out before checking that no new advancements happen
 * Improve logging