### PR TITLE
IGNITE-23140 .NET: Fix TestBasicLogging flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
@@ -63,8 +63,6 @@ public class LoggingTests
 
         StringAssert.Contains("[Debug] Connection established", log);
         StringAssert.Contains("[Debug] Handshake succeeded [remoteAddress=[", log);
-        StringAssert.Contains("ClientFailoverSocket [Debug] Trying to establish secondary connections - awaiting 2 tasks", log);
-        StringAssert.Contains("ClientFailoverSocket [Debug] 2 secondary connections established, 0 failed", log);
         StringAssert.Contains("[Trace] Sending request [requestId=1, op=TablesGet, remoteAddress=", log);
         StringAssert.Contains("[Trace] Received response [requestId=1, flags=PartitionAssignmentChanged, remoteAddress=", log);
         StringAssert.Contains("op=SqlExec", log);


### PR DESCRIPTION
Remove flaky assertions. Those log messages can vary when secondary connections are established very quickly.

https://issues.apache.org/jira/browse/IGNITE-23140