### PR TITLE
IGNITE-23228 Remove mavenLocal repository from Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ plugins {
 apply from: "$rootDir/buildscripts/javadoc.gradle"
 
 repositories {
-    mavenLocal()
     maven {
         url = uri('https://repository.apache.org/snapshots')
     }
@@ -118,7 +117,6 @@ subprojects {
     apply plugin: 'base'
 
     repositories {
-        mavenLocal()
         maven {
             url = uri('https://repository.apache.org/snapshots')
             mavenContent {


### PR DESCRIPTION
To fix build failures caused by Gradle bug (https://github.com/gradle/gradle/issues/30601), remove `mavenLocal()` from Gradle repositories.

Build time is not affected - 31 minutes is same as main branch: https://ci.ignite.apache.org/buildConfiguration/ApacheIgnite3xGradle_Test_RunAllTests/8480930?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildChangesSection=true&expandBuildDeploymentsSection=false&expandCode+Inspection=true

https://issues.apache.org/jira/browse/IGNITE-23228