### PR TITLE
IGNITE-23257 Switch to partition-operation thread to handle client me…

### DIFF
--- a/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/TestServer.java
+++ b/modules/client-handler/src/integrationTest/java/org/apache/ignite/client/handler/TestServer.java
@@ -138,7 +138,8 @@ public class TestServer {
                 mock(CatalogService.class),
                 mock(PlacementDriver.class),
                 clientConnectorConfiguration,
-                new TestLowWatermark()
+                new TestLowWatermark(),
+                Runnable::run
         );
 
         module.startAsync(componentContext).join();

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientHandlerModule.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientHandlerModule.java
@@ -36,6 +36,7 @@ import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.nio.channels.UnresolvedAddressException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -125,6 +126,8 @@ public class ClientHandlerModule implements IgniteComponent {
 
     private final ClientConnectorConfiguration clientConnectorConfiguration;
 
+    private final Executor partitionOperationsExecutor;
+
     @TestOnly
     @SuppressWarnings("unused")
     private volatile ChannelHandler handler;
@@ -144,6 +147,7 @@ public class ClientHandlerModule implements IgniteComponent {
      * @param clockService Clock service.
      * @param clientConnectorConfiguration Configuration of the connector.
      * @param lowWatermark Low watermark.
+     * @param partitionOperationsExecutor Executor for a partition operation.
      */
     public ClientHandlerModule(
             QueryProcessor queryProcessor,
@@ -161,7 +165,8 @@ public class ClientHandlerModule implements IgniteComponent {
             CatalogService catalogService,
             PlacementDriver placementDriver,
             ClientConnectorConfiguration clientConnectorConfiguration,
-            LowWatermark lowWatermark
+            LowWatermark lowWatermark,
+            Executor partitionOperationsExecutor
     ) {
         assert igniteTables != null;
         assert queryProcessor != null;
@@ -178,6 +183,7 @@ public class ClientHandlerModule implements IgniteComponent {
         assert placementDriver != null;
         assert clientConnectorConfiguration != null;
         assert lowWatermark != null;
+        assert partitionOperationsExecutor != null;
 
         this.queryProcessor = queryProcessor;
         this.igniteTables = igniteTables;
@@ -195,6 +201,7 @@ public class ClientHandlerModule implements IgniteComponent {
         this.primaryReplicaTracker = new ClientPrimaryReplicaTracker(placementDriver, catalogService, clockService, schemaSyncService,
                 lowWatermark);
         this.clientConnectorConfiguration = clientConnectorConfiguration;
+        this.partitionOperationsExecutor = partitionOperationsExecutor;
     }
 
     /** {@inheritDoc} */
@@ -384,7 +391,8 @@ public class ClientHandlerModule implements IgniteComponent {
                 schemaSyncService,
                 catalogService,
                 connectionId,
-                primaryReplicaTracker
+                primaryReplicaTracker,
+                partitionOperationsExecutor
         );
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -211,6 +212,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
 
     private final long connectionId;
 
+    private final Executor partitionOperationsExecutor;
+
     /**
      * Constructor.
      *
@@ -239,7 +242,8 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
             SchemaSyncService schemaSyncService,
             CatalogService catalogService,
             long connectionId,
-            ClientPrimaryReplicaTracker primaryReplicaTracker
+            ClientPrimaryReplicaTracker primaryReplicaTracker,
+            Executor partitionOperationsExecutor
     ) {
         assert igniteTables != null;
         assert igniteTransactions != null;
@@ -254,6 +258,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
         assert schemaSyncService != null;
         assert catalogService != null;
         assert primaryReplicaTracker != null;
+        assert partitionOperationsExecutor != null;
 
         this.igniteTables = igniteTables;
         this.igniteTransactions = igniteTransactions;
@@ -266,6 +271,7 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
         this.authenticationManager = authenticationManager;
         this.clockService = clockService;
         this.primaryReplicaTracker = primaryReplicaTracker;
+        this.partitionOperationsExecutor = partitionOperationsExecutor;
 
         jdbcQueryCursorHandler = new JdbcQueryCursorHandlerImpl(resources);
         jdbcQueryEventHandler = new JdbcQueryEventHandlerImpl(
@@ -596,52 +602,13 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
                         + ", remoteAddress=" + ctx.channel().remoteAddress() + "]");
             }
 
-            out.packLong(requestId);
-            writeFlags(out, ctx, false, false);
+            if (isPartitionOperation(opCode)) {
+                long requestId0 = requestId;
+                int opCode0 = opCode;
 
-            // Observable timestamp should be calculated after the operation is processed; reserve space, write later.
-            int observableTimestampIdx = out.reserveLong();
-
-            CompletableFuture fut = processOperation(in, out, opCode, requestId);
-
-            if (fut == null) {
-                // Operation completed synchronously.
-                in.close();
-                out.setLong(observableTimestampIdx, observableTimestamp(out));
-                write(out, ctx);
-
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("Client request processed synchronously [id=" + requestId + ", op=" + opCode
-                            + ", remoteAddress=" + ctx.channel().remoteAddress() + "]");
-                }
-
-                metrics.requestsProcessedIncrement();
-                metrics.requestsActiveDecrement();
+                partitionOperationsExecutor.execute(() -> processOperationInternal(ctx, in, out, requestId0, opCode0));
             } else {
-                var reqId = requestId;
-                var op = opCode;
-
-                fut.whenComplete((Object res, Object err) -> {
-                    in.close();
-                    metrics.requestsActiveDecrement();
-
-                    if (err != null) {
-                        out.close();
-                        writeError(reqId, op, (Throwable) err, ctx, false);
-
-                        metrics.requestsFailedIncrement();
-                    } else {
-                        out.setLong(observableTimestampIdx, observableTimestamp(out));
-                        write(out, ctx);
-
-                        metrics.requestsProcessedIncrement();
-
-                        if (LOG.isTraceEnabled()) {
-                            LOG.trace("Client request processed [id=" + reqId + ", op=" + op
-                                    + ", remoteAddress=" + ctx.channel().remoteAddress() + "]");
-                        }
-                    }
-                });
+                processOperationInternal(ctx, in, out, requestId, opCode);
             }
         } catch (Throwable t) {
             in.close();
@@ -650,6 +617,89 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
             writeError(requestId, opCode, t, ctx, false);
 
             metrics.requestsFailedIncrement();
+        }
+    }
+
+    private boolean isPartitionOperation(int opCode) {
+        return opCode == ClientOp.TABLES_GET ||
+                opCode == ClientOp.TUPLE_UPSERT ||
+                opCode == ClientOp.TUPLE_GET ||
+                opCode == ClientOp.TUPLE_UPSERT_ALL ||
+                opCode == ClientOp.TUPLE_GET_ALL ||
+                opCode == ClientOp.TUPLE_GET_AND_UPSERT ||
+                opCode == ClientOp.TUPLE_INSERT ||
+                opCode == ClientOp.TUPLE_INSERT_ALL ||
+                opCode == ClientOp.TUPLE_REPLACE ||
+                opCode == ClientOp.TUPLE_REPLACE_EXACT ||
+                opCode == ClientOp.TUPLE_GET_AND_REPLACE ||
+                opCode == ClientOp.TUPLE_DELETE ||
+                opCode == ClientOp.TUPLE_DELETE_ALL ||
+                opCode == ClientOp.TUPLE_DELETE_EXACT ||
+                opCode == ClientOp.TUPLE_DELETE_ALL_EXACT ||
+                opCode == ClientOp.TUPLE_GET_AND_DELETE ||
+                opCode == ClientOp.TUPLE_CONTAINS_KEY ||
+                opCode == ClientOp.TUPLE_CONTAINS_ALL_KEYS;
+    }
+
+    private void processOperationInternal(
+            ChannelHandlerContext ctx,
+            ClientMessageUnpacker in,
+            ClientMessagePacker out,
+            long requestId,
+            int opCode
+    ) {
+        out.packLong(requestId);
+        writeFlags(out, ctx, false, false);
+
+        // Observable timestamp should be calculated after the operation is processed; reserve space, write later.
+        int observableTimestampIdx = out.reserveLong();
+
+        CompletableFuture fut;
+
+        try {
+            fut = processOperation(in, out, opCode, requestId);
+        } catch (IgniteInternalCheckedException e) {
+            fut = CompletableFuture.failedFuture(e);
+        }
+
+        if (fut == null) {
+            // Operation completed synchronously.
+            in.close();
+            out.setLong(observableTimestampIdx, observableTimestamp(out));
+            write(out, ctx);
+
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Client request processed synchronously [id=" + requestId + ", op=" + opCode
+                        + ", remoteAddress=" + ctx.channel().remoteAddress() + "]");
+            }
+
+            metrics.requestsProcessedIncrement();
+            metrics.requestsActiveDecrement();
+        } else {
+            var reqId = requestId;
+            var op = opCode;
+
+            fut.whenComplete((Object res, Object err) -> {
+                in.close();
+                metrics.requestsActiveDecrement();
+
+                if (err != null) {
+                    out.close();
+                    writeError(reqId, op, (Throwable) err, ctx, false);
+
+                    metrics.requestsFailedIncrement();
+                } else {
+                    out.setLong(observableTimestampIdx, observableTimestamp(out));
+                    write(out, ctx);
+
+                    metrics.requestsProcessedIncrement();
+
+                    if (LOG.isTraceEnabled()) {
+                        LOG.trace("Client request processed [id=" + reqId + ", op=" + op
+                                + ", remoteAddress=" + ctx.channel().remoteAddress() + "]");
+                    }
+                }
+            });
         }
     }
 

--- a/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
@@ -235,7 +235,8 @@ public class TestClientHandlerModule implements IgniteComponent {
                                                 clockService,
                                                 new AlwaysSyncedSchemaSyncService(),
                                                 new TestLowWatermark()
-                                        )
+                                        ),
+                                        Runnable::run
                                 )
                         );
                     }

--- a/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestServer.java
@@ -261,7 +261,8 @@ public class TestServer implements AutoCloseable {
                         new FakeCatalogService(FakeInternalTable.PARTITIONS),
                         ignite.placementDriver(),
                         clientConnectorConfiguration,
-                        new TestLowWatermark()
+                        new TestLowWatermark(),
+                        Runnable::run
                 );
 
         module.startAsync(componentContext).join();

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
@@ -1099,7 +1099,8 @@ public class IgniteImpl implements Ignite {
                 catalogManager,
                 placementDriverMgr.placementDriver(),
                 clientConnectorConfiguration,
-                lowWatermark
+                lowWatermark,
+                threadPoolsManager.partitionOperationsExecutor()
         );
 
         restComponent = createRestComponent(name);


### PR DESCRIPTION
…ssages

https://issues.apache.org/jira/browse/IGNITE-23257

```
Benchmark                  (clusterSize)  (fsync)  (switchThreadFast)   Mode  Cnt      Score      Error  Units
SelectBenchmark.kvThinGet              1    false                true  thrpt   20  40282.523 ± 2473.945  ops/s
SelectBenchmark.kvThinGet              1    false               false  thrpt   20  38442.755 ± 1818.741  ops/s

Benchmark                  (clusterSize)  (fsync)  (switchThreadFast)   Mode  Cnt      Score      Error  Units
SelectBenchmark.kvThinGet              1    false                true  thrpt   20  40148.831 ± 2015.947  ops/s
SelectBenchmark.kvThinGet              1    false               false  thrpt   20  38457.850 ± 1604.763  ops/s
```