### PR TITLE
IGNITE-23396 Fix Netty buffer leak on client

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -474,7 +474,16 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
         if (err == null) {
             metrics.requestsCompletedIncrement();
 
-            pendingReq.future().complete(unpacker.retain());
+            unpacker.retain();
+            try {
+                if (!pendingReq.future().complete(unpacker)) {
+                    unpacker.close();
+                }
+            } catch (Throwable t) {
+                unpacker.close();
+                throw t;
+            }
+
         } else {
             metrics.requestsFailedIncrement();
             notificationHandlers.remove(resId);

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -785,7 +785,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
     }
 
     private static void completeRequestFuture(CompletableFuture<ClientMessageUnpacker> fut, ClientMessageUnpacker unpacker) {
-        // We jump to another thread - add reference count.
+        // Add reference count before jumping onto another thread (due to handleAsync() in send()).
         unpacker.retain();
 
         try {

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientComputeTest.java
@@ -351,6 +351,10 @@ public class ClientComputeTest extends BaseIgniteAbstractTest {
             CompletableFuture<String> threadNameFut = new CompletableFuture<>();
             execution.resultAsync().thenAccept(unused -> threadNameFut.complete(Thread.currentThread().getName()));
 
+            // Wait for the job to start on the server.
+            execution.idAsync().join();
+
+            // Complete job future to trigger server -> client notification.
             jobFut.complete("res");
             assertThat(threadNameFut.join(), startsWith("ForkJoinPool.commonPool-worker-"));
         }


### PR DESCRIPTION
* Add checks for `CompletableFuture#complete` results - when false, the future is already completed by another thread (e.g. channel is closing), so the buffer has to be released.
* Use `asyncContinuationExecutor` for notifications, add test.