### PR TITLE
IGNITE-22865 Add a hint to enable the full stack trace

### DIFF
--- a/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerMetricsTest.java
+++ b/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerMetricsTest.java
@@ -181,7 +181,7 @@ public class ItClientHandlerMetricsTest extends BaseIgniteAbstractTest {
         ItClientHandlerTestUtils.connectAndHandshake(serverModule, false, true);
 
         assertTrue(
-                IgniteTestUtils.waitForCondition(() -> testServer.metrics().bytesSent() == 210, 1000),
+                IgniteTestUtils.waitForCondition(() -> testServer.metrics().bytesSent() == 302, 1000),
                 () -> "bytesSent: " + testServer.metrics().bytesSent());
 
         assertTrue(

--- a/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerTest.java
+++ b/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/ItClientHandlerTest.java
@@ -28,7 +28,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -228,7 +227,7 @@ public class ItClientHandlerTest extends BaseIgniteAbstractTest {
                     "org.apache.ignite.security.exception.UnsupportedAuthenticationTypeException",
                     errClassName
             );
-            assertNull(errStackTrace);
+            assertEquals("To see the full stack trace set clientConnector.sendServerExceptionStackTraceToClient:true", errStackTrace);
         }
     }
 
@@ -354,7 +353,7 @@ public class ItClientHandlerTest extends BaseIgniteAbstractTest {
 
             assertThat(errMsg, containsString("Authentication failed"));
             assertEquals("org.apache.ignite.security.exception.InvalidCredentialsException", errClassName);
-            assertNull(errStackTrace);
+            assertEquals("To see the full stack trace set clientConnector.sendServerExceptionStackTraceToClient:true", errStackTrace);
         }
     }
 
@@ -409,7 +408,7 @@ public class ItClientHandlerTest extends BaseIgniteAbstractTest {
 
             assertThat(errMsg, containsString("Authentication failed"));
             assertEquals("org.apache.ignite.security.exception.InvalidCredentialsException", errClassName);
-            assertNull(errStackTrace);
+            assertEquals("To see the full stack trace set clientConnector.sendServerExceptionStackTraceToClient:true", errStackTrace);
         }
     }
 
@@ -462,7 +461,7 @@ public class ItClientHandlerTest extends BaseIgniteAbstractTest {
 
             assertThat(errMsg, containsString("Unsupported version: 2.8.0"));
             assertEquals("org.apache.ignite.lang.IgniteException", errClassName);
-            assertNull(errStackTrace);
+            assertEquals("To see the full stack trace set clientConnector.sendServerExceptionStackTraceToClient:true", errStackTrace);
         }
     }
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -560,7 +560,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
         if (configuration.sendServerExceptionStackTraceToClient()) {
             packer.packString(ExceptionUtils.getFullStackTrace(pubErr));
         } else {
-            packer.packNil();
+            packer.packString("To see the full stack trace set clientConnector.sendServerExceptionStackTraceToClient:true");
         }
 
         // Extensions.

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -47,7 +47,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientComputeTest.java
@@ -334,7 +334,10 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
         assertEquals(TRACE_ID, cause.traceId());
         assertEquals(COLUMN_ALREADY_EXISTS_ERR, cause.code());
         assertInstanceOf(CustomException.class, cause);
-        assertNull(cause.getCause()); // No stack trace by default.
+        assertNotNull(cause.getCause());
+        String hint = cause.getCause().getMessage();
+
+        assertEquals("To see the full stack trace set clientConnector.sendServerExceptionStackTraceToClient:true", hint);
     }
 
     @Test
@@ -347,7 +350,10 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
         assertEquals(TRACE_ID, cause.traceId());
         assertEquals(COLUMN_ALREADY_EXISTS_ERR, cause.code());
         assertInstanceOf(CustomException.class, cause);
-        assertNull(cause.getCause()); // No stack trace by default.
+        assertNotNull(cause.getCause());
+        String hint = cause.getCause().getMessage();
+
+        assertEquals("To see the full stack trace set clientConnector.sendServerExceptionStackTraceToClient:true", hint);
     }
 
     @ParameterizedTest
@@ -535,7 +541,10 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
         String expectedMessage = "Job execution failed: java.lang.ArithmeticException: math err";
         assertTraceableException(cause, ComputeException.class, COMPUTE_JOB_FAILED_ERR, expectedMessage);
 
-        assertNull(cause.getCause()); // No stack trace by default.
+        assertNotNull(cause.getCause());
+        String hint = cause.getCause().getMessage();
+
+        assertEquals("To see the full stack trace set clientConnector.sendServerExceptionStackTraceToClient:true", hint);
     }
 
     private static void assertComputeExceptionWithStackTrace(IgniteException cause) {
@@ -758,7 +767,10 @@ public class ItThinClientComputeTest extends ItAbstractThinClientTest {
         assertEquals(TRACE_ID, cause.traceId());
         assertEquals(COLUMN_ALREADY_EXISTS_ERR, cause.code());
         assertInstanceOf(CustomException.class, cause);
-        assertNull(cause.getCause()); // No stack trace by default.
+        assertNotNull(cause.getCause());
+        String hint = cause.getCause().getMessage();
+
+        assertEquals("To see the full stack trace set clientConnector.sendServerExceptionStackTraceToClient:true", hint);
     }
 
     private void testEchoArg(Object arg) {

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.concurrent.CompletionException;
 import org.apache.ignite.client.IgniteClient;
 import org.apache.ignite.internal.client.ClientChannel;
 import org.apache.ignite.internal.client.TcpIgniteClient;
@@ -115,5 +116,14 @@ public class ItThinClientConnectionTest extends ItAbstractThinClientTest {
             channel.heartbeatAsync(w -> w.out().packString("foo-bar")).join();
             channel.heartbeatAsync(w -> w.out().writePayload(new byte[]{1, 2, 3})).join();
         }
+    }
+
+    @Test
+    void testExceptionHasHint() {
+        var client = IgniteClient.builder().addresses(getClientAddresses().get(0)).build();
+
+        IgniteException ex = assertThrows(IgniteException.class, () -> client.sql().execute(null, "select x from bad"));
+        assertEquals("To see the full stack trace set clientConnector.sendServerExceptionStackTraceToClient:true",
+                ex.getCause().getCause().getCause().getCause().getMessage());
     }
 }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientConnectionTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
-import java.util.concurrent.CompletionException;
 import org.apache.ignite.client.IgniteClient;
 import org.apache.ignite.internal.client.ClientChannel;
 import org.apache.ignite.internal.client.TcpIgniteClient;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-22865

- Added hint if the `clientConnector.sendServerExceptionStackTraceToClient` is set to `false`;
- Added test.