### PR TITLE
IGNITE-23520 Fix flaky IndexAvailabilityControllerTest#testMetastoreKeysAfterDropIndexWithTwoRemainingPartitions

### DIFF
--- a/modules/index/src/test/java/org/apache/ignite/internal/index/IndexAvailabilityControllerTest.java
+++ b/modules/index/src/test/java/org/apache/ignite/internal/index/IndexAvailabilityControllerTest.java
@@ -384,17 +384,7 @@ public class IndexAvailabilityControllerTest extends BaseIgniteAbstractTest {
                 .thenReturn(new RowId(partitionId))
                 .thenReturn(null);
 
-        indexBuilder.scheduleBuildIndex(
-                tableId(TABLE_NAME),
-                partitionId,
-                indexId,
-                indexStorage,
-                mock(MvPartitionStorage.class),
-                mock(ClusterNode.class),
-                ANY_ENLISTMENT_CONSISTENCY_TOKEN
-        );
-
-        CompletableFuture<Void> finishBuildIndexFuture = new CompletableFuture<>();
+        var finishBuildIndexFuture = new CompletableFuture<Void>();
 
         indexBuilder.listen(new IndexBuildCompletionListener() {
             @Override
@@ -404,6 +394,16 @@ public class IndexAvailabilityControllerTest extends BaseIgniteAbstractTest {
                 }
             }
         });
+
+        indexBuilder.scheduleBuildIndex(
+                tableId(TABLE_NAME),
+                partitionId,
+                indexId,
+                indexStorage,
+                mock(MvPartitionStorage.class),
+                mock(ClusterNode.class),
+                ANY_ENLISTMENT_CONSISTENCY_TOKEN
+        );
 
         assertThat(finishBuildIndexFuture, willCompleteSuccessfully());
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23520