### PR TITLE
IGNITE-23734 Sql. Fix race in RootNode between requesting first batch and exceptional termination

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/rel/AsyncRootNode.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/rel/AsyncRootNode.java
@@ -124,15 +124,15 @@ public class AsyncRootNode<InRowT, OutRowT> implements Downstream<InRowT>, Async
     public CompletableFuture<BatchedResult<OutRowT>> requestNextAsync(int rows) {
         CompletableFuture<BatchedResult<OutRowT>> next = new CompletableFuture<>();
 
-        Throwable t = ex.get();
-
-        if (t != null) {
-            next.completeExceptionally(t);
-
-            return next;
-        }
-
         synchronized (lock) {
+            Throwable t = ex.get();
+
+            if (t != null) {
+                next.completeExceptionally(t);
+
+                return next;
+            }
+
             if (closed) {
                 next.completeExceptionally(new CursorClosedException());
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23734

To reproduce the race, add `Thread.sleep(300)` just before synchronized block in `AsyncRootNode#requestNextAsync` and run `ItCastToIntWithoutFastQueryOptimizationTest#explicitCastOfLiteralsOnSelectWithOverflow`.

---------------

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)