### PR TITLE
IGNITE-23233 Fix infinite recursion in RemoteJobExecution#stateAsync()

### DIFF
--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/ComputeJobFailover.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/ComputeJobFailover.java
@@ -136,7 +136,7 @@ class ComputeJobFailover<R> {
     }
 
     private JobExecution<R> launchJobOn(ClusterNode runningWorkerNode) {
-        if (runningWorkerNode.id().equals(topologyService.localMember().id())) {
+        if (runningWorkerNode.name().equals(topologyService.localMember().name())) {
             return computeComponent.executeLocally(
                     jobContext.executionOptions(), jobContext.units(), jobContext.jobClassName(), jobContext.arg()
             );

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeImpl.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeImpl.java
@@ -119,19 +119,6 @@ public class IgniteComputeImpl implements IgniteComputeInternal, StreamerReceive
         if (target instanceof AnyNodeJobTarget) {
             Set<ClusterNode> nodes = ((AnyNodeJobTarget) target).nodes();
 
-            if (nodes.size() == 1) {
-                ClusterNode node = nodes.iterator().next();
-                if (node.id().equals(topologyService.localMember().id())) {
-                    return new ResultUnmarshallingJobExecution<>(
-                            executeAsyncWithFailover(
-                                    nodes, descriptor.units(), descriptor.jobClassName(), descriptor.options(),
-                                    tryMarshalOrCast(argumentMarshaller, args)
-                            ),
-                            resultMarshaller
-                    );
-                }
-            }
-
             return new ResultUnmarshallingJobExecution<>(
                     executeAsyncWithFailover(
                             nodes, descriptor.units(), descriptor.jobClassName(), descriptor.options(),
@@ -266,7 +253,7 @@ public class IgniteComputeImpl implements IgniteComputeInternal, StreamerReceive
     }
 
     private boolean isLocal(ClusterNode targetNode) {
-        return targetNode.id().equals(topologyService.localMember().id());
+        return targetNode.name().equals(topologyService.localMember().name());
     }
 
     @Override

--- a/modules/compute/src/test/java/org/apache/ignite/internal/compute/IgniteComputeImplTest.java
+++ b/modules/compute/src/test/java/org/apache/ignite/internal/compute/IgniteComputeImplTest.java
@@ -122,6 +122,24 @@ class IgniteComputeImplTest extends BaseIgniteAbstractTest {
     }
 
     @Test
+    void whenNodeIsLocalAndIdIsChangedThenExecutesLocally() {
+        respondWhenExecutingSimpleJobLocally(ExecutionOptions.DEFAULT);
+
+        // Imitate node restart by changing the id.
+        ClusterNode newNode = new ClusterNodeImpl(randomUUID(), localNode.name(), localNode.address());
+
+        assertThat(
+                compute.executeAsync(
+                        JobTarget.node(newNode),
+                        JobDescriptor.builder(JOB_CLASS_NAME).units(testDeploymentUnits).build(),
+                        "a"),
+                willBe("jobResponse")
+        );
+
+        verify(computeComponent).executeLocally(ExecutionOptions.DEFAULT, testDeploymentUnits, JOB_CLASS_NAME, "a");
+    }
+
+    @Test
     void whenNodeIsRemoteThenExecutesRemotely() {
         respondWhenExecutingSimpleJobRemotely(ExecutionOptions.DEFAULT);
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/app/ItInProcessRestartApiReferencesTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/app/ItInProcessRestartApiReferencesTest.java
@@ -17,12 +17,16 @@
 
 package org.apache.ignite.internal.app;
 
+import static org.apache.ignite.compute.JobTarget.anyNode;
 import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willCompleteSuccessfully;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import org.apache.ignite.compute.JobDescriptor;
+import org.apache.ignite.compute.JobExecution;
 import org.apache.ignite.internal.ClusterPerClassIntegrationTest;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Enum;
 
@@ -35,8 +39,6 @@ import org.junitpioneer.jupiter.cartesian.CartesianTest.Enum;
  * </ul>
  */
 class ItInProcessRestartApiReferencesTest extends ClusterPerClassIntegrationTest {
-    private static IgniteServerImpl server;
-
     private static References beforeRestart;
 
     private static References afterRestart;
@@ -47,8 +49,8 @@ class ItInProcessRestartApiReferencesTest extends ClusterPerClassIntegrationTest
     }
 
     @BeforeAll
-    void init() throws Exception {
-        server = (IgniteServerImpl) CLUSTER.server(0);
+    static void init() throws Exception {
+        IgniteServerImpl server = (IgniteServerImpl) CLUSTER.server(0);
 
         server.api().sql().executeScript("CREATE TABLE test (id INT PRIMARY KEY, val VARCHAR)");
 
@@ -57,6 +59,16 @@ class ItInProcessRestartApiReferencesTest extends ClusterPerClassIntegrationTest
         assertThat(server.restartAsync(), willCompleteSuccessfully());
 
         afterRestart = new References(server);
+    }
+
+    @Test
+    void submitStaysLocalAfterRestart() {
+        JobExecution<String> execution = beforeRestart.compute.submit(
+                anyNode(beforeRestart.clusterNodes),
+                JobDescriptor.builder(NoOpJob.class).build(),
+                null
+        );
+        assertThat(execution.stateAsync(), willCompleteSuccessfully());
     }
 
     @CartesianTest


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23233

Compare cluster nodes by consistent id rather than id when determining whether the execution should be local or remote.
Send the network messages by consistent id.