### PR TITLE
IGNITE-23727: Sql. SqlRowHandler map returns rows with incorrect schema

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/SqlRowHandler.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/SqlRowHandler.java
@@ -107,9 +107,12 @@ public class SqlRowHandler implements RowHandler<RowWrapper> {
     @Override
     public RowWrapper map(RowWrapper row, int[] mapping) {
         Object[] fields = new Object[mapping.length];
+        Builder schemaBuilder = RowSchema.builder();
 
         for (int i = 0; i < mapping.length; i++) {
-            fields[i] = row.get(mapping[i]);
+            int src = mapping[i];
+            fields[i] = row.get(src);
+            schemaBuilder.addField(row.rowSchema().fields().get(src));
         }
 
         return new ObjectsArrayRowWrapper(row.rowSchema(), fields);


### PR DESCRIPTION
Fixes `SqlRowHandler::map` to build correct schema.
Moves `SqlRowHandlerTest` to the same package as `SqlRowHandler` so we can check `RowWrapper::rowSchema`

https://issues.apache.org/jira/browse/IGNITE-23727

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)