### PR TITLE
IGNITE-22975 Improve detection of minimum catalog version required by active transactions

### DIFF
--- a/modules/catalog-compaction/build.gradle
+++ b/modules/catalog-compaction/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation libs.jetbrains.annotations
     implementation libs.fastutil.core
 
+    testImplementation project(':ignite-index')
     testImplementation(testFixtures(project(':ignite-core')))
     testImplementation(testFixtures(project(':ignite-metastorage')))
     testImplementation(testFixtures(project(':ignite-catalog')))

--- a/modules/catalog-compaction/build.gradle
+++ b/modules/catalog-compaction/build.gradle
@@ -51,10 +51,12 @@ dependencies {
     integrationTestImplementation libs.fastutil.core
     integrationTestImplementation project(':ignite-api')
     integrationTestImplementation project(':ignite-catalog')
+    integrationTestImplementation project(':ignite-cluster-management')
     integrationTestImplementation project(':ignite-placement-driver-api')
     integrationTestImplementation project(':ignite-transactions')
     integrationTestImplementation project(':ignite-raft')
     integrationTestImplementation project(':ignite-raft-api')
+    integrationTestImplementation project(':ignite-system-view')
     integrationTestImplementation project(':ignite-system-view-api')
     integrationTestImplementation project(':ignite-table')
     integrationTestImplementation testFixtures(project(':ignite-core'))

--- a/modules/catalog-compaction/src/integrationTest/java/org/apache/ignite/internal/catalog/compaction/ItCatalogCompactionTest.java
+++ b/modules/catalog-compaction/src/integrationTest/java/org/apache/ignite/internal/catalog/compaction/ItCatalogCompactionTest.java
@@ -168,21 +168,21 @@ class ItCatalogCompactionTest extends ClusterPerClassIntegrationTest {
 
         compactors.forEach(compactor -> {
             TimeHolder timeHolder = await(compactor.determineGlobalMinimumRequiredTime(topologyNodes, 0L));
-            assertThat(timeHolder.minActiveTxBeginTime, is(catalog1.time()));
+            assertThat(timeHolder.txMinRequiredTime, is(catalog1.time()));
         });
 
         tx1.rollback();
 
         compactors.forEach(compactor -> {
             TimeHolder timeHolder = await(compactor.determineGlobalMinimumRequiredTime(topologyNodes, 0L));
-            assertThat(timeHolder.minActiveTxBeginTime, is(catalog2.time()));
+            assertThat(timeHolder.txMinRequiredTime, is(catalog2.time()));
         });
 
         tx2.commit();
 
         compactors.forEach(compactor -> {
             TimeHolder timeHolder = await(compactor.determineGlobalMinimumRequiredTime(topologyNodes, 0L));
-            assertThat(timeHolder.minActiveTxBeginTime, is(catalog3.time()));
+            assertThat(timeHolder.txMinRequiredTime, is(catalog3.time()));
         });
 
         tx3.rollback();
@@ -196,10 +196,10 @@ class ItCatalogCompactionTest extends ClusterPerClassIntegrationTest {
             long maxTime = Stream.of(node0, node1, node2).map(node -> node.clockService().nowLong()).min(Long::compareTo).orElseThrow();
 
             // Read-only transactions are not counted,
-            assertThat(timeHolder.minActiveTxBeginTime, greaterThan(ignoredReadonlyTx.startTimestamp().longValue()));
+            assertThat(timeHolder.txMinRequiredTime, greaterThan(ignoredReadonlyTx.startTimestamp().longValue()));
 
-            assertThat(timeHolder.minActiveTxBeginTime, greaterThanOrEqualTo(minTime));
-            assertThat(timeHolder.minActiveTxBeginTime, lessThanOrEqualTo(maxTime));
+            assertThat(timeHolder.txMinRequiredTime, greaterThanOrEqualTo(minTime));
+            assertThat(timeHolder.txMinRequiredTime, lessThanOrEqualTo(maxTime));
         });
 
         ignoredReadonlyTx.rollback();

--- a/modules/catalog-compaction/src/main/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunner.java
+++ b/modules/catalog-compaction/src/main/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunner.java
@@ -301,13 +301,13 @@ public class CatalogCompactionRunner implements IgniteComponent {
                             allPartitions
                     );
 
-                    LOG.debug("Propagate minimum active tx begin time to replicas [timestamp={}].", txMinRequiredTime);
+                    LOG.debug("Propagate minimum required tx time to replicas [timestamp={}].", txMinRequiredTime);
 
                     CompletableFuture<Void> propagateToReplicasFut =
                             propagateTimeToNodes(txMinRequiredTime, topologySnapshot.nodes())
                                     .whenComplete((ignore, ex) -> {
                                         if (ex != null) {
-                                            LOG.warn("Failed to propagate minimum required time to replicas.", ex);
+                                            LOG.warn("Failed to propagate minimum required tx time to replicas.", ex);
                                         }
                                     });
 

--- a/modules/catalog-compaction/src/main/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunner.java
+++ b/modules/catalog-compaction/src/main/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunner.java
@@ -72,7 +72,7 @@ import org.apache.ignite.internal.replicator.message.ReplicaMessagesFactory;
 import org.apache.ignite.internal.replicator.message.TablePartitionIdMessage;
 import org.apache.ignite.internal.schema.SchemaSyncService;
 import org.apache.ignite.internal.table.distributed.raft.MinimumRequiredTimeCollectorService;
-import org.apache.ignite.internal.tx.ActiveLocalTxMinimumBeginTimeProvider;
+import org.apache.ignite.internal.tx.ActiveLocalTxMinimumRequiredCatalogTimeProvider;
 import org.apache.ignite.internal.util.CompletableFutures;
 import org.apache.ignite.internal.util.IgniteSpinBusyLock;
 import org.apache.ignite.internal.util.Pair;
@@ -125,7 +125,7 @@ public class CatalogCompactionRunner implements IgniteComponent {
 
     private final String localNodeName;
 
-    private final ActiveLocalTxMinimumBeginTimeProvider activeLocalTxMinimumBeginTimeProvider;
+    private final ActiveLocalTxMinimumRequiredCatalogTimeProvider activeLocalTxMinimumBeginTimeProvider;
 
     private final ReplicaService replicaService;
 
@@ -162,7 +162,7 @@ public class CatalogCompactionRunner implements IgniteComponent {
             SchemaSyncService schemaSyncService,
             TopologyService topologyService,
             Executor executor,
-            ActiveLocalTxMinimumBeginTimeProvider activeLocalTxMinimumBeginTimeProvider,
+            ActiveLocalTxMinimumRequiredCatalogTimeProvider activeLocalTxMinimumBeginTimeProvider,
             MinimumRequiredTimeCollectorService minimumRequiredTimeCollectorService
     ) {
         this.localNodeName = localNodeName;
@@ -349,7 +349,7 @@ public class CatalogCompactionRunner implements IgniteComponent {
         return CompletableFuture.allOf(responseFutures.toArray(new CompletableFuture[0]))
                 .thenApply(ignore -> {
                     long globalMinimumRequiredTime = localMinimumRequiredTime;
-                    long globalMinimumActiveTxTime = activeLocalTxMinimumBeginTimeProvider.minimumBeginTime().longValue();
+                    long globalMinimumActiveTxTime = activeLocalTxMinimumBeginTimeProvider.minimumRequiredTime();
 
                     Map<String, Map<Integer, BitSet>> allPartitions = new HashMap<>();
                     allPartitions.put(localNodeName, localPartitions);
@@ -666,7 +666,7 @@ public class CatalogCompactionRunner implements IgniteComponent {
 
             CatalogCompactionMinimumTimesResponse response = COMPACTION_MESSAGES_FACTORY.catalogCompactionMinimumTimesResponse()
                     .minimumRequiredTime(minRequiredTime)
-                    .minimumActiveTxTime(activeLocalTxMinimumBeginTimeProvider.minimumBeginTime().longValue())
+                    .minimumActiveTxTime(activeLocalTxMinimumBeginTimeProvider.minimumRequiredTime())
                     .partitions(availablePartitionsMessages(availablePartitions))
                     .build();
 

--- a/modules/catalog-compaction/src/main/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunner.java
+++ b/modules/catalog-compaction/src/main/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunner.java
@@ -72,7 +72,7 @@ import org.apache.ignite.internal.replicator.message.ReplicaMessagesFactory;
 import org.apache.ignite.internal.replicator.message.TablePartitionIdMessage;
 import org.apache.ignite.internal.schema.SchemaSyncService;
 import org.apache.ignite.internal.table.distributed.raft.MinimumRequiredTimeCollectorService;
-import org.apache.ignite.internal.tx.ActiveLocalTxMinimumRequiredCatalogTimeProvider;
+import org.apache.ignite.internal.tx.ActiveLocalTxMinimumRequiredTimeProvider;
 import org.apache.ignite.internal.util.CompletableFutures;
 import org.apache.ignite.internal.util.IgniteSpinBusyLock;
 import org.apache.ignite.internal.util.Pair;
@@ -125,7 +125,7 @@ public class CatalogCompactionRunner implements IgniteComponent {
 
     private final String localNodeName;
 
-    private final ActiveLocalTxMinimumRequiredCatalogTimeProvider activeLocalTxMinimumBeginTimeProvider;
+    private final ActiveLocalTxMinimumRequiredTimeProvider activeLocalTxMinimumRequiredTimeProvider;
 
     private final ReplicaService replicaService;
 
@@ -162,7 +162,7 @@ public class CatalogCompactionRunner implements IgniteComponent {
             SchemaSyncService schemaSyncService,
             TopologyService topologyService,
             Executor executor,
-            ActiveLocalTxMinimumRequiredCatalogTimeProvider activeLocalTxMinimumBeginTimeProvider,
+            ActiveLocalTxMinimumRequiredTimeProvider activeLocalTxMinimumRequiredTimeProvider,
             MinimumRequiredTimeCollectorService minimumRequiredTimeCollectorService
     ) {
         this.localNodeName = localNodeName;
@@ -175,7 +175,7 @@ public class CatalogCompactionRunner implements IgniteComponent {
         this.placementDriver = placementDriver;
         this.replicaService = replicaService;
         this.executor = executor;
-        this.activeLocalTxMinimumBeginTimeProvider = activeLocalTxMinimumBeginTimeProvider;
+        this.activeLocalTxMinimumRequiredTimeProvider = activeLocalTxMinimumRequiredTimeProvider;
         this.localMinTimeCollectorService = minimumRequiredTimeCollectorService;
     }
 
@@ -291,7 +291,7 @@ public class CatalogCompactionRunner implements IgniteComponent {
                 .thenComposeAsync(timeHolder -> {
 
                     long minRequiredTime = timeHolder.minRequiredTime;
-                    long minActiveTxBeginTime = timeHolder.minActiveTxBeginTime;
+                    long txMinRequiredTime = timeHolder.txMinRequiredTime;
                     Map<String, Map<Integer, BitSet>> allPartitions = timeHolder.allPartitions;
 
                     CompletableFuture<Boolean> catalogCompactionFut = tryCompactCatalog(
@@ -301,10 +301,10 @@ public class CatalogCompactionRunner implements IgniteComponent {
                             allPartitions
                     );
 
-                    LOG.debug("Propagate minimum active tx begin time to replicas [timestamp={}].", minActiveTxBeginTime);
+                    LOG.debug("Propagate minimum active tx begin time to replicas [timestamp={}].", txMinRequiredTime);
 
                     CompletableFuture<Void> propagateToReplicasFut =
-                            propagateTimeToNodes(minActiveTxBeginTime, topologySnapshot.nodes())
+                            propagateTimeToNodes(txMinRequiredTime, topologySnapshot.nodes())
                                     .whenComplete((ignore, ex) -> {
                                         if (ex != null) {
                                             LOG.warn("Failed to propagate minimum required time to replicas.", ex);
@@ -349,7 +349,7 @@ public class CatalogCompactionRunner implements IgniteComponent {
         return CompletableFuture.allOf(responseFutures.toArray(new CompletableFuture[0]))
                 .thenApply(ignore -> {
                     long globalMinimumRequiredTime = localMinimumRequiredTime;
-                    long globalMinimumActiveTxTime = activeLocalTxMinimumBeginTimeProvider.minimumRequiredTime();
+                    long globalMinimumTxRequiredTime = activeLocalTxMinimumRequiredTimeProvider.minimumRequiredTime();
 
                     Map<String, Map<Integer, BitSet>> allPartitions = new HashMap<>();
                     allPartitions.put(localNodeName, localPartitions);
@@ -364,14 +364,14 @@ public class CatalogCompactionRunner implements IgniteComponent {
                             globalMinimumRequiredTime = response.minimumRequiredTime();
                         }
 
-                        if (response.minimumActiveTxTime() < globalMinimumActiveTxTime) {
-                            globalMinimumActiveTxTime = response.minimumActiveTxTime();
+                        if (response.activeTxMinimumRequiredTime() < globalMinimumTxRequiredTime) {
+                            globalMinimumTxRequiredTime = response.activeTxMinimumRequiredTime();
                         }
 
                         allPartitions.put(nodeId, availablePartitionListToMap(response.partitions()));
                     }
 
-                    return new TimeHolder(globalMinimumRequiredTime, globalMinimumActiveTxTime, allPartitions);
+                    return new TimeHolder(globalMinimumRequiredTime, globalMinimumTxRequiredTime, allPartitions);
                 });
     }
 
@@ -666,7 +666,7 @@ public class CatalogCompactionRunner implements IgniteComponent {
 
             CatalogCompactionMinimumTimesResponse response = COMPACTION_MESSAGES_FACTORY.catalogCompactionMinimumTimesResponse()
                     .minimumRequiredTime(minRequiredTime)
-                    .minimumActiveTxTime(activeLocalTxMinimumBeginTimeProvider.minimumRequiredTime())
+                    .activeTxMinimumRequiredTime(activeLocalTxMinimumRequiredTimeProvider.minimumRequiredTime())
                     .partitions(availablePartitionsMessages(availablePartitions))
                     .build();
 
@@ -721,12 +721,12 @@ public class CatalogCompactionRunner implements IgniteComponent {
 
     static class TimeHolder {
         final long minRequiredTime;
-        final long minActiveTxBeginTime;
+        final long txMinRequiredTime;
         final Map<String, Map<Integer, BitSet>> allPartitions;
 
-        private TimeHolder(long minRequiredTime, long minActiveTxBeginTime, Map<String, Map<Integer, BitSet>> allPartitions) {
+        private TimeHolder(long minRequiredTime, long txMinRequiredTime, Map<String, Map<Integer, BitSet>> allPartitions) {
             this.minRequiredTime = minRequiredTime;
-            this.minActiveTxBeginTime = minActiveTxBeginTime;
+            this.txMinRequiredTime = txMinRequiredTime;
             this.allPartitions = allPartitions;
         }
     }

--- a/modules/catalog-compaction/src/main/java/org/apache/ignite/internal/catalog/compaction/message/CatalogCompactionMinimumTimesResponse.java
+++ b/modules/catalog-compaction/src/main/java/org/apache/ignite/internal/catalog/compaction/message/CatalogCompactionMinimumTimesResponse.java
@@ -36,8 +36,8 @@ public interface CatalogCompactionMinimumTimesResponse extends NetworkMessage {
     /** Returns node's minimum required time. */
     long minimumRequiredTime();
 
-    /** Returns node's minimum starting time among locally started active RW transactions. */
-    long minimumActiveTxTime();
+    /** Returns node's minimum time required by active RW transactions. */
+    long activeTxMinimumRequiredTime();
 
     /** Returns available table partitions. */
     List<AvailablePartitionsMessage> partitions();

--- a/modules/catalog-compaction/src/test/java/org/apache/ignite/internal/catalog/compaction/AbstractCatalogCompactionTest.java
+++ b/modules/catalog-compaction/src/test/java/org/apache/ignite/internal/catalog/compaction/AbstractCatalogCompactionTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 /** Base class for catalog compaction unit testing. */
 abstract class AbstractCatalogCompactionTest extends BaseIgniteAbstractTest {
-    private final HybridClock clock = new HybridClockImpl();
+    final HybridClock clock = new HybridClockImpl();
 
     private final ClockWaiter clockWaiter = new ClockWaiter("test-node", clock);
 

--- a/modules/catalog-compaction/src/test/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunnerSelfTest.java
+++ b/modules/catalog-compaction/src/test/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunnerSelfTest.java
@@ -1054,7 +1054,7 @@ public class CatalogCompactionRunnerSelfTest extends AbstractCatalogCompactionTe
                 schemaSyncService,
                 topologyService,
                 ForkJoinPool.commonPool(),
-                clockService::now,
+                clockService::nowLong,
                 minTimeCollector
         );
 

--- a/modules/catalog-compaction/src/test/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunnerSelfTest.java
+++ b/modules/catalog-compaction/src/test/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunnerSelfTest.java
@@ -1148,7 +1148,7 @@ public class CatalogCompactionRunnerSelfTest extends AbstractCatalogCompactionTe
 
             return messagesFactory.catalogCompactionMinimumTimesResponse()
                     .minimumRequiredTime(time)
-                    .minimumActiveTxTime(clockService.nowLong())
+                    .activeTxMinimumRequiredTime(clockService.nowLong())
                     .partitions(availablePartitions)
                     .build();
         }

--- a/modules/catalog-compaction/src/test/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunnerSelfTest.java
+++ b/modules/catalog-compaction/src/test/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunnerSelfTest.java
@@ -30,7 +30,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -89,6 +91,7 @@ import org.apache.ignite.internal.cluster.management.topology.api.LogicalTopolog
 import org.apache.ignite.internal.cluster.management.topology.api.LogicalTopologySnapshot;
 import org.apache.ignite.internal.hlc.ClockService;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
+import org.apache.ignite.internal.index.IndexNodeFinishedRwTransactionsChecker;
 import org.apache.ignite.internal.manager.ComponentContext;
 import org.apache.ignite.internal.network.ClusterNodeImpl;
 import org.apache.ignite.internal.network.MessagingService;
@@ -930,6 +933,65 @@ public class CatalogCompactionRunnerSelfTest extends AbstractCatalogCompactionTe
             //noinspection ThrowableNotThrown
             assertThrows(ArithmeticException.class, () -> await(fut), "Expected exception");
         }
+    }
+
+    @Test
+    public void txMinimumRequiredTime() {
+        MessagingService messagingService = mock(MessagingService.class);
+
+        IndexNodeFinishedRwTransactionsChecker checker =
+                new IndexNodeFinishedRwTransactionsChecker(catalogManager, messagingService, clock);
+
+        int catalogsCount = 5;
+        int txPerCatalogCount = 100;
+
+        List<HybridTimestamp> txsBeginTime = new ArrayList<>(catalogsCount * txPerCatalogCount);
+
+        int initCatalogVersion = catalogManager.latestCatalogVersion();
+
+        for (int c = 0; c < catalogsCount; c++) {
+            await(catalogManager.execute(TestCommand.ok()));
+
+            for (int i = 0; i < txPerCatalogCount; i++) {
+                checker.inUpdateRwTxCountLock(() -> {
+                    HybridTimestamp ts = clockService.now();
+                    txsBeginTime.add(ts);
+                    checker.incrementRwTxCount(ts);
+
+                    return null;
+                });
+            }
+        }
+
+        // Sequentially decrease the transaction counter and check the minimum required time.
+        int expectedCatalogVersion = initCatalogVersion;
+
+        for (int n = 0; n < txsBeginTime.size(); n++) {
+            if (n % txPerCatalogCount == 0) {
+                ++expectedCatalogVersion;
+            }
+
+            Catalog catalog = catalogManager.catalog(expectedCatalogVersion);
+            assertNotNull(catalog);
+
+            assertThat("i=" + n + ", expVer=" + expectedCatalogVersion, checker.minimumRequiredTime(), is(catalog.time()));
+
+            HybridTimestamp txTs = txsBeginTime.get(n);
+
+            checker.inUpdateRwTxCountLock(() -> {
+                checker.decrementRwTxCount(txTs);
+
+                return null;
+            });
+        }
+
+        // No active transactions - method must return current time.
+        long ts1 = clock.nowLong();
+        long time = checker.minimumRequiredTime();
+        long ts2 = clock.nowLong();
+
+        assertThat(ts2, greaterThan(time));
+        assertThat(ts1, lessThan(time));
     }
 
     private Catalog prepareCatalogWithTables() {

--- a/modules/index/src/main/java/org/apache/ignite/internal/index/IndexNodeFinishedRwTransactionsChecker.java
+++ b/modules/index/src/main/java/org/apache/ignite/internal/index/IndexNodeFinishedRwTransactionsChecker.java
@@ -152,14 +152,16 @@ public class IndexNodeFinishedRwTransactionsChecker implements LocalRwTxCounter,
 
     @Override
     public long minimumRequiredTime() {
-        readWriteLock.writeLock().lock();
-
         int minRequiredVer;
+
+        readWriteLock.writeLock().lock();
 
         try {
             Entry<Integer, Long> entry = txCountByCatalogVersion.firstEntry();
 
             if (entry == null) {
+                // Write lock guarantees that this timestamp will be less
+                // than the begin time of any concurrently started transaction.
                 return clock.now().longValue();
             }
 

--- a/modules/index/src/main/java/org/apache/ignite/internal/index/IndexNodeFinishedRwTransactionsChecker.java
+++ b/modules/index/src/main/java/org/apache/ignite/internal/index/IndexNodeFinishedRwTransactionsChecker.java
@@ -22,6 +22,7 @@ import static org.apache.ignite.internal.util.IgniteUtils.inBusyLock;
 import static org.apache.ignite.internal.util.IgniteUtils.inBusyLockAsync;
 
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,6 +30,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
+import org.apache.ignite.internal.catalog.Catalog;
 import org.apache.ignite.internal.catalog.CatalogService;
 import org.apache.ignite.internal.hlc.HybridClock;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
@@ -40,7 +42,7 @@ import org.apache.ignite.internal.manager.IgniteComponent;
 import org.apache.ignite.internal.network.MessagingService;
 import org.apache.ignite.internal.network.NetworkMessage;
 import org.apache.ignite.internal.network.NetworkMessageHandler;
-import org.apache.ignite.internal.tx.ActiveLocalTxMinimumBeginTimeProvider;
+import org.apache.ignite.internal.tx.ActiveLocalTxMinimumRequiredCatalogTimeProvider;
 import org.apache.ignite.internal.tx.LocalRwTxCounter;
 import org.apache.ignite.internal.util.IgniteSpinBusyLock;
 import org.apache.ignite.network.ClusterNode;
@@ -50,7 +52,8 @@ import org.jetbrains.annotations.Nullable;
  * Local node RW transaction completion checker for indexes. Main task is to handle the
  * {@link IsNodeFinishedRwTransactionsStartedBeforeRequest}.
  */
-public class IndexNodeFinishedRwTransactionsChecker implements LocalRwTxCounter, ActiveLocalTxMinimumBeginTimeProvider, IgniteComponent {
+public class IndexNodeFinishedRwTransactionsChecker implements LocalRwTxCounter, ActiveLocalTxMinimumRequiredCatalogTimeProvider,
+        IgniteComponent {
     private static final IndexMessagesFactory FACTORY = new IndexMessagesFactory();
 
     private final ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
@@ -148,17 +151,28 @@ public class IndexNodeFinishedRwTransactionsChecker implements LocalRwTxCounter,
     }
 
     @Override
-    public HybridTimestamp minimumBeginTime() {
+    public long minimumRequiredTime() {
         readWriteLock.writeLock().lock();
 
+        int minRequiredVer;
+
         try {
-            // TODO https://issues.apache.org/jira/browse/IGNITE-22975 Improve minimum begin time determination
-            return txCatalogVersionByBeginTxTs.keySet().stream()
-                    .min(HybridTimestamp::compareTo)
-                    .orElse(clock.now());
+            Entry<Integer, Long> entry = txCountByCatalogVersion.lastEntry();
+
+            if (entry == null) {
+                return clock.now().longValue();
+            }
+
+            minRequiredVer = entry.getKey();;
         } finally {
             readWriteLock.writeLock().unlock();
         }
+
+        Catalog catalog = catalogService.catalog(minRequiredVer);
+
+        assert catalog != null : "ver=" + minRequiredVer;
+
+        return catalog.time();
     }
 
     /**

--- a/modules/index/src/main/java/org/apache/ignite/internal/index/IndexNodeFinishedRwTransactionsChecker.java
+++ b/modules/index/src/main/java/org/apache/ignite/internal/index/IndexNodeFinishedRwTransactionsChecker.java
@@ -157,7 +157,7 @@ public class IndexNodeFinishedRwTransactionsChecker implements LocalRwTxCounter,
         int minRequiredVer;
 
         try {
-            Entry<Integer, Long> entry = txCountByCatalogVersion.lastEntry();
+            Entry<Integer, Long> entry = txCountByCatalogVersion.firstEntry();
 
             if (entry == null) {
                 return clock.now().longValue();

--- a/modules/index/src/main/java/org/apache/ignite/internal/index/IndexNodeFinishedRwTransactionsChecker.java
+++ b/modules/index/src/main/java/org/apache/ignite/internal/index/IndexNodeFinishedRwTransactionsChecker.java
@@ -42,7 +42,7 @@ import org.apache.ignite.internal.manager.IgniteComponent;
 import org.apache.ignite.internal.network.MessagingService;
 import org.apache.ignite.internal.network.NetworkMessage;
 import org.apache.ignite.internal.network.NetworkMessageHandler;
-import org.apache.ignite.internal.tx.ActiveLocalTxMinimumRequiredCatalogTimeProvider;
+import org.apache.ignite.internal.tx.ActiveLocalTxMinimumRequiredTimeProvider;
 import org.apache.ignite.internal.tx.LocalRwTxCounter;
 import org.apache.ignite.internal.util.IgniteSpinBusyLock;
 import org.apache.ignite.network.ClusterNode;
@@ -52,7 +52,7 @@ import org.jetbrains.annotations.Nullable;
  * Local node RW transaction completion checker for indexes. Main task is to handle the
  * {@link IsNodeFinishedRwTransactionsStartedBeforeRequest}.
  */
-public class IndexNodeFinishedRwTransactionsChecker implements LocalRwTxCounter, ActiveLocalTxMinimumRequiredCatalogTimeProvider,
+public class IndexNodeFinishedRwTransactionsChecker implements LocalRwTxCounter, ActiveLocalTxMinimumRequiredTimeProvider,
         IgniteComponent {
     private static final IndexMessagesFactory FACTORY = new IndexMessagesFactory();
 
@@ -163,14 +163,14 @@ public class IndexNodeFinishedRwTransactionsChecker implements LocalRwTxCounter,
                 return clock.now().longValue();
             }
 
-            minRequiredVer = entry.getKey();;
+            minRequiredVer = entry.getKey();
         } finally {
             readWriteLock.writeLock().unlock();
         }
 
         Catalog catalog = catalogService.catalog(minRequiredVer);
 
-        assert catalog != null : "ver=" + minRequiredVer;
+        assert catalog != null : "minRequiredVer=" + minRequiredVer;
 
         return catalog.time();
     }

--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/ActiveLocalTxMinimumRequiredCatalogTimeProvider.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/ActiveLocalTxMinimumRequiredCatalogTimeProvider.java
@@ -18,12 +18,14 @@
 package org.apache.ignite.internal.tx;
 
 /**
- * Provides the minimum required catalog timestamp among all active RW transactions started locally.
+ * Provides a timestamp corresponding to the activation time of the
+ * earliest catalog version that can be used by active local RW transactions.
  */
 @SuppressWarnings("InterfaceMayBeAnnotatedFunctional")
 public interface ActiveLocalTxMinimumRequiredCatalogTimeProvider {
     /**
-     * Returns the minimum required catalog timestamp among all active RW transactions started locally,
+     * Returns a timestamp corresponding to the activation time of the
+     * earliest catalog version that active local RW transactions can use,
      * or the current time if there are no active RW transactions.
      */
     long minimumRequiredTime();

--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/ActiveLocalTxMinimumRequiredCatalogTimeProvider.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/ActiveLocalTxMinimumRequiredCatalogTimeProvider.java
@@ -17,16 +17,14 @@
 
 package org.apache.ignite.internal.tx;
 
-import org.apache.ignite.internal.hlc.HybridTimestamp;
-
 /**
- * Provides the minimum begin time among all active RW transactions started locally.
+ * Provides the minimum required catalog timestamp among all active RW transactions started locally.
  */
 @SuppressWarnings("InterfaceMayBeAnnotatedFunctional")
-public interface ActiveLocalTxMinimumBeginTimeProvider {
+public interface ActiveLocalTxMinimumRequiredCatalogTimeProvider {
     /**
-     * Returns the minimum begin time among all active RW transactions started locally,
+     * Returns the minimum required catalog timestamp among all active RW transactions started locally,
      * or the current time if there are no active RW transactions.
      */
-    HybridTimestamp minimumBeginTime();
+    long minimumRequiredTime();
 }

--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/ActiveLocalTxMinimumRequiredTimeProvider.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/ActiveLocalTxMinimumRequiredTimeProvider.java
@@ -22,7 +22,7 @@ package org.apache.ignite.internal.tx;
  * earliest catalog version that can be used by active local RW transactions.
  */
 @SuppressWarnings("InterfaceMayBeAnnotatedFunctional")
-public interface ActiveLocalTxMinimumRequiredCatalogTimeProvider {
+public interface ActiveLocalTxMinimumRequiredTimeProvider {
     /**
      * Returns a timestamp corresponding to the activation time of the
      * earliest catalog version that active local RW transactions can use,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22975

`ActiveLocalTxMinimumBeginTimeProvider` (renamed `ActiveLocalTxMinimumRequiredTimeProvider`) now returns not the minimum start time among transactions, but the minimum time corresponding to the activation time of the earliest catalog version required by active transactions.

This change significantly reduces the time a write lock is held and makes it independent of the number of active transactions. For example, for 100 000 active transactions, the previous method could hold a lock for about 1_000_000 nanoseconds (on my PC), the current method for the same number of transactions holds a lock for about 50 nanoseconds.