### PR TITLE
IGNITE-23221 Update a message about java version and jvm startup params 

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/util/BrokenPointerWrapping.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/BrokenPointerWrapping.java
@@ -26,6 +26,6 @@ class BrokenPointerWrapping implements PointerWrapping {
     @Override
     public ByteBuffer wrapPointer(long ptr, int len) {
         throw new RuntimeException(
-                "All alternatives for a new DirectByteBuffer() creation failed: " + FeatureChecker.JAVA_VER_SPECIFIC_WARN);
+                "All alternatives for a new DirectByteBuffer() creation failed: " + FeatureChecker.JAVA_VERSION_OR_STARTUP_PARAMS_WARN);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/BrokenPointerWrapping.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/BrokenPointerWrapping.java
@@ -26,6 +26,6 @@ class BrokenPointerWrapping implements PointerWrapping {
     @Override
     public ByteBuffer wrapPointer(long ptr, int len) {
         throw new RuntimeException(
-                "All alternatives for a new DirectByteBuffer() creation failed: " + FeatureChecker.JAVA_VERSION_OR_STARTUP_PARAMS_WARN);
+                "All alternatives for a new DirectByteBuffer() creation failed: " + FeatureChecker.JAVA_STARTUP_PARAMS_WARN);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/FeatureChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/FeatureChecker.java
@@ -24,5 +24,18 @@ public class FeatureChecker {
     /** Java specific startup parameters warning to be added in case access failed. */
     public static final String JAVA_STARTUP_PARAMS_WARN = System.lineSeparator()
             + "Please check the required parameters to JVM startup settings and restart the application."
+            + " Parameters: " + System.lineSeparator()
+            + "\t--add-opens java.base/java.lang=ALL-UNNAMED" + System.lineSeparator()
+            + "\t--add-opens java.base/java.lang.invoke=ALL-UNNAMED" + System.lineSeparator()
+            + "\t--add-opens java.base/java.lang.reflect=ALL-UNNAMED" + System.lineSeparator()
+            + "\t--add-opens java.base/java.io=ALL-UNNAMED" + System.lineSeparator()
+            + "\t--add-opens java.base/java.nio=ALL-UNNAMED" + System.lineSeparator()
+            + "\t--add-opens java.base/java.math=ALL-UNNAMED" + System.lineSeparator()
+            + "\t--add-opens java.base/java.util=ALL-UNNAMED" + System.lineSeparator()
+            + "\t--add-opens java.base/java.time=ALL-UNNAMED" + System.lineSeparator()
+            + "\t--add-opens java.base/jdk.internal.misc=ALL-UNNAMED" + System.lineSeparator()
+            + "\t--add-opens java.base/jdk.internal.access=ALL-UNNAMED" + System.lineSeparator()
+            + "\t--add-opens java.base/sun.nio.ch=ALL-UNNAMED" + System.lineSeparator()
+            + "\t-Dio.netty.tryReflectionSetAccessible=true" + System.lineSeparator()
             + " See https://ignite.apache.org/docs/3.0.0-beta/quick-start/getting-started-guide for more information.";
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/FeatureChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/FeatureChecker.java
@@ -21,8 +21,8 @@ package org.apache.ignite.internal.util;
  * Class extracted for fields from GridUnsafe to be absolutely independent with current and future static block initialization effects.
  */
 public class FeatureChecker {
-    /** Java version specific warning to be added in case access failed. */
-    public static final String JAVA_VERSION_OR_STARTUP_PARAMS_WARN = System.lineSeparator()
+    /** Java specific startup parameters warning to be added in case access failed. */
+    public static final String JAVA_STARTUP_PARAMS_WARN = System.lineSeparator()
             + "Please check the required parameters to JVM startup settings and restart the application."
             + " See https://ignite.apache.org/docs/3.0.0-beta/quick-start/getting-started-guide for more information.";
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/FeatureChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/FeatureChecker.java
@@ -21,23 +21,8 @@ package org.apache.ignite.internal.util;
  * Class extracted for fields from GridUnsafe to be absolutely independent with current and future static block initialization effects.
  */
 public class FeatureChecker {
-    /** Required options to run on Java 9, 10, 11. */
-    public static final String JAVA_9_10_11_OPTIONS = ""
-            + "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED\n"
-            + "--add-exports=java.base/jdk.internal.access=ALL-UNNAMED\n"
-            + "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED\n"
-            + "--add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED\n"
-            + "--add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED\n"
-            + "--add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED\n"
-            + "--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED\n"
-            + "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED\n"
-            + "--illegal-access=permit";
-
     /** Java version specific warning to be added in case access failed. */
-    public static final String JAVA_VER_SPECIFIC_WARN =
-            "\nPlease add the following parameters to JVM startup settings and restart the application: {parameters: "
-                    + JAVA_9_10_11_OPTIONS
-                    + "\n}"
-                    + "\nSee https://apacheignite.readme.io/docs/getting-started#section-running-ignite-with-java-9-10-11 "
-                    + "for more information.";
+    public static final String JAVA_VERSION_OR_STARTUP_PARAMS_WARN = System.lineSeparator()
+            + "Please check the required parameters to JVM startup settings and restart the application."
+            + " See https://ignite.apache.org/docs/3.0.0-beta/quick-start/getting-started-guide for more information.";
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/GridUnsafe.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/GridUnsafe.java
@@ -213,7 +213,7 @@ public abstract class GridUnsafe {
             return newDirectBuf.order(NATIVE_BYTE_ORDER);
         } catch (Throwable e) {
             throw new RuntimeException("DirectByteBuffer#constructor is unavailable."
-                    + FeatureChecker.JAVA_VERSION_OR_STARTUP_PARAMS_WARN, e);
+                    + FeatureChecker.JAVA_STARTUP_PARAMS_WARN, e);
         }
     }
 
@@ -232,7 +232,7 @@ public abstract class GridUnsafe {
             return newDirectBuf.order(NATIVE_BYTE_ORDER);
         } catch (Throwable e) {
             throw new RuntimeException("DirectByteBuffer#constructor is unavailable."
-                    + FeatureChecker.JAVA_VERSION_OR_STARTUP_PARAMS_WARN, e);
+                    + FeatureChecker.JAVA_STARTUP_PARAMS_WARN, e);
         }
     }
 
@@ -1619,7 +1619,7 @@ public abstract class GridUnsafe {
             return mth.invoke(null);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(pkgName + ".JavaNioAccess class is unavailable."
-                    + FeatureChecker.JAVA_VERSION_OR_STARTUP_PARAMS_WARN, e);
+                    + FeatureChecker.JAVA_STARTUP_PARAMS_WARN, e);
         }
     }
 
