### PR TITLE
IGNITE-23661 Eliminate race in onBeforeApply within StandaloneMetaStorageManager

### DIFF
--- a/modules/distribution-zones/src/integrationTest/java/org/apache/ignite/internal/distributionzones/ItIgniteDistributionZoneManagerNodeRestartTest.java
+++ b/modules/distribution-zones/src/integrationTest/java/org/apache/ignite/internal/distributionzones/ItIgniteDistributionZoneManagerNodeRestartTest.java
@@ -130,7 +130,6 @@ import org.apache.ignite.internal.worker.fixtures.NoOpCriticalWorkerRegistry;
 import org.apache.ignite.network.NetworkAddress;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -434,7 +433,6 @@ public class ItIgniteDistributionZoneManagerNodeRestartTest extends BaseIgniteRe
     }
 
     @Test
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-23661")
     public void testLogicalTopologyRestoredAfterRestart() throws Exception {
         PartialNode node = startPartialNode(0);
 
@@ -538,7 +536,6 @@ public class ItIgniteDistributionZoneManagerNodeRestartTest extends BaseIgniteRe
     }
 
     @Test
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-23661")
     public void testFirstLogicalTopologyUpdateInterruptedEventRestoredAfterRestart() throws Exception {
         PartialNode node = startPartialNode(0);
 
@@ -705,7 +702,6 @@ public class ItIgniteDistributionZoneManagerNodeRestartTest extends BaseIgniteRe
 
     @ParameterizedTest(name = "defaultZone={0}")
     @ValueSource(booleans = {true, false})
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-23660")
     public void testScaleUpTimerIsRestoredAfterRestart(boolean defaultZone) throws Exception {
         PartialNode node = startPartialNode(0);
 

--- a/modules/distribution-zones/src/main/java/org/apache/ignite/internal/distributionzones/DistributionZoneManager.java
+++ b/modules/distribution-zones/src/main/java/org/apache/ignite/internal/distributionzones/DistributionZoneManager.java
@@ -310,6 +310,8 @@ public class DistributionZoneManager implements IgniteComponent {
 
         busyLock.block();
 
+        zonesState.values().forEach(ZoneState::stopTimers);
+
         rebalanceEngine.stop();
 
         logicalTopologyService.removeEventListener(topologyEventListener);

--- a/modules/distribution-zones/src/main/java/org/apache/ignite/internal/distributionzones/rebalance/DistributionZoneRebalanceEngine.java
+++ b/modules/distribution-zones/src/main/java/org/apache/ignite/internal/distributionzones/rebalance/DistributionZoneRebalanceEngine.java
@@ -92,7 +92,7 @@ public class DistributionZoneRebalanceEngine {
     public static final boolean ENABLED = getBoolean(FEATURE_FLAG_NAME, false);
 
     /** Special flag to skip rebalance on node recovery for tests. */
-    // TODO: IGNITE-23466 Remove it
+    // TODO: IGNITE-23561 Remove it
     @TestOnly
     public static final String SKIP_REBALANCE_TRIGGERS_RECOVERY = "IGNITE_SKIP_REBALANCE_TRIGGERS_RECOVERY";
 

--- a/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/server/WatchProcessor.java
+++ b/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/server/WatchProcessor.java
@@ -220,6 +220,13 @@ public class WatchProcessor implements ManuallyCloseable {
 
                                 return notificationFuture;
                             }, watchExecutor);
+                }, watchExecutor)
+                .whenCompleteAsync((unused, throwable) -> {
+                    if (throwable != null) {
+                        LOG.error("Failed to notify watches.", throwable);
+
+                        notifyFailureHandlerOnFirstFailureInNotificationChain(throwable);
+                    }
                 }, watchExecutor);
 
         notificationFuture = newFuture;

--- a/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/server/WatchProcessor.java
+++ b/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/server/WatchProcessor.java
@@ -220,13 +220,6 @@ public class WatchProcessor implements ManuallyCloseable {
 
                                 return notificationFuture;
                             }, watchExecutor);
-                }, watchExecutor)
-                .whenCompleteAsync((unused, throwable) -> {
-                    if (throwable != null) {
-                        LOG.error("Failed to notify watches.", throwable);
-
-                        notifyFailureHandlerOnFirstFailureInNotificationChain(throwable);
-                    }
                 }, watchExecutor);
 
         notificationFuture = newFuture;

--- a/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/server/WatchProcessor.java
+++ b/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/server/WatchProcessor.java
@@ -177,6 +177,7 @@ public class WatchProcessor implements ManuallyCloseable {
     public CompletableFuture<Void> notifyWatches(List<Entry> updatedEntries, HybridTimestamp time) {
         assert time != null;
 
+        // TODO https://issues.apache.org/jira/browse/IGNITE-23675
         CompletableFuture<Void> newFuture = notificationFuture
                 .thenComposeAsync(v -> {
                     // Revision must be the same for all entries.

--- a/modules/metastorage/src/testFixtures/java/org/apache/ignite/internal/metastorage/impl/StandaloneMetaStorageManager.java
+++ b/modules/metastorage/src/testFixtures/java/org/apache/ignite/internal/metastorage/impl/StandaloneMetaStorageManager.java
@@ -255,7 +255,7 @@ public class StandaloneMetaStorageManager extends MetaStorageManagerImpl {
             synchronized (listener) {
                 Command command = invocation.getArgument(0);
 
-                if (listener instanceof BeforeApplyHandler) {
+                if (listener instanceof BeforeApplyHandler && command instanceof WriteCommand) {
                     ((BeforeApplyHandler) listener).onBeforeApply(command);
                 }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23661

Long story short, the stack trace of a problem is following:

1. `assertTrue(waitForCondition(() -> newLogicalTopology.equals(finalDistributionZoneManager.logicalTopology())` fails because `finalDistributionZoneManager.logicalTopology()` is not updated because 

2. `notificationFuture` in `WatchProcessor#notifyWatches()` is not completed because `notifyUpdateRevisionFuture` is not completed because 
 
3. `assert causalityToken > lastCompleteToken` in `org.apache.ignite.internal.causality.IncrementalVersionedValue#completeInternal` isn't matched (but not logged though) because

 
4. watch events are reordered by revision despite the fact that they are properly ordered by timestamp, see `org.apache.ignite.internal.metastorage.server.NotifyWatchProcessorEvent#compareTo` for more details.
 
5. All in all, order mismatch is a result of non-thread safe `StandaloneMetaStorageManager`. Both `onBeforeApply` and command processing within listener should be thread-safe. That's why there's a race between operation safeTime assignment and revision calculation. onBeforeApply is guarded by group specific monitor, precisely `synchronized (groupIdSyncMonitor(request.groupId()))`
See `ActionRequestProcessor.handleRequestInternal` for more details. Command processing on its turn is expected to be processed under raft umbrella, meaning in single-thread environment.

And corresponding synchronisation was missed in `StandaloneMetaStorageManager`.