### PR TITLE
IGNITE-23825 Returning Tuple from table fails

### DIFF
--- a/modules/api/src/main/java/org/apache/ignite/table/TupleImpl.java
+++ b/modules/api/src/main/java/org/apache/ignite/table/TupleImpl.java
@@ -18,6 +18,8 @@
 package org.apache.ignite.table;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -347,7 +349,7 @@ class TupleImpl implements Tuple, Serializable {
      * @throws IOException            If failed.
      * @throws ClassNotFoundException If failed.
      */
-    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
 
         // Recover column name->index mapping.
@@ -356,6 +358,17 @@ class TupleImpl implements Tuple, Serializable {
         for (int i = 0; i < colNames.size(); i++) {
             colMapping.put(colNames.get(i), i);
         }
+    }
+
+    /**
+     * Serializes an object. Required to be implemented in pair with the {@link #readObject(ObjectInputStream)} so that the
+     * {@code StructuredObjectMarshaller#fillStructuredObjectLayerFrom} will actually call the {@link #readObject(ObjectInputStream)}.
+     *
+     * @param out Output object stream.
+     * @throws IOException If failed.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
     }
 
     <T> @Nullable T valueOrDefaultSkipNormalization(String columnName, @Nullable T def) {

--- a/modules/api/src/main/java/org/apache/ignite/table/TupleImpl.java
+++ b/modules/api/src/main/java/org/apache/ignite/table/TupleImpl.java
@@ -363,6 +363,7 @@ class TupleImpl implements Tuple, Serializable {
     /**
      * Serializes an object. Required to be implemented in pair with the {@link #readObject(ObjectInputStream)} so that the
      * {@code StructuredObjectMarshaller#fillStructuredObjectLayerFrom} will actually call the {@link #readObject(ObjectInputStream)}.
+     * TODO https://issues.apache.org/jira/browse/IGNITE-23868
      *
      * @param out Output object stream.
      * @throws IOException If failed.

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/serialization/ClassDescriptorFactory.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/serialization/ClassDescriptorFactory.java
@@ -20,7 +20,10 @@ package org.apache.ignite.internal.network.serialization;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static org.apache.ignite.internal.network.serialization.Classes.getReadResolve;
 import static org.apache.ignite.internal.network.serialization.Classes.hasWriteReplace;
+import static org.apache.ignite.internal.network.serialization.Classes.isExternalizable;
+import static org.apache.ignite.internal.network.serialization.Classes.isSerializable;
 
 import java.io.Externalizable;
 import java.io.ObjectInputStream;
@@ -111,10 +114,10 @@ public class ClassDescriptorFactory {
 
         int descriptorId = registry.getId(clazz);
 
-        if (Classes.isExternalizable(clazz)) {
+        if (isExternalizable(clazz)) {
             //noinspection unchecked
             return externalizable(descriptorId, (Class<? extends Externalizable>) clazz);
-        } else if (Classes.isSerializable(clazz)) {
+        } else if (isSerializable(clazz)) {
             //noinspection unchecked
             return serializable(descriptorId, (Class<? extends Serializable>) clazz);
         } else {
@@ -240,19 +243,19 @@ public class ClassDescriptorFactory {
         );
     }
 
-    private boolean hasReadResolve(Class<? extends Serializable> clazz) {
+    private static boolean hasReadResolve(Class<? extends Serializable> clazz) {
         return getReadResolve(clazz) != null;
     }
 
-    private boolean hasReadObject(Class<? extends Serializable> clazz) {
+    private static boolean hasReadObject(Class<? extends Serializable> clazz) {
         return getReadObject(clazz) != null;
     }
 
-    private boolean hasWriteObject(Class<? extends Serializable> clazz) {
+    private static boolean hasWriteObject(Class<? extends Serializable> clazz) {
         return getWriteObject(clazz) != null;
     }
 
-    private boolean hasReadObjectNoData(Class<? extends Serializable> clazz) {
+    private static boolean hasReadObjectNoData(Class<? extends Serializable> clazz) {
         return getReadObjectNoData(clazz) != null;
     }
 
@@ -288,7 +291,7 @@ public class ClassDescriptorFactory {
 
     @SuppressWarnings("CodeBlock2Expr")
     private Optional<List<FieldDescriptor>> maybeSerialPersistentFields(Class<?> clazz) {
-        if (!Classes.isSerializable(clazz)) {
+        if (!isSerializable(clazz)) {
             return Optional.empty();
         }
 
@@ -351,22 +354,6 @@ public class ClassDescriptorFactory {
                 })
                 .map(field -> FieldDescriptor.local(field, registry.getId(field.getType())))
                 .collect(toList());
-    }
-
-    /**
-     * Gets a method with the signature
-     * {@code ANY-ACCESS-MODIFIER Object readResolve() throws ObjectStreamException}.
-     *
-     * @param clazz Class.
-     * @return Method.
-     */
-    @Nullable
-    private static Method getReadResolve(Class<? extends Serializable> clazz) {
-        try {
-            return clazz.getDeclaredMethod("readResolve");
-        } catch (NoSuchMethodException e) {
-            return null;
-        }
     }
 
     /**

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/serialization/Classes.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/serialization/Classes.java
@@ -171,16 +171,14 @@ public class Classes {
 
     @Nullable
     private static Method findInheritableMethod(Class<?> clazz, String name) {
-        Method method = null;
         while (clazz != null) {
             try {
-                method = clazz.getDeclaredMethod(name);
-                break;
+                return clazz.getDeclaredMethod(name);
             } catch (NoSuchMethodException ex) {
                 clazz = clazz.getSuperclass();
             }
         }
-        return method;
+        return null;
     }
 
     private Classes() {

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/serialization/Classes.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/serialization/Classes.java
@@ -153,12 +153,34 @@ public class Classes {
      * @return Method.
      */
     @Nullable
-    private static Method getWriteReplace(Class<?> clazz) {
-        try {
-            return clazz.getDeclaredMethod("writeReplace");
-        } catch (NoSuchMethodException e) {
-            return null;
+    static Method getWriteReplace(Class<?> clazz) {
+        return findInheritableMethod(clazz, "writeReplace");
+    }
+
+    /**
+     * Gets a method with the signature
+     * {@code ANY-ACCESS-MODIFIER Object readResolve() throws ObjectStreamException}.
+     *
+     * @param clazz Class.
+     * @return Method.
+     */
+    @Nullable
+    static Method getReadResolve(Class<?> clazz) {
+        return findInheritableMethod(clazz, "readResolve");
+    }
+
+    @Nullable
+    private static Method findInheritableMethod(Class<?> clazz, String name) {
+        Method method = null;
+        while (clazz != null) {
+            try {
+                method = clazz.getDeclaredMethod(name);
+                break;
+            } catch (NoSuchMethodException ex) {
+                clazz = clazz.getSuperclass();
+            }
         }
+        return method;
     }
 
     private Classes() {

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/serialization/SpecialSerializationMethodsImpl.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/serialization/SpecialSerializationMethodsImpl.java
@@ -56,23 +56,21 @@ class SpecialSerializationMethodsImpl implements SpecialSerializationMethods {
     }
 
     private static Method writeReplaceInvoker(ClassDescriptor descriptor) {
-        try {
-            Method method = descriptor.localClass().getDeclaredMethod("writeReplace");
-            method.setAccessible(true);
-            return method;
-        } catch (ReflectiveOperationException e) {
-            throw new ReflectionException("Cannot find writeReplace() in " + descriptor.localClass(), e);
+        Method method = Classes.getWriteReplace(descriptor.localClass());
+        if (method == null) {
+            throw new ReflectionException("Cannot find writeReplace() in " + descriptor.localClass(), null);
         }
+        method.setAccessible(true);
+        return method;
     }
 
     private static Method readResolveInvoker(ClassDescriptor descriptor) {
-        try {
-            Method method = descriptor.localClass().getDeclaredMethod("readResolve");
-            method.setAccessible(true);
-            return method;
-        } catch (ReflectiveOperationException e) {
-            throw new ReflectionException("Cannot find readResolve() in " + descriptor.localClass(), e);
+        Method method = Classes.getReadResolve(descriptor.localClass());
+        if (method == null) {
+            throw new ReflectionException("Cannot find readResolve() in " + descriptor.localClass(), null);
         }
+        method.setAccessible(true);
+        return method;
     }
 
     private static Method writeObjectInvoker(ClassDescriptor descriptor) {

--- a/modules/network/src/test/java/org/apache/ignite/internal/network/serialization/marshal/DefaultUserObjectMarshallerWithSerializableTest.java
+++ b/modules/network/src/test/java/org/apache/ignite/internal/network/serialization/marshal/DefaultUserObjectMarshallerWithSerializableTest.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import org.apache.ignite.internal.network.serialization.ClassDescriptor;
 import org.apache.ignite.internal.network.serialization.ClassDescriptorFactory;
 import org.apache.ignite.internal.network.serialization.ClassDescriptorRegistry;
+import org.apache.ignite.table.Tuple;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
@@ -255,11 +256,20 @@ class DefaultUserObjectMarshallerWithSerializableTest {
 
     @Test
     void supportsSerialPersistedFieldsNamesDifferentFromRealFieldNamesWithPutFields() throws Exception {
-        var oririnalObject = new SerializableWithSerialPersistentFieldsDifferingFromRealFieldNamesAndPutFields(42);
+        var originalObject = new SerializableWithSerialPersistentFieldsDifferingFromRealFieldNamesAndPutFields(42);
 
-        SerializableWithSerialPersistentFieldsDifferingFromRealFieldNamesAndPutFields result = marshalAndUnmarshalNonNull(oririnalObject);
+        SerializableWithSerialPersistentFieldsDifferingFromRealFieldNamesAndPutFields result = marshalAndUnmarshalNonNull(originalObject);
 
         assertThat(result.value, is(42));
+    }
+
+    @Test
+    void tupleSerialization() throws Exception {
+        Tuple originalObject = Tuple.create().set("INT", 1);
+
+        Tuple result = marshalAndUnmarshalNonNull(originalObject);
+
+        assertThat(result.intValue("INT"), is(1));
     }
 
     /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23825

There were two problems:
* `TupleImpl` doesn't declare `writeObject` so the `StructuredObjectMarshaller.fillStructuredObjectLayerFrom` method doesn't call `readObject` to properly deserialize it.
* `ClassDescriptorFactory` doesn't search for the `writeReplace` method in superclasses.

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)