@@ -1655,7 +1655,7 @@ public abstract class GridUnsafe {
                     .asType(mtdType);
         } catch (ReflectiveOperationException | PrivilegedActionException e) {
             throw new RuntimeException(accessPackage() + ".JavaNioAccess#newDirectByteBuffer() method is unavailable."
-                    + FeatureChecker.JAVA_VERSION_OR_STARTUP_PARAMS_WARN, e);
+                    + FeatureChecker.JAVA_STARTUP_PARAMS_WARN, e);
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/GridUnsafe.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/GridUnsafe.java
@@ -213,7 +213,7 @@ public abstract class GridUnsafe {
             return newDirectBuf.order(NATIVE_BYTE_ORDER);
         } catch (Throwable e) {
             throw new RuntimeException("DirectByteBuffer#constructor is unavailable."
-                    + FeatureChecker.JAVA_VER_SPECIFIC_WARN, e);
+                    + FeatureChecker.JAVA_VERSION_OR_STARTUP_PARAMS_WARN, e);
         }
     }
 
@@ -232,7 +232,7 @@ public abstract class GridUnsafe {
             return newDirectBuf.order(NATIVE_BYTE_ORDER);
         } catch (Throwable e) {
             throw new RuntimeException("DirectByteBuffer#constructor is unavailable."
-                    + FeatureChecker.JAVA_VER_SPECIFIC_WARN, e);
+                    + FeatureChecker.JAVA_VERSION_OR_STARTUP_PARAMS_WARN, e);
         }
     }
 
@@ -1619,7 +1619,7 @@ public abstract class GridUnsafe {
             return mth.invoke(null);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(pkgName + ".JavaNioAccess class is unavailable."
-                    + FeatureChecker.JAVA_VER_SPECIFIC_WARN, e);
+                    + FeatureChecker.JAVA_VERSION_OR_STARTUP_PARAMS_WARN, e);
         }
     }
 
