### PR TITLE
IGNITE-23381 Fix excessive locking in VersatileReadWriteLock

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/util/VersatileReadWriteLock.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/VersatileReadWriteLock.java
@@ -367,8 +367,6 @@ public class VersatileReadWriteLock {
         }
 
         for (Iterator<CompletableFuture<Void>> iterator = writeLockWaitSet.iterator(); iterator.hasNext(); ) {
-            CompletableFuture<Void> future = iterator.next();
-
             if (!tryWriteLock()) {
                 // Someone has already acquired a conflicting lock, we're too late, let's wait for next opportunity.
                 break;
@@ -379,6 +377,8 @@ public class VersatileReadWriteLock {
             // we will need to release the lock.
             // We can use non-atomic pattern 'check whether future is done, and if not, finalize acquisition and complete the future'
             // because this is done in the critical section (under protection 'holding the write lock' invariant).
+
+            CompletableFuture<Void> future = iterator.next();
 
             // Removing as soon as possible to avoid an infinite recursion in the #writeUnlock() call that follows.
             iterator.remove();
@@ -406,12 +406,12 @@ public class VersatileReadWriteLock {
         }
 
         for (Iterator<CompletableFuture<Void>> iterator = readLockWaitSet.iterator(); iterator.hasNext(); ) {
-            CompletableFuture<Void> future = iterator.next();
-
             if (!tryReadLock()) {
                 // Someone has already acquired a write lock, we're too late, let's wait for next opportunity.
                 break;
             }
+
+            CompletableFuture<Void> future = iterator.next();
 
             iterator.remove();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/VersatileReadWriteLock.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/VersatileReadWriteLock.java
@@ -340,12 +340,13 @@ public class VersatileReadWriteLock {
     public void writeUnlock() {
         while (true) {
             int curState = state;
-            // There could still be some read locks if the write lock was taken forcefully.
-            int readLocks = readLocks(curState);
 
             if (!writeLocked(curState)) {
                 throw new IllegalMonitorStateException();
             }
+
+            // There could still be some read locks if the write lock was taken forcefully.
+            int readLocks = readLocks(curState);
 
             if (STATE_VH.compareAndSet(this, state, state(false, readLocks))) {
                 break;

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/VersatileReadWriteLock.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/VersatileReadWriteLock.java
@@ -105,7 +105,7 @@ public class VersatileReadWriteLock {
     /** Futures to be completed when read locks (one per future) are acquired after a write lock is released. */
     private final Set<CompletableFuture<Void>> readLockWaitSet = ConcurrentHashMap.newKeySet();
 
-    /** Futures to be completed when a write lock (one per future) is acquired after an impeding lock is released. */
+    /** Futures to be completed when a write lock (one per future) is acquired after a conflicting lock is released. */
     private final Set<CompletableFuture<Void>> writeLockWaitSet = ConcurrentHashMap.newKeySet();
 
     /** In this pool {@link #readLockWaitSet} and {@link #writeLockWaitSet} will be completed. */
@@ -391,7 +391,7 @@ public class VersatileReadWriteLock {
                     writeUnlock();
                 }
             } else {
-                // Someone has already acquired an impeding lock, we're too late, let's wait for next opportunity.
+                // Someone has already acquired a conflicting lock, we're too late, let's wait for next opportunity.
                 break;
             }
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/VersatileReadWriteLock.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/VersatileReadWriteLock.java
@@ -348,7 +348,7 @@ public class VersatileReadWriteLock {
             // There could still be some read locks if the write lock was taken forcefully.
             int readLocks = readLocks(curState);
 
-            if (STATE_VH.compareAndSet(this, state, state(false, readLocks))) {
+            if (STATE_VH.compareAndSet(this, curState, state(false, readLocks))) {
                 break;
             }
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/VersatileReadWriteLock.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/VersatileReadWriteLock.java
@@ -380,7 +380,7 @@ public class VersatileReadWriteLock {
                 iterator.remove();
 
                 if (!future.isDone()) {
-                    // First finalize the aqcuisition.
+                    // First finalize the acquisition.
                     decrementPendingWriteLocks();
 
                     asyncContinuationExecutor.execute(() -> future.complete(null));

--- a/modules/core/src/test/java/org/apache/ignite/internal/util/VersatileReadWriteLockTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/util/VersatileReadWriteLockTest.java
@@ -382,15 +382,11 @@ class VersatileReadWriteLockTest {
     }
 
     private void assertThatNoReadLockIsHeld() {
-        assertTrue(lock.tryWriteLock(), "Read lock is still held");
-
-        lock.writeUnlock();
+        assertThat("Read locks are still held", lock.readLocksHeld(), is(0));
     }
 
     private void assertThatNoWriteLockIsHeld() {
-        assertTrue(lock.tryReadLock(), "Write lock is still held");
-
-        lock.readUnlock();
+        assertFalse(lock.isWriteLocked(), "Write lock is still held");
     }
 
     @Test
@@ -452,7 +448,7 @@ class VersatileReadWriteLockTest {
     }
 
     @Test
-    void concurrentInReadLockAsyncAndWriteLockWorkCorrectly() {
+    void concurrentInReadLockAsyncAndWriteLockWorkCorrectly() throws Exception {
         RunnableX readLocker = () -> {
             for (int i = 0; i < 300; i++) {
                 lock.inReadLockAsync(CompletableFutures::nullCompletedFuture).get(10, SECONDS);
@@ -467,8 +463,22 @@ class VersatileReadWriteLockTest {
 
         runRace(10_000, readLocker, writeLocker);
 
-        assertThatNoReadLockIsHeld();
-        assertThatNoWriteLockIsHeld();
+        assertThatReadLocksHeldReachesZero();
+        assertThatWriteLockGetsUnlocked();
+    }
+
+    private void assertThatReadLocksHeldReachesZero() throws InterruptedException {
+        assertTrue(
+                waitForCondition(() -> lock.readLocksHeld() == 0, SECONDS.toMillis(10)),
+                () -> "Read locks are still held " + lock.readLocksHeld()
+        );
+    }
+
+    private void assertThatWriteLockGetsUnlocked() throws InterruptedException {
+        assertTrue(
+                waitForCondition(() -> !lock.isWriteLocked(), SECONDS.toMillis(10)),
+                () -> "Still write locked"
+        );
     }
 
     @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23381

* When async attempt to acquire a write lock is handled, lock acquisition could be registered twice
* Write unlocking logic could corrupt read lock count
* A test was flaky because it did not account for asynchrony
