### PR TITLE
IGNITE-23437 Do not use ByteUtils#toBytes to persist timestamps in LowWatermark

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/hlc/HybridTimestamp.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/hlc/HybridTimestamp.java
@@ -22,6 +22,7 @@ import static org.apache.ignite.internal.lang.JavaLoggerFormatter.DATE_FORMATTER
 import java.io.Serializable;
 import java.time.Instant;
 import java.time.ZoneId;
+import org.apache.ignite.internal.util.ByteUtils;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -119,6 +120,15 @@ public final class HybridTimestamp implements Comparable<HybridTimestamp>, Seria
      */
     public static long hybridTimestampToLong(@Nullable HybridTimestamp timestamp) {
         return timestamp == null ? NULL_HYBRID_TIMESTAMP : timestamp.time;
+    }
+
+    /**
+     * Restores a timestamp converted to bytes using {@link #toBytes()}.
+     *
+     * @param bytes Byte array representing a timestamp.
+     */
+    public static HybridTimestamp fromBytes(byte[] bytes) {
+        return hybridTimestamp(ByteUtils.bytesToLong(bytes));
     }
 
     /**
@@ -238,5 +248,12 @@ public final class HybridTimestamp implements Comparable<HybridTimestamp>, Seria
         } else {
             return new HybridTimestamp(getPhysical() + 1, 0);
         }
+    }
+
+    /**
+     * Returns a byte array representing this timestamp.
+     */
+    public byte[] toBytes() {
+        return ByteUtils.longToBytes(longValue());
     }
 }

--- a/modules/low-watermark/src/main/java/org/apache/ignite/internal/lowwatermark/LowWatermarkImpl.java
+++ b/modules/low-watermark/src/main/java/org/apache/ignite/internal/lowwatermark/LowWatermarkImpl.java
@@ -59,7 +59,6 @@ import org.apache.ignite.internal.network.NetworkMessage;
 import org.apache.ignite.internal.schema.configuration.LowWatermarkConfiguration;
 import org.apache.ignite.internal.schema.configuration.LowWatermarkConfigurationSchema;
 import org.apache.ignite.internal.thread.NamedThreadFactory;
-import org.apache.ignite.internal.util.ByteUtils;
 import org.apache.ignite.internal.util.IgniteSpinBusyLock;
 import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.vault.VaultEntry;
@@ -170,7 +169,7 @@ public class LowWatermarkImpl extends AbstractEventProducer<LowWatermarkEvent, L
     private @Nullable HybridTimestamp readLowWatermarkFromVault() {
         VaultEntry vaultEntry = vaultManager.get(LOW_WATERMARK_VAULT_KEY);
 
-        return vaultEntry == null ? null : ByteUtils.fromBytes(vaultEntry.value());
+        return vaultEntry == null ? null : HybridTimestamp.fromBytes(vaultEntry.value());
     }
 
     @Override
@@ -335,7 +334,7 @@ public class LowWatermarkImpl extends AbstractEventProducer<LowWatermarkEvent, L
 
     CompletableFuture<Void> updateAndNotify(HybridTimestamp newLowWatermark) {
         return inBusyLockAsync(busyLock, () -> {
-                    vaultManager.put(LOW_WATERMARK_VAULT_KEY, ByteUtils.toBytes(newLowWatermark));
+                    vaultManager.put(LOW_WATERMARK_VAULT_KEY, newLowWatermark.toBytes());
 
                     return waitForLocksAndSetLowWatermark(newLowWatermark)
                             .thenComposeAsync(unused2 -> fireEvent(

--- a/modules/low-watermark/src/test/java/org/apache/ignite/internal/lowwatermark/LowWatermarkImplTest.java
+++ b/modules/low-watermark/src/test/java/org/apache/ignite/internal/lowwatermark/LowWatermarkImplTest.java
@@ -69,7 +69,6 @@ import org.apache.ignite.internal.network.MessagingService;
 import org.apache.ignite.internal.network.NetworkMessage;
 import org.apache.ignite.internal.schema.configuration.LowWatermarkConfiguration;
 import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
-import org.apache.ignite.internal.util.ByteUtils;
 import org.apache.ignite.internal.vault.VaultEntry;
 import org.apache.ignite.internal.vault.VaultManager;
 import org.apache.ignite.network.ClusterNode;
@@ -134,7 +133,7 @@ public class LowWatermarkImplTest extends BaseIgniteAbstractTest {
         var lowWatermark = new HybridTimestamp(10, 10);
 
         when(vaultManager.get(LOW_WATERMARK_VAULT_KEY))
-                .thenReturn(new VaultEntry(LOW_WATERMARK_VAULT_KEY, ByteUtils.toBytes(lowWatermark)));
+                .thenReturn(new VaultEntry(LOW_WATERMARK_VAULT_KEY, lowWatermark.toBytes()));
 
         assertThat(this.lowWatermark.startAsync(new ComponentContext()), willCompleteSuccessfully());
 
@@ -189,7 +188,7 @@ public class LowWatermarkImplTest extends BaseIgniteAbstractTest {
 
         InOrder inOrder = inOrder(vaultManager, lwmChangedListener);
 
-        inOrder.verify(vaultManager, timeout(1_000)).put(LOW_WATERMARK_VAULT_KEY, ByteUtils.toBytes(newLowWatermarkCandidate));
+        inOrder.verify(vaultManager, timeout(1_000)).put(LOW_WATERMARK_VAULT_KEY, newLowWatermarkCandidate.toBytes());
 
         inOrder.verify(lwmChangedListener, timeout(1_000)).notify(any());
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23437