### PR TITLE
IGNITE-23262 Java thin: cache table partition count

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/AbstractClientStreamerPartitionAwarenessProvider.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/AbstractClientStreamerPartitionAwarenessProvider.java
@@ -50,6 +50,10 @@ abstract class AbstractClientStreamerPartitionAwarenessProvider<T> implements St
     public CompletableFuture<Void> refreshAsync() {
         var schemaFut = tbl.getLatestSchema().thenAccept(schema -> this.schema = schema);
 
+        if (partitions < 0) {
+            partitions = tbl.tryGetPartitionCount();
+        }
+
         if (partitions > 0) {
             // Partition count can't change.
             return schemaFut;

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -662,7 +662,12 @@ public class ClientTable implements Table {
         }
     }
 
-    int partitionCount() {
+    /**
+     * Gets partition count when available; otherwise, returns -1.
+     *
+     * @return Partition count, or -1 if not available.
+     */
+    int tryGetPartitionCount() {
         return partitionCount;
     }
 


### PR DESCRIPTION
Data streamer does not accept data while schema and partition count are loading.

Cache table partition count on client to speed up data streamer startup. Fresh assignment is not required to initialize streamer buffers.