### PR TITLE
IGNITE-23496 Optimize lease batch serialization

### DIFF
--- a/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/ClusterStatePersistentSerializer.java
+++ b/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/ClusterStatePersistentSerializer.java
@@ -17,13 +17,9 @@
 
 package org.apache.ignite.internal.cluster.management;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import org.apache.ignite.internal.cluster.management.network.messages.CmgMessagesFactory;
 import org.apache.ignite.internal.util.io.IgniteDataInput;
@@ -58,20 +54,6 @@ public class ClusterStatePersistentSerializer extends VersionedSerializer<Cluste
         }
     }
 
-    private static void writeStringSet(Set<String> strings, IgniteDataOutput out) throws IOException {
-        out.writeVarInt(strings.size());
-        for (String str : strings) {
-            out.writeUTF(str);
-        }
-    }
-
-    private static void writeNullableString(@Nullable String str, IgniteDataOutput out) throws IOException {
-        out.writeVarInt(str == null ? -1 : str.length());
-        if (str != null) {
-            out.writeByteArray(str.getBytes(UTF_8));
-        }
-    }
-
     @Override
     protected ClusterState readExternalData(byte protoVer, IgniteDataInput in) throws IOException {
         return CMG_MSGS_FACTORY.clusterState()
@@ -82,26 +64,6 @@ public class ClusterStatePersistentSerializer extends VersionedSerializer<Cluste
                 .initialClusterConfiguration(readNullableString(in))
                 .formerClusterIds(readFormerClusterIds(in))
                 .build();
-    }
-
-    private static Set<String> readStringSet(IgniteDataInput in) throws IOException {
-        int size = in.readVarIntAsInt();
-
-        Set<String> result = new HashSet<>(size);
-        for (int i = 0; i < size; i++) {
-            result.add(in.readUTF());
-        }
-
-        return result;
-    }
-
-    private static @Nullable String readNullableString(IgniteDataInput in) throws IOException {
-        int lengthOrMinusOne = in.readVarIntAsInt();
-        if (lengthOrMinusOne == -1) {
-            return null;
-        }
-
-        return new String(in.readByteArray(lengthOrMinusOne), UTF_8);
     }
 
     private static @Nullable List<UUID> readFormerClusterIds(IgniteDataInput in) throws IOException {

--- a/modules/core/src/main/java/org/apache/ignite/internal/replicator/PartitionGroupId.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/replicator/PartitionGroupId.java
@@ -15,23 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.internal.placementdriver;
+package org.apache.ignite.internal.replicator;
 
-import java.util.UUID;
-import org.apache.ignite.internal.hlc.HybridTimestamp;
-import org.jetbrains.annotations.Nullable;
+/**
+ * A {@link ReplicationGroupId} which corresponds to partition of a partitioned object.
+ */
+public interface PartitionGroupId extends ReplicationGroupId {
+    /** Returns ID of the partitioned object. */
+    int objectId();
 
-/** Replica lease meta. */
-public interface ReplicaMeta {
-    /** Gets a leaseholder node consistent ID (assigned to a node once), {@code null} if nothing holds the lease. */
-    @Nullable String getLeaseholder();
-
-    /** Gets a leaseholder node ID (changes on every node startup), {@code null} if nothing holds the lease. */
-    @Nullable UUID getLeaseholderId();
-
-    /** Gets a lease start timestamp. */
-    HybridTimestamp getStartTime();
-
-    /** Gets a lease expiration timestamp. */
-    HybridTimestamp getExpirationTime();
+    /** Returns partition ID. */
+    int partitionId();
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/replicator/ReplicationGroupId.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/replicator/ReplicationGroupId.java
@@ -17,10 +17,8 @@
 
 package org.apache.ignite.internal.replicator;
 
-import java.io.Serializable;
-
 /**
  * The interface represents a replication group identifier.
  */
-public interface ReplicationGroupId extends Serializable {
+public interface ReplicationGroupId {
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/replicator/TablePartitionId.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/replicator/TablePartitionId.java
@@ -18,10 +18,11 @@
 package org.apache.ignite.internal.replicator;
 
 // TODO: https://issues.apache.org/jira/browse/IGNITE-19170 Should be refactored to ZonePartitionId.
+
 /**
  * The class is used to identify a table replication group.
  */
-public class TablePartitionId implements ReplicationGroupId {
+public class TablePartitionId implements PartitionGroupId {
 
     /** Table id. */
     private final int tableId;
@@ -52,11 +53,17 @@ public class TablePartitionId implements ReplicationGroupId {
         return new TablePartitionId(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]));
     }
 
+    @Override
+    public int objectId() {
+        return tableId;
+    }
+
     /**
      * Get the partition id.
      *
      * @return Partition id.
      */
+    @Override
     public int partitionId() {
         return partId;
     }

--- a/modules/placement-driver/src/main/java/org/apache/ignite/internal/placementdriver/leases/Lease.java
+++ b/modules/placement-driver/src/main/java/org/apache/ignite/internal/placementdriver/leases/Lease.java
@@ -17,23 +17,15 @@
 
 package org.apache.ignite.internal.placementdriver.leases;
 
-import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static org.apache.ignite.internal.hlc.HybridTimestamp.HYBRID_TIMESTAMP_SIZE;
 import static org.apache.ignite.internal.hlc.HybridTimestamp.MIN_VALUE;
 import static org.apache.ignite.internal.hlc.HybridTimestamp.hybridTimestamp;
-import static org.apache.ignite.internal.util.ArrayUtils.BYTE_EMPTY_ARRAY;
-import static org.apache.ignite.internal.util.ByteUtils.stringFromBytes;
-import static org.apache.ignite.internal.util.ByteUtils.stringToBytes;
-import static org.apache.ignite.internal.util.ByteUtils.toBytes;
 
-import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.UUID;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.apache.ignite.internal.placementdriver.ReplicaMeta;
 import org.apache.ignite.internal.replicator.ReplicationGroupId;
 import org.apache.ignite.internal.tostring.S;
-import org.apache.ignite.internal.util.ByteUtils;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -41,8 +33,6 @@ import org.jetbrains.annotations.Nullable;
  * The real lease is stored in Meta storage.
  */
 public class Lease implements ReplicaMeta {
-    private static final long serialVersionUID = 394641185393949608L;
-
     /** Node consistent ID (assigned to a node once), {@code null} if nothing holds the lease. */
     private final @Nullable String leaseholder;
 
@@ -200,63 +190,6 @@ public class Lease implements ReplicaMeta {
     }
 
     /**
-     * Encodes this lease into sequence of bytes.
-     *
-     * @return Lease representation in a byte array.
-     */
-    public byte[] bytes() {
-        byte[] leaseholderBytes = stringToBytes(leaseholder);
-        byte[] leaseholderIdBytes = leaseholderId == null ? null : stringToBytes(leaseholderId.toString());
-        byte[] proposedCandidateBytes = stringToBytes(proposedCandidate);
-        byte[] groupIdBytes = toBytes(replicationGroupId);
-
-        int bufSize = 2 // accepted + prolongable
-                + HYBRID_TIMESTAMP_SIZE * 2 // startTime + expirationTime
-                + bytesSizeForWrite(leaseholderBytes) + bytesSizeForWrite(leaseholderIdBytes) + bytesSizeForWrite(proposedCandidateBytes)
-                + bytesSizeForWrite(groupIdBytes);
-
-        ByteBuffer buf = ByteBuffer.allocate(bufSize).order(LITTLE_ENDIAN);
-
-        putBoolean(buf, accepted);
-        putBoolean(buf, prolongable);
-
-        putHybridTimestamp(buf, startTime);
-        putHybridTimestamp(buf, expirationTime);
-
-        putBytes(buf, leaseholderBytes);
-        putBytes(buf, leaseholderIdBytes);
-        putBytes(buf, proposedCandidateBytes);
-        putBytes(buf, groupIdBytes);
-
-        return buf.array();
-    }
-
-    /**
-     * Decodes a lease from the sequence of bytes.
-     *
-     * @param buf Byte buffer containing lease representation. Requires to be in little-endian.
-     * @return Decoded lease.
-     */
-    public static Lease fromBytes(ByteBuffer buf) {
-        assert buf.order() == LITTLE_ENDIAN;
-
-        boolean accepted = getBoolean(buf);
-        boolean prolongable = getBoolean(buf);
-
-        HybridTimestamp startTime = getHybridTimestamp(buf);
-        HybridTimestamp expirationTime = getHybridTimestamp(buf);
-
-        String leaseholder = stringFromBytes(getBytes(buf));
-        String leaseholderIdString = stringFromBytes(getBytes(buf));
-        UUID leaseholderId = leaseholderIdString == null ? null : UUID.fromString(leaseholderIdString);
-        String proposedCandidate = stringFromBytes(getBytes(buf));
-
-        ReplicationGroupId groupId = ByteUtils.fromBytes(getBytes(buf));
-
-        return new Lease(leaseholder, leaseholderId, startTime, expirationTime, prolongable, accepted, proposedCandidate, groupId);
-    }
-
-    /**
      * Returns a lease that no one holds and is always expired.
      *
      * @param replicationGroupId Replication group ID.
@@ -288,49 +221,5 @@ public class Lease implements ReplicaMeta {
     @Override
     public int hashCode() {
         return Objects.hash(leaseholder, leaseholderId, accepted, startTime, expirationTime, prolongable, replicationGroupId);
-    }
-
-    private static int bytesSizeForWrite(byte @Nullable [] bytes) {
-        return Integer.BYTES + (bytes == null ? 0 : bytes.length);
-    }
-
-    private static void putBoolean(ByteBuffer buffer, boolean b) {
-        buffer.put((byte) (b ? 1 : 0));
-    }
-
-    private static boolean getBoolean(ByteBuffer buffer) {
-        return buffer.get() == 1;
-    }
-
-    private static void putHybridTimestamp(ByteBuffer buffer, HybridTimestamp hybridTimestamp) {
-        buffer.putLong(hybridTimestamp.longValue());
-    }
-
-    private static HybridTimestamp getHybridTimestamp(ByteBuffer buffer) {
-        return hybridTimestamp(buffer.getLong());
-    }
-
-    private static void putBytes(ByteBuffer buffer, byte @Nullable [] bytes) {
-        buffer.putInt(bytes == null ? -1 : bytes.length);
-
-        if (bytes != null) {
-            buffer.put(bytes);
-        }
-    }
-
-    private static byte @Nullable [] getBytes(ByteBuffer buffer) {
-        int bytesLen = buffer.getInt();
-
-        if (bytesLen < 0) {
-            return null;
-        } else if (bytesLen == 0) {
-            return BYTE_EMPTY_ARRAY;
-        }
-
-        byte[] bytes = new byte[bytesLen];
-
-        buffer.get(bytes);
-
-        return bytes;
     }
 }

--- a/modules/placement-driver/src/main/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatch.java
+++ b/modules/placement-driver/src/main/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatch.java
@@ -17,11 +17,10 @@
 
 package org.apache.ignite.internal.placementdriver.leases;
 
-import static org.apache.ignite.internal.util.IgniteUtils.bytesToList;
-import static org.apache.ignite.internal.util.IgniteUtils.collectionToBytes;
-
 import java.nio.ByteBuffer;
 import java.util.Collection;
+import org.apache.ignite.internal.util.ByteUtils;
+import org.apache.ignite.internal.versioned.VersionedSerialization;
 
 /**
  * Representation of leases batch.
@@ -38,10 +37,11 @@ public class LeaseBatch {
     }
 
     public byte[] bytes() {
-        return collectionToBytes(leases, Lease::bytes);
+        return VersionedSerialization.toBytes(this, LeaseBatchSerializer.INSTANCE);
     }
 
     public static LeaseBatch fromBytes(ByteBuffer bytes) {
-        return new LeaseBatch(bytesToList(bytes, Lease::fromBytes));
+        byte[] byteArray = ByteUtils.toByteArray(bytes);
+        return VersionedSerialization.fromBytes(byteArray, LeaseBatchSerializer.INSTANCE);
     }
 }

--- a/modules/placement-driver/src/main/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatchSerializer.java
+++ b/modules/placement-driver/src/main/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatchSerializer.java
@@ -117,7 +117,7 @@ public class LeaseBatchSerializer extends VersionedSerializer<LeaseBatch> {
         long periodGcd = periodGcd(batch);
 
         out.writeVarInt(minExpirationTimePhysical);
-        out.writeVarInt(commonExpirationTime.getPhysical());
+        out.writeVarInt(commonExpirationTime.getPhysical() - minExpirationTimePhysical);
         out.writeVarInt(commonExpirationTime.getLogical());
         out.writeVarInt(periodGcd);
 
@@ -371,7 +371,7 @@ public class LeaseBatchSerializer extends VersionedSerializer<LeaseBatch> {
     @Override
     protected LeaseBatch readExternalData(byte protoVer, IgniteDataInput in) throws IOException {
         long minExpirationTimePhysical = in.readVarInt();
-        HybridTimestamp commonExpirationTime = new HybridTimestamp(in.readVarInt(), in.readVarIntAsInt());
+        HybridTimestamp commonExpirationTime = new HybridTimestamp(minExpirationTimePhysical + in.readVarInt(), in.readVarIntAsInt());
         long periodGcd = in.readVarInt();
         NodesDictionary nodesDictionary = NodesDictionary.readFrom(in);
 

--- a/modules/placement-driver/src/main/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatchSerializer.java
+++ b/modules/placement-driver/src/main/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatchSerializer.java
@@ -1,0 +1,485 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.placementdriver.leases;
+
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+
+import it.unimi.dsi.fastutil.longs.Long2IntMap;
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+import java.util.UUID;
+import org.apache.ignite.internal.hlc.HybridTimestamp;
+import org.apache.ignite.internal.replicator.PartitionGroupId;
+import org.apache.ignite.internal.replicator.TablePartitionId;
+import org.apache.ignite.internal.replicator.ZonePartitionId;
+import org.apache.ignite.internal.util.io.IgniteDataInput;
+import org.apache.ignite.internal.util.io.IgniteDataOutput;
+import org.apache.ignite.internal.versioned.VersionedSerializer;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * {@link VersionedSerializer} for {@link LeaseBatch} instances.
+ *
+ * <p>The following optimizations are applied to minimize the amount of bytes a batch is serialized to:</p>
+ * <ul>
+ *     <li>Java Serialization is not used to serialize components (it's pretty verbose)</li>
+ *     <li>Varints are used extensively</li>
+ *     <li>A dictionary of all nodes mentioned as lease holders and proposed candidates is collected and written in the header once
+ *     per batch. This is beneficial as we usually a lot more leases than number of nodes in cluster, so we can just represent nodes
+ *     and their names as indices in the dictionary (this is especially effective given we use varints as indices are usually very small).
+ *     </li>
+ *     <li>Leases are grouped per table/zone ID (aka object ID), so an object ID is only written once per table </li>
+ * </ul>
+ */
+public class LeaseBatchSerializer extends VersionedSerializer<LeaseBatch> {
+    /*
+     * The following optimizations are applied to minimize the number of bytes a batch is serialized to:
+     *
+     * - Java Serialization is not used to serialize components (it's pretty verbose)
+     * - Varints are used extensively
+     * - A dictionary of all nodes mentioned as lease holders and proposed candidates is collected and written in the header once
+     * per batch. This is beneficial as we usually a lot more leases than number of nodes in cluster, so we can just represent nodes
+     * and their names as indices in the dictionary (this is especially effective given we use varints as indices are usually very small).
+     * - Leases are grouped per table/zone ID (aka object ID), so an object ID is only written once per object
+     * - Object IDs are represented as deltas with respect to the previous object; as leases are sorted by object IDs, the deltas are
+     * encoded effectively as varints
+     * - Partition IDs are not written, instead their index represents partition ID. Holes are rare (if possible), so we just write
+     * special markers to denote holes
+     * - Expiration timestamps are always computed from Start timestamps. To account for a possibility of this duration being changed
+     * on the go, we pass the most frequent duration once per batch (in the header), and then we only write lease duration for leases with
+     * uncommon duration (that is, duration different from the most frequent one). We use a flag to distinguish such leases.
+     * - Expiration timestamps always have their logical part equal to 0, so it's never written.
+     * - Physical parts of Start timestamps are coded as deltas with respect to the least timestamp present in the batch; this allows to
+     * have those deltas small and encode them effectively as varints
+     */
+
+    /** Serializer instance. */
+    public static final LeaseBatchSerializer INSTANCE = new LeaseBatchSerializer();
+
+    /** Contains {@link Lease#isAccepted()}. */
+    @SuppressWarnings("PointlessBitwiseExpression")
+    private static final int ACCEPTED_MASK = 1 << 0;
+
+    /** Contains {@link Lease#isProlongable()}. */
+    private static final int PROLONGABLE_MASK = 1 << 1;
+
+    /** Whether the lease has a non-null {@link Lease#proposedCandidate()}. */
+    private static final int HAS_PROPOSED_CANDIDATE_MASK = 1 << 2;
+
+    /** Whether lease period (in absolute time) differs from the most common period in the batch. */
+    private static final int HAS_UNCOMMON_PERIOD_MASK = 1 << 3;
+
+    /** Whether expiration timestamp logical part is not zero (this is uncommon). */
+    private static final int HAS_EXPIRATION_LOGICAL_PART_MASK = 1 << 4;
+
+    /** Whether this is not a real lease, but a hole in partitionId sequence. Having this flag allows us to omit partitionId. */
+    private static final int DUMMY_LEASE_MASK = 1 << 5;
+
+    // When there are no more 8 nodes in the cluster, node name index and node index are guaranteed to fit in 7 bits we have in a varint
+    // byte, which allows us to enable 'compact mode' to save 1 byte per lease.
+
+    /** Number of bits to fit name index/node index in to enable compact mode. */
+    private static final int BIT_WIDTH_TO_FIT_IN_HALF_BYTE = 3;
+
+    /** Max size of cluster which allows compact mode. */
+    private static final int MAX_NODES_FOR_COMPACT_MODE = 1 << BIT_WIDTH_TO_FIT_IN_HALF_BYTE;
+
+    /** Mask to extract lease holder index from compact representation. */
+    private static final int COMPACT_HOLDER_INDEX_MASK = (1 << BIT_WIDTH_TO_FIT_IN_HALF_BYTE) - 1;
+
+    @Override
+    protected void writeExternalData(LeaseBatch batch, IgniteDataOutput out) throws IOException {
+        long minTimestampPhysical = minTimestampPhysicalPart(batch);
+        long commonLeasePeriod = mostFrequentLeasePeriod(batch);
+
+        out.writeVarInt(minTimestampPhysical);
+        out.writeVarInt(commonLeasePeriod);
+
+        NodesDictionary nodesDictionary = buildNodesDictionary(batch);
+        nodesDictionary.writeTo(out);
+
+        List<Lease> tableLeases = batch.leases().stream()
+                .filter(lease -> lease.replicationGroupId() instanceof TablePartitionId)
+                .collect(toList());
+        List<Lease> zoneLeases = batch.leases().stream()
+                .filter(lease -> lease.replicationGroupId() instanceof ZonePartitionId)
+                .collect(toList());
+        assert tableLeases.size() + zoneLeases.size() == batch.leases().size() : "There are " + batch.leases().size()
+                + " leases in total, "
+                + tableLeases.size() + " of them are table leases, " + zoneLeases.size() + " are zone leases, but "
+                + (batch.leases().size() - tableLeases.size() - zoneLeases.size()) + " are neither";
+
+        writePartitionedGroupLeases(tableLeases, minTimestampPhysical, commonLeasePeriod, nodesDictionary, out);
+
+        assert zoneLeases.isEmpty() : "There are zone leases which are not supported yet";
+    }
+
+    private static long minTimestampPhysicalPart(LeaseBatch batch) {
+        long min = HybridTimestamp.MAX_VALUE.getPhysical();
+
+        for (Lease lease : batch.leases()) {
+            min = Math.min(min, lease.getStartTime().getPhysical());
+            min = Math.min(min, lease.getExpirationTime().getPhysical());
+        }
+
+        return min;
+    }
+
+    private static long mostFrequentLeasePeriod(LeaseBatch batch) {
+        if (batch.leases().isEmpty()) {
+            return 0;
+        }
+
+        Long2IntMap counts = new Long2IntOpenHashMap();
+
+        for (Lease lease : batch.leases()) {
+            long period = lease.getExpirationTime().getPhysical() - lease.getStartTime().getPhysical();
+            counts.mergeInt(period, 1, Integer::sum);
+        }
+
+        long commonPeriod = -1;
+        int maxCount = -1;
+        for (Long2IntMap.Entry entry : counts.long2IntEntrySet()) {
+            if (entry.getIntValue() > maxCount) {
+                commonPeriod = entry.getLongKey();
+                maxCount = entry.getIntValue();
+            }
+        }
+
+        return commonPeriod;
+    }
+
+    private static NodesDictionary buildNodesDictionary(LeaseBatch batch) {
+        NodesDictionary nodesDictionary = new NodesDictionary();
+
+        for (Lease lease : batch.leases()) {
+            if (lease.getLeaseholderId() != null) {
+                assert lease.getLeaseholder() != null : lease;
+                nodesDictionary.putNode(lease.getLeaseholderId(), lease.getLeaseholder());
+            }
+            if (lease.proposedCandidate() != null) {
+                //noinspection DataFlowIssue
+                nodesDictionary.putName(lease.proposedCandidate());
+            }
+        }
+
+        return nodesDictionary;
+    }
+
+    private static void writePartitionedGroupLeases(
+            List<Lease> leases,
+            long minTsPhysical,
+            long commonLeasePeriod,
+            NodesDictionary nodesDictionary,
+            IgniteDataOutput out
+    ) throws IOException {
+        Map<Integer, List<Lease>> leasesByObjectId = leases.stream()
+                .collect(
+                        groupingBy(
+                                lease -> partitionedGroupIdFrom(lease).objectId(),
+                                TreeMap::new,
+                                toList()
+                        )
+                );
+
+        out.writeVarInt(leasesByObjectId.size());
+
+        int objectIdBase = 0;
+        for (Entry<Integer, List<Lease>> entry : leasesByObjectId.entrySet()) {
+            int objectId = entry.getKey();
+            List<Lease> objectLeases = entry.getValue();
+
+            objectIdBase = writeLeasesForObject(
+                    objectId,
+                    objectLeases,
+                    minTsPhysical,
+                    commonLeasePeriod,
+                    nodesDictionary,
+                    out,
+                    objectIdBase
+            );
+        }
+    }
+
+    private static PartitionGroupId partitionedGroupIdFrom(Lease lease) {
+        return (PartitionGroupId) lease.replicationGroupId();
+    }
+
+    private static int writeLeasesForObject(
+            int objectId,
+            List<Lease> objectLeases,
+            long minTsPhysical,
+            long commonLeasePeriod,
+            NodesDictionary nodesDictionary,
+            IgniteDataOutput out,
+            int objectIdBase
+    ) throws IOException {
+        objectLeases.sort(comparing(LeaseBatchSerializer::partitionedGroupIdFrom, comparing(PartitionGroupId::partitionId)));
+
+        out.writeVarInt(objectId - objectIdBase);
+
+        int partitionCount = partitionedGroupIdFrom(objectLeases.get(objectLeases.size() - 1)).partitionId() + 1;
+        out.writeVarInt(partitionCount);
+
+        int partitionId = 0;
+        for (Lease lease : objectLeases) {
+            partitionId = writeLease(lease, partitionId, minTsPhysical, commonLeasePeriod, nodesDictionary, out);
+        }
+
+        return objectId;
+    }
+
+    private static int writeLease(
+            Lease lease,
+            int partitionId,
+            long minTsPhysical,
+            long commonLeasePeriod,
+            NodesDictionary nodesDictionary,
+            IgniteDataOutput out
+    ) throws IOException {
+        PartitionGroupId groupId = partitionedGroupIdFrom(lease);
+
+        while (partitionId < groupId.partitionId()) {
+            // It's a hole in partitionId sequence, let's write a 'dummy lease'.
+            out.write(DUMMY_LEASE_MASK);
+            partitionId++;
+        }
+
+        assert partitionId == groupId.partitionId() : "Duplicate partitionId in " + lease;
+
+        assert lease.getLeaseholder() != null && lease.getLeaseholderId() != null : lease + " doesn't have a leaseholder";
+        assert lease.getStartTime() != HybridTimestamp.MIN_VALUE : lease + " has illegal start time";
+        assert lease.getExpirationTime() != HybridTimestamp.MIN_VALUE : lease + " has illegal expiration time";
+
+        UUID leaseHolderId = lease.getLeaseholderId();
+        String proposedCandidate = lease.proposedCandidate();
+        boolean hasProposedCandidate = proposedCandidate != null;
+
+        long periodAbsolutePart = lease.getExpirationTime().getPhysical() - lease.getStartTime().getPhysical();
+        boolean hasUncommonPeriod = periodAbsolutePart != commonLeasePeriod;
+        boolean hasExpirationLogicalPart = lease.getExpirationTime().getLogical() != 0;
+
+        out.write(flags(lease.isAccepted(), lease.isProlongable(), hasProposedCandidate, hasUncommonPeriod, hasExpirationLogicalPart));
+
+        if (holderIdAndProposedCandidateFitIn1Byte(nodesDictionary)) {
+            int nodesInfo = packNodesInfo(
+                    nodesDictionary.getNodeIndex(leaseHolderId),
+                    hasProposedCandidate ? nodesDictionary.getNameIndex(proposedCandidate) : 0
+            );
+            out.writeVarInt(nodesInfo);
+        } else {
+            out.writeVarInt(nodesDictionary.getNodeIndex(leaseHolderId));
+            if (hasProposedCandidate) {
+                out.writeVarInt(nodesDictionary.getNameIndex(proposedCandidate));
+            }
+        }
+
+        out.writeVarInt(lease.getStartTime().getPhysical() - minTsPhysical);
+        out.writeVarInt(lease.getStartTime().getLogical());
+
+        if (hasUncommonPeriod) {
+            out.writeVarInt(lease.getExpirationTime().getPhysical() - lease.getStartTime().getPhysical());
+        }
+        if (hasExpirationLogicalPart) {
+            out.writeVarInt(lease.getExpirationTime().getLogical());
+        }
+
+        return partitionId + 1;
+    }
+
+    private static int packNodesInfo(int holderNodeIndex, int proposedCandidateNameIndex) {
+        assert holderNodeIndex < MAX_NODES_FOR_COMPACT_MODE : holderNodeIndex;
+        assert proposedCandidateNameIndex < MAX_NODES_FOR_COMPACT_MODE : proposedCandidateNameIndex;
+
+        return holderNodeIndex | (proposedCandidateNameIndex << BIT_WIDTH_TO_FIT_IN_HALF_BYTE);
+    }
+
+    private static boolean holderIdAndProposedCandidateFitIn1Byte(NodesDictionary dictionary) {
+        // Up to 8 names means that for name index it's enough to have 3 bits, same for node index, so, in sum, they
+        // require up to 6 bits, and we have 7 bits in a varint byte.
+        return dictionary.nameCount() <= MAX_NODES_FOR_COMPACT_MODE;
+    }
+
+    private static int flags(
+            boolean accepted,
+            boolean prolongable,
+            boolean hasProposedCandidate,
+            boolean hasUncommonPeriod,
+            boolean hasExpirationLogicalPart
+    ) {
+        return (accepted ? ACCEPTED_MASK : 0)
+                | (prolongable ? PROLONGABLE_MASK : 0)
+                | (hasProposedCandidate ? HAS_PROPOSED_CANDIDATE_MASK : 0)
+                | (hasUncommonPeriod ? HAS_UNCOMMON_PERIOD_MASK : 0)
+                | (hasExpirationLogicalPart ? HAS_EXPIRATION_LOGICAL_PART_MASK : 0);
+    }
+
+    @Override
+    protected LeaseBatch readExternalData(byte protoVer, IgniteDataInput in) throws IOException {
+        long minTimestampPhysical = in.readVarInt();
+        long commonLeasePeriod = in.readVarInt();
+        NodesDictionary nodesDictionary = NodesDictionary.readFrom(in);
+
+        List<Lease> leases = new ArrayList<>();
+
+        readPartitionedGroupLeases(minTimestampPhysical, commonLeasePeriod, nodesDictionary, leases, in, TablePartitionId::new);
+
+        return new LeaseBatch(leases);
+    }
+
+    private static void readPartitionedGroupLeases(
+            long minTimestampPhysical,
+            long commonLeasePeriod,
+            NodesDictionary nodesDictionary,
+            List<Lease> leases,
+            IgniteDataInput in,
+            GroupIdFactory groupIdFactory
+    ) throws IOException {
+        int objectCount = in.readVarIntAsInt();
+
+        int objectIdBase = 0;
+        for (int i = 0; i < objectCount; i++) {
+            objectIdBase = readLeasesForObject(
+                    minTimestampPhysical,
+                    commonLeasePeriod,
+                    nodesDictionary,
+                    leases,
+                    in,
+                    groupIdFactory,
+                    objectIdBase
+            );
+        }
+    }
+
+    private static int readLeasesForObject(
+            long minTimestampPhysical,
+            long commonLeasePeriod,
+            NodesDictionary nodesDictionary,
+            List<Lease> leases,
+            IgniteDataInput in,
+            GroupIdFactory groupIdFactory,
+            int objectIdBase
+    ) throws IOException {
+        int objectId = objectIdBase + in.readVarIntAsInt();
+
+        int partitionCount = in.readVarIntAsInt();
+        for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+            Lease lease = readLeaseForPartition(
+                    partitionId,
+                    objectId,
+                    minTimestampPhysical,
+                    commonLeasePeriod,
+                    nodesDictionary,
+                    in,
+                    groupIdFactory
+            );
+            if (lease != null) {
+                leases.add(lease);
+            }
+        }
+
+        return objectId;
+    }
+
+    private static @Nullable Lease readLeaseForPartition(
+            int partitionId,
+            int objectId,
+            long minTimestampPhysical,
+            long commonLeasePeriod,
+            NodesDictionary nodesDictionary,
+            IgniteDataInput in,
+            GroupIdFactory groupIdFactory
+    ) throws IOException {
+        int flags = in.read();
+        if (flagSet(flags, DUMMY_LEASE_MASK)) {
+            // This represents a hole, just skip it.
+            return null;
+        }
+
+        boolean hasProposedCandidate = flagSet(flags, HAS_PROPOSED_CANDIDATE_MASK);
+
+        int holderNodeIndex;
+        int proposedCandidateNodeIndex = -1;
+        if (holderIdAndProposedCandidateFitIn1Byte(nodesDictionary)) {
+            int nodesInfo = in.readVarIntAsInt();
+
+            holderNodeIndex = unpackHolderNodeIndex(nodesInfo);
+
+            if (hasProposedCandidate) {
+                proposedCandidateNodeIndex = unpackProposedCandidateNameIndex(nodesInfo);
+            }
+        } else {
+            holderNodeIndex = in.readVarIntAsInt();
+
+            if (hasProposedCandidate) {
+                proposedCandidateNodeIndex = in.readVarIntAsInt();
+            }
+        }
+
+        UUID leaseHolderId = nodesDictionary.getNodeId(holderNodeIndex);
+        String leaseHolder = nodesDictionary.getNodeName(holderNodeIndex);
+        String proposedCandidate = null;
+        if (hasProposedCandidate) {
+            proposedCandidate = nodesDictionary.getName(proposedCandidateNodeIndex);
+        }
+
+        HybridTimestamp startTime = new HybridTimestamp(minTimestampPhysical + in.readVarInt(), in.readVarIntAsInt());
+
+        long period = flagSet(flags, HAS_UNCOMMON_PERIOD_MASK) ? startTime.getPhysical() + in.readVarInt()
+                : startTime.getPhysical() + commonLeasePeriod;
+
+        int expirationLogical = flagSet(flags, HAS_EXPIRATION_LOGICAL_PART_MASK) ? in.readVarIntAsInt() : 0;
+
+        HybridTimestamp expirationTime = new HybridTimestamp(period, expirationLogical);
+
+        return new Lease(
+                leaseHolder,
+                leaseHolderId,
+                startTime,
+                expirationTime,
+                flagSet(flags, PROLONGABLE_MASK),
+                flagSet(flags, ACCEPTED_MASK),
+                proposedCandidate,
+                groupIdFactory.create(objectId, partitionId)
+        );
+    }
+
+    private static int unpackHolderNodeIndex(int nodesInfo) {
+        return nodesInfo & COMPACT_HOLDER_INDEX_MASK;
+    }
+
+    private static int unpackProposedCandidateNameIndex(int nodesInfo) {
+        return nodesInfo >> BIT_WIDTH_TO_FIT_IN_HALF_BYTE;
+    }
+
+    private static boolean flagSet(int flags, int mask) {
+        return (flags & mask) != 0;
+    }
+
+    @FunctionalInterface
+    private interface GroupIdFactory {
+        PartitionGroupId create(int objectId, int partitionId);
+    }
+}

--- a/modules/placement-driver/src/main/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatchSerializer.java
+++ b/modules/placement-driver/src/main/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatchSerializer.java
@@ -206,22 +206,18 @@ public class LeaseBatchSerializer extends VersionedSerializer<LeaseBatch> {
     }
 
     private static long periodGcd(LeaseBatch batch) {
-        if (batch.leases().isEmpty()) {
-            // Any value will do for an empty batch.
-            return 1;
-        }
-
         long currentGcd = -1;
         for (Lease lease : batch.leases()) {
             long period = lease.getExpirationTime().getPhysical() - lease.getStartTime().getPhysical();
-            assert period > 0 : lease;
+            assert period >= 0 : "Period is " + period + " for " + lease;
 
-            currentGcd = currentGcd == -1 ? period : gcd(currentGcd, period);
+            if (period > 0) {
+                currentGcd = currentGcd == -1 ? period : gcd(currentGcd, period);
+            }
         }
 
-        assert currentGcd > 0 : batch;
-
-        return currentGcd;
+        // If there is no single positive period (maybe the batch is empty?), any value will do.
+        return currentGcd > 0 ? currentGcd : 1;
     }
 
     private static NodesDictionary buildNodesDictionary(LeaseBatch batch) {

--- a/modules/placement-driver/src/main/java/org/apache/ignite/internal/placementdriver/leases/NodesDictionary.java
+++ b/modules/placement-driver/src/main/java/org/apache/ignite/internal/placementdriver/leases/NodesDictionary.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.placementdriver.leases;
+
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.apache.ignite.internal.util.io.IgniteDataInput;
+import org.apache.ignite.internal.util.io.IgniteDataOutput;
+
+/**
+ * Represents a dictionary of nodes mentioned in a {@link LeaseBatch}.
+ *
+ * <p>Has two parts: table of node names and table of nodes (these are node ID + node name index pairs).
+ */
+final class NodesDictionary {
+    private final List<String> nameIndexToName = new ArrayList<>();
+    private final Object2IntMap<String> nameToNameIndex = new Object2IntOpenHashMap<>();
+
+    private final List<UUID> nodeIndexToId = new ArrayList<>();
+    private final Object2IntMap<UUID> idToNodeIndex = new Object2IntOpenHashMap<>();
+    private final Object2IntMap<UUID> idToNameIndex = new Object2IntOpenHashMap<>();
+
+    NodesDictionary() {
+        nameToNameIndex.defaultReturnValue(-1);
+        idToNodeIndex.defaultReturnValue(-1);
+        idToNameIndex.defaultReturnValue(-1);
+    }
+
+    int putNode(UUID id, String name) {
+        if (idToNodeIndex.containsKey(id)) {
+            return idToNodeIndex.getInt(id);
+        } else {
+            int nameIndex = putName(name);
+
+            int nodeIndex = idToNodeIndex.size();
+            nodeIndexToId.add(id);
+            idToNodeIndex.put(id, nodeIndex);
+            idToNameIndex.put(id, nameIndex);
+
+            return nodeIndex;
+        }
+    }
+
+    int putName(String name) {
+        int nameIndex;
+        if (nameToNameIndex.containsKey(name)) {
+            nameIndex = nameToNameIndex.getInt(name);
+        } else {
+            nameIndex = nameIndexToName.size();
+            nameIndexToName.add(name);
+            nameToNameIndex.put(name, nameIndex);
+        }
+
+        return nameIndex;
+    }
+
+    String getName(int nameIndex) {
+        return nameIndexToName.get(nameIndex);
+    }
+
+    UUID getNodeId(int nodeIndex) {
+        return nodeIndexToId.get(nodeIndex);
+    }
+
+    String getNodeName(int nodeIndex) {
+        UUID id = getNodeId(nodeIndex);
+        int nameIndex = idToNameIndex.getInt(id);
+        return getName(nameIndex);
+    }
+
+    int getNameIndex(String name) {
+        return nameToNameIndex.getInt(name);
+    }
+
+    int getNodeIndex(UUID leaseHolderId) {
+        return idToNodeIndex.getInt(leaseHolderId);
+    }
+
+    void writeTo(IgniteDataOutput out) throws IOException {
+        out.writeVarInt(nameIndexToName.size());
+        for (String name : nameIndexToName) {
+            out.writeUTF(name);
+        }
+
+        out.writeVarInt(nodeIndexToId.size());
+        for (UUID id : nodeIndexToId) {
+            out.writeUuid(id);
+            out.writeVarInt(idToNameIndex.getInt(id));
+        }
+    }
+
+    static NodesDictionary readFrom(IgniteDataInput in) throws IOException {
+        NodesDictionary dict = new NodesDictionary();
+
+        int namesCount = in.readVarIntAsInt();
+        for (int i = 0; i < namesCount; i++) {
+            dict.putName(in.readUTF());
+        }
+
+        int nodesCount = in.readVarIntAsInt();
+        for (int i = 0; i < nodesCount; i++) {
+            UUID id = in.readUuid();
+            int nameIndex = in.readVarIntAsInt();
+
+            String name = dict.nameIndexToName.get(nameIndex);
+            dict.putNode(id, name);
+        }
+
+        return dict;
+    }
+
+    int nameCount() {
+        return nameIndexToName.size();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        NodesDictionary that = (NodesDictionary) o;
+        return nameIndexToName.equals(that.nameIndexToName)
+                && nameToNameIndex.equals(that.nameToNameIndex)
+                && nodeIndexToId.equals(that.nodeIndexToId)
+                && idToNodeIndex.equals(that.idToNodeIndex)
+                && idToNameIndex.equals(that.idToNameIndex);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = nameIndexToName.hashCode();
+        result = 31 * result + nameToNameIndex.hashCode();
+        result = 31 * result + nodeIndexToId.hashCode();
+        result = 31 * result + idToNodeIndex.hashCode();
+        result = 31 * result + idToNameIndex.hashCode();
+        return result;
+    }
+}

--- a/modules/placement-driver/src/test/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatchSerializerTest.java
+++ b/modules/placement-driver/src/test/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatchSerializerTest.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.placementdriver.leases;
+
+import static java.util.Collections.emptyList;
+import static java.util.UUID.randomUUID;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.apache.ignite.internal.hlc.HybridTimestamp;
+import org.apache.ignite.internal.replicator.TablePartitionId;
+import org.apache.ignite.internal.versioned.VersionedSerialization;
+import org.junit.jupiter.api.Test;
+
+class LeaseBatchSerializerTest {
+    private static final UUID NODE1_ID = new UUID(0x1234567890ABCDEFL, 0xFEDCBA0987654321L);
+    private static final UUID NODE2_ID = new UUID(0xFEDCBA0987654321L, 0x1234567890ABCDEFL);
+
+    private static final long STANDARD_LEASE_DURATION_MS = 5000;
+
+    private final LeaseBatchSerializer serializer = new LeaseBatchSerializer();
+
+    @Test
+    void emptyBatch() {
+        LeaseBatch originalBatch = new LeaseBatch(emptyList());
+
+        verifySerializationAndDeserializationGivesSameResult(originalBatch);
+    }
+
+    private void verifySerializationAndDeserializationGivesSameResult(LeaseBatch originalBatch) {
+        byte[] bytes = VersionedSerialization.toBytes(originalBatch, serializer);
+        LeaseBatch restoredBatch = VersionedSerialization.fromBytes(bytes, serializer);
+
+        assertThat(restoredBatch.leases(), equalTo(originalBatch.leases()));
+        assertEquals(
+                originalBatch.leases().stream().map(Lease::proposedCandidate).collect(toList()),
+                restoredBatch.leases().stream().map(Lease::proposedCandidate).collect(toList())
+        );
+    }
+
+    @Test
+    void batchWithTablePartitionsOnly() {
+        HybridTimestamp baseTs = baseTs();
+
+        List<Lease> originalLeases = List.of(
+                new Lease("node1", NODE1_ID, baseTs, expiration(baseTs), true, true, "node2", new TablePartitionId(1, 0)),
+                new Lease(
+                        "node2",
+                        NODE2_ID,
+                        baseTs.addPhysicalTime(100),
+                        expiration(baseTs.addPhysicalTime(100)),
+                        false,
+                        false,
+                        null,
+                        new TablePartitionId(1, 1)
+                ),
+                new Lease("node1", NODE1_ID, baseTs, expiration(baseTs), true, true, "node2", new TablePartitionId(2, 0)),
+                new Lease(
+                        "node2",
+                        NODE2_ID,
+                        baseTs.addPhysicalTime(100),
+                        expiration(baseTs.addPhysicalTime(100)),
+                        false,
+                        false,
+                        null,
+                        new TablePartitionId(2, 1)
+                )
+        );
+
+        LeaseBatch originalBatch = new LeaseBatch(originalLeases);
+
+        verifySerializationAndDeserializationGivesSameResult(originalBatch);
+    }
+
+    private static HybridTimestamp baseTs() {
+        long physicalBase = LocalDateTime.of(2024, Month.JANUARY, 1, 0, 0)
+                .atOffset(ZoneOffset.UTC)
+                .toInstant()
+                .toEpochMilli();
+        return new HybridTimestamp(physicalBase, 0);
+    }
+
+    private static HybridTimestamp expiration(HybridTimestamp startTs) {
+        return expiration(startTs, STANDARD_LEASE_DURATION_MS);
+    }
+
+    private static HybridTimestamp expiration(HybridTimestamp startTs, long interval) {
+        return new HybridTimestamp(startTs.getPhysical() + interval, 0);
+    }
+
+    @Test
+    void batchWithTablePartitionsOnlyWithNulls() {
+        HybridTimestamp baseTs = baseTs();
+
+        List<Lease> originalLeases = List.of(
+                new Lease("node1", NODE1_ID, baseTs, expiration(baseTs), true, true, null, new TablePartitionId(1, 0))
+        );
+        LeaseBatch originalBatch = new LeaseBatch(originalLeases);
+
+        verifySerializationAndDeserializationGivesSameResult(originalBatch);
+    }
+
+    @Test
+    void batchWithTablePartitionsOnlyWithUncommonPeriod() {
+        HybridTimestamp baseTs = baseTs();
+
+        List<Lease> originalLeases = List.of(
+                new Lease("node1", NODE1_ID, baseTs, expiration(baseTs), true, true, null, new TablePartitionId(1, 0)),
+                new Lease("node1", NODE1_ID, baseTs, expiration(baseTs), true, true, null, new TablePartitionId(1, 1)),
+                // This lease has an uncommon period (1000 instead of 5000).
+                new Lease("node1", NODE1_ID, baseTs, expiration(baseTs, 1000), true, true, null, new TablePartitionId(1, 2))
+        );
+        LeaseBatch originalBatch = new LeaseBatch(originalLeases);
+
+        verifySerializationAndDeserializationGivesSameResult(originalBatch);
+    }
+
+    @Test
+    void batchWithExpirationTimeWithLogicalPart() {
+        HybridTimestamp baseTs = baseTs();
+
+        List<Lease> originalLeases = List.of(
+                new Lease("node1", NODE1_ID, baseTs, expiration(baseTs).tick(), true, true, "node2", new TablePartitionId(1, 0))
+        );
+
+        LeaseBatch originalBatch = new LeaseBatch(originalLeases);
+
+        verifySerializationAndDeserializationGivesSameResult(originalBatch);
+    }
+
+    @Test
+    void batchWithExactly8NodeNames() {
+        List<Lease> originalLeases = IntStream.range(0, 8)
+                .mapToObj(n -> {
+                    String nodeName = "node" + n;
+                    return tableLease(nodeName, randomUUID(), nodeName, n);
+                })
+                .collect(toList());
+        LeaseBatch originalBatch = new LeaseBatch(originalLeases);
+
+        verifySerializationAndDeserializationGivesSameResult(originalBatch);
+    }
+
+    @Test
+    void batchWithMoreThan8NodeNames() {
+        List<Lease> originalLeases = IntStream.range(0, 9)
+                .mapToObj(n -> tableLease("node" + n, randomUUID(), "candidate" + n, n))
+                .collect(toList());
+        LeaseBatch originalBatch = new LeaseBatch(originalLeases);
+
+        verifySerializationAndDeserializationGivesSameResult(originalBatch);
+    }
+
+    private static Lease tableLease(String holderName, UUID holderId, String proposedCandidate, int partitionId) {
+        TablePartitionId groupId = new TablePartitionId(1, partitionId);
+        return new Lease(holderName, holderId, baseTs(), expiration(baseTs()), true, true, proposedCandidate, groupId);
+    }
+
+    @Test
+    void batchWithHoleInTable() {
+        List<Lease> originalLeases = IntStream.of(0, 2)
+                .mapToObj(n -> {
+                    String nodeName = "node" + n;
+                    return tableLease(nodeName, randomUUID(), nodeName, n);
+                })
+                .collect(toList());
+        LeaseBatch originalBatch = new LeaseBatch(originalLeases);
+
+        verifySerializationAndDeserializationGivesSameResult(originalBatch);
+    }
+
+    @Test
+    void v1CanBeDeserialized() {
+        byte[] bytes = Base64.getDecoder().decode("Ae++Q4Hox5LMMYknAwZub2RlMQZub2RlMgPvzauQeFY0EiFDZYcJutz+ASFDZYcJutz+782rkHhWNBICAgID"
+                + "BwkBAQACZQE=");
+        LeaseBatch restoredBatch = VersionedSerialization.fromBytes(bytes, serializer);
+
+        assertThat(restoredBatch.leases(), hasSize(2));
+        Iterator<Lease> iterator = restoredBatch.leases().iterator();
+
+        Lease lease1 = iterator.next();
+        assertThat(
+                lease1,
+                equalTo(new Lease("node1", NODE1_ID, baseTs(), expiration(baseTs()), true, true, "node2", new TablePartitionId(1, 0)))
+        );
+        assertThat(lease1.proposedCandidate(), is("node2"));
+
+        Lease lease2 = iterator.next();
+        assertThat(
+                lease2,
+                equalTo(new Lease(
+                        "node2",
+                        NODE2_ID,
+                        baseTs().addPhysicalTime(100),
+                        expiration(baseTs().addPhysicalTime(100)),
+                        false,
+                        false,
+                        null,
+                        new TablePartitionId(1, 1)
+                ))
+        );
+        assertThat(lease2.proposedCandidate(), is(nullValue()));
+    }
+
+    @SuppressWarnings("unused")
+    private String v1LeaseBatchAsBase64() {
+        HybridTimestamp baseTs = baseTs();
+
+        List<Lease> originalLeases = List.of(
+                new Lease("node1", NODE1_ID, baseTs, expiration(baseTs), true, true, "node2", new TablePartitionId(1, 0)),
+                new Lease(
+                        "node2",
+                        NODE2_ID,
+                        baseTs.addPhysicalTime(100),
+                        expiration(baseTs.addPhysicalTime(100)),
+                        false,
+                        false,
+                        null,
+                        new TablePartitionId(1, 1)
+                )
+        );
+
+        LeaseBatch originalBatch = new LeaseBatch(originalLeases);
+
+        byte[] originalBytes = VersionedSerialization.toBytes(originalBatch, serializer);
+        return Base64.getEncoder().encodeToString(originalBytes);
+    }
+}

--- a/modules/placement-driver/src/test/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatchSerializerTest.java
+++ b/modules/placement-driver/src/test/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatchSerializerTest.java
@@ -46,8 +46,8 @@ class LeaseBatchSerializerTest {
 
     private static final long STANDARD_LEASE_DURATION_MS = 5000;
 
-    private static final String SERIALIZED_WITH_V1 = "Ae++Q4mPyJLMMQEBiScDBm5vZGUxBm5vZGUyA+/Nq5B4VjQSIUNlhwm63P4BIUNlhwm63P7vzauQeFY0Eg"
-            + "ICAgMHCQIBCAJlAgE";
+    private static final String SERIALIZED_WITH_V1 = "Ae++Q4mPyJLMMQEBAwZub2RlMQZub2RlMgPvzauQeFY0EiFDZYcJutz+ASFDZYcJutz+782rkHhWNBICA"
+            + "gIDBwmJJwEIAmWJJwE=";
 
     private final LeaseBatchSerializer serializer = new LeaseBatchSerializer();
 

--- a/modules/placement-driver/src/test/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatchSerializerTest.java
+++ b/modules/placement-driver/src/test/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatchSerializerTest.java
@@ -38,6 +38,7 @@ import java.util.stream.IntStream;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.apache.ignite.internal.replicator.TablePartitionId;
 import org.apache.ignite.internal.versioned.VersionedSerialization;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class LeaseBatchSerializerTest {
@@ -198,6 +199,7 @@ class LeaseBatchSerializerTest {
     }
 
     @Test
+    @Disabled
     void v1CanBeDeserialized() {
         byte[] bytes = Base64.getDecoder().decode("Ae++Q4Hox5LMMYknAwZub2RlMQZub2RlMgPvzauQeFY0EiFDZYcJutz+ASFDZYcJutz+782rkHhWNBICAgID"
                 + "BwkBAQACZQE=");

--- a/modules/placement-driver/src/test/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatchSerializerTest.java
+++ b/modules/placement-driver/src/test/java/org/apache/ignite/internal/placementdriver/leases/LeaseBatchSerializerTest.java
@@ -38,7 +38,6 @@ import java.util.stream.IntStream;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.apache.ignite.internal.replicator.TablePartitionId;
 import org.apache.ignite.internal.versioned.VersionedSerialization;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class LeaseBatchSerializerTest {
@@ -46,6 +45,9 @@ class LeaseBatchSerializerTest {
     private static final UUID NODE2_ID = new UUID(0xFEDCBA0987654321L, 0x1234567890ABCDEFL);
 
     private static final long STANDARD_LEASE_DURATION_MS = 5000;
+
+    private static final String SERIALIZED_WITH_V1 = "Ae++Q4mPyJLMMQEBiScDBm5vZGUxBm5vZGUyA+/Nq5B4VjQSIUNlhwm63P4BIUNlhwm63P7vzauQeFY0Eg"
+            + "ICAgMHCQIBCAJlAgE";
 
     private final LeaseBatchSerializer serializer = new LeaseBatchSerializer();
 
@@ -199,10 +201,8 @@ class LeaseBatchSerializerTest {
     }
 
     @Test
-    @Disabled
     void v1CanBeDeserialized() {
-        byte[] bytes = Base64.getDecoder().decode("Ae++Q4Hox5LMMYknAwZub2RlMQZub2RlMgPvzauQeFY0EiFDZYcJutz+ASFDZYcJutz+782rkHhWNBICAgID"
-                + "BwkBAQACZQE=");
+        byte[] bytes = Base64.getDecoder().decode(SERIALIZED_WITH_V1);
         LeaseBatch restoredBatch = VersionedSerialization.fromBytes(bytes, serializer);
 
         assertThat(restoredBatch.leases(), hasSize(2));

--- a/modules/placement-driver/src/test/java/org/apache/ignite/internal/placementdriver/leases/LeaseSerializationTest.java
+++ b/modules/placement-driver/src/test/java/org/apache/ignite/internal/placementdriver/leases/LeaseSerializationTest.java
@@ -32,30 +32,8 @@ import org.junit.jupiter.api.Test;
 /** Tests for lease encoding and decoding from byte arrays. */
 public class LeaseSerializationTest {
     @Test
-    public void testLeaseSerialization() {
-        long now = System.currentTimeMillis();
-        ReplicationGroupId groupId = new TablePartitionId(1, 1);
-
-        checksSerialization(Lease.emptyLease(groupId));
-
-        checksSerialization(newLease("node1", timestamp(now, 1), timestamp(now + 1_000_000, 100), true, true, null, groupId));
-
-        checksSerialization(newLease("node1", timestamp(now, 1), timestamp(now + 1_000_000, 100), false, false, "node2", groupId));
-
-        checksSerialization(newLease("node1", timestamp(now, 1), timestamp(now + 1_000_000, 100), false, true, "node2", groupId));
-
-        checksSerialization(newLease("node1", timestamp(now, 1), timestamp(now + 1_000_000, 100), true, false, null, groupId));
-
-        checksSerialization(newLease(null, timestamp(1, 1), timestamp(2 + 1_000_000, 100), true, true, null, groupId));
-
-        checksSerialization(newLease("node" + new String(new byte[1000]), timestamp(1, 1), timestamp(2, 100), false, false, null, groupId));
-    }
-
-    @Test
     public void testLeaseBatchSerialization() {
         var leases = new ArrayList<Lease>();
-
-        ReplicationGroupId groupId = new TablePartitionId(1, 1);
 
         for (int i = 0; i < 25; i++) {
             leases.add(newLease(
@@ -65,7 +43,7 @@ public class LeaseSerializationTest {
                     i % 2 == 0,
                     i % 2 == 1,
                     i % 2 == 0 ? null : "node" + i,
-                    groupId
+                    new TablePartitionId(1, i)
             ));
         }
 
@@ -74,12 +52,8 @@ public class LeaseSerializationTest {
         assertEquals(leases, LeaseBatch.fromBytes(wrap(leaseBatchBytes)).leases());
     }
 
-    private static void checksSerialization(Lease lease) {
-        assertEquals(lease, Lease.fromBytes(wrap(lease.bytes())));
-    }
-
     private static Lease newLease(
-            @Nullable String leaseholder,
+            String leaseholder,
             HybridTimestamp startTime,
             HybridTimestamp expirationTime,
             boolean prolong,
@@ -89,7 +63,7 @@ public class LeaseSerializationTest {
     ) {
         return new Lease(
                 leaseholder,
-                leaseholder == null ? null : randomUUID(),
+                randomUUID(),
                 startTime,
                 expirationTime,
                 prolong,

--- a/modules/placement-driver/src/test/java/org/apache/ignite/internal/placementdriver/leases/NodesDictionaryTest.java
+++ b/modules/placement-driver/src/test/java/org/apache/ignite/internal/placementdriver/leases/NodesDictionaryTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.placementdriver.leases;
+
+import static java.util.UUID.randomUUID;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.util.UUID;
+import org.apache.ignite.internal.util.io.IgniteDataInput;
+import org.apache.ignite.internal.util.io.IgniteDataOutput;
+import org.apache.ignite.internal.util.io.IgniteUnsafeDataInput;
+import org.apache.ignite.internal.util.io.IgniteUnsafeDataOutput;
+import org.junit.jupiter.api.Test;
+
+class NodesDictionaryTest {
+    private final NodesDictionary dictionary = new NodesDictionary();
+
+    @Test
+    void putsNames() {
+        dictionary.putName("a");
+        dictionary.putName("b");
+
+        assertThat(dictionary.getName(0), is("a"));
+        assertThat(dictionary.getName(1), is("b"));
+    }
+
+    @Test
+    void puttingNewNameReturnsNewIndex() {
+        assertThat(dictionary.putName("a"), is(0));
+        assertThat(dictionary.putName("b"), is(1));
+    }
+
+    @Test
+    void puttingExistingNameReturnsSameIndex() {
+        dictionary.putName("a");
+
+        assertThat(dictionary.putName("a"), is(0));
+    }
+
+    @Test
+    void putsNodes() {
+        UUID id1 = randomUUID();
+        UUID id2 = randomUUID();
+        dictionary.putNode(id1, "a");
+        dictionary.putNode(id2, "b");
+
+        assertThat(dictionary.getName(0), is("a"));
+        assertThat(dictionary.getName(1), is("b"));
+        assertThat(dictionary.getNodeId(0), is(id1));
+        assertThat(dictionary.getNodeId(1), is(id2));
+        assertThat(dictionary.getNodeName(0), is("a"));
+        assertThat(dictionary.getNodeName(1), is("b"));
+    }
+
+    @Test
+    void puttingNewNodeReturnsNewIndex() {
+        assertThat(dictionary.putNode(randomUUID(), "a"), is(0));
+        assertThat(dictionary.putNode(randomUUID(), "b"), is(1));
+    }
+
+    @Test
+    void puttingExistingNodeReturnsSameIndex() {
+        UUID id = randomUUID();
+        dictionary.putNode(id, "a");
+
+        assertThat(dictionary.putNode(id, "a"), is(0));
+    }
+
+    @Test
+    void supportsNodesWithSameName() {
+        UUID id1 = randomUUID();
+        UUID id2 = randomUUID();
+        dictionary.putNode(id1, "a");
+        dictionary.putNode(id2, "a");
+
+        assertThat(dictionary.getName(0), is("a"));
+        assertThat(dictionary.getNodeId(0), is(id1));
+        assertThat(dictionary.getNodeId(1), is(id2));
+        assertThat(dictionary.getNodeName(0), is("a"));
+        assertThat(dictionary.getNodeName(1), is("a"));
+    }
+
+    @Test
+    void putNodeAddsName() {
+        dictionary.putNode(randomUUID(), "a");
+
+        assertThat(dictionary.putName("a"), is(0));
+    }
+
+    @Test
+    void namesAndNodesHaveIndependentIndexes() {
+        assertThat(dictionary.putName("a"), is(0));
+        assertThat(dictionary.putNode(randomUUID(), "b"), is(0));
+    }
+
+    @Test
+    void nameCountIsZeroInitially() {
+        assertThat(dictionary.nameCount(), is(0));
+    }
+
+    @Test
+    void nameCountIsIncreasedWhenPuttingNewName() {
+        dictionary.putName("a");
+        assertThat(dictionary.nameCount(), is(1));
+
+        dictionary.putName("b");
+        assertThat(dictionary.nameCount(), is(2));
+    }
+
+    @Test
+    void nameCountIsNotIncreasedWhenPuttingExistingName() {
+        dictionary.putName("a");
+        dictionary.putName("a");
+
+        assertThat(dictionary.nameCount(), is(1));
+    }
+
+    @Test
+    void nameCountIsIncreasedWhenPuttingNewNode() {
+        dictionary.putNode(randomUUID(), "a");
+        assertThat(dictionary.nameCount(), is(1));
+
+        dictionary.putNode(randomUUID(), "b");
+        assertThat(dictionary.nameCount(), is(2));
+    }
+
+    @Test
+    void nameCountIsNotIncreasedWhenPuttingExistingNode() {
+        UUID id = randomUUID();
+        dictionary.putNode(id, "a");
+        dictionary.putNode(id, "a");
+
+        assertThat(dictionary.nameCount(), is(1));
+    }
+
+    @Test
+    void serializationAndDeserialization() throws Exception {
+        dictionary.putName("stray-name");
+        dictionary.putNode(randomUUID(), "node1");
+        dictionary.putNode(randomUUID(), "node2");
+        dictionary.putNode(randomUUID(), "node2");
+
+        IgniteDataOutput out = new IgniteUnsafeDataOutput(100);
+        dictionary.writeTo(out);
+        byte[] bytes = out.array();
+
+        IgniteDataInput in = new IgniteUnsafeDataInput(bytes);
+        NodesDictionary restoredDict = NodesDictionary.readFrom(in);
+
+        assertThat(restoredDict, equalTo(dictionary));
+    }
+}

--- a/modules/system-disaster-recovery/src/main/java/org/apache/ignite/internal/disaster/system/ResetClusterMessagePersistentSerializer.java
+++ b/modules/system-disaster-recovery/src/main/java/org/apache/ignite/internal/disaster/system/ResetClusterMessagePersistentSerializer.java
@@ -17,8 +17,6 @@
 
 package org.apache.ignite.internal.disaster.system;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -67,20 +65,6 @@ public class ResetClusterMessagePersistentSerializer extends VersionedSerializer
         }
     }
 
-    private static void writeStringSet(Set<String> strings, IgniteDataOutput out) throws IOException {
-        out.writeVarInt(strings.size());
-        for (String str : strings) {
-            out.writeUTF(str);
-        }
-    }
-
-    private static void writeNullableString(@Nullable String str, IgniteDataOutput out) throws IOException {
-        out.writeVarInt(str == null ? -1 : str.length());
-        if (str != null) {
-            out.writeByteArray(str.getBytes(UTF_8));
-        }
-    }
-
     @Override
     protected ResetClusterMessage readExternalData(byte protoVer, IgniteDataInput in) throws IOException {
         Set<String> newCmgNodes = readStringSet(in);
@@ -106,12 +90,6 @@ public class ResetClusterMessagePersistentSerializer extends VersionedSerializer
                 .build();
     }
 
-    private static Set<String> readStringSet(IgniteDataInput in) throws IOException {
-        int size = in.readVarIntAsInt();
-
-        return readStringSet(size, in);
-    }
-
     private static Set<String> readStringSet(int size, IgniteDataInput in) throws IOException {
         Set<String> result = new HashSet<>(size);
         for (int i = 0; i < size; i++) {
@@ -119,15 +97,6 @@ public class ResetClusterMessagePersistentSerializer extends VersionedSerializer
         }
 
         return result;
-    }
-
-    private static @Nullable String readNullableString(IgniteDataInput in) throws IOException {
-        int lengthOrMinusOne = in.readVarIntAsInt();
-        if (lengthOrMinusOne == -1) {
-            return null;
-        }
-
-        return new String(in.readByteArray(lengthOrMinusOne), UTF_8);
     }
 
     private static List<UUID> readFormerClusterIds(IgniteDataInput in) throws IOException {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23496

Apart from removing Java Serialization (which might make it more difficult to maintain backwards compatibility), new serialization is more compact and faster.

For the case of 1000 tables (25 partitions each) and 3 nodes in cluster, the gain in the number of bytes is approximately 30 times:

>Old 4710568 bytes, new 240456 bytes

Performance has also improved (serializing and deserializing same batch of 25000 leases):

```
Benchmark                                         Mode  Cnt      Score      Error  Units
LeaseBatchSerializationBenchmark.deserializeNew   avgt   15   1443,554 ±   52,776  us/op
LeaseBatchSerializationBenchmark.deserializeOld   avgt   15  67598,438 ± 2111,874  us/op
LeaseBatchSerializationBenchmark.serializeNew     avgt   15   5409,242 ±  310,886  us/op
LeaseBatchSerializationBenchmark.serializeOld     avgt   15  21167,838 ±  345,363  us/op
```