### PR TITLE
IGNITE-23133 Java thin: fix NPE in handshakeRes

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/io/netty/NettyClientConnection.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/io/netty/NettyClientConnection.java
@@ -35,6 +35,9 @@ public class NettyClientConnection implements ClientConnection {
     /** Connection attribute. */
     static final AttributeKey<NettyClientConnection> ATTR_CONN = AttributeKey.newInstance("CONN");
 
+    /** Target address. */
+    private final InetSocketAddress addr;
+
     /** Channel. */
     private final Channel channel;
 
@@ -50,16 +53,19 @@ public class NettyClientConnection implements ClientConnection {
     /**
      * Constructor.
      *
+     * @param addr Target address.
      * @param channel Channel.
      * @param msgHnd Message handler.
      * @param stateHnd State handler.
      * @param metrics Metrics.
      */
     NettyClientConnection(
+            InetSocketAddress addr,
             Channel channel,
             ClientMessageHandler msgHnd,
             ClientConnectionStateHandler stateHnd,
             ClientMetricSource metrics) {
+        this.addr = addr;
         this.channel = channel;
         this.msgHnd = msgHnd;
         this.stateHnd = stateHnd;
@@ -91,7 +97,7 @@ public class NettyClientConnection implements ClientConnection {
     /** {@inheritDoc} */
     @Override
     public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) channel.remoteAddress();
+        return addr;
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/io/netty/NettyClientConnectionMultiplexer.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/io/netty/NettyClientConnectionMultiplexer.java
@@ -168,7 +168,8 @@ public class NettyClientConnectionMultiplexer implements ClientConnectionMultipl
 
     /** {@inheritDoc} */
     @Override
-    public CompletableFuture<ClientConnection> openAsync(InetSocketAddress addr,
+    public CompletableFuture<ClientConnection> openAsync(
+            InetSocketAddress addr,
             ClientMessageHandler msgHnd,
             ClientConnectionStateHandler stateHnd)
             throws IgniteClientConnectionException {
@@ -184,7 +185,7 @@ public class NettyClientConnectionMultiplexer implements ClientConnectionMultipl
                 ChannelFuture chFut = (ChannelFuture) f;
                 chFut.channel().closeFuture().addListener(unused -> metrics.connectionsActiveDecrement());
 
-                NettyClientConnection conn = new NettyClientConnection(chFut.channel(), msgHnd, stateHnd, metrics);
+                NettyClientConnection conn = new NettyClientConnection(addr, chFut.channel(), msgHnd, stateHnd, metrics);
 
                 fut.complete(conn);
             } else {


### PR DESCRIPTION
Pass the original address to `NettyClientConnection` to avoid using `channel.remoteAddress()`, which can return null on disconnect. We want have the address for logging and debugging purposes even after disconnect.