### PR TITLE
IGNITE-23374 Java thin: Fix Netty buffer leak

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -607,7 +607,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
         });
 
         return fut
-                .thenApplyAsync(ClientMessageUnpacker::retain)
+                .thenApply(ClientMessageUnpacker::retain)
                 .handleAsync((unpacker, err) -> {
                     if (err != null) {
                         if (err instanceof TimeoutException || err.getCause() instanceof TimeoutException) {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -425,22 +425,22 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
      * @param notificationFut Notify future.
      * @param unpacker Unpacked message.
      */
-    private <T> T complete(
-            PayloadReader<T> payloadReader,
-            CompletableFuture<PayloadInputChannel> notificationFut,
+    private <T> @Nullable T complete(
+            @Nullable PayloadReader<T> payloadReader,
+            @Nullable CompletableFuture<PayloadInputChannel> notificationFut,
             ClientMessageUnpacker unpacker
     ) {
         try (unpacker) {
             if (payloadReader != null) {
                 return payloadReader.apply(new PayloadInputChannel(this, unpacker, notificationFut));
             }
+
+            return null;
         } catch (Throwable e) {
             log.error("Failed to deserialize server response [remoteAddress=" + cfg.getAddress() + "]: " + e.getMessage(), e);
 
             throw new IgniteException(PROTOCOL_ERR, "Failed to deserialize server response: " + e.getMessage(), e);
         }
-
-        return null;
     }
 
     /**

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -607,7 +607,8 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
         });
 
         return fut
-                .handle((unpacker, err) -> {
+                .thenApplyAsync(ClientMessageUnpacker::retain)
+                .handleAsync((unpacker, err) -> {
                     if (err != null) {
                         if (err instanceof TimeoutException || err.getCause() instanceof TimeoutException) {
                             metrics.handshakesFailedTimeoutIncrement();
@@ -624,7 +625,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
                         metrics.handshakesFailedIncrement();
                         throw new IgniteClientConnectionException(CONNECTION_ERR, "Handshake error", endpoint(), th);
                     }
-                });
+                }, asyncContinuationExecutor);
     }
 
     /**

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -280,6 +280,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
 
             processNextMessage(unpacker);
         } catch (Throwable t) {
+            buf.release();
             close(t, false);
         }
     }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -576,7 +576,9 @@ public class ClientTable implements Table {
         assert in != null;
         assert schemaId != null;
 
-        var resFut = getSchema(schemaId).thenApply(schema -> fn.apply(schema, in));
+        // Retain unpacker while schema is loading.
+        in.in().retain();
+        CompletableFuture<T> resFut = getSchema(schemaId).thenApply(schema -> fn.apply(schema, in));
 
         // Close unpacker.
         resFut.handle((tuple, err) -> {

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTable.java
@@ -576,8 +576,6 @@ public class ClientTable implements Table {
         assert in != null;
         assert schemaId != null;
 
-        // Retain unpacker while schema is loading.
-        in.in().retain();
         CompletableFuture<T> resFut = getSchema(schemaId).thenApply(schema -> fn.apply(schema, in));
 
         // Close unpacker.

--- a/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -79,7 +79,7 @@ public class ConnectionTest extends AbstractClientTest {
 
         // It does not seem possible to verify that it's a 'Connection refused' exception because with different
         // user locales the message differs, so let's just check that the message ends with the known suffix.
-        assertThat(errMsg, endsWith(" [endpoint=127.0.0.1:47500]"));
+        assertThat(errMsg, endsWith(":47500]"));
     }
 
     @Test
@@ -147,7 +147,7 @@ public class ConnectionTest extends AbstractClientTest {
             assertThrowsWithCause(
                     clientBuilder::build,
                     IgniteClientConnectionException.class,
-                    "Handshake timeout [endpoint=127.0.0.1:" + testServer.port() + "]"
+                    "Handshake timeout [endpoint=127.0.0.1"
             );
 
             testServer.enableClientRequestHandling();


### PR DESCRIPTION
* Restore `try (var unpacker = new ClientMessageUnpacker(buf)) {` in `onMessage` (entry point)
* Add `retain()` where needed

Adding `retain()` in places where the buffer escapes current thread is easier than hunting leaks (forgotten `release` calls).

https://issues.apache.org/jira/browse/IGNITE-23374