### PR TITLE
IGNITE-23733 Sql. Fix flaky test ItSqlQueriesSystemViewTest.multiStatement

### DIFF
--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/BaseSqlMultiStatementTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/BaseSqlMultiStatementTest.java
@@ -107,6 +107,8 @@ public abstract class BaseSqlMultiStatementTest extends BaseSqlIntegrationTest {
 
         if (close) {
             cursor.closeAsync();
+        } else {
+            cursorsToClose.add(cursor);
         }
 
         while ((count < 0 || --count > 0) && cursor.hasNextResult()) {
@@ -115,10 +117,11 @@ public abstract class BaseSqlMultiStatementTest extends BaseSqlIntegrationTest {
             assertNotNull(cursor);
 
             cursors.add(cursor);
-            cursorsToClose.add(cursor);
 
             if (close) {
                 cursor.closeAsync();
+            } else {
+                cursorsToClose.add(cursor);
             }
         }
 

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlQueriesSystemViewTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlQueriesSystemViewTest.java
@@ -30,7 +30,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.util.HashSet;
@@ -44,6 +43,7 @@ import org.apache.ignite.internal.sql.engine.util.MetadataMatcher;
 import org.apache.ignite.internal.tx.InternalTransaction;
 import org.apache.ignite.lang.ErrorGroups.Sql;
 import org.apache.ignite.sql.ColumnType;
+import org.awaitility.Awaitility;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.jetbrains.annotations.Nullable;
@@ -63,7 +63,7 @@ public class ItSqlQueriesSystemViewTest extends BaseSqlMultiStatementTest {
     }
 
     @AfterEach
-    void cleanup() throws InterruptedException {
+    void cleanup() {
         sql("DELETE FROM test");
 
         checkNoPendingQueries();
@@ -100,11 +100,12 @@ public class ItSqlQueriesSystemViewTest extends BaseSqlMultiStatementTest {
 
         ClockService clockService = unwrapIgniteImpl(initiator).clockService();
 
-
         String schema = "SYSTEM";
 
         // Test with explicit tx.
         InternalTransaction tx = (InternalTransaction) initiator.transactions().begin();
+
+        checkNoPendingQueries();
 
         try {
             long tsBefore = clockService.now().getPhysical();
@@ -120,6 +121,8 @@ public class ItSqlQueriesSystemViewTest extends BaseSqlMultiStatementTest {
         } finally {
             tx.rollback();
         }
+
+        checkNoPendingQueries();
 
         // Implicit tx.
         {
@@ -195,12 +198,13 @@ public class ItSqlQueriesSystemViewTest extends BaseSqlMultiStatementTest {
 
         // Closing cursors.
         await(cursors.get(0).closeAsync());
-        assertThat(queryProcessor().runningQueries(), is(3));
+        Awaitility.await().untilAsserted(() -> assertThat(queryProcessor().runningQueries(), is(3)));
 
         await(cursors.get(1).closeAsync());
-        assertThat(queryProcessor().runningQueries(), is(2));
+        Awaitility.await().untilAsserted(() -> assertThat(queryProcessor().runningQueries(), is(2)));
 
         await(cursors.get(2).closeAsync());
+        checkNoPendingQueries();
     }
 
     @Test
@@ -249,6 +253,7 @@ public class ItSqlQueriesSystemViewTest extends BaseSqlMultiStatementTest {
 
         // Commit transaction.
         await(await(cursors.get(cursors.size() - 1).nextResult()).closeAsync());
+        checkNoPendingQueries();
     }
 
     @Test
@@ -297,14 +302,13 @@ public class ItSqlQueriesSystemViewTest extends BaseSqlMultiStatementTest {
         }
     }
 
-    private void checkNoPendingQueries() throws InterruptedException {
+    private void checkNoPendingQueries() {
         List<Ignite> nodes = CLUSTER.runningNodes().collect(Collectors.toList());
 
         for (Ignite node : nodes) {
             SqlQueryProcessor queryProcessor = (SqlQueryProcessor) unwrapIgniteImpl(node).queryEngine();
 
-            boolean success = waitForCondition(() -> queryProcessor.runningQueries() == 0, 5_000);
-            assertTrue(success, "node=" + node.name() + ", count=" + queryProcessor().runningQueries());
+            Awaitility.await().untilAsserted(() -> assertThat(queryProcessor.runningQueries(), is(0)));
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23733

The problem is that the test code assumed that the cursor closing and the removal of this query from the registry (`QueryExecutor.runningQueries`) were synchronized but this is not true.

So the test must take into account that after closing the cursor we can observe the query among running for some time.