### PR TITLE
IGNITE-23367 Fix testManyItemsWithDisconnectAndRetry flakiness

### DIFF
--- a/modules/client/src/test/java/org/apache/ignite/client/DataStreamerTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/DataStreamerTest.java
@@ -241,7 +241,7 @@ public class DataStreamerTest extends AbstractClientTableTest {
         try (var publisher = new SimplePublisher<Tuple>()) {
             var options = DataStreamerOptions.builder()
                     .pageSize(2)
-                    .perPartitionParallelOperations(4)
+                    .perPartitionParallelOperations(2)
                     .build();
 
             streamFut = withReceiver


### PR DESCRIPTION
Reduce `perPartitionParallelOperations` to avoid exhausting retry count.