### PR TITLE
IGNITE-23405 Fix some issues reported by undefined behavior sanitizer

### DIFF
--- a/modules/platforms/cpp/ignite/tuple/binary_tuple_builder.cpp
+++ b/modules/platforms/cpp/ignite/tuple/binary_tuple_builder.cpp
@@ -348,8 +348,10 @@ void binary_tuple_builder::append_bytes(bytes_view bytes) {
     assert(element_index < element_count);
     assert(next_value + bytes.size() <= value_base + value_area_size);
 
-    std::memcpy(next_value, bytes.data(), bytes.size());
-    next_value += bytes.size();
+    if (!bytes.empty()) {
+        std::memcpy(next_value, bytes.data(), bytes.size());
+        next_value += bytes.size();
+    }
 
     append_entry();
 }

--- a/modules/platforms/cpp/ignite/tuple/binary_tuple_builder.h
+++ b/modules/platforms/cpp/ignite/tuple/binary_tuple_builder.h
@@ -442,9 +442,7 @@ private:
         static_assert(std::is_signed_v<SRC>);
         static_assert(std::is_signed_v<TGT>);
         static_assert(sizeof(TGT) < sizeof(SRC));
-        // Check if TGT::min <= value <= TGT::max.
-        return std::make_unsigned_t<SRC>(value + std::numeric_limits<TGT>::max() + 1)
-            <= std::numeric_limits<std::make_unsigned_t<TGT>>::max();
+        return std::numeric_limits<TGT>::min() <= value && value <= std::numeric_limits<TGT>::max();
     }
 
     /**


### PR DESCRIPTION
The old calculation in `fits` could result in a signed integer overflow. The new version uses two comparisons combined with a logical and, but the compiler is smart enough to generate even better code than for the old version.

If append_bytes is called with an empty view memcpy could be called with a nullptr which ubsan complained about, even though we are not copying anything.

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)