### PR TITLE
IGNITE-23076 Add shared timeout worker for all client channels

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientTimeoutWorker.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientTimeoutWorker.java
@@ -18,21 +18,19 @@
 package org.apache.ignite.internal.client;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.apache.ignite.internal.lang.IgniteSystemProperties.getLong;
 import static org.apache.ignite.internal.util.FastTimestamps.coarseCurrentTimeMillis;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import org.apache.ignite.internal.future.timeout.TimeoutWorker;
 import org.apache.ignite.internal.logger.Loggers;
 import org.apache.ignite.internal.thread.NamedThreadFactory;
 import org.jetbrains.annotations.Nullable;
 
 final class ClientTimeoutWorker {
     static final ClientTimeoutWorker INSTANCE = new ClientTimeoutWorker();
-
-    private static final long sleepInterval = getLong("IGNITE_TIMEOUT_WORKER_SLEEP_INTERVAL", 500);
 
     private static final int emptyCountThreshold = 10;
 
@@ -53,6 +51,7 @@ final class ClientTimeoutWorker {
             executor = createExecutor();
             emptyCount = 0;
 
+            long sleepInterval = TimeoutWorker.getSleepInterval();
             executor.scheduleAtFixedRate(this::checkTimeouts, sleepInterval, sleepInterval, MILLISECONDS);
         }
     }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientTimeoutWorker.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientTimeoutWorker.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.client;
