### PR TITLE
IGNITE-23575 Fix docfx build on CI

### DIFF
--- a/modules/platforms/dotnet/version.json
+++ b/modules/platforms/dotnet/version.json
@@ -6,6 +6,7 @@
         "^refs/heads/\\d+.*$"
     ],
     "cloudBuild": {
+        "setVersionVariables": false,
         "buildNumber": {
             "enabled": false
         }


### PR DESCRIPTION
Disable `setVersionVariables` in GitVersioning config to fix docfx build hang.

More details: https://github.com/dotnet/docfx/issues/10144