### PR TITLE
IGNITE-23757 .NET: Fix TestDroppedConnectionsAreRestoredInBackground flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteClientGroupTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteClientGroupTests.cs
@@ -29,7 +29,10 @@ public class IgniteClientGroupTests
     private FakeServer _server;
 
     [SetUp]
-    public void StartServer() => _server = new FakeServer();
+    public void StartServer() => _server = new FakeServer
+    {
+        AllowMultipleConnections = true
+    };
 
     [TearDown]
     public void StopServer() => _server.Dispose();

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteServerBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteServerBase.cs
@@ -59,6 +59,8 @@ public abstract class IgniteServerBase : IDisposable
 
     public string Endpoint => "127.0.0.1:" + Port;
 
+    public bool AllowMultipleConnections { get; set; }
+
     public bool DropNewConnections
     {
         get => _dropNewConnections;
@@ -174,6 +176,8 @@ public abstract class IgniteServerBase : IDisposable
         while (!_cts.IsCancellationRequested)
         {
             Socket handler = _listener.Accept();
+            handler.NoDelay = true;
+
             if (DropNewConnections)
             {
                 handler.Disconnect(true);
@@ -184,22 +188,24 @@ public abstract class IgniteServerBase : IDisposable
 
             _handlers[handler] = null;
 
-            Task.Run(() =>
+            var handleAction = () =>
             {
                 using (handler)
                 {
-                    handler.NoDelay = true;
-
-                    if (!DropNewConnections)
-                    {
-                        Handle(handler, _cts.Token);
-                    }
-
+                    Handle(handler, _cts.Token);
                     handler.Disconnect(true);
-                    handler.Dispose();
                     _handlers.TryRemove(handler, out _);
                 }
-            });
+            };
+
+            if (AllowMultipleConnections)
+            {
+                Task.Run(handleAction);
+            }
+            else
+            {
+                handleAction();
+            }
         }
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteServerBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteServerBase.cs
@@ -190,8 +190,13 @@ public abstract class IgniteServerBase : IDisposable
                 {
                     handler.NoDelay = true;
 
-                    Handle(handler, _cts.Token);
+                    if (!DropNewConnections)
+                    {
+                        Handle(handler, _cts.Token);
+                    }
+
                     handler.Disconnect(true);
+                    handler.Dispose();
                     _handlers.TryRemove(handler, out _);
                 }
             });

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ReconnectTests.cs
@@ -86,6 +86,7 @@ public class ReconnectTests
     }
 
     [Test]
+    [Timeout(30_000)]
     public async Task TestDroppedConnectionsAreRestoredInBackground()
     {
         var cfg = new IgniteClientConfiguration


### PR DESCRIPTION
Add `IgniteServerBase.AllowMultipleConnections` (default false) to speed up tests based on `FakeServer`.