### PR TITLE
IGNITE-23456 Fix RetryLimitPolicy behavior

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/client/RetryLimitPolicy.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/RetryLimitPolicy.java
@@ -39,7 +39,7 @@ public class RetryLimitPolicy implements RetryPolicy {
     }
 
     /**
-     * Sets the retry limit. 0 or less for no limit.
+     * Sets the retry limit. 0 for no retries. -1 or less for unlimited retries.
      *
      * @return this instance.
      */
@@ -54,7 +54,11 @@ public class RetryLimitPolicy implements RetryPolicy {
     public boolean shouldRetry(RetryPolicyContext context) {
         Objects.requireNonNull(context);
 
-        if (retryLimit <= 0) {
+        if (retryLimit == 0) {
+            return false;
+        }
+
+        if (retryLimit < 0) {
             return true;
         }
 

--- a/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -101,7 +101,7 @@ public class ConnectionTest extends AbstractClientTest {
         try (var srv = new TestServer(300, new FakeIgnite(), x -> false, responseDelay, null, UUID.randomUUID(), null, null)) {
             Builder builder = IgniteClient.builder()
                     .addresses("127.0.0.1:" + srv.port())
-                    .retryPolicy(new RetryLimitPolicy().retryLimit(1))
+                    .retryPolicy(new RetryLimitPolicy().retryLimit(0))
                     .connectTimeout(50);
 
             assertThrowsWithCause(builder::build, TimeoutException.class);
@@ -117,7 +117,7 @@ public class ConnectionTest extends AbstractClientTest {
         try (var srv = new TestServer(300, new FakeIgnite(), x -> false, responseDelay, null, UUID.randomUUID(), null, null)) {
             Builder builder = IgniteClient.builder()
                     .addresses("127.0.0.1:" + srv.port())
-                    .retryPolicy(new RetryLimitPolicy().retryLimit(1))
+                    .retryPolicy(new RetryLimitPolicy().retryLimit(0))
                     .operationTimeout(30);
 
             try (IgniteClient client = builder.build()) {
@@ -141,7 +141,7 @@ public class ConnectionTest extends AbstractClientTest {
 
             Builder clientBuilder = IgniteClient.builder()
                     .addresses("127.0.0.1:" + testServer.port())
-                    .retryPolicy(new RetryLimitPolicy().retryLimit(1))
+                    .retryPolicy(new RetryLimitPolicy().retryLimit(0))
                     .connectTimeout(500);
 
             assertThrowsWithCause(
@@ -169,7 +169,7 @@ public class ConnectionTest extends AbstractClientTest {
 
             Builder clientBuilder = IgniteClient.builder()
                     .addresses("127.0.0.1:" + testServer.port())
-                    .retryPolicy(new RetryLimitPolicy().retryLimit(1))
+                    .retryPolicy(new RetryLimitPolicy().retryLimit(0))
                     .connectTimeout(30_000);
 
             CountDownLatch syncLatch = new CountDownLatch(1);

--- a/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -96,9 +96,9 @@ public class ConnectionTest extends AbstractClientTest {
     @SuppressWarnings("ThrowableNotThrown")
     @Test
     public void testNoResponseFromServerWithinConnectTimeoutThrowsException() {
-        Function<Integer, Integer> responseDelay = x -> 500;
+        Function<Integer, Integer> responseDelay = x -> 1000;
 
-        try (var srv = new TestServer(300, new FakeIgnite(), x -> false, responseDelay, null, UUID.randomUUID(), null, null)) {
+        try (var srv = new TestServer(3000, new FakeIgnite(), x -> false, responseDelay, null, UUID.randomUUID(), null, null)) {
             Builder builder = IgniteClient.builder()
                     .addresses("127.0.0.1:" + srv.port())
                     .retryPolicy(new RetryLimitPolicy().retryLimit(0))

--- a/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -96,6 +96,7 @@ public class ConnectionTest extends AbstractClientTest {
     @SuppressWarnings("ThrowableNotThrown")
     @Test
     public void testNoResponseFromServerWithinConnectTimeoutThrowsException() {
+        // Delay should be more than TimeoutWorker#sleepInterval.
         Function<Integer, Integer> responseDelay = x -> 1000;
 
         try (var srv = new TestServer(3000, new FakeIgnite(), x -> false, responseDelay, null, UUID.randomUUID(), null, null)) {

--- a/modules/client/src/test/java/org/apache/ignite/client/DataStreamerTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/DataStreamerTest.java
@@ -308,7 +308,7 @@ public class DataStreamerTest extends AbstractClientTableTest {
         Builder builder = IgniteClient.builder()
                 .addresses("localhost:" + testServer2.port())
                 .loggerFactory(logger)
-                .retryPolicy(new RetryLimitPolicy().retryLimit(1));
+                .retryPolicy(new RetryLimitPolicy().retryLimit(0));
 
         client2 = builder.build();
         RecordView<Tuple> view = defaultTableView(ignite2, client2);

--- a/modules/client/src/test/java/org/apache/ignite/client/DataStreamerTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/DataStreamerTest.java
@@ -227,10 +227,9 @@ public class DataStreamerTest extends AbstractClientTableTest {
         Function<Integer, Boolean> shouldDropConnection = idx -> idx % 5 == 4;
         var ignite2 = startTestServer2(shouldDropConnection, idx -> 0);
 
-        // Streamer has it's own retry policy, so we can disable retries on the client.
         Builder builder = IgniteClient.builder()
                 .addresses("localhost:" + testServer2.port())
-                .retryPolicy(new RetryLimitPolicy().retryLimit(0))
+                .retryPolicy(new RetryLimitPolicy().retryLimit(8))
                 .reconnectThrottlingPeriod(0)
                 .loggerFactory(new ConsoleLoggerFactory("client-2"));
 

--- a/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
@@ -93,7 +93,7 @@ public class HeartbeatTest extends BaseIgniteAbstractTest {
 
             Builder builder = IgniteClient.builder()
                     .addresses("127.0.0.1:" + srvPort)
-                    .retryPolicy(new RetryLimitPolicy().retryLimit(1))
+                    .retryPolicy(new RetryLimitPolicy().retryLimit(0))
                     .heartbeatTimeout(30)
                     .reconnectThrottlingPeriod(5000)
                     .reconnectThrottlingRetries(0)

--- a/modules/client/src/test/java/org/apache/ignite/client/SchemaUpdateTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/SchemaUpdateTest.java
@@ -100,7 +100,7 @@ public class SchemaUpdateTest extends BaseIgniteAbstractTest {
                 .addresses("127.0.0.1:" + server.port())
                 .metricsEnabled(true)
                 .loggerFactory(new TestLoggerFactory("client"))
-                .retryPolicy(new RetryLimitPolicy().retryLimit(0))
+                .retryPolicy(new RetryLimitPolicy().retryLimit(-1))
                 .build();
     }
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItClientDataStreamerLoadTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItClientDataStreamerLoadTest.java
@@ -66,7 +66,7 @@ public final class ItClientDataStreamerLoadTest extends ClusterPerClassIntegrati
                     .addresses("localhost")
                     .heartbeatInterval(1000)
                     .heartbeatTimeout(2000)
-                    .retryPolicy(new RetryLimitPolicy().retryLimit(1))
+                    .retryPolicy(new RetryLimitPolicy().retryLimit(0))
                     .build();
         }
     }


### PR DESCRIPTION
It was not possible to disable retries previously, 0 meant infinite retries and 1 meant 1 retry. Some tests were using incorrect values.

Change to:
* -1 for infinite retries
* 0 for disabled retries
* N for max N retries