### PR TITLE
IGNITE-23704: Incorrect equal implementation in TemporalNativeType and VarlenNativeType

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/type/TemporalNativeType.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/type/TemporalNativeType.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.type;
 
 import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
 
+import java.util.Objects;
 import org.apache.ignite.internal.tostring.S;
 
 /**
@@ -93,6 +94,28 @@ public class TemporalNativeType extends NativeType {
     @Override
     public String displayName() {
         return format("{}({})", super.displayName(), precision);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        TemporalNativeType that = (TemporalNativeType) o;
+        return precision == that.precision;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), precision);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/type/VarlenNativeType.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/type/VarlenNativeType.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.type;
 
 import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
 
+import java.util.Objects;
 import org.apache.ignite.internal.tostring.S;
 
 /**
@@ -59,6 +60,29 @@ public class VarlenNativeType extends NativeType {
         return len;
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        VarlenNativeType that = (VarlenNativeType) o;
+        return len == that.len;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), len);
+    }
+
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return S.toString(VarlenNativeType.class.getSimpleName(), "name", spec(), "len", len);

--- a/modules/core/src/test/java/org/apache/ignite/internal/type/NativeTypeTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/type/NativeTypeTest.java
@@ -17,8 +17,10 @@
 
 package org.apache.ignite.internal.type;
 
+import static org.apache.ignite.internal.type.NativeTypes.BOOLEAN;
 import static org.apache.ignite.internal.type.NativeTypes.BYTES;
 import static org.apache.ignite.internal.type.NativeTypes.DATE;
+import static org.apache.ignite.internal.type.NativeTypes.DOUBLE;
 import static org.apache.ignite.internal.type.NativeTypes.FLOAT;
 import static org.apache.ignite.internal.type.NativeTypes.INT16;
 import static org.apache.ignite.internal.type.NativeTypes.INT32;
@@ -26,10 +28,14 @@ import static org.apache.ignite.internal.type.NativeTypes.INT64;
 import static org.apache.ignite.internal.type.NativeTypes.INT8;
 import static org.apache.ignite.internal.type.NativeTypes.STRING;
 import static org.apache.ignite.internal.type.NativeTypes.UUID;
+import static org.apache.ignite.internal.type.NativeTypes.blobOf;
 import static org.apache.ignite.internal.type.NativeTypes.datetime;
+import static org.apache.ignite.internal.type.NativeTypes.decimalOf;
+import static org.apache.ignite.internal.type.NativeTypes.stringOf;
 import static org.apache.ignite.internal.type.NativeTypes.time;
 import static org.apache.ignite.internal.type.NativeTypes.timestamp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -140,5 +146,66 @@ public class NativeTypeTest {
     @Test
     public void compareVarlenTypesByDesc() {
         assertTrue(BYTES.compareTo(STRING) < 0);
+    }
+
+    @Test
+    public void basicTypeEquality() {
+        assertEquals(BOOLEAN, new NativeType(NativeTypeSpec.BOOLEAN, 1));
+
+        assertEquals(INT8, new NativeType(NativeTypeSpec.INT8, 1));
+        assertEquals(INT16, new NativeType(NativeTypeSpec.INT16, 2));
+        assertEquals(INT32, new NativeType(NativeTypeSpec.INT32, 4));
+        assertEquals(INT64, new NativeType(NativeTypeSpec.INT64, 8));
+
+        assertEquals(FLOAT, new NativeType(NativeTypeSpec.FLOAT, 4));
+        assertEquals(DOUBLE, new NativeType(NativeTypeSpec.DOUBLE, 8));
+
+        assertEquals(DATE, new NativeType(NativeTypeSpec.DATE, 3));
+        assertEquals(UUID, new NativeType(NativeTypeSpec.UUID, 16));
+    }
+
+    @Test
+    public void temporalTypeEquality() {
+        assertEquals(time(0), time(0));
+        assertNotEquals(time(1), time(0));
+        assertNotEquals(time(0), time(1));
+
+        assertEquals(timestamp(1), timestamp(1));
+        assertEquals(timestamp(0), timestamp(0));
+        assertNotEquals(timestamp(1), timestamp(0));
+        assertNotEquals(timestamp(0), timestamp(1));
+
+        assertEquals(datetime(1), datetime(1));
+        assertEquals(datetime(0), datetime(0));
+        assertNotEquals(datetime(1), datetime(0));
+        assertNotEquals(datetime(0), datetime(1));
+    }
+
+    @Test
+    public void decimalTypeEquality() {
+        assertEquals(decimalOf(10, 2), decimalOf(10, 2));
+        assertNotEquals(decimalOf(10, 2), decimalOf(10, 3));
+    }
+
+    @Test
+    public void stringTypeEquality() {
+        assertEquals(stringOf(10), stringOf(10));
+        assertEquals(stringOf(2), stringOf(2));
+
+        assertNotEquals(stringOf(10), stringOf(5));
+        assertNotEquals(stringOf(5), stringOf(10));
+        assertNotEquals(STRING, stringOf(10));
+        assertNotEquals(stringOf(10), STRING);
+    }
+
+    @Test
+    public void blobTypeEquality() {
+        assertEquals(blobOf(10), blobOf(10));
+        assertEquals(blobOf(2), blobOf(2));
+
+        assertNotEquals(blobOf(10), blobOf(5));
+        assertNotEquals(blobOf(5), blobOf(10));
+        assertNotEquals(BYTES, blobOf(10));
+        assertNotEquals(blobOf(10), BYTES);
     }
 }

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/TypeUtilsTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/TypeUtilsTest.java
@@ -80,8 +80,8 @@ public class TypeUtilsTest extends BaseIgniteAbstractTest {
     private static final BaseTypeSpec INT64 = RowSchemaTypes.nativeType(NativeTypes.INT64);
     private static final BaseTypeSpec FLOAT = RowSchemaTypes.nativeType(NativeTypes.FLOAT);
     private static final BaseTypeSpec DOUBLE = RowSchemaTypes.nativeType(NativeTypes.DOUBLE);
-    private static final BaseTypeSpec STRING = RowSchemaTypes.nativeType(NativeTypes.STRING);
-    private static final BaseTypeSpec BYTES = RowSchemaTypes.nativeType(NativeTypes.BYTES);
+    private static final BaseTypeSpec STRING = RowSchemaTypes.nativeType(NativeTypes.stringOf(65536));
+    private static final BaseTypeSpec BYTES = RowSchemaTypes.nativeType(NativeTypes.blobOf(65536));
     private static final BaseTypeSpec UUID = RowSchemaTypes.nativeType(NativeTypes.UUID);
 
     @Test


### PR DESCRIPTION
Fixes `equals` method of `TemporalNativeType` and `VarlenNativeType `.

https://issues.apache.org/jira/browse/IGNITE-23704

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)