### PR TITLE
IGNITE-23786 .NET: Fix OverflowException on ErrorGroups.Common.Internal

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/lang/IgniteExceptionTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/lang/IgniteExceptionTest.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.lang;
 
 import static java.lang.invoke.MethodType.methodType;
 import static org.apache.ignite.lang.ErrorGroup.errorMessage;
+import static org.apache.ignite.lang.ErrorGroups.Common.COMMON_ERR_GROUP;
 import static org.apache.ignite.lang.ErrorGroups.Common.INTERNAL_ERR;
 import static org.apache.ignite.lang.util.TraceIdUtils.getOrCreateTraceId;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -199,6 +200,17 @@ public class IgniteExceptionTest {
         UUID traceId = getOrCreateTraceId(cause2);
 
         assertThat(traceId, is(any(UUID.class)));
+    }
+
+    @Test
+    public void testExceptionProperties() {
+        var ex = new IgniteException(UUID.randomUUID(), INTERNAL_ERR, "msg");
+
+        assertEquals(INTERNAL_ERR, ex.code());
+        assertEquals(-1, ex.errorCode());
+        assertEquals(COMMON_ERR_GROUP.groupCode(), ex.groupCode());
+        assertEquals(COMMON_ERR_GROUP.name(), ex.groupName());
+        assertEquals("IGN-CMN--1", ex.codeAsString());
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/lang/IgniteExceptionTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/lang/IgniteExceptionTest.java
@@ -19,7 +19,6 @@ package org.apache.ignite.internal.lang;
 
 import static java.lang.invoke.MethodType.methodType;
 import static org.apache.ignite.lang.ErrorGroup.errorMessage;
-import static org.apache.ignite.lang.ErrorGroups.Common.COMMON_ERR_GROUP;
 import static org.apache.ignite.lang.ErrorGroups.Common.INTERNAL_ERR;
 import static org.apache.ignite.lang.util.TraceIdUtils.getOrCreateTraceId;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -207,10 +206,12 @@ public class IgniteExceptionTest {
         var ex = new IgniteException(UUID.randomUUID(), INTERNAL_ERR, "msg");
 
         assertEquals(INTERNAL_ERR, ex.code());
+
         assertEquals(-1, ex.errorCode());
-        assertEquals(COMMON_ERR_GROUP.groupCode(), ex.groupCode());
-        assertEquals(COMMON_ERR_GROUP.name(), ex.groupName());
         assertEquals("IGN-CMN--1", ex.codeAsString());
+
+        assertEquals(1, ex.groupCode());
+        assertEquals("CMN", ex.groupName());
     }
 
     /**

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ErrorGroupTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ErrorGroupTests.cs
@@ -194,9 +194,12 @@ namespace Apache.Ignite.Tests
             var ex = new IgniteException(Guid.Empty, ErrorGroups.Common.Internal, "msg");
 
             Assert.AreEqual(ErrorGroups.Common.Internal, ex.Code);
+
             Assert.AreEqual(-1, ex.ErrorCode);
+            Assert.AreEqual("IGN-CMN--1", ex.CodeAsString);
+
+            Assert.AreEqual(1, ex.GroupCode);
             Assert.AreEqual("CMN", ex.GroupName);
-            Assert.AreEqual("IGN-CMN-1", ex.CodeAsString);
         }
 
         private static IEnumerable<(short Code, string Name)> GetErrorGroups() => typeof(ErrorGroups).GetNestedTypes()

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/ErrorGroupTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/ErrorGroupTests.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Tests
 {
+    using System;
     using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
@@ -185,6 +186,17 @@ namespace Apache.Ignite.Tests
             // Newer servers may return unknown to us error codes.
             Assert.AreEqual("UNKNOWN", ErrorGroups.GetGroupName(-1));
             Assert.AreEqual(ErrorGroups.UnknownGroupName, ErrorGroups.GetGroupName(9999));
+        }
+
+        [Test]
+        public void TestExceptionProperties()
+        {
+            var ex = new IgniteException(Guid.Empty, ErrorGroups.Common.Internal, "msg");
+
+            Assert.AreEqual(ErrorGroups.Common.Internal, ex.Code);
+            Assert.AreEqual(-1, ex.ErrorCode);
+            Assert.AreEqual("CMN", ex.GroupName);
+            Assert.AreEqual("IGN-CMN-1", ex.CodeAsString);
         }
 
         private static IEnumerable<(short Code, string Name)> GetErrorGroups() => typeof(ErrorGroups).GetNestedTypes()

--- a/modules/platforms/dotnet/Apache.Ignite/ErrorGroups.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/ErrorGroups.cs
@@ -48,14 +48,14 @@ namespace Apache.Ignite
         /// </summary>
         /// <param name="fullCode">Full error code.</param>
         /// <returns>Error code.</returns>
-        public static short GetErrorCode(int fullCode) => checked((short)(fullCode & 0xFFFF));
+        public static short GetErrorCode(int fullCode) => unchecked((short)(fullCode & 0xFFFF));
 
         /// <summary>
         /// Returns group code extracted from the given full error code.
         /// </summary>
         /// <param name="fullCode">Full error code.</param>
         /// <returns>Group code.</returns>
-        public static short GetGroupCode(int fullCode) => checked((short)(fullCode >> 16));
+        public static short GetGroupCode(int fullCode) => unchecked((short)(fullCode >> 16));
 
         /// <summary>
         /// Gets the full error code from group and error codes.

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteException.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteException.cs
@@ -65,6 +65,11 @@ namespace Apache.Ignite
         public short ErrorCode => ErrorGroups.GetErrorCode(Code);
 
         /// <summary>
+        /// Gets the group code.
+        /// </summary>
+        public short GroupCode => ErrorGroups.GetGroupCode(Code);
+
+        /// <summary>
         /// Gets the code as string.
         /// </summary>
         public string CodeAsString => ErrorGroups.ErrPrefix + GroupName + '-' + ErrorCode;


### PR DESCRIPTION
* Use unchecked context to calculate error codes
* Add missing `IgniteException.GroupCode`
* Add tests in .NET and Java to ensure consistent behavior