+
+import java.util.ArrayList;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.apache.ignite.internal.future.timeout.TimeoutWorker;
+
+final class ClientTimeoutWorker {
+    public static final ClientTimeoutWorker INSTANCE = new ClientTimeoutWorker();
+
+    private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
+
+    private final ArrayList<TcpClientChannel> channels = new ArrayList<>();
+
+    void registerClientChannel(TcpClientChannel ch) {
+        // TODO: Register channels
+        // Loop in worker body, remove closed channels
+
+        rwLock.writeLock().lock();
+
+        try {
+            channels.add(ch);
+        } finally {
+            rwLock.writeLock().unlock();
+        }
+    }
+}

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientTimeoutWorker.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientTimeoutWorker.java
@@ -46,6 +46,7 @@ final class ClientTimeoutWorker {
 
     synchronized void registerClientChannel(TcpClientChannel ch) {
         channels.put(ch, ch);
+        emptyCount = 0;
 
         if (executor == null) {
             executor = createExecutor();

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientTimeoutWorker.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientTimeoutWorker.java
@@ -20,7 +20,7 @@ package org.apache.ignite.internal.client;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.ignite.internal.util.FastTimestamps.coarseCurrentTimeMillis;
 
-import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -36,7 +36,7 @@ final class ClientTimeoutWorker {
 
     private @Nullable ScheduledExecutorService executor = null;
 
-    private final Map<TcpClientChannel, TcpClientChannel> channels = new ConcurrentHashMap<>();
+    private final Set<TcpClientChannel> channels = ConcurrentHashMap.newKeySet();
 
     private int emptyCount;
 
@@ -45,7 +45,7 @@ final class ClientTimeoutWorker {
     }
 
     synchronized void registerClientChannel(TcpClientChannel ch) {
-        channels.put(ch, ch);
+        channels.add(ch);
         emptyCount = 0;
 
         if (executor == null) {
@@ -78,7 +78,7 @@ final class ClientTimeoutWorker {
     private void checkTimeouts() {
         long now = coarseCurrentTimeMillis();
 
-        for (TcpClientChannel ch : channels.keySet()) {
+        for (TcpClientChannel ch : channels) {
             if (ch.closed()) {
                 channels.remove(ch);
             }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientTimeoutWorker.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientTimeoutWorker.java
@@ -21,8 +21,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.ignite.internal.lang.IgniteSystemProperties.getLong;
 import static org.apache.ignite.internal.util.FastTimestamps.coarseCurrentTimeMillis;
 
+import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -41,14 +41,14 @@ final class ClientTimeoutWorker {
 
     private @Nullable ScheduledExecutorService executor = null;
 
-    private final Set<TcpClientChannel> channels = new ConcurrentHashMap<TcpClientChannel, Object>().keySet();
+    private final Map<TcpClientChannel, TcpClientChannel> channels = new ConcurrentHashMap<>();
 
     private ClientTimeoutWorker() {
         // No-op.
     }
 
     synchronized void registerClientChannel(TcpClientChannel ch) {
-        channels.add(ch);
+        channels.put(ch, ch);
 
         if (executor == null) {
             executor = createExecutor();
@@ -73,7 +73,7 @@ final class ClientTimeoutWorker {
     private void checkTimeouts() {
         long now = coarseCurrentTimeMillis();
 
-        for (TcpClientChannel ch : channels) {
+        for (TcpClientChannel ch : channels.keySet()) {
             if (ch.closed()) {
                 channels.remove(ch);
             }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -99,7 +99,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
     private final AtomicLong reqId = new AtomicLong(1);
 
     /** Pending requests. */
-    private final ConcurrentMap<Long, TimeoutObjectImpl> pendingReqs = new ConcurrentHashMap<>();
+    final ConcurrentMap<Long, TimeoutObject> pendingReqs = new ConcurrentHashMap<>();
 
     /** Notification handlers. */
     private final Map<Long, CompletableFuture<PayloadInputChannel>> notificationHandlers = new ConcurrentHashMap<>();
@@ -257,7 +257,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
                 sock.close();
             }
 
-            for (TimeoutObjectImpl pendingReq : pendingReqs.values()) {
+            for (TimeoutObject pendingReq : pendingReqs.values()) {
                 pendingReq.future().completeExceptionally(
                         new IgniteClientConnectionException(CONNECTION_ERR, "Channel is closed", endpoint(), cause));
             }
@@ -466,7 +466,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
             return;
         }
 
-        TimeoutObjectImpl pendingReq = pendingReqs.remove(resId);
+        TimeoutObject pendingReq = pendingReqs.remove(resId);
 
         if (pendingReq == null) {
             log.error("Unexpected response ID [remoteAddress=" + cfg.getAddress() + "]: " + resId);

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
@@ -43,6 +43,7 @@ import org.apache.ignite.internal.metrics.AbstractMetricSource;
 import org.apache.ignite.internal.metrics.MetricSet;
 import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
 import org.apache.ignite.internal.testframework.IgniteTestUtils;
+import org.apache.ignite.internal.testframework.WithSystemProperty;
 import org.apache.ignite.lang.ErrorGroups.Sql;
 import org.apache.ignite.table.DataStreamerItem;
 import org.apache.ignite.table.Table;
@@ -138,6 +139,7 @@ public class ClientMetricsTest extends BaseIgniteAbstractTest {
     }
 
     @Test
+    @WithSystemProperty(key = "IGNITE_TIMEOUT_WORKER_SLEEP_INTERVAL", value = "10")
     public void testHandshakesFailedTimeout() throws InterruptedException {
         AtomicInteger counter = new AtomicInteger();
         Function<Integer, Boolean> shouldDropConnection = requestIdx -> false;

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
@@ -56,6 +56,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Tests client-side metrics (see also server-side metrics tests in {@link ServerMetricsTest}).
  */
+@WithSystemProperty(key = "IGNITE_TIMEOUT_WORKER_SLEEP_INTERVAL", value = "10")
 public class ClientMetricsTest extends BaseIgniteAbstractTest {
     private TestServer server;
     private IgniteClient client;
@@ -139,7 +140,6 @@ public class ClientMetricsTest extends BaseIgniteAbstractTest {
     }
 
     @Test
-    @WithSystemProperty(key = "IGNITE_TIMEOUT_WORKER_SLEEP_INTERVAL", value = "10")
     public void testHandshakesFailedTimeout() throws InterruptedException {
         AtomicInteger counter = new AtomicInteger();
         Function<Integer, Boolean> shouldDropConnection = requestIdx -> false;

--- a/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests client connection to various addresses.
  */
+@WithSystemProperty(key = "IGNITE_TIMEOUT_WORKER_SLEEP_INTERVAL", value = "10")
 public class ConnectionTest extends AbstractClientTest {
     @Test
     public void testEmptyNodeAddress() {
@@ -111,7 +112,6 @@ public class ConnectionTest extends AbstractClientTest {
 
     @SuppressWarnings("ThrowableNotThrown")
     @Test
-    @WithSystemProperty(key = "IGNITE_TIMEOUT_WORKER_SLEEP_INTERVAL", value = "10")
     public void testNoResponseFromServerWithinOperationTimeoutThrowsException() {
         Function<Integer, Integer> responseDelay = x -> x > 2 ? 100 : 0;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutWorker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutWorker.java
@@ -36,7 +36,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public class TimeoutWorker extends IgniteWorker {
     /** Worker sleep interval. */
-    private final long sleepInterval = getLong("IGNITE_TIMEOUT_WORKER_SLEEP_INTERVAL", 500);
+    private final long sleepInterval = getSleepInterval();
 
     /** Active operations. */
     public final ConcurrentMap<Long, TimeoutObject<?>> requestsMap;
@@ -118,5 +118,9 @@ public class TimeoutWorker extends IgniteWorker {
                 log.error("Timeout worker failed and can't process the timeouts any longer [worker={}].", t, name());
             }
         }
+    }
+
+    public static long getSleepInterval() {
+        return getLong("IGNITE_TIMEOUT_WORKER_SLEEP_INTERVAL", 500);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutWorker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/future/timeout/TimeoutWorker.java
@@ -41,9 +41,6 @@ public class TimeoutWorker extends IgniteWorker {
     /** Active operations. */
     public final ConcurrentMap<Long, TimeoutObject<?>> requestsMap;
 
-    /** True means removing object from the operation map on timeout. */
-    private final boolean removeOnTimeout;
-
     /** Closure to process throwables in the worker thread. */
     @Nullable
     private final FailureProcessor failureProcessor;
@@ -56,7 +53,6 @@ public class TimeoutWorker extends IgniteWorker {
      * @param name Worker name. Note that in general thread name and worker (runnable) name are two different things. The same
      *         worker can be executed by multiple threads and therefore for logging and debugging purposes we separate the two.
      * @param requestsMap Active operations.
-     * @param removeOnTimeout Remove operation from map.
      * @param failureProcessor Closure to process throwables in the worker thread.
      */
     public TimeoutWorker(
@@ -64,13 +60,11 @@ public class TimeoutWorker extends IgniteWorker {
             String igniteInstanceName,
             String name,
             ConcurrentMap requestsMap,
-            boolean removeOnTimeout,
             @Nullable FailureProcessor failureProcessor
     ) {
         super(log, igniteInstanceName, name, null);
 
         this.requestsMap = requestsMap;
-        this.removeOnTimeout = removeOnTimeout;
         this.failureProcessor = failureProcessor;
     }
 
@@ -95,9 +89,7 @@ public class TimeoutWorker extends IgniteWorker {
                         if (!fut.isDone()) {
                             fut.completeExceptionally(new TimeoutException());
 
-                            if (removeOnTimeout) {
-                                requestsMap.remove(entry.getKey(), timeoutObject);
-                            }
+                            requestsMap.remove(entry.getKey(), timeoutObject);
                         }
                     }
                 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/future/timeout/TimeoutWorkerTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/future/timeout/TimeoutWorkerTest.java
@@ -52,7 +52,7 @@ public class TimeoutWorkerTest {
     private static final IgniteLogger LOG = Loggers.forClass(TimeoutWorkerTest.class);
 
     private TimeoutWorker createTimeoutWorker(String name, ConcurrentMap reqMap, FailureProcessor failureProcessor) {
-        return new TimeoutWorker(LOG, "node", name, reqMap, true, failureProcessor);
+        return new TimeoutWorker(LOG, "node", name, reqMap, failureProcessor);
     }
 
     @Test

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/DefaultMessagingService.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/DefaultMessagingService.java
@@ -173,7 +173,6 @@ public class DefaultMessagingService extends AbstractMessagingService {
                 nodeName,
                 "MessagingService-timeout-worker",
                 requestsMap,
-                true,
                 failureManager
         );
     }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/FutureTimeoutBenchmark.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/FutureTimeoutBenchmark.java
@@ -94,9 +94,6 @@ public class FutureTimeoutBenchmark {
                     "test-node",
                     "FutureTimeoutBenchmark-timeout-worker",
                     requestsMap,
-                    // Client-facing future will fail with a timeout, but internal ClientRequestFuture will stay in the map -
-                    // otherwise we'll fail with "protocol breakdown" error when a late response arrives from the server.
-                    true,
                     null
             );
 


### PR DESCRIPTION
Use shared timeout worker for all client channels within the JVM instead of one worker per channel.

The worker starts on demand, and shuts down if there are no active channels during some period of time.

https://issues.apache.org/jira/browse/IGNITE-23076