### PR TITLE
IGNITE-23375 Write logs to console and file in zip distribution

### DIFF
--- a/packaging/db/zip/ignite.java.util.logging.properties
+++ b/packaging/db/zip/ignite.java.util.logging.properties
@@ -25,9 +25,7 @@
 #
 # Comma-separated list of logging "handlers". Note that some of them may be
 # reconfigured (or even removed) at runtime according to system properties.
-# Add file handler to log output to the file along with console:
-# handlers=java.util.logging.ConsoleHandler, java.util.logging.FileHandler
-handlers=java.util.logging.ConsoleHandler
+handlers=java.util.logging.ConsoleHandler, java.util.logging.FileHandler
 
 #
 # Default global logging level.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23375

There's a separate log configuration for the deb/rpm/msi packages in the `packaging/db/ignite.java.util.logging.properties` which logs to the file only.
The configuration for docker in the `packaging/docker/ignite.java.util.logging.properties` logs to console only.
The zip distribution configuration in the `packaging/zip/ignite.java.util.logging.properties` logs to both file and console.