@@ -1655,7 +1655,7 @@ public abstract class GridUnsafe {
                     .asType(mtdType);
         } catch (ReflectiveOperationException | PrivilegedActionException e) {
             throw new RuntimeException(accessPackage() + ".JavaNioAccess#newDirectByteBuffer() method is unavailable."
-                    + FeatureChecker.JAVA_VER_SPECIFIC_WARN, e);
+                    + FeatureChecker.JAVA_VERSION_OR_STARTUP_PARAMS_WARN, e);
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/JavaNioPointerWrapping.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/JavaNioPointerWrapping.java
@@ -47,7 +47,7 @@ class JavaNioPointerWrapping implements PointerWrapping {
             return buf;
         } catch (Throwable e) {
             throw new RuntimeException("JavaNioAccess#newDirectByteBuffer() method is unavailable."
-                    + FeatureChecker.JAVA_VERSION_OR_STARTUP_PARAMS_WARN, e);
+                    + FeatureChecker.JAVA_STARTUP_PARAMS_WARN, e);
         }
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/JavaNioPointerWrapping.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/JavaNioPointerWrapping.java
@@ -47,7 +47,7 @@ class JavaNioPointerWrapping implements PointerWrapping {
             return buf;
         } catch (Throwable e) {
             throw new RuntimeException("JavaNioAccess#newDirectByteBuffer() method is unavailable."
-                    + FeatureChecker.JAVA_VER_SPECIFIC_WARN, e);
+                    + FeatureChecker.JAVA_VERSION_OR_STARTUP_PARAMS_WARN, e);
         }
     }
 }

--- a/modules/raft/src/main/java/org/apache/ignite/internal/raft/storage/logit/LogitLogStorageFactory.java
+++ b/modules/raft/src/main/java/org/apache/ignite/internal/raft/storage/logit/LogitLogStorageFactory.java
@@ -77,7 +77,10 @@ public class LogitLogStorageFactory implements LogStorageFactory {
         try {
             Class.forName(DirectBuffer.class.getName());
         } catch (Throwable e) {
-            throw new IgniteInternalException("sun.nio.ch.DirectBuffer is unavailable." + FeatureChecker.JAVA_VER_SPECIFIC_WARN, e);
+            throw new IgniteInternalException(
+                    "sun.nio.ch.DirectBuffer is unavailable." + FeatureChecker.JAVA_VERSION_OR_STARTUP_PARAMS_WARN,
+                    e
+            );
         }
     }
 

--- a/modules/raft/src/main/java/org/apache/ignite/internal/raft/storage/logit/LogitLogStorageFactory.java
+++ b/modules/raft/src/main/java/org/apache/ignite/internal/raft/storage/logit/LogitLogStorageFactory.java
@@ -77,10 +77,7 @@ public class LogitLogStorageFactory implements LogStorageFactory {
         try {
             Class.forName(DirectBuffer.class.getName());
         } catch (Throwable e) {
-            throw new IgniteInternalException(
-                    "sun.nio.ch.DirectBuffer is unavailable." + FeatureChecker.JAVA_VERSION_OR_STARTUP_PARAMS_WARN,
-                    e
-            );
+            throw new IgniteInternalException("sun.nio.ch.DirectBuffer is unavailable." + FeatureChecker.JAVA_STARTUP_PARAMS_WARN, e);
         }
     }
 


### PR DESCRIPTION
JIRA Ticket: [IGNITE-23221](https://issues.apache.org/jira/browse/IGNITE-23221)

## The goal

The main goal is to remove obsolete links on Apache Ignite documentation website.

## The reason

We should use proper up-to-date documentation warning messages for our users.

## The solution

The only place that contains a link with the noticed prefix https://apacheignite.readme.io/ is JAVA_VER_WARN variable that is used for user's notification about Java version specific startup parameters. But for now we're supporting only Java 11+, so at most the message is obsolete and we should to inform a user about proper JVM's startup parameters with a link on a proper documentation about Ignite startup but 3.0.0-beta version until release: https://ignite.apache.org/docs/3.0.0-beta/quick-start/getting-started-guide 

Also the constant itself was renamed accordingly.

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)