### PR TITLE
IGNITE-23464 Implement cancellation in JDBC

### DIFF
--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientOp.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientOp.java
@@ -180,6 +180,9 @@ public class ClientOp {
     /** Check if all tuples with the given keys collection exist. */
     public static final int TUPLE_CONTAINS_ALL_KEYS = 67;
 
+    /** Cancels the execution of JDBC statement .*/
+    public static final int JDBC_CANCEL = 68;
+
     /** Reserved for extensions: min. */
     @SuppressWarnings("unused")
     public static final int RESERVED_EXTENSION_RANGE_START = 1000;

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/JdbcQueryEventHandler.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/JdbcQueryEventHandler.java
@@ -33,6 +33,7 @@ import org.apache.ignite.internal.jdbc.proto.event.JdbcMetaSchemasRequest;
 import org.apache.ignite.internal.jdbc.proto.event.JdbcMetaSchemasResult;
 import org.apache.ignite.internal.jdbc.proto.event.JdbcMetaTablesRequest;
 import org.apache.ignite.internal.jdbc.proto.event.JdbcMetaTablesResult;
+import org.apache.ignite.internal.jdbc.proto.event.JdbcQueryCancelResult;
 import org.apache.ignite.internal.jdbc.proto.event.JdbcQueryExecuteRequest;
 import org.apache.ignite.internal.jdbc.proto.event.Response;
 
@@ -116,4 +117,13 @@ public interface JdbcQueryEventHandler {
      * @return Result future.
      */
     CompletableFuture<JdbcFinishTxResult> finishTxAsync(long connectionId, boolean commit);
+
+    /**
+     * Cancels the execution of JDBC statement.
+     *
+     * @param connectionId An identifier of the connection on a server.
+     * @param correlationToken A token associated with the execution.
+     * @return Result future.
+     */
+    CompletableFuture<JdbcQueryCancelResult> cancelAsync(long connectionId, long correlationToken);
 }

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcBatchExecuteRequest.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcBatchExecuteRequest.java
@@ -42,6 +42,12 @@ public class JdbcBatchExecuteRequest implements ClientMessage {
     private long queryTimeoutMillis;
 
     /**
+     * Token is used to uniquely identify execution request within single connection, which is required to properly coordinate cancellation
+     * request.
+     */
+    private long correlationToken;
+
+    /**
      * Default constructor.
      */
     public JdbcBatchExecuteRequest() {
@@ -51,15 +57,17 @@ public class JdbcBatchExecuteRequest implements ClientMessage {
      * Constructor.
      *
      * @param schemaName Schema name.
-     * @param queries    Queries.
+     * @param queries Queries.
      * @param autoCommit Flag indicating whether auto-commit mode is enabled.
      * @param queryTimeoutMillis Query timeout in millseconds.
+     * @param correlationToken Token is used to uniquely identify execution request within single connection.
      */
     public JdbcBatchExecuteRequest(
-            String schemaName, 
-            List<String> queries, 
+            String schemaName,
+            List<String> queries,
             boolean autoCommit,
-            long queryTimeoutMillis
+            long queryTimeoutMillis,
+            long correlationToken
     ) {
         assert !CollectionUtils.nullOrEmpty(queries);
 
@@ -67,6 +75,7 @@ public class JdbcBatchExecuteRequest implements ClientMessage {
         this.queries = queries;
         this.autoCommit = autoCommit;
         this.queryTimeoutMillis = queryTimeoutMillis;
+        this.correlationToken = correlationToken;
     }
 
     /**
@@ -105,6 +114,10 @@ public class JdbcBatchExecuteRequest implements ClientMessage {
         return queryTimeoutMillis;
     }
 
+    public long correlationToken() {
+        return correlationToken;
+    }
+
     /** {@inheritDoc} */
     @Override
     public void writeBinary(ClientMessagePacker packer) {
@@ -118,6 +131,7 @@ public class JdbcBatchExecuteRequest implements ClientMessage {
         }
 
         packer.packLong(queryTimeoutMillis);
+        packer.packLong(correlationToken);
     }
 
     /** {@inheritDoc} */
@@ -135,6 +149,7 @@ public class JdbcBatchExecuteRequest implements ClientMessage {
         }
 
         queryTimeoutMillis = unpacker.unpackLong();
+        correlationToken = unpacker.unpackLong();
     }
 
     /** {@inheritDoc} */

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcBatchPreparedStmntRequest.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcBatchPreparedStmntRequest.java
@@ -46,6 +46,12 @@ public class JdbcBatchPreparedStmntRequest implements ClientMessage {
     private long queryTimeoutMillis;
 
     /**
+     * Token is used to uniquely identify execution request within single connection, which is required to properly coordinate cancellation
+     * request.
+     */
+    private long correlationToken;
+
+    /**
      * Default constructor.
      */
     public JdbcBatchPreparedStmntRequest() {
@@ -59,13 +65,15 @@ public class JdbcBatchPreparedStmntRequest implements ClientMessage {
      * @param args Sql query arguments.
      * @param autoCommit Flag indicating whether auto-commit mode is enabled.
      * @param queryTimeoutMillis Query timeout in millseconds.
+     * @param correlationToken Token is used to uniquely identify execution request within single connection.
      */
     public JdbcBatchPreparedStmntRequest(
             String schemaName, 
             String query, 
             List<Object[]> args, 
             boolean autoCommit, 
-            long queryTimeoutMillis
+            long queryTimeoutMillis,
+            long correlationToken
     ) {
         assert !StringUtil.isNullOrEmpty(query);
         assert !CollectionUtils.nullOrEmpty(args);
@@ -75,6 +83,7 @@ public class JdbcBatchPreparedStmntRequest implements ClientMessage {
         this.schemaName = schemaName;
         this.autoCommit = autoCommit;
         this.queryTimeoutMillis = queryTimeoutMillis;
+        this.correlationToken = correlationToken;
     }
 
     /**
@@ -122,6 +131,10 @@ public class JdbcBatchPreparedStmntRequest implements ClientMessage {
         return queryTimeoutMillis;
     }
 
+    public long correlationToken() {
+        return correlationToken;
+    }
+
     /** {@inheritDoc} */
     @Override
     public void writeBinary(ClientMessagePacker packer) {
@@ -136,6 +149,7 @@ public class JdbcBatchPreparedStmntRequest implements ClientMessage {
         }
 
         packer.packLong(queryTimeoutMillis);
+        packer.packLong(correlationToken);
     }
 
     /** {@inheritDoc} */
@@ -155,6 +169,7 @@ public class JdbcBatchPreparedStmntRequest implements ClientMessage {
         }
 
         queryTimeoutMillis = unpacker.unpackLong();
+        correlationToken = unpacker.unpackLong();
     }
 
     /** {@inheritDoc} */

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcQueryCancelResult.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcQueryCancelResult.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.jdbc.proto.event;
+
+import org.apache.ignite.internal.tostring.S;
+
+/**
+ * JDBC query cancel result.
+ */
+public class JdbcQueryCancelResult extends Response {
+    /**
+     * Default constructor is used for deserialization.
+     */
+    public JdbcQueryCancelResult() { }
+
+    /**
+     * Constructor.
+     *
+     * @param status Status code.
+     * @param err    Error message.
+     */
+    public JdbcQueryCancelResult(int status, String err) {
+        super(status, err);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return S.toString(JdbcQueryCancelResult.class, this);
+    }
+}

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcQueryExecuteRequest.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/jdbc/proto/event/JdbcQueryExecuteRequest.java
@@ -56,6 +56,12 @@ public class JdbcQueryExecuteRequest implements ClientMessage {
     private long queryTimeoutMillis;
 
     /**
+     * Token is used to uniquely identify execution request within single connection, which is required to properly coordinate cancellation
+     * request.
+     */
+    private long correlationToken;
+
+    /**
      * Default constructor. For deserialization purposes.
      */
     public JdbcQueryExecuteRequest() {
@@ -73,6 +79,7 @@ public class JdbcQueryExecuteRequest implements ClientMessage {
      * @param autoCommit Flag indicating whether auto-commit mode is enabled.
      * @param multiStatement Multiple statement flag.
      * @param queryTimeoutMillis Query timeout in millseconds.
+     * @param correlationToken Token is used to uniquely identify execution request within single connection.
      */
     public JdbcQueryExecuteRequest(
             JdbcStatementType stmtType,
@@ -83,7 +90,8 @@ public class JdbcQueryExecuteRequest implements ClientMessage {
             Object[] args,
             boolean autoCommit,
             boolean multiStatement,
-            long queryTimeoutMillis
+            long queryTimeoutMillis,
+            long correlationToken
     ) {
         Objects.requireNonNull(stmtType);
 
@@ -96,6 +104,7 @@ public class JdbcQueryExecuteRequest implements ClientMessage {
         this.args = args;
         this.multiStatement = multiStatement;
         this.queryTimeoutMillis = queryTimeoutMillis;
+        this.correlationToken = correlationToken;
     }
 
     /**
@@ -177,6 +186,10 @@ public class JdbcQueryExecuteRequest implements ClientMessage {
         return queryTimeoutMillis;
     }
 
+    public long correlationToken() {
+        return correlationToken;
+    }
+
     /** {@inheritDoc} */
     @Override
     public void writeBinary(ClientMessagePacker packer) {
@@ -190,6 +203,7 @@ public class JdbcQueryExecuteRequest implements ClientMessage {
 
         packer.packObjectArrayAsBinaryTuple(args);
         packer.packLong(queryTimeoutMillis);
+        packer.packLong(correlationToken);
     }
 
     /** {@inheritDoc} */
@@ -205,6 +219,7 @@ public class JdbcQueryExecuteRequest implements ClientMessage {
 
         args = unpacker.unpackObjectArrayFromBinaryTuple();
         queryTimeoutMillis = unpacker.unpackLong();
+        correlationToken = unpacker.unpackLong();
     }
 
     /** {@inheritDoc} */

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -49,6 +49,7 @@ import org.apache.ignite.client.handler.requests.compute.ClientComputeExecuteCol
 import org.apache.ignite.client.handler.requests.compute.ClientComputeExecuteMapReduceRequest;
 import org.apache.ignite.client.handler.requests.compute.ClientComputeExecuteRequest;
 import org.apache.ignite.client.handler.requests.compute.ClientComputeGetStateRequest;
+import org.apache.ignite.client.handler.requests.jdbc.ClientJdbcCancelRequest;
 import org.apache.ignite.client.handler.requests.jdbc.ClientJdbcCloseRequest;
 import org.apache.ignite.client.handler.requests.jdbc.ClientJdbcColumnMetadataRequest;
 import org.apache.ignite.client.handler.requests.jdbc.ClientJdbcConnectRequest;
@@ -716,6 +717,9 @@ public class ClientInboundMessageHandler extends ChannelInboundHandlerAdapter im
 
             case ClientOp.JDBC_EXEC:
                 return ClientJdbcExecuteRequest.execute(in, out, jdbcQueryEventHandler);
+
+            case ClientOp.JDBC_CANCEL:
+                return ClientJdbcCancelRequest.execute(in, out, jdbcQueryEventHandler);
 
             case ClientOp.JDBC_EXEC_BATCH:
                 return ClientJdbcExecuteBatchRequest.process(in, out, jdbcQueryEventHandler);

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/jdbc/ClientJdbcCancelRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/jdbc/ClientJdbcCancelRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client.handler.requests.jdbc;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.ignite.internal.client.proto.ClientMessagePacker;
+import org.apache.ignite.internal.client.proto.ClientMessageUnpacker;
+import org.apache.ignite.internal.jdbc.proto.JdbcQueryEventHandler;
+
+/**
+ * Client jdbc cancel request handler.
+ */
+public class ClientJdbcCancelRequest {
+    /**
+     * Processes a remote JDBC request to cancel the current execution.
+     *
+     * @param in Client message unpacker.
+     * @param out Client message packer.
+     * @param handler Query event handler.
+     * @return Operation future.
+     */
+    public static CompletableFuture<Void> execute(
+            ClientMessageUnpacker in,
+            ClientMessagePacker out,
+            JdbcQueryEventHandler handler
+    ) {
+        long connectionId = in.unpackLong();
+        long correlationToken = in.unpackLong();
+
+        return handler.cancelAsync(connectionId, correlationToken).thenAccept(res -> res.writeBinary(out));
+    }
+}

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientUtils.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientUtils.java
@@ -109,6 +109,9 @@ public class ClientUtils {
             case ClientOp.JDBC_EXEC:
                 return null;
 
+            case ClientOp.JDBC_CANCEL:
+                return null;
+
             case ClientOp.JDBC_NEXT:
                 return null;
 

--- a/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/RetryPolicyTest.java
@@ -226,7 +226,7 @@ public class RetryPolicyTest extends BaseIgniteAbstractTest {
             }
         }
 
-        long expectedNullCount = 21;
+        long expectedNullCount = 22;
 
         String msg = nullOpFields.size()
                 + " operation codes do not have public equivalent. When adding new codes, update ClientOperationType too. Missing ops: "

--- a/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcStatementCancelSelfTest.java
+++ b/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcStatementCancelSelfTest.java
@@ -17,140 +17,221 @@
 
 package org.apache.ignite.jdbc;
 
+import static org.apache.ignite.internal.testframework.IgniteTestUtils.await;
+import static org.apache.ignite.internal.testframework.IgniteTestUtils.runAsync;
+import static org.apache.ignite.internal.testframework.IgniteTestUtils.waitForCondition;
+import static org.apache.ignite.jdbc.util.JdbcTestUtils.assertThrowsSqlException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
-import org.apache.ignite.jdbc.util.JdbcTestUtils;
-import org.junit.jupiter.api.Disabled;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 /**
  * Statement cancel test.
  */
-@Disabled("https://issues.apache.org/jira/browse/IGNITE-16205")
-public class ItJdbcStatementCancelSelfTest extends ItJdbcAbstractStatementSelfTest {
-    /**
-     * Trying to cancel stament without query. In given case cancel is noop, so no exception expected.
-     */
-    @Test
-    public void testCancelingStmtWithoutQuery() {
-        try {
-            stmt.cancel();
-        } catch (Exception e) {
-            log.error("Unexpected exception.", e);
+@SuppressWarnings({"ThrowableNotThrown", "JDBCResourceOpenedButNotSafelyClosed"})
+public class ItJdbcStatementCancelSelfTest extends AbstractJdbcSelfTest {
+    @AfterEach
+    void reset() throws SQLException {
+        if (!stmt.isClosed()) {
+            stmt.setFetchSize(1024);
+        }
 
-            fail("Unexpected exception");
+        dropAllTables();
+    }
+
+    @Test
+    void cancelIsNoopWhenThereIsNoRunningQuery() throws SQLException {
+        stmt.cancel();
+    }
+
+    @Test
+    void cancellationOfLongRunningQuery() throws Exception {
+        CompletableFuture<?> result = runAsync(() ->
+                stmt.executeQuery("SELECT count(*) FROM system_range(0, 10000000000)")
+        );
+
+        assertTrue(
+                waitForCondition(() -> sql("SELECT * FROM system.sql_queries").size() == 2, 5_000),
+                "Query didn't appear in running queries view or disappeared too fast"
+        );
+
+        stmt.cancel();
+
+        // second cancellation should not throw any error
+        stmt.cancel();
+
+        assertThrowsSqlException(
+                "The query was cancelled while executing.",
+                () -> await(result)
+        );
+    }
+
+    @Test
+    void cancellationOfMultiStatementQuery() throws Exception {
+        stmt.executeUpdate("CREATE TABLE dummy (id INT PRIMARY KEY, val INT)");
+        stmt.setFetchSize(1);
+
+        stmt.execute("START TRANSACTION;"
+                + "SELECT x FROM system_range(0, 100000) ORDER BY x;" // result should be big enough, so it doesn't fit into a single page
+                + "COMMIT;" // script processing is expected to hung on COMMIT until all cursors have been closed
+                + "INSERT INTO dummy VALUES (1, 1);");
+
+        stmt.getMoreResults(); // move to SELECT
+
+        ResultSet rs = stmt.getResultSet();
+
+        assertNotNull(rs);
+
+        assertTrue(rs.next());
+        assertEquals(0, rs.getInt(1));
+        assertTrue(rs.next());
+        assertEquals(1, rs.getInt(1));
+
+        stmt.cancel();
+
+        assertThrowsSqlException(
+                "The query was cancelled while executing.",
+                stmt::getMoreResults
+        );
+    }
+
+    @Test
+    void cancelOfClosedStatementThrows() throws Exception {
+        stmt.close();
+
+        assertThrowsSqlException("Statement is closed.", stmt::cancel);
+    }
+
+    @Test
+    void fetchingNextPageAfterCancelingShouldThrow() throws Exception {
+        stmt.setFetchSize(50);
+
+        {
+            ResultSet rs = stmt.executeQuery("SELECT * FROM system_range(0, 75)");
+
+            assertTrue(rs.next());
+
+            stmt.cancel();
+
+            assertThrowsSqlException("The query was cancelled while executing.", () -> {
+                //noinspection StatementWithEmptyBody
+                while (rs.next()) { }
+            });
+        }
+
+        {
+            // but new execute should work
+            ResultSet rs = stmt.executeQuery("SELECT * FROM system_range(0, 75)");
+
+            //noinspection StatementWithEmptyBody
+            while (rs.next()) { }
         }
     }
 
-    /**
-     * Trying to retrieve result set of a canceled query.
-     * SQLException with message "The query was cancelled while executing." expected.
-     *
-     * @throws Exception If failed.
-     */
     @Test
-    public void testResultSetRetrievalInCanceledStatement() throws Exception {
-        stmt.execute("SELECT 1; SELECT 2; SELECT 3;");
-
-        assertNotNull(stmt.getResultSet());
-
-        stmt.cancel();
-
-        JdbcTestUtils.assertThrowsSqlException("The query was cancelled while executing.", stmt::getResultSet);
-    }
-
-    /**
-     * Trying to cancel already cancelled query.
-     * No exceptions exceped.
-     *
-     * @throws Exception If failed.
-     */
-    @Test
-    public void testCancelCanceledQuery() throws Exception {
-        stmt.execute("SELECT 1;");
-
-        assertNotNull(stmt.getResultSet());
-
-        stmt.cancel();
-
-        stmt.cancel();
-
-        JdbcTestUtils.assertThrowsSqlException("The query was cancelled while executing.", stmt::getResultSet);
-    }
-
-    /**
-     * Trying to cancel closed query.
-     * SQLException with message "Statement is closed." expected.
-     *
-     * @throws Exception If failed.
-     */
-    @Test
-    public void testCancelClosedStmt() throws Exception {
-        stmt.close();
-
-        JdbcTestUtils.assertThrowsSqlException("Statement is closed.", stmt::cancel);
-    }
-
-    /**
-     * Trying to call <code>resultSet.next()</code> on a canceled query.
-     * SQLException with message "The query was cancelled while executing." expected.
-     *
-     * @throws Exception If failed.
-     */
-    @Test
-    public void testResultSetNextAfterCanceling() throws Exception {
-        stmt.setFetchSize(10);
-
-        ResultSet rs = stmt.executeQuery("select * from PUBLIC.PERSON");
-
-        assertTrue(rs.next());
-
-        stmt.cancel();
-
-        JdbcTestUtils.assertThrowsSqlException("The query was cancelled while executing.", rs::next);
-    }
-
-    /**
-     * Ensure that it's possible to execute new query on cancelled statement.
-     *
-     * @throws Exception If failed.
-     */
-    @Test
-    public void testCancelAnotherStmt() throws Exception {
-        stmt.setFetchSize(10);
-
-        ResultSet rs = stmt.executeQuery("select * from PUBLIC.PERSON");
-
-        assertTrue(rs.next());
-
-        stmt.cancel();
-
-        ResultSet rs2 = stmt.executeQuery("select * from PUBLIC.PERSON order by ID asc");
-
-        assertTrue(rs2.next(), "The other cursor mustn't be closed");
-    }
-
-    /**
-     * Ensure that stament cancel doesn't affect another statement workflow, created by the same connection.
-     *
-     * @throws Exception If failed.
-     */
-    @Test
-    public void testCancelAnotherStmtResultSet() throws Exception {
+    public void cancellationOfOneStatementShouldNotAffectAnother() throws Exception {
+        stmt.setFetchSize(50);
         try (Statement anotherStmt = conn.createStatement()) {
-            ResultSet rs1 = stmt.executeQuery("select * from PUBLIC.PERSON WHERE ID % 2 = 0");
+            anotherStmt.setFetchSize(50);
 
-            ResultSet rs2 = anotherStmt.executeQuery("select * from PUBLIC.PERSON  WHERE ID % 2 <> 0");
+            ResultSet rs1 = stmt.executeQuery("SELECT * FROM system_range(0, 75)");
+
+            ResultSet rs2 = anotherStmt.executeQuery("SELECT * FROM system_range(0, 75)");
 
             stmt.cancel();
 
-            JdbcTestUtils.assertThrowsSqlException("The query was cancelled while executing.", rs1::next);
+            assertThrowsSqlException("The query was cancelled while executing.", () -> {
+                //noinspection StatementWithEmptyBody
+                while (rs1.next()) { }
+            });
 
-            assertTrue(rs2.next(), "The other cursor mustn't be closed");
+            //noinspection StatementWithEmptyBody
+            while (rs2.next()) { }
+        }
+    }
+
+    @Test
+    void cancellationOfPreparedStatement() throws Exception {
+        try (PreparedStatement ps = conn.prepareStatement("SELECT count(*) FROM system_range(0, ?)")) {
+            CompletableFuture<?> result = runAsync(() -> {
+                ps.setLong(1, 10000000000L);
+
+                ps.executeQuery();
+            });
+
+            assertTrue(
+                    waitForCondition(() -> sql("SELECT * FROM system.sql_queries").size() == 2, 5_000),
+                    "Query didn't appear in running queries view or disappeared too fast"
+            );
+
+            ps.cancel();
+
+            assertThrowsSqlException(
+                    "The query was cancelled while executing.",
+                    () -> await(result)
+            );
+        }
+    }
+
+    @Test
+    void cancellationOfBatch() throws Exception {
+        stmt.executeUpdate("CREATE TABLE dummy (id INT PRIMARY KEY, val INT)");
+        stmt.addBatch("INSERT INTO dummy SELECT x, x FROM system_range(1, 1)");
+        stmt.addBatch("INSERT INTO dummy SELECT x, x FROM system_range(2, 2)");
+        stmt.addBatch("INSERT INTO dummy SELECT x, x FROM system_range(3, 1000000)");
+
+        CompletableFuture<?> result = runAsync(stmt::executeBatch);
+
+        assertTrue(
+                waitForCondition(() -> sql("SELECT * FROM system.sql_queries").size() >= 2, 5_000),
+                "Query didn't appear in running queries view or disappeared too fast"
+        );
+
+        stmt.cancel();
+
+        assertThrowsSqlException(
+                "The query was cancelled while executing.",
+                () -> await(result)
+        );
+    }
+
+    @Test
+    void cancellationOfPreparedBatch() throws Exception {
+        stmt.executeUpdate("CREATE TABLE dummy (id INT PRIMARY KEY, val INT)");
+        try (PreparedStatement ps = conn.prepareStatement("INSERT INTO dummy SELECT x, x FROM system_range(?, ?)")) {
+            ps.setInt(1, 1);
+            ps.setInt(2, 1);
+            ps.addBatch();
+
+            ps.setInt(1, 2);
+            ps.setInt(2, 2);
+            ps.addBatch();
+
+            ps.setInt(1, 3);
+            ps.setInt(2, 1000000);
+            ps.addBatch();
+
+            CompletableFuture<?> result = runAsync(ps::executeBatch);
+
+            assertTrue(
+                    waitForCondition(() -> sql("SELECT * FROM system.sql_queries").size() >= 2, 5_000),
+                    "Query didn't appear in running queries view or disappeared too fast"
+            );
+
+            ps.cancel();
+
+            assertThrowsSqlException(
+                    "The query was cancelled while executing.",
+                    () -> await(result)
+            );
         }
     }
 }

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcClientQueryEventHandler.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcClientQueryEventHandler.java
@@ -35,6 +35,7 @@ import org.apache.ignite.internal.jdbc.proto.event.JdbcMetaSchemasRequest;
 import org.apache.ignite.internal.jdbc.proto.event.JdbcMetaSchemasResult;
 import org.apache.ignite.internal.jdbc.proto.event.JdbcMetaTablesRequest;
 import org.apache.ignite.internal.jdbc.proto.event.JdbcMetaTablesResult;
+import org.apache.ignite.internal.jdbc.proto.event.JdbcQueryCancelResult;
 import org.apache.ignite.internal.jdbc.proto.event.JdbcQueryExecuteRequest;
 import org.apache.ignite.internal.jdbc.proto.event.Response;
 
@@ -50,7 +51,7 @@ public class JdbcClientQueryEventHandler implements JdbcQueryEventHandler {
      *
      * @param client TcpIgniteClient.
      */
-    public JdbcClientQueryEventHandler(TcpIgniteClient client) {
+    JdbcClientQueryEventHandler(TcpIgniteClient client) {
         this.client = client;
     }
 
@@ -172,6 +173,21 @@ public class JdbcClientQueryEventHandler implements JdbcQueryEventHandler {
             w.out().packBoolean(commit);
         }, r -> {
             JdbcFinishTxResult res = new JdbcFinishTxResult();
+
+            res.readBinary(r.in());
+
+            return res;
+        });
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public CompletableFuture<JdbcQueryCancelResult> cancelAsync(long connectionId, long correlationToken) {
+        return client.sendRequestAsync(ClientOp.JDBC_CANCEL, w -> {
+            w.out().packLong(connectionId);
+            w.out().packLong(correlationToken);
+        }, r -> {
+            JdbcQueryCancelResult res = new JdbcQueryCancelResult();
 
             res.readBinary(r.in());
 

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcConnection.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcConnection.java
@@ -52,6 +52,7 @@ import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.ignite.client.BasicAuthenticator;
 import org.apache.ignite.client.IgniteClient;
 import org.apache.ignite.client.IgniteClientAuthenticator;
@@ -77,6 +78,8 @@ public class JdbcConnection implements Connection {
 
     /** Statements modification mutex. */
     private final Object stmtsMux = new Object();
+
+    private final AtomicLong tokenGenerator = new AtomicLong(Long.MIN_VALUE);
 
     /** Handler. */
     private final JdbcQueryEventHandler handler;
@@ -952,5 +955,9 @@ public class JdbcConnection implements Connection {
      */
     public String url() {
         return connProps.getUrl();
+    }
+
+    long nextToken() {
+        return tokenGenerator.getAndIncrement();
     }
 }

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcPreparedStatement.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcPreparedStatement.java
@@ -142,8 +142,11 @@ public class JdbcPreparedStatement extends JdbcStatement implements PreparedStat
             return INT_EMPTY_ARRAY;
         }
 
-        JdbcBatchPreparedStmntRequest req
-                = new JdbcBatchPreparedStmntRequest(conn.getSchema(), sql, batchedArgs, conn.getAutoCommit(), queryTimeoutMillis);
+        long correlationToken = nextToken();
+
+        JdbcBatchPreparedStmntRequest req = new JdbcBatchPreparedStmntRequest(
+                conn.getSchema(), sql, batchedArgs, conn.getAutoCommit(), queryTimeoutMillis, correlationToken
+        );
 
         try {
             JdbcBatchExecuteResult res = conn.handler().batchPrepStatementAsync(conn.connectionId(), req).get();

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcStatement.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcStatement.java
@@ -44,8 +44,10 @@ import org.apache.ignite.internal.jdbc.proto.SqlStateCode;
 import org.apache.ignite.internal.jdbc.proto.event.JdbcBatchExecuteRequest;
 import org.apache.ignite.internal.jdbc.proto.event.JdbcBatchExecuteResult;
 import org.apache.ignite.internal.jdbc.proto.event.JdbcColumnMeta;
+import org.apache.ignite.internal.jdbc.proto.event.JdbcQueryCancelResult;
 import org.apache.ignite.internal.jdbc.proto.event.JdbcQueryExecuteRequest;
 import org.apache.ignite.internal.jdbc.proto.event.JdbcQuerySingleResult;
+import org.apache.ignite.internal.jdbc.proto.event.Response;
 import org.apache.ignite.internal.util.ArrayUtils;
 import org.apache.ignite.internal.util.CollectionUtils;
 import org.jetbrains.annotations.Nullable;
@@ -70,7 +72,7 @@ public class JdbcStatement implements Statement {
     private volatile boolean closed;
 
     /** Query timeout. */
-    protected long queryTimeoutMillis;
+    long queryTimeoutMillis;
 
     /** Rows limit. */
     private int maxRows;
@@ -89,6 +91,8 @@ public class JdbcStatement implements Statement {
 
     /** Current result index. */
     private int curRes;
+
+    private volatile @Nullable Long lastCorrelationToken;
 
     /**
      * Creates new statement.
@@ -136,8 +140,10 @@ public class JdbcStatement implements Statement {
             throw new SQLException("SQL query is empty.");
         }
 
+        long correlationToken = nextToken();
+
         JdbcQueryExecuteRequest req = new JdbcQueryExecuteRequest(stmtType, schema, pageSize, maxRows, sql, args,
-                conn.getAutoCommit(), multiStatement, queryTimeoutMillis);
+                conn.getAutoCommit(), multiStatement, queryTimeoutMillis, correlationToken);
 
         JdbcQueryExecuteResponse res;
         try {
@@ -305,7 +311,25 @@ public class JdbcStatement implements Statement {
     public void cancel() throws SQLException {
         ensureNotClosed();
 
-        throw new SQLException("Cancellation is not supported.");
+        Long correlationToken = lastCorrelationToken;
+
+        if (correlationToken == null) {
+            return;
+        }
+
+        try {
+            JdbcQueryCancelResult res = conn.handler().cancelAsync(conn.connectionId(), correlationToken).get();
+
+            if (res.status() != Response.STATUS_SUCCESS) {
+                throw IgniteQueryErrorCode.createJdbcSqlException(res.err(), res.status());
+            }
+        } catch (CancellationException e) {
+            throw new SQLException("Request to cancel the statement has been canceled.", e);
+        } catch (ExecutionException e) {
+            throw new SQLException("Request to cancel the statement has failed.", e);
+        } catch (InterruptedException e) {
+            throw new SQLException("Thread was interrupted.", e);
+        }
     }
 
     /** {@inheritDoc} */
@@ -565,7 +589,11 @@ public class JdbcStatement implements Statement {
             return INT_EMPTY_ARRAY;
         }
 
-        JdbcBatchExecuteRequest req = new JdbcBatchExecuteRequest(conn.getSchema(), batch, conn.getAutoCommit(), queryTimeoutMillis);
+        long correlationToken = nextToken();
+
+        JdbcBatchExecuteRequest req = new JdbcBatchExecuteRequest(
+                conn.getSchema(), batch, conn.getAutoCommit(), queryTimeoutMillis, correlationToken
+        );
 
         try {
             JdbcBatchExecuteResult res = conn.handler().batchAsync(conn.connectionId(), req).get();
@@ -726,6 +754,8 @@ public class JdbcStatement implements Statement {
             resSets = null;
             curRes = 0;
         }
+
+        lastCorrelationToken = null;
     }
 
     /**
@@ -770,6 +800,14 @@ public class JdbcStatement implements Statement {
         }
 
         this.queryTimeoutMillis = timeout;
+    }
+
+    long nextToken() {
+        long correlationToken = conn.nextToken();
+
+        lastCorrelationToken = correlationToken;
+
+        return correlationToken;
     }
 
     private static SQLException toSqlException(ExecutionException e) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23464

To address the issue, every execution is assigned with `correlationToken` which is unique within a single connection. Using this token, now it's possible to cancel particular execution by sending special request to server.

--------
Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)