### PR TITLE
IGNITE-23481 Remove useless ItTablesApiTest#testGetTableFromLaggedNode.

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItTablesApiTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItTablesApiTest.java
@@ -127,49 +127,6 @@ public class ItTablesApiTest extends ClusterPerTestIntegrationTest {
     }
 
     /**
-     * Test scenario when we have lagged node, and tables with the same name are deleted and created again.
-     */
-    @Test
-    public void testGetTableFromLaggedNode() {
-        cluster.runningNodes().forEach(ign -> assertNull(ign.tables().table(TABLE_NAME)));
-
-        Ignite ignite0 = cluster.node(0);
-
-        Ignite ignite1 = cluster.node(1);
-
-        Table tbl = createTable(ignite0, TABLE_NAME);
-
-        Tuple tableKey = Tuple.create()
-                .set("key", 123L);
-
-        Tuple value = Tuple.create()
-                .set("valInt", 1234)
-                .set("valStr", "some string row");
-
-        tbl.keyValueView().put(null, tableKey, value);
-
-        assertEquals(value, tbl.keyValueView().get(null, tableKey));
-
-        assertEquals(value, ignite1.tables().table(TABLE_NAME).keyValueView().get(null, tableKey));
-
-        WatchListenerInhibitor ignite1Inhibitor = metastorageEventsInhibitor(ignite1);
-
-        ignite1Inhibitor.startInhibit();
-
-        Tuple otherValue = Tuple.create()
-                .set("valInt", 12345)
-                .set("valStr", "some other string row");
-
-        tbl.keyValueView().put(null, tableKey, otherValue);
-
-        assertEquals(otherValue, tbl.keyValueView().get(null, tableKey));
-
-        ignite1Inhibitor.stopInhibit();
-
-        assertEquals(otherValue, ignite1.tables().table(TABLE_NAME).keyValueView().get(null, tableKey));
-    }
-
-    /**
      * Tries to create an index which is already created.
      */
     @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23481