### PR TITLE
IGNITE-23569 Fix TcpClientChannel.close reliability

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -248,7 +248,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
             try {
                 handler.completeExceptionally(
                         new IgniteClientConnectionException(CONNECTION_ERR, "Channel is closed", endpoint(), cause));
-            } catch (Exception ignored) {
+            } catch (Throwable ignored) {
                 // Ignore.
             }
         }
@@ -702,7 +702,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
                     srvVer, ProtocolBitmaskFeature.allFeaturesAsEnumSet(), serverIdleTimeout, clusterNode, clusterIds, clusterName);
 
             return null;
-        } catch (Exception e) {
+        } catch (Throwable e) {
             log.warn("Failed to handle handshake response [remoteAddress=" + cfg.getAddress() + "]: " + e.getMessage(), e);
 
             throw e;

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientMetricsTest.java
@@ -143,7 +143,7 @@ public class ClientMetricsTest extends BaseIgniteAbstractTest {
     public void testHandshakesFailedTimeout() throws InterruptedException {
         AtomicInteger counter = new AtomicInteger();
         Function<Integer, Boolean> shouldDropConnection = requestIdx -> false;
-        Function<Integer, Integer> responseDelay = idx -> counter.incrementAndGet() == 1 ? 500 : 0;
+        Function<Integer, Integer> responseDelay = idx -> counter.incrementAndGet() == 1 ? 600 : 0;
         server = new TestServer(
                 1000,
                 new FakeIgnite(),

--- a/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -113,7 +113,7 @@ public class ConnectionTest extends AbstractClientTest {
     @SuppressWarnings("ThrowableNotThrown")
     @Test
     public void testNoResponseFromServerWithinOperationTimeoutThrowsException() {
-        Function<Integer, Integer> responseDelay = x -> x > 2 ? 100 : 0;
+        Function<Integer, Integer> responseDelay = x -> x > 2 ? 600 : 0;
 
         try (var srv = new TestServer(300, new FakeIgnite(), x -> false, responseDelay, null, UUID.randomUUID(), null, null)) {
             Builder builder = IgniteClient.builder()

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -557,8 +557,9 @@ public class IgniteUtils {
      * will be propagated to the caller, after all other objects are closed, similar to the try-with-resources block.
      *
      * @param closeables Stream of objects to close.
+     * @throws Exception If failed to close.
      */
-    public static void closeAll(Stream<? extends AutoCloseable> closeables) {
+    public static void closeAll(Stream<? extends AutoCloseable> closeables) throws Exception {
         AtomicReference<Throwable> ex = new AtomicReference<>();
 
         closeables.filter(Objects::nonNull).forEach(closeable -> {
@@ -594,7 +595,7 @@ public class IgniteUtils {
      * @throws Exception If failed to close.
      * @see #closeAll(Collection)
      */
-    public static void closeAll(AutoCloseable... closeables) {
+    public static void closeAll(AutoCloseable... closeables) throws Exception {
         closeAll(Arrays.stream(closeables));
     }
 
@@ -605,7 +606,7 @@ public class IgniteUtils {
      * @param closeables Stream of objects to close.
      * @throws Exception If failed to close.
      */
-    public static void closeAllManually(Stream<? extends ManuallyCloseable> closeables) {
+    public static void closeAllManually(Stream<? extends ManuallyCloseable> closeables) throws Exception {
         AtomicReference<Throwable> ex = new AtomicReference<>();
 
         closeables.filter(Objects::nonNull).forEach(closeable -> {

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -557,9 +557,8 @@ public class IgniteUtils {
      * will be propagated to the caller, after all other objects are closed, similar to the try-with-resources block.
      *
      * @param closeables Stream of objects to close.
-     * @throws Exception If failed to close.
      */
-    public static void closeAll(Stream<? extends AutoCloseable> closeables) throws Exception {
+    public static void closeAll(Stream<? extends AutoCloseable> closeables) {
         AtomicReference<Throwable> ex = new AtomicReference<>();
 
         closeables.filter(Objects::nonNull).forEach(closeable -> {
@@ -595,7 +594,7 @@ public class IgniteUtils {
      * @throws Exception If failed to close.
      * @see #closeAll(Collection)
      */
-    public static void closeAll(AutoCloseable... closeables) throws Exception {
+    public static void closeAll(AutoCloseable... closeables) {
         closeAll(Arrays.stream(closeables));
     }
 
@@ -606,7 +605,7 @@ public class IgniteUtils {
      * @param closeables Stream of objects to close.
      * @throws Exception If failed to close.
      */
-    public static void closeAllManually(Stream<? extends ManuallyCloseable> closeables) throws Exception {
+    public static void closeAllManually(Stream<? extends ManuallyCloseable> closeables) {
         AtomicReference<Throwable> ex = new AtomicReference<>();
 
         closeables.filter(Objects::nonNull).forEach(closeable -> {


### PR DESCRIPTION
* Make sure all cleanup steps are performed
* Handle exception in `sock.close()` - we don't care about network issues when closing the channel