### PR TITLE
IGNITE-23422 .NET: Update to .NET 8

### DIFF
--- a/modules/platforms/dotnet/.editorconfig
+++ b/modules/platforms/dotnet/.editorconfig
@@ -40,6 +40,7 @@ dotnet_diagnostic.CA2016.severity = error # Forward the CancellationToken parame
 dotnet_diagnostic.CA2017.severity = error # Parameter count mismatch in logging template
 dotnet_diagnostic.CA1806.severity = error # Do not ignore method results
 dotnet_diagnostic.CA1813.severity = error # Avoid unsealed attributes
+dotnet_diagnostic.CA1062.severity = error # Validate arguments of public methods // TODO - review
 dotnet_diagnostic.SA1600.severity = error # Elements should be documented
 
 dotnet_diagnostic.CA1024.severity = none # Use properties where appropriate

--- a/modules/platforms/dotnet/.editorconfig
+++ b/modules/platforms/dotnet/.editorconfig
@@ -59,3 +59,4 @@ dotnet_diagnostic.SA1013.severity = none # A closing brace within a C# element i
 dotnet_diagnostic.SA1413.severity = none # Trailing commas
 dotnet_diagnostic.SA1135.severity = none # Qualified references
 dotnet_diagnostic.CA1062.severity = none # Validate arguments of public methods // TODO - review
+dotnet_diagnostic.CA1859.severity = none # Use concrete types when possible for improved performance

--- a/modules/platforms/dotnet/.editorconfig
+++ b/modules/platforms/dotnet/.editorconfig
@@ -40,7 +40,6 @@ dotnet_diagnostic.CA2016.severity = error # Forward the CancellationToken parame
 dotnet_diagnostic.CA2017.severity = error # Parameter count mismatch in logging template
 dotnet_diagnostic.CA1806.severity = error # Do not ignore method results
 dotnet_diagnostic.CA1813.severity = error # Avoid unsealed attributes
-dotnet_diagnostic.CA1062.severity = error # Validate arguments of public methods // TODO - review
 dotnet_diagnostic.SA1600.severity = error # Elements should be documented
 
 dotnet_diagnostic.CA1024.severity = none # Use properties where appropriate
@@ -59,3 +58,4 @@ dotnet_diagnostic.SA1012.severity = none # Braces spacing
 dotnet_diagnostic.SA1013.severity = none # A closing brace within a C# element is not spaced correctly
 dotnet_diagnostic.SA1413.severity = none # Trailing commas
 dotnet_diagnostic.SA1135.severity = none # Qualified references
+dotnet_diagnostic.CA1062.severity = none # Validate arguments of public methods // TODO - review

--- a/modules/platforms/dotnet/.editorconfig
+++ b/modules/platforms/dotnet/.editorconfig
@@ -58,5 +58,5 @@ dotnet_diagnostic.SA1012.severity = none # Braces spacing
 dotnet_diagnostic.SA1013.severity = none # A closing brace within a C# element is not spaced correctly
 dotnet_diagnostic.SA1413.severity = none # Trailing commas
 dotnet_diagnostic.SA1135.severity = none # Qualified references
-dotnet_diagnostic.CA1062.severity = none # Validate arguments of public methods // TODO - review
+dotnet_diagnostic.CA1062.severity = none # Validate arguments of public methods (lots of false positives)
 dotnet_diagnostic.CA1859.severity = none # Use concrete types when possible for improved performance

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Apache.Ignite.Benchmarks.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Apache.Ignite.Benchmarks.csproj
@@ -19,7 +19,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>Apache.Ignite.Benchmarks.snk</AssemblyOriginatorKeyFile>
         <ServerGarbageCollection>true</ServerGarbageCollection>

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Sql/ResultSetBenchmarks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Sql/ResultSetBenchmarks.cs
@@ -163,6 +163,6 @@ namespace Apache.Ignite.Benchmarks.Sql
             }
         }
 
