### PR TITLE
IGNITE-23821 Check whether INSTALLING_SNAPSHOT will not be discarded on leader stop

### DIFF
--- a/modules/raft/src/integrationTest/java/org/apache/ignite/raft/jraft/core/ItNodeTest.java
+++ b/modules/raft/src/integrationTest/java/org/apache/ignite/raft/jraft/core/ItNodeTest.java
@@ -17,6 +17,7 @@
 package org.apache.ignite.raft.jraft.core;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.synchronizedList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willCompleteSuccessfully;
@@ -74,7 +75,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import java.util.function.BooleanSupplier;
-import java.util.function.Consumer;
 import java.util.stream.IntStream;
 import org.apache.ignite.internal.logger.IgniteLogger;
 import org.apache.ignite.internal.logger.Loggers;
@@ -585,7 +585,7 @@ public class ItNodeTest extends BaseIgniteAbstractTest {
         UserReplicatorStateListener listener2 = new UserReplicatorStateListener();
 
         cluster = new TestCluster("unitest", dataPath, peers, new LinkedHashSet<>(), ELECTION_TIMEOUT_MILLIS,
-            opts -> opts.setReplicationStateListeners(List.of(listener1, listener2)), testInfo);
+                (peerId, opts) -> opts.setReplicationStateListeners(List.of(listener1, listener2)), testInfo);
 
         for (TestPeer peer : peers)
             assertTrue(cluster.start(peer));
@@ -685,7 +685,7 @@ public class ItNodeTest extends BaseIgniteAbstractTest {
         List<TestPeer> peers = TestUtils.generatePeers(testInfo, 3);
 
         cluster = new TestCluster("unitest", dataPath, peers, new LinkedHashSet<>(), ELECTION_TIMEOUT_MILLIS,
-            opts -> opts.setReplicationStateListeners(List.of(new UserReplicatorStateListener())), testInfo);
+                (peerId, opts) -> opts.setReplicationStateListeners(List.of(new UserReplicatorStateListener())), testInfo);
 
         for (TestPeer peer : peers)
             assertTrue(cluster.start(peer));
