### PR TITLE
IGNITE-23696 Fix return result for remote execution

### DIFF
--- a/modules/compute/src/jobs/java/org/apache/ignite/internal/compute/SilentSleepJob.java
+++ b/modules/compute/src/jobs/java/org/apache/ignite/internal/compute/SilentSleepJob.java
@@ -22,15 +22,15 @@ import java.util.concurrent.TimeUnit;
 import org.apache.ignite.compute.ComputeJob;
 import org.apache.ignite.compute.JobExecutionContext;
 
-/** Compute job that sleeps for a number of milliseconds passed in the argument and throws a {@link RuntimeException} if interrupted. */
-public class SleepJob implements ComputeJob<Long, Void> {
+/** Compute job that sleeps for a number of milliseconds passed in the argument and completes successfully in any case. */
+public class SilentSleepJob implements ComputeJob<Long, Void> {
     @Override
     public CompletableFuture<Void> executeAsync(JobExecutionContext jobExecutionContext, Long timeout) {
         try {
             TimeUnit.SECONDS.sleep(timeout);
-            return null;
         } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+            // no op.
         }
+        return null;
     }
 }

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/FailSafeJobExecution.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/FailSafeJobExecution.java
@@ -158,7 +158,6 @@ class FailSafeJobExecution<T> implements JobExecution<T>, MarshallerProvider<T> 
 
     @Override
     public CompletableFuture<@Nullable Boolean> cancelAsync() {
-        resultFuture.cancel(false);
         return runningJobExecution.get().cancelAsync();
     }
 

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/queue/QueueExecutionImpl.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/queue/QueueExecutionImpl.java
@@ -21,6 +21,7 @@ import static org.apache.ignite.lang.ErrorGroups.Compute.QUEUE_OVERFLOW_ERR;
 
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
@@ -186,10 +187,11 @@ class QueueExecutionImpl<R> implements QueueExecution<R> {
             } else {
                 if (queueEntry.isInterrupted()) {
                     stateMachine.cancelJob(jobId);
+                    result.completeExceptionally(new CancellationException());
                 } else {
                     stateMachine.completeJob(jobId);
+                    result.complete(r);
                 }
-                result.complete(r);
             }
         });
     }

--- a/modules/compute/src/test/java/org/apache/ignite/internal/compute/queue/PriorityQueueExecutorTest.java
+++ b/modules/compute/src/test/java/org/apache/ignite/internal/compute/queue/PriorityQueueExecutorTest.java
@@ -245,7 +245,7 @@ public class PriorityQueueExecutorTest extends BaseIgniteAbstractTest {
                 execution::state,
                 jobStateWithStatusAndCreateTimeStartTime(CANCELED, executingState.createTime(), executingState.startTime())
         );
-        assertThat(execution.resultAsync(), willBe(0));
+        assertThat(execution.resultAsync(), willThrow(CancellationException.class));
     }
 
     @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23696

Complete result future exceptionally when cancellation was requested before the job completion.