### PR TITLE
IGNITE-23834 Avoid state machines divergence due to permissive error handling

### DIFF
--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/raft/PartitionListener.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/raft/PartitionListener.java
@@ -26,6 +26,7 @@ import static org.apache.ignite.internal.tx.TxState.ABORTED;
 import static org.apache.ignite.internal.tx.TxState.COMMITTED;
 import static org.apache.ignite.internal.tx.TxState.PENDING;
 import static org.apache.ignite.internal.util.CollectionUtils.last;
+import static org.apache.ignite.internal.util.IgniteUtils.inBusyLock;
 
 import java.io.Serializable;
 import java.nio.file.Path;
@@ -38,7 +39,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.apache.ignite.internal.catalog.CatalogService;
@@ -181,7 +181,14 @@ public class PartitionListener implements RaftGroupListener, BeforeApplyHandler 
     @Override
     public void onWrite(Iterator<CommandClosure<WriteCommand>> iterator) {
         if (!busyLock.enterBusy()) {
+            // Here, we just complete the closures with an exception and then return. From the point of view of JRaft, this means that
+            // we 'applied' the commands, even though we didn't. JRaft will wrongly increment its appliedIndex. But it doesn't seem to be
+            // a problem because the current run is being finished (the node is stopping itself), and the only way to persist appliedIndex
+            // (which might affect subsequent runs) is to save it into snapshot, but we use the busy lock in #onSnapshotSave(), so
+            // the snapshot with wrong appliedIndex will not be saved.
             iterator.forEachRemaining(clo -> clo.result(new ShutdownException()));
+
+            return;
         }
 
         try {
@@ -255,16 +262,14 @@ public class PartitionListener implements RaftGroupListener, BeforeApplyHandler 
                 } else {
                     assert false : "Command was not found [cmd=" + command + ']';
                 }
-            } catch (IgniteInternalException e) {
-                result = e;
-            } catch (CompletionException e) {
-                result = e.getCause();
             } catch (Throwable t) {
                 LOG.error(
                         "Unknown error while processing command [commandIndex={}, commandTerm={}, command={}]",
                         t,
                         clo.index(), clo.index(), command
                 );
+
+                clo.result(t);
 
                 throw t;
             } finally {
@@ -539,6 +544,10 @@ public class PartitionListener implements RaftGroupListener, BeforeApplyHandler 
 
     @Override
     public void onSnapshotSave(Path path, Consumer<Throwable> doneClo) {
+        inBusyLock(busyLock, () -> onSnapshotSaveBusy(doneClo));
+    }
+
+    private void onSnapshotSaveBusy(Consumer<Throwable> doneClo) {
         // The max index here is required for local recovery and a possible scenario
         // of false node failure when we actually have all required data. This might happen because we use the minimal index
         // among storages on a node restart.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23834

* Currently, these implementations only let the client know about some exceptions occurring when executing write commands, but JRaft is not notified, so application of subsequent commands is not prohibited. This might cause state machines diverge in the same group if some command fails on just one of the machines. This commit makes sure that the state machine is marked as broken if something is thrown when executing a command
* Busy locks usage is improved (they were not actually protecting the machines from applying commands even when the locks were blocked)

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)