### PR TITLE
IGNITE-23132 fix NullPointerException in LogManagerImpl

### DIFF
--- a/modules/raft/src/main/java/org/apache/ignite/raft/jraft/core/NodeImpl.java
+++ b/modules/raft/src/main/java/org/apache/ignite/raft/jraft/core/NodeImpl.java
@@ -1584,15 +1584,16 @@ public class NodeImpl implements Node, RaftServerService {
 
     private void executeApplyingTasks(final List<LogEntryAndClosure> tasks) {
         if (!this.logManager.hasAvailableCapacityToAppendEntries(1)) {
-        	// It's overload, fail-fast
-        	final List<Closure> dones = tasks.stream().map(ele -> ele.done).filter(Objects::nonNull)
-        			.collect(Collectors.toList());
-        	Utils.runInThread(this.getOptions().getCommonExecutor(), () -> {
-        		for (final Closure done : dones) {
-        			done.run(new Status(RaftError.EBUSY, "Node %s log manager is busy.", this.getNodeId()));
-        		}
-        	});
-        	return;
+            // It's overload, fail-fast
+            final List<Closure> dones = tasks.stream().map(ele -> ele.done).filter(Objects::nonNull)
+                     .collect(Collectors.toList());
+            Utils.runInThread(this.getOptions().getCommonExecutor(), () -> {
+                for (final Closure done : dones) {
+                    done.run(new Status(RaftError.EBUSY, "Node %s log manager is busy.", this.getNodeId()));
+                }
+            });
+
+            return;
         }
 
         this.writeLock.lock();

--- a/modules/raft/src/main/java/org/apache/ignite/raft/jraft/storage/impl/LogManagerImpl.java
+++ b/modules/raft/src/main/java/org/apache/ignite/raft/jraft/storage/impl/LogManagerImpl.java
@@ -947,6 +947,21 @@ public class LogManagerImpl implements LogManager {
             Thread.currentThread().interrupt();
             throw new IllegalStateException(e);
         }
+
+        if (c.lastLogId == null) {
+            assert stopped;
+
+            try {
+                shutDownLatch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+
+                throw new IllegalStateException(e);
+            }
+
+            return new LogId(this.lastLogIndex, unsafeGetTerm(this.lastLogIndex));
+        }
+
         return c.lastLogId;
     }
 

--- a/modules/raft/src/main/java/org/apache/ignite/raft/jraft/storage/impl/LogManagerImpl.java
+++ b/modules/raft/src/main/java/org/apache/ignite/raft/jraft/storage/impl/LogManagerImpl.java
@@ -891,6 +891,13 @@ public class LogManagerImpl implements LogManager {
             Thread.currentThread().interrupt();
             throw new IllegalStateException(e);
         }
+
+        if (c.lastLogId == null) {
+            assert stopped : "Last log id can be null only when node is stopping.";
+
+            throw new IllegalStateException("Node is shutting down");
+        }
+
         return c.lastLogId.getIndex();
     }
 
@@ -942,19 +949,10 @@ public class LogManagerImpl implements LogManager {
             Thread.currentThread().interrupt();
             throw new IllegalStateException(e);
         }
-
         if (c.lastLogId == null) {
-            assert stopped;
+            assert stopped : "Last log id can be null only when node is stopping.";
 
-            try {
-                shutDownLatch.await();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-
-                throw new IllegalStateException(e);
-            }
-
-            return new LogId(this.lastLogIndex, unsafeGetTerm(this.lastLogIndex));
+            throw new IllegalStateException("Node is shutting down");
         }
 
         return c.lastLogId;

--- a/modules/raft/src/main/java/org/apache/ignite/raft/jraft/storage/impl/LogManagerImpl.java
+++ b/modules/raft/src/main/java/org/apache/ignite/raft/jraft/storage/impl/LogManagerImpl.java
@@ -353,13 +353,8 @@ public class LogManagerImpl implements LogManager {
     private void offerEvent(final StableClosure done, final EventType type) {
         assert(done != null);
 
-            if (this.stopped) {
-                if (type == EventType.LAST_LOG_ID) {
-                    // TODO: remove after fixing the issue https://issues.apache.org/jira/browse/IGNITE-23132
-                    LOG.info("Received a last log id request, but log manager is stopped.");
-                }
-
-                Utils.runClosureInThread(nodeOptions.getCommonExecutor(), done, new Status(RaftError.ESTOP, "Log manager is stopped."));
+        if (this.stopped) {
+            Utils.runClosureInThread(nodeOptions.getCommonExecutor(), done, new Status(RaftError.ESTOP, "Log manager is stopped."));
             return;
         }
         this.diskQueue.publishEvent((event, sequence) -> {

--- a/modules/raft/src/test/java/org/apache/ignite/raft/jraft/storage/impl/LogManagerTest.java
+++ b/modules/raft/src/test/java/org/apache/ignite/raft/jraft/storage/impl/LogManagerTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -454,4 +455,23 @@ public class LogManagerTest extends BaseStorageTest {
         assertEquals("localhost:8081,localhost:8082", lastEntry.getOldConf().toString());
     }
 
+    @Test
+    public void testLastLogIdWhenShutdown() throws Exception {
+        mockAddEntries();
+        assertEquals(1, this.logManager.getFirstLogIndex());
+        assertEquals(10, this.logManager.getLastLogIndex());
+        this.logManager.shutdown();
+        Exception e = assertThrows(IllegalStateException.class, () -> this.logManager.getLastLogId(true));
+        assertEquals("Node is shutting down", e.getMessage());
+    }
+
+    @Test
+    public void testLastLogIndexWhenShutdown() throws Exception {
+        mockAddEntries();
+        assertEquals(1, this.logManager.getFirstLogIndex());
+        assertEquals(10, this.logManager.getLastLogIndex());
+        this.logManager.shutdown();
+        Exception e = assertThrows(IllegalStateException.class, () -> this.logManager.getLastLogIndex(true));
+        assertEquals("Node is shutting down", e.getMessage());
+    }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23132

In this PR we change a behaviour of `org.apache.ignite.raft.jraft.storage.impl.LogManagerImpl#getLastLogIndex(boolean)` and 
`org.apache.ignite.raft.jraft.storage.impl.LogManagerImpl#getLastLogId` so they do not fail with NPE if were invoked after `org.apache.ignite.raft.jraft.storage.impl.LogManagerImpl#shutdown`, but they throw `IllegalStateException` 

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)