### PR TITLE
IGNITE-23754 Do not fail initialized node start because of CMG or MG unavailability

### DIFF
--- a/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/raft/CmgRaftService.java
+++ b/modules/cluster-management/src/main/java/org/apache/ignite/internal/cluster/management/raft/CmgRaftService.java
@@ -49,6 +49,7 @@ import org.apache.ignite.internal.network.ClusterService;
 import org.apache.ignite.internal.properties.IgniteProductVersion;
 import org.apache.ignite.internal.raft.Peer;
 import org.apache.ignite.internal.raft.PeersAndLearners;
+import org.apache.ignite.internal.raft.service.RaftCommandRunner;
 import org.apache.ignite.internal.raft.service.RaftGroupService;
 import org.apache.ignite.network.ClusterNode;
 import org.jetbrains.annotations.Nullable;
@@ -152,7 +153,9 @@ public class CmgRaftService implements ManuallyCloseable {
                 .clusterTag(clusterTag)
                 .build();
 
-        return raftService.run(command)
+        // Using NO_TIMEOUT because we want a node that doesn't see CMG majority at start to hang out until someone else starts; otherwise,
+        // if we employ a timeout here, node-by-node starts might cause inability to form a cluster.
+        return raftService.run(command, RaftCommandRunner.NO_TIMEOUT)
                 .thenAccept(response -> {
                     if (response instanceof ValidationErrorResponse) {
                         throw new JoinDeniedException("Join request denied, reason: " + ((ValidationErrorResponse) response).reason());

--- a/modules/cluster-management/src/test/java/org/apache/ignite/internal/cluster/management/ClusterManagementGroupManagerTest.java
+++ b/modules/cluster-management/src/test/java/org/apache/ignite/internal/cluster/management/ClusterManagementGroupManagerTest.java
@@ -23,6 +23,7 @@ import static org.apache.ignite.internal.util.CompletableFutures.nullCompletedFu
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -97,6 +98,8 @@ class ClusterManagementGroupManagerTest extends BaseIgniteAbstractTest {
                 .build();
 
         when(raftGroupService.run(any()))
+                .thenReturn(nullCompletedFuture());
+        when(raftGroupService.run(any(), anyLong()))
                 .thenReturn(nullCompletedFuture());
 
         when(raftGroupService.run(any(InitCmgStateCommand.class)))

--- a/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/impl/MetaStorageServiceImpl.java
+++ b/modules/metastorage/src/main/java/org/apache/ignite/internal/metastorage/impl/MetaStorageServiceImpl.java
@@ -58,6 +58,7 @@ import org.apache.ignite.internal.metastorage.dsl.Iif;
 import org.apache.ignite.internal.metastorage.dsl.Operation;
 import org.apache.ignite.internal.metastorage.dsl.StatementResult;
 import org.apache.ignite.internal.raft.ReadCommand;
+import org.apache.ignite.internal.raft.service.RaftCommandRunner;
 import org.apache.ignite.internal.raft.service.RaftGroupService;
 import org.apache.ignite.internal.thread.NamedThreadFactory;
 import org.apache.ignite.internal.util.IgniteSpinBusyLock;
@@ -264,7 +265,7 @@ public class MetaStorageServiceImpl implements MetaStorageService {
     public CompletableFuture<RevisionsInfo> currentRevisions() {
         GetCurrentRevisionsCommand cmd = context.commandsFactory().getCurrentRevisionsCommand().build();
 
-        return context.raftService().run(cmd);
+        return context.raftService().run(cmd, RaftCommandRunner.NO_TIMEOUT);
     }
 
     @Override

--- a/modules/metastorage/src/test/java/org/apache/ignite/internal/metastorage/impl/MetaStorageDeployWatchesCorrectnessTest.java
+++ b/modules/metastorage/src/test/java/org/apache/ignite/internal/metastorage/impl/MetaStorageDeployWatchesCorrectnessTest.java
@@ -23,6 +23,7 @@ import static org.apache.ignite.internal.testframework.matchers.CompletableFutur
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -83,7 +84,7 @@ public class MetaStorageDeployWatchesCorrectnessTest extends IgniteAbstractTest 
         when(clusterService.nodeName()).thenReturn(mcNodeName);
         when(raftManager.startRaftGroupNodeAndWaitNodeReady(any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(raftGroupService);
-        when(raftGroupService.run(any(GetCurrentRevisionsCommand.class)))
+        when(raftGroupService.run(any(GetCurrentRevisionsCommand.class), anyLong()))
                 .thenAnswer(invocation -> completedFuture(new RevisionsInfo(0, -1)));
 
         var readOperationForCompactionTracker = new ReadOperationForCompactionTracker();

--- a/modules/metastorage/src/test/java/org/apache/ignite/internal/metastorage/impl/MetaStorageManagerRecoveryTest.java
+++ b/modules/metastorage/src/test/java/org/apache/ignite/internal/metastorage/impl/MetaStorageManagerRecoveryTest.java
@@ -25,6 +25,7 @@ import static org.apache.ignite.internal.testframework.matchers.CompletableFutur
 import static org.apache.ignite.internal.util.CompletableFutures.nullCompletedFuture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -109,7 +110,7 @@ public class MetaStorageManagerRecoveryTest extends BaseIgniteAbstractTest {
 
         RaftGroupService service = mock(TopologyAwareRaftGroupService.class);
 
-        when(service.run(any(GetCurrentRevisionsCommand.class)))
+        when(service.run(any(GetCurrentRevisionsCommand.class), anyLong()))
                 .thenAnswer(invocation -> completedFuture(new RevisionsInfo(remoteRevision, -1)));
 
         when(raft.startRaftGroupNodeAndWaitNodeReady(any(), any(), any(), any(), any(), any(), any()))

--- a/modules/metastorage/src/testFixtures/java/org/apache/ignite/internal/metastorage/impl/StandaloneMetaStorageManager.java
+++ b/modules/metastorage/src/testFixtures/java/org/apache/ignite/internal/metastorage/impl/StandaloneMetaStorageManager.java
@@ -19,7 +19,9 @@ package org.apache.ignite.internal.metastorage.impl;
 
 import static java.util.Collections.singleton;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -62,6 +64,7 @@ import org.jetbrains.annotations.TestOnly;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockSettings;
 import org.mockito.quality.Strictness;
+import org.mockito.stubbing.Answer;
 
 /**
  * MetaStorageManager dummy implementation.
@@ -246,7 +249,7 @@ public class StandaloneMetaStorageManager extends MetaStorageManagerImpl {
             throw new RuntimeException(e);
         }
 
-        when(raftGroupService.run(any())).thenAnswer(invocation -> {
+        Answer<Object> answer = invocation -> {
             RaftGroupListener listener = listenerCaptor.getValue();
             // Both onBeforeApply and command processing within listener should be thread-safe.
             // onBeforeApply is guarded by group specific monitor, precisely synchronized (groupIdSyncMonitor(request.groupId())).
@@ -261,7 +264,9 @@ public class StandaloneMetaStorageManager extends MetaStorageManagerImpl {
 
                 return runCommand(command, listener);
             }
-        });
+        };
+        lenient().when(raftGroupService.run(any())).thenAnswer(answer);
+        lenient().when(raftGroupService.run(any(), anyLong())).thenAnswer(answer);
 
         return raftManager;
     }

--- a/modules/raft-api/src/main/java/org/apache/ignite/internal/raft/service/RaftCommandRunner.java
+++ b/modules/raft-api/src/main/java/org/apache/ignite/internal/raft/service/RaftCommandRunner.java
@@ -26,14 +26,31 @@ import org.apache.ignite.internal.raft.Command;
  * @see RaftGroupService
  */
 public interface RaftCommandRunner {
+    /** Constant meaning that an operation will never timeout. */
+    long NO_TIMEOUT = -1;
+
     /**
      * Runs a command on a replication group leader.
      *
      * <p>Read commands always see up to date data.
+     *
+     * <p>In contrast with {@link #run(Command, long)}, this method uses a default timeout.
      *
      * @param cmd The command.
      * @param <R> Execution result type.
      * @return A future with the execution result.
      */
     <R> CompletableFuture<R> run(Command cmd);
+
+    /**
+     * Runs a command on a replication group leader with the given timeout.
+     *
+     * <p>Read commands always see up to date data.
+     *
+     * @param cmd The command.
+     * @param timeoutMillis Timeout to use, in milliseconds (if this is negative, the timeout is disabled).
+     * @param <R> Execution result type.
+     * @return A future with the execution result.
+     */
+    <R> CompletableFuture<R> run(Command cmd, long timeoutMillis);
 }

--- a/modules/raft/src/test/java/org/apache/ignite/internal/raft/ExecutorInclinedRaftCommandRunnerTest.java
+++ b/modules/raft/src/test/java/org/apache/ignite/internal/raft/ExecutorInclinedRaftCommandRunnerTest.java
@@ -95,6 +95,23 @@ class ExecutorInclinedRaftCommandRunnerTest extends BaseIgniteAbstractTest {
         verify(actualRunner).run(command);
     }
 
+    @Test
+    void delegatesRunWithTimeout() {
+        CompletableFuture<Void> originalFuture = new CompletableFuture<>();
+
+        when(actualRunner.<Void>run(command, 100)).thenReturn(originalFuture);
+
+        CompletableFuture<Void> finalFuture = decorator.run(command, 100);
+
+        assertThat(finalFuture, not(completedFuture()));
+
+        originalFuture.complete(null);
+
+        assertThat(finalFuture, willCompleteSuccessfully());
+
+        verify(actualRunner).run(command, 100);
+    }
+
     /**
      * Makes sure that, if the future returned from run() is completed right from its creation, its dependant
      * is completed either in the supplied executor or the current thread.

--- a/modules/replicator/src/main/java/org/apache/ignite/internal/raft/client/TopologyAwareRaftGroupService.java
+++ b/modules/replicator/src/main/java/org/apache/ignite/internal/raft/client/TopologyAwareRaftGroupService.java
@@ -470,6 +470,11 @@ public class TopologyAwareRaftGroupService implements RaftGroupService {
     }
 
     @Override
+    public <R> CompletableFuture<R> run(Command cmd, long timeoutMillis) {
+        return raftClient.run(cmd, timeoutMillis);
+    }
+
+    @Override
     public void shutdown() {
         logicalTopologyService.removeEventListener(topologyEventsListener);
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/ItIgniteStartTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/ItIgniteStartTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.ignite.internal.testframework.IgniteTestUtils.waitForCondition;
+import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willCompleteSuccessfully;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.typesafe.config.parser.ConfigDocument;
+import com.typesafe.config.parser.ConfigDocumentFactory;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+import org.apache.ignite.internal.Cluster.ServerRegistration;
+import org.apache.ignite.internal.app.IgniteImpl;
+import org.apache.ignite.internal.app.IgniteServerImpl;
+import org.apache.ignite.network.ClusterNode;
+import org.junit.jupiter.api.Test;
+
+class ItIgniteStartTest extends ClusterPerTestIntegrationTest {
+    private static final long RAFT_RETRY_TIMEOUT_MILLIS = 2500;
+
+    @Override
+    protected int initialNodes() {
+        return 0;
+    }
+
+    @Override
+    protected String getNodeBootstrapConfigTemplate() {
+        ConfigDocument document = ConfigDocumentFactory.parseString(super.getNodeBootstrapConfigTemplate())
+                .withValueText("ignite.raft.retryTimeout", Long.toString(RAFT_RETRY_TIMEOUT_MILLIS));
+        return document.render();
+    }
+
+    @Test
+    void nodeStartDoesntTimeoutWhenCmgIsUnavailable() throws Exception {
+        int nodeCount = 2;
+        cluster.startAndInit(nodeCount, new int[]{0, 1});
+
+        IntStream.range(0, nodeCount).parallel().forEach(nodeIndex -> cluster.stopNode(nodeIndex));
+
+        ServerRegistration registration0 = cluster.startEmbeddedNode(0);
+
+        // Now allow an attempt to join to timeout (if it doesn't have an infinite timeout).
+        waitTillRaftTimeoutPasses();
+
+        assertDoesNotThrow(() -> cluster.startNode(1));
+
+        assertThat(registration0.registrationFuture(), willCompleteSuccessfully());
+    }
+
+    private static void waitTillRaftTimeoutPasses() throws InterruptedException {
+        Thread.sleep(RAFT_RETRY_TIMEOUT_MILLIS + 1000);
+    }
+
+    @Test
+    void nodeStartDoesntTimeoutWhenMgIsUnavailable() throws Exception {
+        int nodeCount = 3;
+        cluster.startAndInit(nodeCount, builder -> {
+            builder.cmgNodeNames(cluster.nodeName(0), cluster.nodeName(1));
+            builder.metaStorageNodeNames(cluster.nodeName(1), cluster.nodeName(2));
+        });
+
+        IntStream.range(0, nodeCount).parallel().forEach(nodeIndex -> cluster.stopNode(nodeIndex));
+
+        // These 2 nodes have majority of CMG, but not MG.
+        ServerRegistration registration0 = cluster.startEmbeddedNode(0);
+        ServerRegistration registration1 = cluster.startEmbeddedNode(1);
+
+        waitTill2NodesValidateThemselvesWithCmg(registration0);
+
+        // Now allow an attempt to recover Metastorage to timeout (if it doesn't have an infinite timeout).
+        waitTillRaftTimeoutPasses();
+
+        assertDoesNotThrow(() -> cluster.startNode(2));
+
+        assertThat(registration0.registrationFuture(), willCompleteSuccessfully());
+        assertThat(registration1.registrationFuture(), willCompleteSuccessfully());
+    }
+
+    private static void waitTill2NodesValidateThemselvesWithCmg(ServerRegistration registration) throws InterruptedException {
+        IgniteImpl ignite = ((IgniteServerImpl) registration.server()).igniteImpl();
+
+        assertTrue(
+                waitForCondition(() -> validatedNodes(ignite).size() == 2, SECONDS.toMillis(10)),
+                "Did not see 2 nodes being validated in time after restart"
+        );
+    }
+
+    private static Set<ClusterNode> validatedNodes(IgniteImpl ignite) {
+        CompletableFuture<Set<ClusterNode>> validatededNodesFuture = ignite.clusterManagementGroupManager().validatedNodes();
+        assertThat(validatededNodesFuture, willCompleteSuccessfully());
+        return validatededNodesFuture.join();
+    }
+}

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/storage/InternalTableEstimatedSizeTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/storage/InternalTableEstimatedSizeTest.java
@@ -281,6 +281,11 @@ public class InternalTableEstimatedSizeTest extends BaseIgniteAbstractTest {
                     public <R> CompletableFuture<R> run(Command cmd) {
                         return nullCompletedFuture();
                     }
+
+                    @Override
+                    public <R> CompletableFuture<R> run(Command cmd, long timeoutMillis) {
+                        return nullCompletedFuture();
+                    }
                 },
                 txManager,
                 lockManager,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23754

Also, TimeoutException from Raft client is enriched with information about current and original commands