### PR TITLE
IGNITE-22783 Handle CMG-related network messages in CMG thread pool

### DIFF
--- a/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/ClusterManagementGroupManager.java
+++ b/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/ClusterManagementGroupManager.java
@@ -198,7 +198,7 @@ public class ClusterManagementGroupManager extends AbstractEventProducer<Cluster
 
         cmgMessageHandler = createMessageHandler();
 
-        clusterService.messagingService().addMessageHandler(CmgMessageGroup.class, cmgMessageHandler);
+        clusterService.messagingService().addMessageHandler(CmgMessageGroup.class, message -> scheduledExecutor, cmgMessageHandler);
     }
 
     private CmgMessageHandler createMessageHandler() {

--- a/modules/system-disaster-recovery/src/integrationTest/java/org/apache/ignite/internal/disaster/system/ItCmgDisasterRecoveryTest.java
+++ b/modules/system-disaster-recovery/src/integrationTest/java/org/apache/ignite/internal/disaster/system/ItCmgDisasterRecoveryTest.java
@@ -83,7 +83,7 @@ class ItCmgDisasterRecoveryTest extends ItSystemGroupDisasterRecoveryTest {
     }
 
     private void initiateCmgRepairVia(IgniteImpl conductor, int... newCmgIndexes) throws InterruptedException {
-        NodeMetadata nodeMetadata = conductor.node().nodeMetadata();
+        NodeMetadata nodeMetadata = obtainNodeMetadata(conductor);
 
         recoveryClient.initiateCmgRepair(nodeMetadata.restHost(), nodeMetadata.httpPort(), nodeNames(newCmgIndexes));
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22783

Handling of CMG network messages may cause I/O and hence must be offloaded to its own thread pool to avoid blocking network threads