### PR TITLE
IGNITE-23707 Optimize update() in hybrid clocks

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/hlc/HybridClockImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/hlc/HybridClockImpl.java
@@ -114,7 +114,6 @@ public class HybridClockImpl implements HybridClock {
         long requestTimeLong = requestTime.longValue();
 
         while (true) {
-            // Read the latest time after accessing UTC time to reduce contention.
             long oldLatestTime = this.latestTime;
 
             if (oldLatestTime >= requestTimeLong) {

--- a/modules/core/src/test/java/org/apache/ignite/internal/hlc/HybridClockTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/hlc/HybridClockTest.java
@@ -75,13 +75,13 @@ class HybridClockTest extends BaseIgniteAbstractTest {
         assertTimestampEquals(100, new HybridTimestamp(100, 2),
                 () -> clock.update(new HybridTimestamp(60, 1000)));
 
-        assertTimestampEquals(200, new HybridTimestamp(200, 0),
+        assertTimestampEquals(200, new HybridTimestamp(100, 3),
                 () -> clock.update(new HybridTimestamp(70, 1)));
 
-        assertTimestampEquals(50, new HybridTimestamp(200, 1),
+        assertTimestampEquals(50, new HybridTimestamp(100, 4),
                 () -> clock.update(new HybridTimestamp(70, 1)));
 
-        assertTimestampEquals(500, new HybridTimestamp(500, 0),
+        assertTimestampEquals(500, new HybridTimestamp(100, 5),
                 () -> clock.update(new HybridTimestamp(70, 1)));
 
         assertTimestampEquals(500, new HybridTimestamp(600, 1),

--- a/modules/core/src/test/java/org/apache/ignite/internal/hlc/benchmarks/HybridClockBenchmark.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/hlc/benchmarks/HybridClockBenchmark.java
@@ -46,8 +46,8 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Fork(1)
 @Warmup(iterations = 5, time = 2)
 @Measurement(iterations = 10, time = 2)
-@BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
 public class HybridClockBenchmark {
     /** Clock to benchmark. */
     private HybridClock clock;
@@ -104,7 +104,9 @@ public class HybridClockBenchmark {
 
     private void hybridClockUpdate() {
         for (int i = 0; i < 1000; i++) {
-            clock.update(HybridTimestamp.hybridTimestamp((System.currentTimeMillis() << LOGICAL_TIME_BITS_SIZE) + i));
+            long ts = ((System.currentTimeMillis() + (i % 2 == 0 ? 5 : -5)) << LOGICAL_TIME_BITS_SIZE) + (i % 10);
+
+            clock.update(HybridTimestamp.hybridTimestamp(ts));
         }
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/hlc/benchmarks/HybridClockBenchmark.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/hlc/benchmarks/HybridClockBenchmark.java
@@ -17,9 +17,12 @@
 
 package org.apache.ignite.internal.hlc.benchmarks;
 
+import static org.apache.ignite.internal.hlc.HybridTimestamp.LOGICAL_TIME_BITS_SIZE;
+
 import java.util.concurrent.TimeUnit;
 import org.apache.ignite.internal.hlc.HybridClock;
 import org.apache.ignite.internal.hlc.HybridClockImpl;
+import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -75,9 +78,33 @@ public class HybridClockBenchmark {
         hybridClockNow();
     }
 
+    @Benchmark
+    @Threads(1)
+    public void hybridClockUpdateSingleThread() {
+        hybridClockUpdate();
+    }
+
+    @Benchmark
+    @Threads(5)
+    public void hybridClockUpdateFiveThreads() {
+        hybridClockUpdate();
+    }
+
+    @Benchmark
+    @Threads(10)
+    public void hybridClockUpdateTenThreads() {
+        hybridClockUpdate();
+    }
+
     private void hybridClockNow() {
         for (int i = 0; i < 1000; i++) {
             clock.now();
+        }
+    }
+
+    private void hybridClockUpdate() {
+        for (int i = 0; i < 1000; i++) {
+            clock.update(HybridTimestamp.hybridTimestamp((System.currentTimeMillis() << LOGICAL_TIME_BITS_SIZE) + i));
         }
     }
 

--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/HeapLockManager.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/HeapLockManager.java
@@ -174,7 +174,7 @@ public class HeapLockManager extends AbstractEventProducer<LockEvent, LockEventP
         if (lockKey.contextId() == null) { // Treat this lock as a hierarchy(coarse) lock.
             CoarseLockState state = coarseMap.computeIfAbsent(lockKey, key -> new CoarseLockState(lockKey));
 
-            return state.acquire(txId, lockKey, lockMode);
+            return state.acquire(txId, lockMode);
         }
 
         while (true) {
@@ -521,11 +521,10 @@ public class HeapLockManager extends AbstractEventProducer<LockEvent, LockEventP
          * Acquires a lock.
          *
          * @param txId Tx id.
-         * @param lockKey Lock key.
          * @param lockMode Lock mode.
          * @return The future.
          */
-        public CompletableFuture<Lock> acquire(UUID txId, LockKey lockKey, LockMode lockMode) {
+        public CompletableFuture<Lock> acquire(UUID txId, LockMode lockMode) {
             switch (lockMode) {
                 case S:
                     stripedLock.writeLock().lock();


### PR DESCRIPTION
```
Before
Benchmark                                            Mode  Cnt       Score      Error  Units
HybridClockBenchmark.hybridClockNowFiveThreads      thrpt   10   37536.317 ± 2033.320  ops/s
HybridClockBenchmark.hybridClockNowSingleThread     thrpt   10  238352.974 ± 4753.761  ops/s
HybridClockBenchmark.hybridClockNowTenThreads       thrpt   10   34136.852 ±  283.247  ops/s
HybridClockBenchmark.hybridClockUpdateFiveThreads   thrpt   10   14143.705 ±  365.301  ops/s
HybridClockBenchmark.hybridClockUpdateSingleThread  thrpt   10  124273.226 ± 3827.199  ops/s
HybridClockBenchmark.hybridClockUpdateTenThreads    thrpt   10    9028.719 ±  249.099  ops/s


After
Benchmark                                            Mode  Cnt       Score      Error  Units
HybridClockBenchmark.hybridClockNowFiveThreads      thrpt   10   35338.271 ± 5234.633  ops/s
HybridClockBenchmark.hybridClockNowSingleThread     thrpt   10  253800.841 ± 1555.133  ops/s
HybridClockBenchmark.hybridClockNowTenThreads       thrpt   10   35570.363 ±  581.248  ops/s
HybridClockBenchmark.hybridClockUpdateFiveThreads   thrpt   10   56725.796 ± 1055.919  ops/s
HybridClockBenchmark.hybridClockUpdateSingleThread  thrpt   10  241928.824 ± 3441.524  ops/s
HybridClockBenchmark.hybridClockUpdateTenThreads    thrpt   10   53343.884 ±  136.487  ops/s
```

https://issues.apache.org/jira/browse/IGNITE-23707