### PR TITLE
IGNITE-23314 PartitionReplicaListener#ensureReplicaIsPrimary does not require to use hybrid timestamp

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/hlc/ClockService.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/hlc/ClockService.java
@@ -32,11 +32,27 @@ public interface ClockService {
     HybridTimestamp now();
 
     /**
+     * Gets a current timestamp. It is a fast way to get timestamp because it does not have to update internal state.
+     * This timestamp is not unique and equal to or less than that value returned by {@link this#now()}.
+     *
+     * @return The hybrid timestamp.
+     */
+    HybridTimestamp current();
+
+    /**
      * Creates a timestamp for new event.
      *
      * @return The hybrid timestamp as long.
      */
     long nowLong();
+
+    /**
+     * Gets a current timestamp as long. It is a fast way to get timestamp because it does not have to update internal state.
+     * This timestamp is not unique and equal to or less than that value returned by {@link this#nowLong()}.
+     *
+     * @return The hybrid timestamp.
+     */
+    long currentLong();
 
     /**
      * Advances the clock in accordance with the request time. If the request time is ahead of the clock,

--- a/modules/core/src/main/java/org/apache/ignite/internal/hlc/ClockService.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/hlc/ClockService.java
@@ -32,7 +32,7 @@ public interface ClockService {
     HybridTimestamp now();
 
     /**
-     * Gets a current timestamp. It is a fast way to get timestamp because it does not have to update internal state.
+     * Gets a current timestamp. It is a fast way to get timestamp because it doesn't have to tick the logical part of the clock.
      * This timestamp is not unique, and equal to or less than that value is returned by {@link this#now()}.
      *
      * @return The hybrid timestamp.
@@ -47,7 +47,7 @@ public interface ClockService {
     long nowLong();
 
     /**
-     * Gets a current timestamp as long. It is a fast way to get timestamp because it does not have to update internal state.
+     * Gets a current timestamp as long. It is a fast way to get timestamp because it doesn't have to tick the logical part of the clock.
      * This timestamp is not unique, and equal to or less than that value is returned by {@link this#nowLong()}.
      *
      * @return The hybrid timestamp.

--- a/modules/core/src/main/java/org/apache/ignite/internal/hlc/ClockService.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/hlc/ClockService.java
@@ -33,7 +33,7 @@ public interface ClockService {
 
     /**
      * Gets a current timestamp. It is a fast way to get timestamp because it does not have to update internal state.
-     * This timestamp is not unique and equal to or less than that value returned by {@link this#now()}.
+     * This timestamp is not unique, and equal to or less than that value is returned by {@link this#now()}.
      *
      * @return The hybrid timestamp.
      */
@@ -48,7 +48,7 @@ public interface ClockService {
 
     /**
      * Gets a current timestamp as long. It is a fast way to get timestamp because it does not have to update internal state.
-     * This timestamp is not unique and equal to or less than that value returned by {@link this#nowLong()}.
+     * This timestamp is not unique, and equal to or less than that value is returned by {@link this#nowLong()}.
      *
      * @return The hybrid timestamp.
      */

--- a/modules/core/src/main/java/org/apache/ignite/internal/hlc/ClockServiceImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/hlc/ClockServiceImpl.java
@@ -44,8 +44,18 @@ public class ClockServiceImpl implements ClockService {
     }
 
     @Override
+    public HybridTimestamp current() {
+        return clock.current();
+    }
+
+    @Override
     public long nowLong() {
         return clock.nowLong();
+    }
+
+    @Override
+    public long currentLong() {
+        return clock.currentLong();
     }
 
     @Override

--- a/modules/core/src/main/java/org/apache/ignite/internal/hlc/HybridClock.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/hlc/HybridClock.java
@@ -29,7 +29,7 @@ public interface HybridClock {
     long nowLong();
 
     /**
-     * Gets a current timestamp as long. It is a fast way to get timestamp because it does not have to update internal state.
+     * Gets a current timestamp as long. It is a fast way to get timestamp because it doesn't have to tick the logical part of the clock.
      * This timestamp is not unique, and equal to or less than that value is returned by {@link this#nowLong()}.
      *
      * @return The hybrid timestamp.
@@ -44,7 +44,7 @@ public interface HybridClock {
     HybridTimestamp now();
 
     /**
-     * Gets a current timestamp. It is a fast way to get timestamp because it does not have to update internal state.
+     * Gets a current timestamp. It is a fast way to get timestamp because it doesn't have to tick the logical part of the clock.
      * This timestamp is not unique, and equal to or less than that value is returned by {@link this#now()}.
      *
      * @return The hybrid timestamp.

--- a/modules/core/src/main/java/org/apache/ignite/internal/hlc/HybridClock.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/hlc/HybridClock.java
@@ -29,11 +29,27 @@ public interface HybridClock {
     long nowLong();
 
     /**
+     * Gets a current timestamp as long. It is a fast way to get timestamp because it does not have to update internal state.
+     * This timestamp is not unique and equal to or less than that value returned by {@link this#nowLong()}.
+     *
+     * @return The hybrid timestamp.
+     */
+    long currentLong();
+
+    /**
      * Creates a timestamp for new event.
      *
      * @return The hybrid timestamp.
      */
     HybridTimestamp now();
+
+    /**
+     * Gets a current timestamp. It is a fast way to get timestamp because it does not have to update internal state.
+     * This timestamp is not unique and equal to or less than that value returned by {@link this#now()}.
+     *
+     * @return The hybrid timestamp.
+     */
+    HybridTimestamp current();
 
     /**
      * Advances the clock in accordance with the request time. If the request time is ahead of the clock,

--- a/modules/core/src/main/java/org/apache/ignite/internal/hlc/HybridClock.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/hlc/HybridClock.java
@@ -30,7 +30,7 @@ public interface HybridClock {
 
     /**
      * Gets a current timestamp as long. It is a fast way to get timestamp because it does not have to update internal state.
-     * This timestamp is not unique and equal to or less than that value returned by {@link this#nowLong()}.
+     * This timestamp is not unique, and equal to or less than that value is returned by {@link this#nowLong()}.
      *
      * @return The hybrid timestamp.
      */
@@ -45,7 +45,7 @@ public interface HybridClock {
 
     /**
      * Gets a current timestamp. It is a fast way to get timestamp because it does not have to update internal state.
-     * This timestamp is not unique and equal to or less than that value returned by {@link this#now()}.
+     * This timestamp is not unique, and equal to or less than that value is returned by {@link this#now()}.
      *
      * @return The hybrid timestamp.
      */

--- a/modules/core/src/main/java/org/apache/ignite/internal/hlc/HybridClockImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/hlc/HybridClockImpl.java
@@ -87,9 +87,9 @@ public class HybridClockImpl implements HybridClock {
 
     @Override
     public long currentLong() {
-        long now = currentTime();
+        long current = currentTime();
 
-        return max(latestTime, now);
+        return max(latestTime, current);
     }
 
     private void notifyUpdateListeners(long newTs) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/hlc/HybridClockImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/hlc/HybridClockImpl.java
@@ -85,6 +85,13 @@ public class HybridClockImpl implements HybridClock {
         }
     }
 
+    @Override
+    public long currentLong() {
+        long now = currentTime();
+
+        return max(latestTime, now);
+    }
+
     private void notifyUpdateListeners(long newTs) {
         for (ClockUpdateListener listener : updateListeners) {
             try {
@@ -102,6 +109,11 @@ public class HybridClockImpl implements HybridClock {
     @Override
     public HybridTimestamp now() {
         return hybridTimestamp(nowLong());
+    }
+
+    @Override
+    public HybridTimestamp current() {
+        return hybridTimestamp(currentLong());
     }
 
     /**

--- a/modules/core/src/testFixtures/java/org/apache/ignite/internal/TestHybridClock.java
+++ b/modules/core/src/testFixtures/java/org/apache/ignite/internal/TestHybridClock.java
@@ -81,6 +81,13 @@ public class TestHybridClock implements HybridClock {
         }
     }
 
+    @Override
+    public long currentLong() {
+        long now = currentTime();
+
+        return max(latestTime, now);
+    }
+
     private void notifyUpdateListeners(long newLatestTime) {
         updateListeners.forEach(listener -> listener.onUpdate(newLatestTime));
     }
@@ -88,6 +95,11 @@ public class TestHybridClock implements HybridClock {
     @Override
     public HybridTimestamp now() {
         return hybridTimestamp(nowLong());
+    }
+
+    @Override
+    public HybridTimestamp current() {
+        return hybridTimestamp(currentLong());
     }
 
     /**

--- a/modules/core/src/testFixtures/java/org/apache/ignite/internal/TestHybridClock.java
+++ b/modules/core/src/testFixtures/java/org/apache/ignite/internal/TestHybridClock.java
@@ -85,7 +85,7 @@ public class TestHybridClock implements HybridClock {
     public long currentLong() {
         long current = currentTime();
 
-        return max(latestTime, now);
+        return max(latestTime, current);
     }
 
     private void notifyUpdateListeners(long newLatestTime) {

--- a/modules/core/src/testFixtures/java/org/apache/ignite/internal/TestHybridClock.java
+++ b/modules/core/src/testFixtures/java/org/apache/ignite/internal/TestHybridClock.java
@@ -83,7 +83,7 @@ public class TestHybridClock implements HybridClock {
 
     @Override
     public long currentLong() {
-        long now = currentTime();
+        long current = currentTime();
 
         return max(latestTime, now);
     }

--- a/modules/core/src/testFixtures/java/org/apache/ignite/internal/hlc/TestClockService.java
+++ b/modules/core/src/testFixtures/java/org/apache/ignite/internal/hlc/TestClockService.java
@@ -51,8 +51,18 @@ public class TestClockService implements ClockService {
     }
 
     @Override
+    public HybridTimestamp current() {
+        return clock.current();
+    }
+
+    @Override
     public long nowLong() {
         return clock.nowLong();
+    }
+
+    @Override
+    public long currentLong() {
+        return clock.currentLong();
     }
 
     @Override

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/replicator/PartitionReplicaListener.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/replicator/PartitionReplicaListener.java
@@ -3520,7 +3520,7 @@ public class PartitionReplicaListener implements ReplicaListener {
      *     lease start time is not {@code null} in case of {@link PrimaryReplicaRequest}.
      */
     private CompletableFuture<IgniteBiTuple<Boolean, Long>> ensureReplicaIsPrimary(ReplicaRequest request) {
-        HybridTimestamp now = clockService.current();
+        HybridTimestamp current = clockService.current();
 
         if (request instanceof PrimaryReplicaRequest) {
             Long enlistmentConsistencyToken = ((PrimaryReplicaRequest) request).enlistmentConsistencyToken();
@@ -3541,7 +3541,7 @@ public class PartitionReplicaListener implements ReplicaListener {
                 long currentEnlistmentConsistencyToken = primaryReplicaMeta.getStartTime().longValue();
 
                 if (enlistmentConsistencyToken != currentEnlistmentConsistencyToken
-                        || clockService.before(primaryReplicaMeta.getExpirationTime(), now)
+                        || clockService.before(primaryReplicaMeta.getExpirationTime(), current)
                         || !isLocalPeer(primaryReplicaMeta.getLeaseholderId())
                 ) {
                     throw new PrimaryReplicaMissException(
@@ -3557,7 +3557,7 @@ public class PartitionReplicaListener implements ReplicaListener {
                 return new IgniteBiTuple<>(null, primaryReplicaMeta.getStartTime().longValue());
             };
 
-            ReplicaMeta meta = placementDriver.getCurrentPrimaryReplica(replicationGroupId, now);
+            ReplicaMeta meta = placementDriver.getCurrentPrimaryReplica(replicationGroupId, current);
 
             if (meta != null) {
                 try {
@@ -3567,9 +3567,9 @@ public class PartitionReplicaListener implements ReplicaListener {
                 }
             }
 
-            return placementDriver.getPrimaryReplica(replicationGroupId, now).thenApply(validateClo);
+            return placementDriver.getPrimaryReplica(replicationGroupId, current).thenApply(validateClo);
         } else if (request instanceof ReadOnlyReplicaRequest || request instanceof ReplicaSafeTimeSyncRequest) {
-            return placementDriver.getPrimaryReplica(replicationGroupId, now)
+            return placementDriver.getPrimaryReplica(replicationGroupId, current)
                     .thenApply(primaryReplica -> new IgniteBiTuple<>(
                             primaryReplica != null && isLocalPeer(primaryReplica.getLeaseholderId()),
                             null

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/replicator/PartitionReplicaListener.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/replicator/PartitionReplicaListener.java
@@ -3520,7 +3520,7 @@ public class PartitionReplicaListener implements ReplicaListener {
      *     lease start time is not {@code null} in case of {@link PrimaryReplicaRequest}.
      */
     private CompletableFuture<IgniteBiTuple<Boolean, Long>> ensureReplicaIsPrimary(ReplicaRequest request) {
-        HybridTimestamp now = clockService.now();
+        HybridTimestamp now = clockService.current();
 
         if (request instanceof PrimaryReplicaRequest) {
             Long enlistmentConsistencyToken = ((PrimaryReplicaRequest) request).enlistmentConsistencyToken();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23314

```
Benchmark                (clusterSize)  (fsync)  (useCurrentTime)   Mode  Cnt       Score       Error  Units
SelectBenchmark.kvGet                1    false              true  thrpt   20  111516.766 ±  4852.060  ops/s
SelectBenchmark.kvGet                1    false             false  thrpt   20  106539.353 ±  7714.372  ops/s
SelectBenchmark.kvGet8               1    false              true  thrpt   20  392582.275 ± 19418.875  ops/s
SelectBenchmark.kvGet8               1    false             false  thrpt   20  360583.874 ± 17743.514  ops/s
SelectBenchmark.kvGet16              1    false              true  thrpt   20  504817.362 ± 33241.876  ops/s
SelectBenchmark.kvGet16              1    false             false  thrpt   20  446573.687 ± 19393.033  ops/s
SelectBenchmark.kvGet32              1    false              true  thrpt   20  605450.488 ± 32179.146  ops/s
SelectBenchmark.kvGet32              1    false             false  thrpt   20  615235.419 ± 37113.918  ops/s
```