-        private record Rec(int Id);
+        private sealed record Rec(int Id);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionTemplate.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionTemplate.cs
@@ -21,7 +21,6 @@ namespace NAMESPACE
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using System.Runtime.Serialization;
 
     /// <summary>
     /// XMLDOC
@@ -42,17 +41,6 @@ namespace NAMESPACE
         /// <param name="innerException">Inner exception.</param>
         public IgniteTemplateException(Guid traceId, int code, string? message, Exception? innerException = null)
             : base(traceId, code, message, innerException)
-        {
-            // No-op.
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IgniteTemplateException"/> class.
-        /// </summary>
-        /// <param name="serializationInfo">Serialization information.</param>
-        /// <param name="streamingContext">Streaming context.</param>
-        private IgniteTemplateException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-            : base(serializationInfo, streamingContext)
         {
             // No-op.
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-#pragma warning disable CA1062 // Validate arguments of public methods
 namespace Apache.Ignite.Internal.Generators
 {
     using System;

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/ExceptionsGenerator.cs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#pragma warning disable CA1062 // Validate arguments of public methods
 namespace Apache.Ignite.Internal.Generators
 {
     using System;

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/.editorconfig
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/.editorconfig
@@ -42,6 +42,7 @@ dotnet_diagnostic.CA1819.severity = none # Properties should not return arrays
 dotnet_diagnostic.CA1812.severity = none # Avoid uninstantiated internal classes
 dotnet_diagnostic.CA5394.severity = none # Use secure random
 dotnet_diagnostic.CA1849.severity = none # Use async API instead of synchronous API
+dotnet_diagnostic.CA1852.severity = none # Type can be sealed
 
 dotnet_diagnostic.NUnit2005.severity = none # Consider using the constraint model
 dotnet_diagnostic.NUnit2006.severity = none # Consider using the constraint model

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/.editorconfig
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/.editorconfig
@@ -41,6 +41,7 @@ dotnet_diagnostic.CA1305.severity = none # Specify IFormatProvider
 dotnet_diagnostic.CA1819.severity = none # Properties should not return arrays
 dotnet_diagnostic.CA1812.severity = none # Avoid uninstantiated internal classes
 dotnet_diagnostic.CA5394.severity = none # Use secure random
+dotnet_diagnostic.CA1849.severity = none # Use async API instead of synchronous API
 
 dotnet_diagnostic.NUnit2005.severity = none # Consider using the constraint model
 dotnet_diagnostic.NUnit2006.severity = none # Consider using the constraint model

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/.editorconfig
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/.editorconfig
@@ -43,6 +43,7 @@ dotnet_diagnostic.CA1812.severity = none # Avoid uninstantiated internal classes
 dotnet_diagnostic.CA5394.severity = none # Use secure random
 dotnet_diagnostic.CA1849.severity = none # Use async API instead of synchronous API
 dotnet_diagnostic.CA1852.severity = none # Type can be sealed
+dotnet_diagnostic.CA1861.severity = none # Prefer 'static readonly' fields over constant array arguments
 
 dotnet_diagnostic.NUnit2005.severity = none # Consider using the constraint model
 dotnet_diagnostic.NUnit2006.severity = none # Consider using the constraint model

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Apache.Ignite.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Apache.Ignite.Tests.csproj
@@ -18,7 +18,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <SignAssembly>true</SignAssembly>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Dml.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Dml.cs
@@ -197,7 +197,7 @@ public partial class LinqTests
     public void TestExecuteUpdateWithResultOperatorsIsNotSupported()
     {
         var ex = Assert.ThrowsAsync<NotSupportedException>(
-            () => PocoView.AsQueryable().DefaultIfEmpty().ExecuteUpdateAsync(x => x.SetProperty(p => p.Key, 2)));
+            () => PocoView.AsQueryable().DefaultIfEmpty().ExecuteUpdateAsync(x => x.SetProperty(p => p!.Key, 2)));
 
         Assert.AreEqual("ExecuteUpdateAsync can not be combined with result operators: DefaultIfEmpty()", ex!.Message);
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Functions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Functions.cs
@@ -91,6 +91,7 @@ public partial class LinqTests
     }
 
     [Test]
+    [SuppressMessage("Globalization", "CA1311:Specify a culture or use an invariant version", Justification = "SQL")]
     public void TestStringFunctions()
     {
         TestOpString(x => x.Val + "_", "v-9_", "select concat(_T0.VAL, ?) from");

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Join.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.Join.cs
@@ -228,11 +228,11 @@ public partial class LinqTests
         var joinQuery = query1.Join(
                 inner: query2.DefaultIfEmpty(),
                 outerKeySelector: a => a.Key,
-                innerKeySelector: b => b.Key,
+                innerKeySelector: b => b!.Key,
                 resultSelector: (a, b) => new
                 {
                     Id = a.Key,
-                    Price = b.Val!.Value
+                    Price = b!.Val!.Value
                 })
             .OrderBy(x => x.Id);
 
@@ -266,11 +266,11 @@ public partial class LinqTests
         var joinQuery = query1.Join(
                 inner: query2.DefaultIfEmpty(),
                 outerKeySelector: a => a.Val,
-                innerKeySelector: b => b.Val,
+                innerKeySelector: b => b!.Val,
                 resultSelector: (a, b) => new
                 {
                     Id = a.Key,
-                    Id2 = b.Key,
+                    Id2 = b!.Key,
                     Name = b.Val
                 })
             .OrderBy(x => x.Id);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Linq/LinqTests.cs
@@ -691,6 +691,8 @@ public partial class LinqTests : IgniteTestsBase
     }
 
     [Test]
+    [SuppressMessage("Globalization", "CA1311:Specify a culture or use an invariant version", Justification = "SQL")]
+    [SuppressMessage("Performance", "CA1862:Use the \'StringComparison\' method overloads to perform case-insensitive string comparisons", Justification = "SQL")]
     public async Task TestGeneratedSqlIsLoggedWithDebugLevel()
     {
         var config = GetConfig();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/SslTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/SslTests.cs
@@ -178,6 +178,8 @@ public class SslTests : IgniteTestsBase
     }
 
     [Test]
+    [Platform("Linux", Reason = "CipherSuitesPolicy is not supported on Windows.")]
+    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Test runs only on Linux")]
     public async Task TestCustomCipherSuite()
     {
         var cipherSuite = OperatingSystem.IsMacOS()

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/SslTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/SslTests.cs
@@ -194,7 +194,7 @@ public class SslTests : IgniteTestsBase
                 SslClientAuthenticationOptions = new SslClientAuthenticationOptions
                 {
                     RemoteCertificateValidationCallback = (_, _, _, _) => true,
-                    CipherSuitesPolicy = new CipherSuitesPolicy(new[] { cipherSuite })
+                    CipherSuitesPolicy = new CipherSuitesPolicy([cipherSuite])
                 }
             }
         };

--- a/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.csproj
@@ -20,7 +20,7 @@
   <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Apache.Ignite.snk</AssemblyOriginatorKeyFile>

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClientConnectionException.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClientConnectionException.cs
@@ -19,7 +19,6 @@ namespace Apache.Ignite
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using System.Runtime.Serialization;
 
     /// <summary>
     /// Ignite thin client exception.
@@ -52,17 +51,6 @@ namespace Apache.Ignite
         /// <param name="innerException">Inner exception.</param>
         public IgniteClientConnectionException(Guid traceId, int code, string message, Exception? innerException = null)
             : base(traceId, code, message, innerException)
-        {
-            // No-op.
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IgniteClientConnectionException"/> class.
-        /// </summary>
-        /// <param name="serializationInfo">Serialization information.</param>
-        /// <param name="streamingContext">Streaming context.</param>
-        protected IgniteClientConnectionException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-            : base(serializationInfo, streamingContext)
         {
             // No-op.
         }

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteClientException.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteClientException.cs
@@ -19,7 +19,6 @@ namespace Apache.Ignite
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using System.Runtime.Serialization;
 
     /// <summary>
     /// Ignite thin client exception.
@@ -52,17 +51,6 @@ namespace Apache.Ignite
         /// <param name="innerException">Inner exception.</param>
         public IgniteClientException(Guid traceId, int code, string message, Exception? innerException = null)
             : base(traceId, code, message, innerException)
-        {
-            // No-op.
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IgniteClientException"/> class.
-        /// </summary>
-        /// <param name="serializationInfo">Serialization information.</param>
-        /// <param name="streamingContext">Streaming context.</param>
-        protected IgniteClientException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-            : base(serializationInfo, streamingContext)
         {
             // No-op.
         }

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteException.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteException.cs
@@ -19,8 +19,6 @@ namespace Apache.Ignite
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using System.Runtime.Serialization;
-    using Internal.Common;
 
     /// <summary>
     /// Ignite exception.
@@ -47,20 +45,6 @@ namespace Apache.Ignite
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="IgniteException"/> class.
-        /// </summary>
-        /// <param name="serializationInfo">Serialization information.</param>
-        /// <param name="streamingContext">Streaming context.</param>
-        protected IgniteException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-            : base(serializationInfo, streamingContext)
-        {
-            IgniteArgumentCheck.NotNull(serializationInfo);
-
-            TraceId = (Guid)serializationInfo.GetValue(nameof(TraceId), typeof(Guid))!;
-            Code = serializationInfo.GetInt32(nameof(Code));
-        }
-
-        /// <summary>
         /// Gets the group name.
         /// </summary>
         public string GroupName => ErrorGroups.GetGroupName(ErrorGroups.GetGroupCode(Code));
@@ -84,14 +68,5 @@ namespace Apache.Ignite
         /// Gets the code as string.
         /// </summary>
         public string CodeAsString => ErrorGroups.ErrPrefix + GroupName + '-' + ErrorCode;
-
-        /// <inheritdoc />
-        public override void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            base.GetObjectData(info, context);
-
-            info.AddValue(nameof(Code), Code);
-            info.AddValue(nameof(TraceId), TraceId);
-        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledBuffer.cs
@@ -108,12 +108,6 @@ namespace Apache.Ignite.Internal.Buffers
             GC.SuppressFinalize(this);
         }
 
-        private void CheckDisposed()
-        {
-            if (_disposed)
-            {
-                throw new ObjectDisposedException(nameof(PooledBuffer));
-            }
-        }
+        private void CheckDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientFailoverSocket.cs
@@ -439,13 +439,7 @@ namespace Apache.Ignite.Internal
         /// <summary>
         /// Throws if disposed.
         /// </summary>
-        private void ThrowIfDisposed()
-        {
-            if (_disposed)
-            {
-                throw new ObjectDisposedException(nameof(ClientFailoverSocket));
-            }
-        }
+        private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
 
         /// <summary>
         /// Gets the next connected socket, or connects a new one.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/ClientSocket.cs
@@ -225,7 +225,7 @@ namespace Apache.Ignite.Internal
             {
                 try
                 {
-                    cts.Cancel();
+                    await cts.CancelAsync().ConfigureAwait(false);
                     socket?.Dispose();
 
                     if (stream != null)
@@ -606,7 +606,7 @@ namespace Apache.Ignite.Internal
             return recommendedHeartbeatInterval;
         }
 
-        private static ISslInfo? GetSslInfo(Stream stream) =>
+        private static SslInfo? GetSslInfo(Stream stream) =>
             stream is SslStream sslStream
                 ? new SslInfo(
                     sslStream.TargetHostName,

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteArgumentCheck.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteArgumentCheck.cs
@@ -37,7 +37,8 @@ namespace Apache.Ignite.Internal.Common
         /// <summary>
         /// Throws an ArgumentNullException if specified arg is null.
         /// <para />
-        /// Unlike <see cref="ArgumentNullException.ThrowIfNull"/>, this is a generic method and does not cause boxing allocations.
+        /// Unlike <see cref="ArgumentNullException.ThrowIfNull(object?,string?)"/>,
+        /// this is a generic method and does not cause boxing allocations.
         /// </summary>
         /// <param name="arg">The argument.</param>
         /// <param name="argName">Name of the argument.</param>
@@ -60,7 +61,8 @@ namespace Apache.Ignite.Internal.Common
         /// <summary>
         /// Throws an ArgumentNullException if specified arg is null.
         /// <para />
-        /// Unlike <see cref="ArgumentNullException.ThrowIfNull"/>, this is a generic method and does not cause boxing allocations.
+        /// Unlike <see cref="ArgumentNullException.ThrowIfNull(object?,string?)"/>,
+        /// this is a generic method and does not cause boxing allocations.
         /// </summary>
         /// <param name="arg">The argument.</param>
         /// <param name="argName">Name of the argument.</param>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -300,7 +300,7 @@ namespace Apache.Ignite.Internal.Compute
             return new TaskState(id, status, createTime.GetValueOrDefault(), startTime, endTime);
         }
 
-        private IJobExecution<T> GetJobExecution<T>(
+        private JobExecution<T> GetJobExecution<T>(
             PooledBuffer computeExecuteResult,
             bool readSchema,
             IMarshaller<T>? marshaller)
@@ -332,7 +332,7 @@ namespace Apache.Ignite.Internal.Compute
             }
         }
 
-        private ITaskExecution<T> GetTaskExecution<T>(PooledBuffer computeExecuteResult)
+        private TaskExecution<T> GetTaskExecution<T>(PooledBuffer computeExecuteResult)
         {
             var reader = computeExecuteResult.GetReader();
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryExpressionVisitor.cs
@@ -297,7 +297,7 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
     {
         var first = true;
 
-        if (expression.NewExpression.Arguments.Any())
+        if (expression.NewExpression.Arguments.Count != 0)
         {
             VisitNew(expression.NewExpression);
             first = false;
@@ -547,7 +547,7 @@ internal sealed class IgniteQueryExpressionVisitor : ThrowingExpressionVisitor
     /// <param name="first">Whether this is the first column and does not need a comma before.</param>
     /// <param name="toSkip">Names to skip.</param>
     /// <param name="populateToSkip">Whether to populate provided toSkip set.</param>
-    private void AppendColumnNames(Type type, string tableName, bool first = true, ISet<string>? toSkip = null, bool populateToSkip = false)
+    private void AppendColumnNames(Type type, string tableName, bool first = true, HashSet<string>? toSkip = null, bool populateToSkip = false)
     {
         if (type.IsPrimitive)
         {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryParser.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Linq/IgniteQueryParser.cs
@@ -55,7 +55,7 @@ internal static class IgniteQueryParser
     /// <summary>
     /// Creates the node type provider.
     /// </summary>
-    private static INodeTypeProvider CreateNodeTypeProvider()
+    private static CompoundNodeTypeProvider CreateNodeTypeProvider()
     {
         var methodInfoRegistry = MethodInfoBasedNodeTypeRegistry.CreateFromRelinqAssembly();
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleIgniteTupleAdapter.cs
@@ -115,7 +115,7 @@ internal sealed class BinaryTupleIgniteTupleAdapter : IIgniteTuple, IEquatable<B
     /// <inheritdoc />
     public override int GetHashCode() => IIgniteTuple.GetHashCode(this);
 
-    private IIgniteTuple InitTuple()
+    private IgniteTuple InitTuple()
     {
         if (_tuple != null)
         {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/UuidSerializer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/UuidSerializer.cs
@@ -42,9 +42,9 @@ namespace Apache.Ignite.Internal.Proto
             var b = MemoryMarshal.Read<short>(span[4..]);
             var c = MemoryMarshal.Read<short>(span[6..]);
 
-            MemoryMarshal.Write(span[4..8], ref a);
-            MemoryMarshal.Write(span[2..4], ref b);
-            MemoryMarshal.Write(span[..2], ref c);
+            MemoryMarshal.Write(span[4..8], in a);
+            MemoryMarshal.Write(span[2..4], in b);
+            MemoryMarshal.Write(span[..2], in c);
 
             // Reverse second part order: defghijk -> kjihgfed.
             span[8..16].Reverse();

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ColumnTypeExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ColumnTypeExtensions.cs
@@ -27,7 +27,7 @@ using NodaTime;
 /// </summary>
 internal static class ColumnTypeExtensions
 {
-    private static readonly IReadOnlyDictionary<Type, ColumnType> ClrToSql = GetClrToSqlMap();
+    private static readonly Dictionary<Type, ColumnType> ClrToSql = GetClrToSqlMap();
 
     /// <summary>
     /// Gets corresponding .NET type.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSet.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/ResultSet.cs
@@ -386,10 +386,7 @@ namespace Apache.Ignite.Internal.Sql
 
             Debug.Assert(resourceId != null, "resourceId != null");
 
-            if (_resourceClosed)
-            {
-                throw new ObjectDisposedException(nameof(ResultSet<T>));
-            }
+            ObjectDisposedException.ThrowIf(_resourceClosed, this);
 
             writer.Write(_resourceId!.Value);
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/Sql.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Sql/Sql.cs
@@ -134,7 +134,7 @@ namespace Apache.Ignite.Internal.Sql
                 ColumnType.ByteArray => reader.GetBytes(idx),
                 ColumnType.Period => reader.GetPeriod(idx),
                 ColumnType.Duration => reader.GetDuration(idx),
-                _ => throw new ArgumentOutOfRangeException(nameof(col.Type), col.Type, "Unknown SQL column type.")
+                _ => throw new InvalidOperationException("Unknown SQL column type: " + col.Type)
             };
         }
 
@@ -202,7 +202,7 @@ namespace Apache.Ignite.Internal.Sql
             w.Write(propTuple.Build().Span);
         }
 
-        private static IIgniteTuple ReadTuple(IReadOnlyList<IColumnMetadata> cols, ref BinaryTupleReader tupleReader)
+        private static IgniteTuple ReadTuple(IReadOnlyList<IColumnMetadata> cols, ref BinaryTupleReader tupleReader)
         {
             var row = new IgniteTuple(cols.Count);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
@@ -109,7 +109,7 @@ internal static class DataStreamer
         }
         finally
         {
-            flushCts.Cancel();
+            await flushCts.CancelAsync().ConfigureAwait(false);
             foreach (var batch in batches.Values)
             {
                 batch.Buffer.Dispose();

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamerWithReceiver.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamerWithReceiver.cs
@@ -133,7 +133,7 @@ internal static class DataStreamerWithReceiver
         }
         finally
         {
-            flushCts.Cancel();
+            await flushCts.CancelAsync().ConfigureAwait(false);
             foreach (var batch in batches.Values)
             {
                 GetPool<TPayload>().Return(batch.Items);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/RecordView.cs
@@ -607,6 +607,7 @@ namespace Apache.Ignite.Internal.Table
             }
         }
 
+        [SuppressMessage("Maintainability", "CA1508:Avoid dead conditional code", Justification = "False positive")]
         private async Task<PooledBuffer?> DoMultiRecordOutOpAsync(
             ClientOp op,
             ITransaction? transaction,

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/BinaryTupleMethods.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/BinaryTupleMethods.cs
@@ -103,7 +103,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         private static readonly MethodInfo GetBigDecimalNullable = typeof(BinaryTupleReader).GetMethod(nameof(BinaryTupleReader.GetBigDecimalNullable))!;
         private static readonly MethodInfo GetBytes = typeof(BinaryTupleReader).GetMethod(nameof(BinaryTupleReader.GetBytesNullable))!;
 
-        private static readonly IReadOnlyDictionary<Type, MethodInfo> WriteMethods = new Dictionary<Type, MethodInfo>
+        private static readonly Dictionary<Type, MethodInfo> WriteMethods = new()
         {
             { typeof(string), AppendString },
             { typeof(sbyte), AppendByte },
@@ -137,7 +137,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
             { typeof(BigDecimal?), AppendBigDecimalNullable }
         };
 
-        private static readonly IReadOnlyDictionary<Type, MethodInfo> ReadMethods = new Dictionary<Type, MethodInfo>
+        private static readonly Dictionary<Type, MethodInfo> ReadMethods = new()
         {
             { typeof(string), GetString },
             { typeof(sbyte), GetByte },

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ReflectionUtils.cs
@@ -24,7 +24,6 @@ namespace Apache.Ignite.Internal.Table.Serialization
     using System.Linq.Expressions;
     using System.Reflection;
     using System.Runtime.CompilerServices;
-    using System.Runtime.Serialization;
 
     /// <summary>
     /// Reflection utilities.
@@ -35,7 +34,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// GetUninitializedObject method.
         /// </summary>
         public static readonly MethodInfo GetUninitializedObjectMethod = GetMethodInfo(
-            () => FormatterServices.GetUninitializedObject(null!));
+            () => RuntimeHelpers.GetUninitializedObject(null!));
 
         /// <summary>
         /// GetTypeFromHandle method.
@@ -213,14 +212,14 @@ namespace Apache.Ignite.Internal.Table.Serialization
         {
             // C# auto property backing field (<MyProperty>k__BackingField)
             // or anonymous type backing field (<MyProperty>i__Field):
-            if (fieldName.StartsWith("<", StringComparison.Ordinal)
-                && fieldName.IndexOf(">", StringComparison.Ordinal) is var endIndex and > 0)
+            if (fieldName.StartsWith('<')
+                && fieldName.IndexOf('>', StringComparison.Ordinal) is var endIndex and > 0)
             {
                 return fieldName.Substring(1, endIndex - 1);
             }
 
             // F# backing field:
-            if (fieldName.EndsWith("@", StringComparison.Ordinal))
+            if (fieldName.EndsWith('@'))
             {
                 return fieldName.Substring(0, fieldName.Length - 1);
             }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Table.cs
@@ -21,6 +21,7 @@ namespace Apache.Ignite.Internal.Table
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.Threading;
     using System.Threading.Tasks;
     using Buffers;
@@ -38,6 +39,10 @@ namespace Apache.Ignite.Internal.Table
     /// <summary>
     /// Table API.
     /// </summary>
+    [SuppressMessage(
+        "Design",
+        "CA1001:Types that own disposable fields should be disposable",
+        Justification = "SemaphoreSlim.m_waitHandle is not used.")]
     internal sealed class Table : ITable
     {
         /// <summary>

--- a/modules/platforms/dotnet/Directory.Build.props
+++ b/modules/platforms/dotnet/Directory.Build.props
@@ -19,7 +19,7 @@
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <WarningsAsErrors>CS8785</WarningsAsErrors>
-        <LangVersion>10</LangVersion>
+        <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
         <AnalysisMode>All</AnalysisMode>
 

--- a/modules/platforms/dotnet/Directory.Build.props
+++ b/modules/platforms/dotnet/Directory.Build.props
@@ -41,7 +41,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0"/>
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all"/>
     </ItemGroup>
 

--- a/modules/platforms/dotnet/global.json
+++ b/modules/platforms/dotnet/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "6.0.100",
+        "version": "8.0.110",
         "rollForward": "latestMinor"
     }
 }


### PR DESCRIPTION
.NET 6 [reaches end of life on November 12, 2024](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core). .NET 7 is already out of support. Switch to .NET 8 (current LTS).

* Remove obsolete `BinaryFormatter`-related code (see https://devblogs.microsoft.com/dotnet/binaryformatter-removed-from-dotnet-9/)
* Fix inspections