@@ -2831,39 +2831,42 @@ public class ItNodeTest extends BaseIgniteAbstractTest {
         List<TestPeer> peers = TestUtils.generatePeers(testInfo, 3);
 
         // Here we need custom SnapshotCopier that is capable of pausing snapshot installation.
-        Consumer<NodeOptions> nodeOptionsConsumer = nodeOptions -> nodeOptions.setServiceFactory(new TestJRaftServiceFactory() {
-            @Override
-            public SnapshotStorage createSnapshotStorage(String uri, RaftOptions raftOptions) {
-                return new LocalSnapshotStorage(uri, raftOptions) {
+        BiConsumer<PeerId, NodeOptions> nodeOptionsConsumer = (peerId, nodeOptions) -> {
 
-                    @Override
-                    public SnapshotCopier startToCopyFrom(String uri, SnapshotCopierOptions opts) {
-                        LocalSnapshotCopier copier = new LocalSnapshotCopier() {
-                            @Override
-                            public void join() throws InterruptedException {
-                                // Pause snapshot installation.
-                                snapshotFuture.join();
-                                super.join();
-                            }
+            nodeOptions.setServiceFactory(new TestJRaftServiceFactory() {
+                @Override
+                public SnapshotStorage createSnapshotStorage(String uri, RaftOptions raftOptions) {
+                    return new LocalSnapshotStorage(uri, raftOptions) {
 
-                            @Override
-                            public void cancel() {
-                                // Unblock snapshot installation if snapshot request is cancelled.
-                                snapshotFuture.complete(null);
-                                super.cancel();
+                        @Override
+                        public SnapshotCopier startToCopyFrom(String uri, SnapshotCopierOptions opts) {
+                            LocalSnapshotCopier copier = new LocalSnapshotCopier() {
+                                @Override
+                                public void join() throws InterruptedException {
+                                    // Pause snapshot installation.
+                                    snapshotFuture.join();
+                                    super.join();
+                                }
+
+                                @Override
+                                public void cancel() {
+                                    // Unblock snapshot installation if snapshot request is cancelled.
+                                    snapshotFuture.complete(null);
+                                    super.cancel();
+                                }
+                            };
+                            copier.setStorage(this);
+                            if (!copier.init(uri, opts)) {
+                                logger().error("Fail to init copier to {}.", uri);
+                                return null;
                             }
-                        };
-                        copier.setStorage(this);
-                        if (!copier.init(uri, opts)) {
-                            logger().error("Fail to init copier to {}.", uri);
-                            return null;
+                            copier.start();
+                            return copier;
                         }
-                        copier.start();
-                        return copier;
-                    }
-                };
-            }
-        });
+                    };
+                }
+            });
+        };
         cluster = new TestCluster("unitest", dataPath, peers, new LinkedHashSet<>(), ELECTION_TIMEOUT_MILLIS, nodeOptionsConsumer,
                 testInfo);
 
@@ -2902,6 +2905,201 @@ public class ItNodeTest extends BaseIgniteAbstractTest {
 
         // Even after 30 seconds (in reality, forever), the snapshot is still installing.
         assertTrue(cluster.getNode(peers.get(2).getPeerId()).isInstallingSnapshot());
+    }
+
+    /**
+     * A case when blocked TimeoutNow leads to nodes fail to elect a new leader.
+     */
+    @Test
+    public void testNodeBlockedTimeoutNow() throws Exception {
+        CompletableFuture<Void> snapshotFuture = new CompletableFuture<>();
+
+        // Create a group of 3 nodes, A,B and C.
+        // A is the leader, B and C are followers.
+        // C is not started, moreover C is on different configuration.
+        // Write data to the group and then start C.
+        // A is killed. C is in INSTALLING_SNAPSHOT.
+        // B starts PreVote. But C cannot vote for it as the configuration does not match.
+        // C cannot start prevote as C is in INSTALLING_SNAPSHOT.
+        List<TestPeer> allPeers = TestUtils.generatePeers(testInfo, 5);
+        List<TestPeer> peers = allPeers.subList(0, 3);
+
+        // Here we need custom SnapshotCopier that is capable of pausing snapshot installation.
+        BiConsumer<PeerId, NodeOptions> nodeOptionsConsumer = (peerId, nodeOptions) -> {
+            if (peerId.equals(peers.get(2).getPeerId())) {
+                nodeOptions.setInitialConf(new Configuration(
+                        allPeers.subList(2, 5).stream().map(TestPeer::getPeerId).collect(toList()),
+                        emptyList()
+                ));
+            }
+
+            nodeOptions.setServiceFactory(new TestJRaftServiceFactory() {
+                @Override
+                public SnapshotStorage createSnapshotStorage(String uri, RaftOptions raftOptions) {
+                    return new LocalSnapshotStorage(uri, raftOptions) {
+
+                        @Override
+                        public SnapshotCopier startToCopyFrom(String uri, SnapshotCopierOptions opts) {
+                            LocalSnapshotCopier copier = new LocalSnapshotCopier() {
+                                @Override
+                                public void join() throws InterruptedException {
+                                    // Pause snapshot installation.
+                                    snapshotFuture.join();
+                                    super.join();
+                                }
+
+                                @Override
+                                public void cancel() {
+                                    // Unblock snapshot installation if snapshot request is cancelled.
+                                    snapshotFuture.complete(null);
+                                    super.cancel();
+                                }
+                            };
+                            copier.setStorage(this);
+                            if (!copier.init(uri, opts)) {
+                                logger().error("Fail to init copier to {}.", uri);
+                                return null;
+                            }
+                            copier.start();
+                            return copier;
+                        }
+                    };
+                }
+            });
+        };
+        cluster = new TestCluster("unitest", dataPath, peers, new LinkedHashSet<>(), ELECTION_TIMEOUT_MILLIS, nodeOptionsConsumer,
+                testInfo);
+
+        assertTrue(cluster.start(peers.get(0)));
+        assertTrue(cluster.start(peers.get(1)));
+
+        Node leader = cluster.waitAndGetLeader();
+        assertNotNull(leader);
+
+        // Add data to the group.
+        sendTestTaskAndWait(leader);
+
+        log.info("Trigger leader snapshot");
+        CountDownLatch latch = new CountDownLatch(1);
+        leader.snapshot(new ExpectClosure(latch));
+        waitLatch(latch);
+        // Doing it twice to trigger log truncation.
+        latch = new CountDownLatch(1);
+        leader.snapshot(new ExpectClosure(latch));
+        waitLatch(latch);
+
+        // Start node C, it should install snapshot from leader.
+        log.info("Start node.");
+        assertTrue(cluster.start(peers.get(2)));
+        blockMessagesOnFollowers(cluster.getNodes().stream().map(Node.class::cast).collect(toList()), (msg, nodeId) -> {
+            if (msg instanceof RpcRequests.TimeoutNowRequest) {
+                log.info("Blocking TimeoutNowRequest on [node={}, msg={}]", nodeId, msg);
+                return true;
+            }
+
+            return false;
+        });
+        assertTrue(waitForCondition(() -> cluster.getNode(peers.get(2).getPeerId()).isInstallingSnapshot(), 10_000));
+        // While snapshot is being installed, stop the leader.
+        log.info("Stopping leader");
+        cluster.stop(leader.getLeaderId());
+        log.info("Leader stopped");
+
+        Thread.sleep(30_000);
+
+        assertTrue(cluster.getNode(peers.get(2).getPeerId()).isInstallingSnapshot());
+    }
+
+    @Test
+    public void testReelectionWithTimeoutNow() throws Exception {
+        CompletableFuture<Void> snapshotFuture = new CompletableFuture<>();
+
+        // Create a group of 3 nodes, A,B and C.
+        // A is the leader, B and C are followers.
+        // C is not started, moreover C is on different configuration.
+        // Write data to the group and then start C.
+        // A is killed. C is in INSTALLING_SNAPSHOT.
+        // A sends TimeoutNow on stop,
+        // B receives it, elects itself a leader and sends RequestVoteRequest.
+        // C votes for it and B becomes the new leader of (A,B,C).
+        List<TestPeer> allPeers = TestUtils.generatePeers(testInfo, 5);
+        List<TestPeer> peers = allPeers.subList(0, 3);
+
+        // Here we need custom SnapshotCopier that is capable of pausing snapshot installation.
+        BiConsumer<PeerId, NodeOptions> nodeOptionsConsumer = (peerId, nodeOptions) -> {
+            if (peerId.equals(peers.get(2).getPeerId())) {
+                nodeOptions.setInitialConf(new Configuration(
+                        allPeers.subList(2, 5).stream().map(TestPeer::getPeerId).collect(toList()),
+                        emptyList()
+                ));
+            }
+
+            nodeOptions.setServiceFactory(new TestJRaftServiceFactory() {
+                @Override
+                public SnapshotStorage createSnapshotStorage(String uri, RaftOptions raftOptions) {
+                    return new LocalSnapshotStorage(uri, raftOptions) {
+
+                        @Override
+                        public SnapshotCopier startToCopyFrom(String uri, SnapshotCopierOptions opts) {
+                            LocalSnapshotCopier copier = new LocalSnapshotCopier() {
+                                @Override
+                                public void join() throws InterruptedException {
+                                    // Pause snapshot installation.
+                                    snapshotFuture.join();
+                                    super.join();
+                                }
+
+                                @Override
+                                public void cancel() {
+                                    // Unblock snapshot installation if snapshot request is cancelled.
+                                    snapshotFuture.complete(null);
+                                    super.cancel();
+                                }
+                            };
+                            copier.setStorage(this);
+                            if (!copier.init(uri, opts)) {
+                                logger().error("Fail to init copier to {}.", uri);
+                                return null;
+                            }
+                            copier.start();
+                            return copier;
+                        }
+                    };
+                }
+            });
+        };
+        cluster = new TestCluster("unitest", dataPath, peers, new LinkedHashSet<>(), ELECTION_TIMEOUT_MILLIS, nodeOptionsConsumer,
+                testInfo);
+
+        assertTrue(cluster.start(peers.get(0)));
+        assertTrue(cluster.start(peers.get(1)));
+
+        Node leader = cluster.waitAndGetLeader();
+        assertNotNull(leader);
+
+        // Add data to the group.
+        sendTestTaskAndWait(leader);
+
+        log.info("Trigger leader snapshot");
+        CountDownLatch latch = new CountDownLatch(1);
+        leader.snapshot(new ExpectClosure(latch));
+        waitLatch(latch);
+        // Doing it twice to trigger log truncation.
+        latch = new CountDownLatch(1);
+        leader.snapshot(new ExpectClosure(latch));
+        waitLatch(latch);
+
+        // Start node C, it should install snapshot from leader.
+        log.info("Start node.");
+        assertTrue(cluster.start(peers.get(2)));
+
+        assertTrue(waitForCondition(() -> cluster.getNode(peers.get(2).getPeerId()).isInstallingSnapshot(), 10_000));
+        // While snapshot is being installed, stop the leader.
+        log.info("Stopping leader");
+        cluster.stop(leader.getLeaderId());
+        log.info("Leader stopped");
+
+        assertFalse(cluster.getNode(peers.get(2).getPeerId()).isInstallingSnapshot());
     }
 
     @Test
@@ -3801,7 +3999,8 @@ public class ItNodeTest extends BaseIgniteAbstractTest {
         int maxElectionRoundsWithoutAdjusting = 3;
 
         cluster = new TestCluster("unittest", dataPath, peers, new LinkedHashSet<>(), ELECTION_TIMEOUT_MILLIS,
-                opts -> opts.setElectionTimeoutStrategy(new ExponentialBackoffTimeoutStrategy(11_000, maxElectionRoundsWithoutAdjusting)),
+                (peerId, opts) ->
+                        opts.setElectionTimeoutStrategy(new ExponentialBackoffTimeoutStrategy(11_000, maxElectionRoundsWithoutAdjusting)),
                 testInfo);
 
         for (TestPeer peer : peers) {
@@ -3939,8 +4138,7 @@ public class ItNodeTest extends BaseIgniteAbstractTest {
 
         assertThat(lastLogIndexAt(forcedLeaderPeer), is(configFromResetIndex));
 
-        Consumer<NodeOptions> installExternalIndex = nodeOptions -> nodeOptions.setExternallyEnforcedConfigIndex(configFromResetIndex);
-        cluster.setNodeOptionsCustomizer(installExternalIndex);
+        cluster.setNodeOptionsCustomizer((peerId, opts) -> opts.setExternallyEnforcedConfigIndex(configFromResetIndex));
 
         assertTrue(cluster.start(originalLeaderPeer));
 
@@ -4004,8 +4202,7 @@ public class ItNodeTest extends BaseIgniteAbstractTest {
         Node node = cluster.waitAndGetLeader();
         assertThat(node.getLeaderId(), is(forcedLeaderPeer.getPeerId()));
 
-        Consumer<NodeOptions> installExternalIndex = nodeOptions -> nodeOptions.setExternallyEnforcedConfigIndex(configFromResetIndex);
-        cluster.setNodeOptionsCustomizer(installExternalIndex);
+        cluster.setNodeOptionsCustomizer((peerId, opts) -> opts.setExternallyEnforcedConfigIndex(configFromResetIndex));
 
         assertTrue(cluster.start(originalLeaderPeer));
 

--- a/modules/raft/src/integrationTest/java/org/apache/ignite/raft/jraft/core/TestCluster.java
+++ b/modules/raft/src/integrationTest/java/org/apache/ignite/raft/jraft/core/TestCluster.java
@@ -41,7 +41,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -96,7 +96,7 @@ public class TestCluster {
     private final ConcurrentMap<PeerId, RaftGroupService> serverMap = new ConcurrentHashMap<>();
     private final int electionTimeoutMs;
     private final Lock lock = new ReentrantLock();
-    private @Nullable Consumer<NodeOptions> optsClo;
+    private @Nullable BiConsumer<PeerId, NodeOptions> optsClo;
 
     /** Test info. */
     private final TestInfo testInfo;
@@ -154,7 +154,7 @@ public class TestCluster {
         List<TestPeer> peers,
         LinkedHashSet<TestPeer> learners,
         int electionTimeoutMs,
-        @Nullable Consumer<NodeOptions> optsClo,
+        @Nullable BiConsumer<PeerId, NodeOptions> optsClo,
         TestInfo testInfo
     ) {
         this.name = name;
@@ -278,7 +278,7 @@ public class TestCluster {
             assertThat(clusterService.startAsync(new ComponentContext()), willCompleteSuccessfully());
 
             if (optsClo != null)
-                optsClo.accept(nodeOptions);
+                optsClo.accept(peer.getPeerId(), nodeOptions);
 
             RaftGroupService server = new RaftGroupService(this.name, peer.getPeerId(),
                 nodeOptions, rpcServer, nodeManager) {
@@ -609,7 +609,7 @@ public class TestCluster {
         }
     }
 
-    public void setNodeOptionsCustomizer(Consumer<NodeOptions> customizer) {
+    public void setNodeOptionsCustomizer(BiConsumer<PeerId, NodeOptions> customizer) {
         this.optsClo = customizer;
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23821

INSTALLING_SNAPSHOT is discarded only when
- a snapshot is installed correctly
- if a leader dies and a new one is elected, the new leader installs new snapshot
- when the node is restarted (INSTALLING_SNAPSHOT is stored in memory only)

In other cases INSTALLING_SNAPSHOT will remain forever.