### PR TITLE
IGNITE-23889 Don't skip build when running PlatformTestNodeRunner

### DIFF
--- a/modules/platforms/cpp/tests/test-common/ignite_runner.cpp
+++ b/modules/platforms/cpp/tests/test-common/ignite_runner.cpp
@@ -47,12 +47,7 @@ void ignite_runner::start() {
     args.emplace_back(SYSTEM_SHELL_ARG_0);
 
     std::string command{GRADLEW_SCRIPT};
-    command += " :ignite-runner:runnerPlatformTest"
-               " --no-daemon"
-               " -x compileJava"
-               " -x compileTestFixturesJava"
-               " -x compileIntegrationTestJava"
-               " -x compileTestJava";
+    command += " :ignite-runner:runnerPlatformTest";
 
     args.emplace_back(command);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -38,8 +38,7 @@ namespace Apache.Ignite.Tests
 
         private const int ConnectTimeoutSeconds = 120;
 
-        private const string GradleCommandExec = ":ignite-runner:runnerPlatformTest"
-          + " -x compileJava -x compileTestFixturesJava -x compileIntegrationTestJava -x compileTestJava --parallel";
+        private const string GradleCommandExec = ":ignite-runner:runnerPlatformTest";
 
          /** Full path to Gradle binary. */
         private static readonly string GradlePath = GetGradle();

--- a/modules/platforms/python/tests/util.py
+++ b/modules/platforms/python/tests/util.py
@@ -14,13 +14,11 @@
 # limitations under the License.
 
 import os
-
 import psutil
+import pyignite3
 import signal
 import subprocess
 import time
-
-import pyignite3
 
 server_host = os.getenv("IGNITE_CLUSTER_HOST", '127.0.0.1')
 server_addresses_invalid = [server_host + ':10000']
@@ -119,8 +117,7 @@ def start_cluster(debug=False, jvm_opts='') -> subprocess.Popen:
                           '-Djava.net.preferIPv4Stack=true -Xdebug -Xnoagent -Djava.compiler=NONE ' \
                           '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 '
 
-    ignite_cmd = [runner, ':ignite-runner:runnerPlatformTest', '--no-daemon', '-x', 'compileJava', '-x',
-                  'compileTestFixturesJava', '-x', 'compileIntegrationTestJava', '-x',  'compileTestJava']
+    ignite_cmd = [runner, ':ignite-runner:runnerPlatformTest']
 
     print('Starting Ignite runner:', ignite_cmd)
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23889

This eliminates required extra step to build the runner integration test classes before running tests.