### PR TITLE
IGNITE-23164 Improve ClientTuple validation for KV view

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTuple.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTuple.java
@@ -91,6 +91,14 @@ public class ClientTuple extends MutableTupleBinaryTupleAdapter {
         }
 
         if (fullBinaryTuple) {
+            if (part == TuplePart.KEY && column.keyIndex() < 0) {
+                return -1;
+            }
+
+            if (part == TuplePart.VAL && column.valIndex() < 0) {
+                return -1;
+            }
+
             return column.schemaIndex();
         }
 

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientKeyValueBinaryViewTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientKeyValueBinaryViewTest.java
@@ -93,7 +93,11 @@ public class ClientKeyValueBinaryViewTest extends AbstractClientTableTest {
         kvView.put(null, key, val);
         Tuple resVal = kvView.get(null, key);
 
+        assertNotNull(resVal);
         assertTupleEquals(val, resVal);
+
+        // Key columns should not be available in the value.
+        assertThrows(IllegalArgumentException.class, () -> resVal.longValue("id"));
     }
 
     @Test

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientTupleTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientTupleTest.java
@@ -260,6 +260,18 @@ public class ClientTupleTest extends AbstractMutableTupleTest {
 
     @SuppressWarnings("ThrowableNotThrown")
     @Test
+    public void testKeyOnlyDoesNotReturnValColumns() {
+        Tuple keyTupleWithFullRow = createTuplePart(TuplePart.KEY, false);
+
+        assertEquals(-1, keyTupleWithFullRow.columnIndex("I8"));
+        assertEquals(-1, keyTupleWithFullRow.columnIndex("\"i16\""));
+
+        assertThrows(IllegalArgumentException.class, () -> keyTupleWithFullRow.byteValue("I8"), "Column doesn't exist [name=I8]");
+        assertThrows(IllegalArgumentException.class, () -> keyTupleWithFullRow.byteValue("\"i16\""), "Column doesn't exist [name=\"i16\"]");
+    }
+
+    @SuppressWarnings("ThrowableNotThrown")
+    @Test
     public void testValOnlyDoesNotReturnKeyColumns() {
         Tuple valTupleWithFullRow = createTuplePart(TuplePart.VAL, false);
 

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientTupleTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientTupleTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.client;
 
+import static org.apache.ignite.internal.testframework.IgniteTestUtils.assertThrows;
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.assertThrowsWithCause;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -255,6 +256,18 @@ public class ClientTupleTest extends AbstractMutableTupleTest {
         assertEquals(valTupleFullData, valTuplePartialData);
         assertEquals(valTupleUser, valTupleFullData);
         assertEquals(valTupleUser, valTuplePartialData);
+    }
+
+    @SuppressWarnings("ThrowableNotThrown")
+    @Test
+    public void testValOnlyDoesNotReturnKeyColumns() {
+        Tuple valTupleWithFullRow = createTuplePart(TuplePart.VAL, false);
+
+        assertEquals(-1, valTupleWithFullRow.columnIndex("I32"));
+        assertEquals(-1, valTupleWithFullRow.columnIndex("\"STR\""));
+
+        assertThrows(IllegalArgumentException.class, () -> valTupleWithFullRow.byteValue("I32"), "Column doesn't exist [name=I32]");
+        assertThrows(IllegalArgumentException.class, () -> valTupleWithFullRow.byteValue("\"STR\""), "Column doesn't exist [name=\"STR\"]");
     }
 
     @Override


### PR DESCRIPTION
When `ClientTuple` wraps a full row but represents only key or value part, don't allow accessing the columns from the other part by name.

P.S. There is no such problem in .NET, because we don't use BinaryTuple wrapper for KV API. Ticket created: IGNITE-23537