### PR TITLE
IGNITE-23585 Fix flaky DeploymentUnitAcquiredWaiterTest

### DIFF
--- a/modules/code-deployment/src/test/java/org/apache/ignite/internal/deployunit/DeploymentUnitAcquiredWaiterTest.java
+++ b/modules/code-deployment/src/test/java/org/apache/ignite/internal/deployunit/DeploymentUnitAcquiredWaiterTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
@@ -135,6 +136,19 @@ class DeploymentUnitAcquiredWaiterTest extends BaseIgniteAbstractTest {
                 .until(() -> removingUnits.contains(unit2), isEqual(false));
 
         deploymentUnit2.release();
+    }
+
+    @Test
+    void notInfinityLoop() {
+        DeploymentUnit unit1 = new DeploymentUnit("unit1", "1.0.0");
+
+        deploymentUnitAccessor.acquire(unit1);
+
+        undeployer.submitToAcquireRelease(unit1);
+
+        // check delay between attempts to undeploy the unit.
+        verify(deploymentUnitAccessor, after(DELAY_IN_MILLIS * 5).atMost(7))
+                .computeIfNotAcquired(eq(unit1), any());
     }
 
     @AfterEach


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23585

This test verifies that there's some delay between invocations but if main thread takes longer to call `verify` the waiter thread can call the method more than expected.
The actual chain of calls for the initial failure is this:
* `setUp` is called, which calls `scheduleWithFixedDelay`, but it's not guaranteed that even with the `initialDelay` of 0 the task will be called immediately, so it's delayed for some time.
* Test is started, `submitToAcquireRelease` is called, adding a unit to the queue so the `computeIfNotAcquired` is called for the first time.
* `processQueue` is called, the queue is not empty, so the `computeIfNotAcquired` is called once more
* 5 more intervals passes in the `verify`, so that total number of calls of `computeIfNotAcquired` is 7.