### PR TITLE
IGNITE-23938 Add verbose levels in CLI

### DIFF
--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/CliIntegrationTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/CliIntegrationTest.java
@@ -286,6 +286,12 @@ public abstract class CliIntegrationTest extends ClusterPerClassIntegrationTest 
                 .contains(expectedErrOutput);
     }
 
+    protected void assertErrOutputDoesNotContain(String expectedOutput) {
+        assertThat(serr.toString())
+                .as("Expected command error output to not contain: " + expectedOutput + " but was " + serr.toString())
+                .doesNotContain(expectedOutput);
+    }
+
     protected void setConfigProperty(CliConfigKeys key, String value) {
         configManagerProvider.configManager.setProperty(key.value(), value);
     }

--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/ItVerbosityReplTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/ItVerbosityReplTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.cli;
+
+import org.apache.ignite.internal.cli.commands.node.config.NodeConfigShowReplCommand;
+
+class ItVerbosityReplTest extends ItVerbosityTest {
+    @Override
+    protected Class<?> getCommandClass() {
+        return NodeConfigShowReplCommand.class;
+    }
+}

--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/ItVerbosityTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/ItVerbosityTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.cli;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.apache.ignite.internal.cli.commands.node.config.NodeConfigShowCommand;
+import org.junit.jupiter.api.Test;
+
+class ItVerbosityTest extends CliIntegrationTest {
+    @Override
+    protected int initialNodes() {
+        return 1;
+    }
+
+    @Override
+    protected Class<?> getCommandClass() {
+        return NodeConfigShowCommand.class;
+    }
+
+    @Test
+    void noVerbose() {
+        execute("--url", NODE_URL);
+
+        assertAll(
+                this::assertExitCodeIsZero,
+                this::assertErrOutputIsEmpty
+        );
+    }
+
+    @Test
+    void verboseBasic() {
+        execute("--url", NODE_URL, "-v");
+
+        assertAll(
+                this::assertExitCodeIsZero,
+                () -> assertErrOutputContains("--> GET"),
+                () -> assertErrOutputDoesNotContain("Accept: application/problem+json"),
+                () -> assertErrOutputDoesNotContain("{\"ignite\"")
+        );
+    }
+
+    @Test
+    void verboseHeaders() {
+        execute("--url", NODE_URL, "-vv");
+
+        assertAll(
+                this::assertExitCodeIsZero,
+                () -> assertErrOutputContains("--> GET"),
+                () -> assertErrOutputContains("Accept: application/problem+json"),
+                () -> assertErrOutputDoesNotContain("{\"ignite\"")
+        );
+    }
+
+    @Test
+    void verboseBody() {
+        execute("--url", NODE_URL, "-vvv");
+
+        assertAll(
+                this::assertExitCodeIsZero,
+                () -> assertErrOutputContains("--> GET"),
+                () -> assertErrOutputContains("Accept: application/problem+json"),
+                () -> assertErrOutputContains("{\"ignite\"")
+        );
+    }
+}

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/BaseCommand.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/BaseCommand.java
@@ -67,7 +67,7 @@ public abstract class BaseCommand {
 
     /** Verbose option specification. */
     @Option(names = {VERBOSE_OPTION, VERBOSE_OPTION_SHORT}, description = VERBOSE_OPTION_DESC, order = VERBOSE_OPTION_ORDER)
-    protected boolean verbose;
+    protected boolean[] verbose = new boolean[0];
 
     /** Instance of picocli command specification. */
     @Spec

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/Options.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/Options.java
@@ -140,7 +140,8 @@ public enum Options {
 
         /** Verbose option description. */
         public static final String VERBOSE_OPTION_DESC = "Show additional information: logs, REST calls. "
-                + "This flag is useful for debugging";
+                + "This flag is useful for debugging. Specify multiple options to increase verbosity for REST calls. "
+                + "Single option shows request and response, second option (-vv) shows headers, third one (-vvv) shows body";
 
         /** Help option long name. */
         public static final String HELP_OPTION = "--help";

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AbstractCallExecutionPipeline.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AbstractCallExecutionPipeline.java
@@ -50,8 +50,8 @@ public abstract class AbstractCallExecutionPipeline<I extends CallInput, T> impl
     /** Provider for call's input. */
     protected final Supplier<I> inputProvider;
 
-    /** If {@code true}, debug output will be printed to console. */
-    protected final boolean verbose;
+    /** If non-empty, debug output will be printed to console. */
+    protected final boolean[] verbose;
 
     AbstractCallExecutionPipeline(
             PrintWriter output,
@@ -59,7 +59,7 @@ public abstract class AbstractCallExecutionPipeline<I extends CallInput, T> impl
             ExceptionHandlers exceptionHandlers,
             Decorator<T, TerminalOutput> decorator,
             Supplier<I> inputProvider,
-            boolean verbose
+            boolean[] verbose
     ) {
         this.output = output;
         this.exceptionHandlers = exceptionHandlers;
@@ -77,12 +77,12 @@ public abstract class AbstractCallExecutionPipeline<I extends CallInput, T> impl
     @Override
     public int runPipeline() {
         try {
-            if (verbose) {
-                CliLoggers.startOutputRedirect(errOutput);
+            if (verbose.length > 0) {
+                CliLoggers.startOutputRedirect(errOutput, verbose);
             }
             return runPipelineInternal();
         } finally {
-            if (verbose) {
+            if (verbose.length > 0) {
                 CliLoggers.stopOutputRedirect();
             }
         }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AsyncCallExecutionPipeline.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AsyncCallExecutionPipeline.java
@@ -43,7 +43,7 @@ public class AsyncCallExecutionPipeline<I extends CallInput, T> extends Abstract
             ExceptionHandlers exceptionHandlers,
             Decorator<T, TerminalOutput> decorator,
             Supplier<I> inputProvider,
-            boolean verbose
+            boolean[] verbose
     ) {
         super(output, errOutput, exceptionHandlers, decorator, inputProvider, verbose);
         this.callFactory = callFactory;

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AsyncCallExecutionPipelineBuilder.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/AsyncCallExecutionPipelineBuilder.java
@@ -55,7 +55,7 @@ public class AsyncCallExecutionPipelineBuilder<I extends CallInput, T> implement
 
     private Decorator<T, TerminalOutput> decorator;
 
-    private boolean verbose;
+    private boolean[] verbose;
 
     AsyncCallExecutionPipelineBuilder(Function<ProgressTracker, AsyncCall<I, T>> callFactory) {
         this.callFactory = callFactory;
@@ -111,7 +111,7 @@ public class AsyncCallExecutionPipelineBuilder<I extends CallInput, T> implement
     }
 
     @Override
-    public AsyncCallExecutionPipelineBuilder<I, T> verbose(boolean verbose) {
+    public AsyncCallExecutionPipelineBuilder<I, T> verbose(boolean[] verbose) {
         this.verbose = verbose;
         return this;
     }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/CallExecutionPipelineBuilder.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/CallExecutionPipelineBuilder.java
@@ -43,7 +43,7 @@ public interface CallExecutionPipelineBuilder<I extends CallInput, T> {
      * @param verbose Verbosity status.
      * @return Instance of the builder.
      */
-    CallExecutionPipelineBuilder<I, T> verbose(boolean verbose);
+    CallExecutionPipelineBuilder<I, T> verbose(boolean[] verbose);
 
     /**
      * Builds the pipeline.

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/SingleCallExecutionPipeline.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/SingleCallExecutionPipeline.java
@@ -40,7 +40,7 @@ public class SingleCallExecutionPipeline<I extends CallInput, T> extends Abstrac
             ExceptionHandlers exceptionHandlers,
             Decorator<T, TerminalOutput> decorator,
             Supplier<I> inputProvider,
-            boolean verbose
+            boolean[] verbose
     ) {
         super(output, errOutput, exceptionHandlers, decorator, inputProvider, verbose);
         this.call = call;

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/SingleCallExecutionPipelineBuilder.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/call/SingleCallExecutionPipelineBuilder.java
@@ -42,7 +42,7 @@ public class SingleCallExecutionPipelineBuilder<I extends CallInput, T> implemen
 
     private Decorator<T, TerminalOutput> decorator;
 
-    private boolean verbose;
+    private boolean[] verbose = new boolean[0];
 
     SingleCallExecutionPipelineBuilder(Call<I, T> call) {
         this.call = call;
@@ -98,7 +98,7 @@ public class SingleCallExecutionPipelineBuilder<I extends CallInput, T> implemen
     }
 
     @Override
-    public SingleCallExecutionPipelineBuilder<I, T> verbose(boolean verbose) {
+    public SingleCallExecutionPipelineBuilder<I, T> verbose(boolean[] verbose) {
         this.verbose = verbose;
         return this;
     }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/flow/builder/FlowBuilder.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/flow/builder/FlowBuilder.java
@@ -146,10 +146,10 @@ public interface FlowBuilder<I, O>  {
     /**
      * Adds verbose output from debug log to the output.
      *
-     * @param verbose If @{code true}, flow execution will print debug logs.
+     * @param verbose If not empty, flow execution will print debug logs.
      * @return Builder instance.
      */
-    FlowBuilder<I, O> verbose(boolean verbose);
+    FlowBuilder<I, O> verbose(boolean[] verbose);
 
     /**
      * Appends print operation which will print the result of the current flow using provided {@code decorator} or call the exception

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/flow/builder/FlowBuilderImpl.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/flow/builder/FlowBuilderImpl.java
@@ -52,10 +52,10 @@ public class FlowBuilderImpl<I, O> implements FlowBuilder<I, O> {
     private final DecoratorRegistry decoratorRegistry;
     private final Set<Consumer<O>> successHandlers = new HashSet<>();
     private final Set<Consumer<Throwable>> failureHandlers = new HashSet<>();
-    private boolean verbose;
+    private boolean[] verbose;
 
     FlowBuilderImpl(Flow<I, O> flow) {
-        this(flow, new DefaultExceptionHandlers(), new DefaultDecoratorRegistry(), false);
+        this(flow, new DefaultExceptionHandlers(), new DefaultDecoratorRegistry(), new boolean[0]);
     }
 
     /**
@@ -66,7 +66,7 @@ public class FlowBuilderImpl<I, O> implements FlowBuilder<I, O> {
      * @param decoratorRegistry decorator registry.
      * @param verbose if @{code true}, flow execution will print debug logs
      */
-    private FlowBuilderImpl(Flow<I, O> flow, ExceptionHandlers exceptionHandlers, DecoratorRegistry decoratorRegistry, boolean verbose) {
+    private FlowBuilderImpl(Flow<I, O> flow, ExceptionHandlers exceptionHandlers, DecoratorRegistry decoratorRegistry, boolean[] verbose) {
         this.flow = flow;
         this.exceptionHandlers = exceptionHandlers;
         this.decoratorRegistry = decoratorRegistry;
@@ -135,7 +135,7 @@ public class FlowBuilderImpl<I, O> implements FlowBuilder<I, O> {
     }
 
     @Override
-    public FlowBuilder<I, O> verbose(boolean verbose) {
+    public FlowBuilder<I, O> verbose(boolean[] verbose) {
         this.verbose = verbose;
         return this;
     }
@@ -172,12 +172,12 @@ public class FlowBuilderImpl<I, O> implements FlowBuilder<I, O> {
      */
     private Flowable<O> run(Flowable<I> input) {
         try {
-            if (verbose) {
-                CliLoggers.startOutputRedirect(CommandLineContextProvider.getContext().err());
+            if (verbose.length > 0) {
+                CliLoggers.startOutputRedirect(CommandLineContextProvider.getContext().err(), verbose);
             }
             return flow.start(input);
         } finally {
-            if (verbose) {
+            if (verbose.length > 0) {
                 CliLoggers.stopOutputRedirect();
             }
         }

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/rest/ApiClientFactory.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/rest/ApiClientFactory.java
@@ -93,7 +93,7 @@ public class ApiClientFactory {
 
     /**
      * Useful for testing in a single JVM with different Micronaut contexts. Clears the {@link CliLoggers} loggers so that the next
-     * invocation of {@link CliLoggers#addApiClient(String, ApiClient)} actually adds a new logger for the new client.
+     * invocation of {@link CliLoggers#addApiClient(ApiClient)} actually adds a new logger for the new client.
      */
     @PreDestroy
     private void clearLoggers() {
@@ -102,7 +102,7 @@ public class ApiClientFactory {
 
     private ApiClient getClientFromSettings(ApiClientSettings settings) {
         ApiClient apiClient = clientMap.computeIfAbsent(settings, ApiClientFactory::buildClient);
-        CliLoggers.addApiClient(settings.basePath(), apiClient);
+        CliLoggers.addApiClient(apiClient);
         return apiClient;
     }
 

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/rest/ApiClientFactory.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/core/rest/ApiClientFactory.java
@@ -26,6 +26,7 @@ import static org.apache.ignite.internal.cli.config.CliConfigKeys.REST_TRUST_STO
 import static org.apache.ignite.internal.cli.config.CliConfigKeys.REST_TRUST_STORE_PATH;
 import static org.apache.ignite.internal.util.StringUtils.nullOrBlank;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
@@ -88,6 +89,15 @@ public class ApiClientFactory {
      */
     public ApiClient getClient(String path) {
         return getClientFromSettings(settingsWithAuth(path));
+    }
+
+    /**
+     * Useful for testing in a single JVM with different Micronaut contexts. Clears the {@link CliLoggers} loggers so that the next
+     * invocation of {@link CliLoggers#addApiClient(String, ApiClient)} actually adds a new logger for the new client.
+     */
+    @PreDestroy
+    private void clearLoggers() {
+        CliLoggers.clearLoggers();
     }
 
     private ApiClient getClientFromSettings(ApiClientSettings settings) {

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/logger/CliLoggers.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/logger/CliLoggers.java
@@ -28,13 +28,15 @@ import org.apache.ignite.lang.LoggerFactory;
 import org.apache.ignite.rest.client.invoker.ApiClient;
 
 /**
- * This class is used when verbose output for command is needed. Instances of loggers created by the {@link CliLoggers#forClass(Class)} and
- * {@link CliLoggers#forName(String)} methods will redirect their output to the console when commands are started with the {@code -v} flag.
+ * This class is used when verbose output for command is needed. Instances of loggers created by the {@link CliLoggers#forClass(Class)}
+ * method will redirect their output to the console when commands are started with the {@code -v} flag.
  */
 public class CliLoggers {
     private static PrintWriter output;
 
     private static boolean isVerbose;
+
+    private static boolean[] verbose;
 
     /** Http loggers for the REST API clients. */
     private static final Map<String, HttpLogging> httpLoggers = new ConcurrentHashMap<>();
@@ -51,37 +53,40 @@ public class CliLoggers {
         return Loggers.forClass(cls, loggerFactory);
     }
 
-    /**
-     * Creates logger for given name.
-     *
-     * @param name The name for a logger.
-     * @return Ignite logger.
-     */
-    public static IgniteLogger forName(String name) {
-        return Loggers.forName(name, loggerFactory);
+    public static void addApiClient(String path, ApiClient client) {
+        HttpLogging logger = httpLoggers.computeIfAbsent(path, s -> new HttpLogging(client));
+        if (isVerbose) {
+            logger.startHttpLogging(output, verbose);
+        }
     }
 
-    public static void addApiClient(String path, ApiClient client) {
-        httpLoggers.computeIfAbsent(path, s -> new HttpLogging(client));
+    /**
+     * Clears loggers.
+     */
+    public static void clearLoggers() {
+        httpLoggers.clear();
     }
 
     /**
      * Starts redirecting output from loggers and from REST API client to the specified print writer.
      *
      * @param out Print writer to write logs to.
+     * @param verbose Boolean array. Should be non-empty. Number of elements represent verbosity level.
      */
-    public static void startOutputRedirect(PrintWriter out) {
+    public static void startOutputRedirect(PrintWriter out, boolean[] verbose) {
         output = out;
         isVerbose = true;
-        httpLoggers.values().forEach(logger -> logger.startHttpLogging(out));
+        CliLoggers.verbose = verbose;
+        httpLoggers.values().forEach(logger -> logger.startHttpLogging(out, verbose));
     }
 
     /**
-     * Stops redirecting output previously started by {@link CliLoggers#startOutputRedirect(PrintWriter)}.
+     * Stops redirecting output previously started by {@link CliLoggers#startOutputRedirect(PrintWriter, boolean[])}.
      */
     public static void stopOutputRedirect() {
         output = null;
         isVerbose = false;
+        verbose = new boolean[0];
         httpLoggers.values().forEach(HttpLogging::stopHttpLogging);
     }
 

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/logger/CliLoggers.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/logger/CliLoggers.java
@@ -53,15 +53,20 @@ public class CliLoggers {
         return Loggers.forClass(cls, loggerFactory);
     }
 
-    public static void addApiClient(String path, ApiClient client) {
-        HttpLogging logger = httpLoggers.computeIfAbsent(path, s -> new HttpLogging(client));
+    /**
+     * Registers a client. If verbose logging is enabled, turn the logging for this client on.
+     *
+     * @param client Api client.
+     */
+    public static void addApiClient(ApiClient client) {
+        HttpLogging logger = httpLoggers.computeIfAbsent(client.getBasePath(), s -> new HttpLogging(client));
         if (isVerbose) {
             logger.startHttpLogging(output, verbose);
         }
     }
 
     /**
-     * Clears loggers.
+     * Unregisters clients.
      */
     public static void clearLoggers() {
         httpLoggers.clear();

--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/logger/HttpLogging.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/logger/HttpLogging.java
@@ -39,21 +39,31 @@ class HttpLogging {
      * Starts logging HTTP requests/responses to specified {@code PrintWriter}.
      *
      * @param output Print writer to print logs to.
+     * @param verbose Boolean array. Should be non-empty. Number of elements represent verbosity level.
      */
-    void startHttpLogging(PrintWriter output) {
+    void startHttpLogging(PrintWriter output, boolean[] verbose) {
         if (interceptor == null) {
             Builder builder = client.getHttpClient().newBuilder();
 
             interceptor = new HttpLoggingInterceptor(output::println);
-            interceptor.setLevel(Level.BASIC);
+            interceptor.setLevel(verbosityLevel(verbose));
             builder.interceptors().add(interceptor);
 
             client.setHttpClient(builder.build());
         }
     }
 
+    private static Level verbosityLevel(boolean[] verbose) {
+        if (verbose.length > 2) {
+            return Level.BODY;
+        } else if (verbose.length > 1) {
+            return Level.HEADERS;
+        }
+        return Level.BASIC;
+    }
+
     /**
-     * Stops logging previously started by {@link HttpLogging#startHttpLogging(PrintWriter)}.
+     * Stops logging previously started by {@link HttpLogging#startHttpLogging(PrintWriter, boolean[])}.
      */
     void stopHttpLogging() {
         if (interceptor != null) {

--- a/modules/cli/src/test/java/org/apache/ignite/internal/cli/commands/flow/FlowTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/internal/cli/commands/flow/FlowTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.ignite.internal.cli.commands.flow;
 
+import static java.lang.System.lineSeparator;
 import static org.apache.ignite.internal.cli.core.call.DefaultCallOutput.success;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.is;
 
 import java.io.FileDescriptor;
 import java.io.FileOutputStream;
@@ -60,7 +60,7 @@ class FlowTest {
     private StringWriter errOut;
 
     @Test
-    void testVerbose() throws IOException {
+    void verbose() throws IOException {
         // Given
         bindAnswers("no");
 
@@ -68,14 +68,31 @@ class FlowTest {
         askQuestion()
                 .then(Flows.fromCall(new ThrowingStrCall(), StringCallInput::new))
                 .exceptionHandler(new TestExceptionHandler())
-                .verbose(true)
+                .verbose(new boolean[]{true})
                 .print()
                 .start();
 
         // Then error output starts with the message from exception and contains verbose output
         assertThat(out.toString(), emptyString());
-        assertThat(errOut.toString(), startsWith("Ooops!" + System.lineSeparator()));
-        assertThat(errOut.toString(), containsString("verbose output"));
+        assertThat(errOut.toString(), is("Ooops!" + lineSeparator() + "verbose output" + lineSeparator()));
+    }
+
+    @Test
+    void noVerbose() throws IOException {
+        // Given
+        bindAnswers("no");
+
+        // When start flow with print
+        askQuestion()
+                .then(Flows.fromCall(new ThrowingStrCall(), StringCallInput::new))
+                .exceptionHandler(new TestExceptionHandler())
+                .verbose(new boolean[0])
+                .print()
+                .start();
+
+        // Then error output is a message from exception and doesn't contain verbose output
+        assertThat(out.toString(), emptyString());
+        assertThat(errOut.toString(), is("Ooops!" + lineSeparator()));
     }
 
     private static Flow<Object, Integer> createFlow() {
@@ -160,7 +177,7 @@ class FlowTest {
                 .start();
 
         // Then output equals to the message from the exception because we use TestExceptionHandler
-        assertThat(errOut.toString(), equalTo("Ooops!" + System.lineSeparator()));
+        assertThat(errOut.toString(), equalTo("Ooops!" + lineSeparator()));
     }
 
     @Test
@@ -194,7 +211,7 @@ class FlowTest {
                 .start();
 
         // Then output equals to the message from the exception because we use TestExceptionHandler
-        assertThat(errOut.toString(), equalTo("Ooops!" + System.lineSeparator()));
+        assertThat(errOut.toString(), equalTo("Ooops!" + lineSeparator()));
     }
 
     @Test
@@ -209,8 +226,8 @@ class FlowTest {
                 .start();
 
         // Then output equals to 2 messages from print operations
-        assertThat(out.toString(), equalTo("2" + System.lineSeparator()
-                + "2" + System.lineSeparator()));
+        assertThat(out.toString(), equalTo("2" + lineSeparator()
+                + "2" + lineSeparator()));
         assertThat(errOut.toString(), emptyString());
     }
 
@@ -229,8 +246,8 @@ class FlowTest {
 
         // Then error output equals to 2 messages from exception handler
         assertThat(out.toString(), emptyString());
-        assertThat(errOut.toString(), equalTo("Ooops!" + System.lineSeparator()
-                + "Ooops!" + System.lineSeparator()));
+        assertThat(errOut.toString(), equalTo("Ooops!" + lineSeparator()
+                + "Ooops!" + lineSeparator()));
     }
 
     @Test
@@ -244,7 +261,7 @@ class FlowTest {
                 .start();
 
         // Then error output equals to the message from answer
-        assertThat(out.toString(), equalTo("2" + System.lineSeparator()));
+        assertThat(out.toString(), equalTo("2" + lineSeparator()));
         assertThat(errOut.toString(), emptyString());
     }
 
@@ -262,7 +279,7 @@ class FlowTest {
 
         // Then error output equals to the message from exception
         assertThat(out.toString(), emptyString());
-        assertThat(errOut.toString(), equalTo("Ooops!" + System.lineSeparator()));
+        assertThat(errOut.toString(), equalTo("Ooops!" + lineSeparator()));
     }
 
     @Test
@@ -276,7 +293,7 @@ class FlowTest {
                 .start();
 
         // Then error output equals to the message from exception
-        assertThat(out.toString(), equalTo("*2*" + System.lineSeparator()));
+        assertThat(out.toString(), equalTo("*2*" + lineSeparator()));
         assertThat(errOut.toString(), emptyString());
     }
 
@@ -286,7 +303,7 @@ class FlowTest {
                 .flatMap(v -> Flows.from(it -> it + "buzz"))
                 .print()
                 .start();
-        assertThat(out.toString(), equalTo("fizzbuzz" + System.lineSeparator()));
+        assertThat(out.toString(), equalTo("fizzbuzz" + lineSeparator()));
     }
 
     @Test
@@ -299,7 +316,7 @@ class FlowTest {
                 .map(it -> it + "2")
                 .print()
                 .start();
-        assertThat(out.toString(), equalTo("fizz1" + System.lineSeparator()));
+        assertThat(out.toString(), equalTo("fizz1" + lineSeparator()));
     }
 
     @Test
@@ -312,7 +329,7 @@ class FlowTest {
                 .map(it -> it + "2")
                 .print()
                 .start();
-        assertThat(out.toString(), equalTo("fizz1" + System.lineSeparator()));
+        assertThat(out.toString(), equalTo("fizz1" + lineSeparator()));
     }
 
     @Test
@@ -340,7 +357,7 @@ class FlowTest {
 
         // Then error output equals to the message from exception
         assertThat(out.toString(), emptyString());
-        assertThat(errOut.toString(), equalTo("Ooops!" + System.lineSeparator()));
+        assertThat(errOut.toString(), equalTo("Ooops!" + lineSeparator()));
     }
 
     @Test
@@ -357,7 +374,7 @@ class FlowTest {
 
         // Then error output equals to the message from exception
         assertThat(out.toString(), emptyString());
-        assertThat(errOut.toString(), equalTo("Ooops!" + System.lineSeparator()));
+        assertThat(errOut.toString(), equalTo("Ooops!" + lineSeparator()));
     }
 
     @Test
@@ -374,7 +391,7 @@ class FlowTest {
 
         // Then error output equals to the message from exception
         assertThat(out.toString(), emptyString());
-        assertThat(errOut.toString(), equalTo("Ooops!" + System.lineSeparator()));
+        assertThat(errOut.toString(), equalTo("Ooops!" + lineSeparator()));
     }
 
     private void bindAnswers(String... answers) throws IOException {

--- a/modules/cli/src/test/java/org/apache/ignite/internal/cli/core/call/PipelineTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/internal/cli/core/call/PipelineTest.java
@@ -17,10 +17,11 @@
 
 package org.apache.ignite.internal.cli.core.call;
 
+import static java.lang.System.lineSeparator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
-import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.is;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -41,20 +42,35 @@ class PipelineTest {
     }
 
     @Test
-    void verboseTest() {
+    void verbose() {
         // When start pipeline with verbose
         CallExecutionPipeline.builder(new ThrowingStrCall())
                 .inputProvider(StringCallInput::new)
                 .exceptionHandler(new TestExceptionHandler())
                 .output(new PrintWriter(out))
                 .errOutput(new PrintWriter(errOut))
-                .verbose(true)
+                .verbose(new boolean[]{true})
                 .build().runPipeline();
 
         // Then error output starts with the message from exception and contains verbose output
         assertThat(out.toString(), emptyString());
-        assertThat(errOut.toString(), startsWith("Ooops!" + System.lineSeparator()));
-        assertThat(errOut.toString(), containsString("verbose output"));
+        assertThat(errOut.toString(), is("Ooops!" + lineSeparator() + "verbose output" + lineSeparator()));
+    }
+
+    @Test
+    void noVerbose() {
+        // When start pipeline without verbose
+        CallExecutionPipeline.builder(new ThrowingStrCall())
+                .inputProvider(StringCallInput::new)
+                .exceptionHandler(new TestExceptionHandler())
+                .output(new PrintWriter(out))
+                .errOutput(new PrintWriter(errOut))
+                .verbose(new boolean[0])
+                .build().runPipeline();
+
+        // Then error output starts with the message from exception and contains verbose output
+        assertThat(out.toString(), emptyString());
+        assertThat(errOut.toString(), is("Ooops!" + lineSeparator()));
     }
 
     @Test
@@ -68,11 +84,11 @@ class PipelineTest {
                 .exceptionHandler(new TestExceptionHandler())
                 .output(new PrintWriter(out))
                 .errOutput(new PrintWriter(errOut))
-                .verbose(true)
+                .verbose(new boolean[]{true})
                 .build().runPipeline();
 
         // Then error output contains the message from exception and contains verbose output
-        assertThat(errOut.toString(), containsString("Ooops!" + System.lineSeparator()));
+        assertThat(errOut.toString(), containsString("Ooops!" + lineSeparator()));
         assertThat(errOut.toString(), containsString("verbose output"));
     }
 
@@ -89,11 +105,11 @@ class PipelineTest {
                 .exceptionHandler(new TestExceptionHandler())
                 .output(new PrintWriter(out))
                 .errOutput(new PrintWriter(errOut))
-                .verbose(true)
+                .verbose(new boolean[]{true})
                 .build().runPipeline();
 
         // Then error output contains the message from exception and contains verbose output
-        assertThat(errOut.toString(), containsString("Ooops!" + System.lineSeparator()));
+        assertThat(errOut.toString(), containsString("Ooops!" + lineSeparator()));
         assertThat(errOut.toString(), containsString("verbose output"));
     }
 }

--- a/modules/cli/src/test/java/org/apache/ignite/internal/cli/logger/CliLoggersTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/internal/cli/logger/CliLoggersTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.cli.logger;
+
+import static okhttp3.logging.HttpLoggingInterceptor.Level.BASIC;
+import static okhttp3.logging.HttpLoggingInterceptor.Level.BODY;
+import static okhttp3.logging.HttpLoggingInterceptor.Level.HEADERS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.io.PrintWriter;
+import java.util.List;
+import okhttp3.logging.HttpLoggingInterceptor;
+import okhttp3.logging.HttpLoggingInterceptor.Level;
+import org.apache.ignite.rest.client.invoker.ApiClient;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CliLoggersTest {
+    private final ApiClient client = new ApiClient();
+
+    @AfterEach
+    void stopLogging() {
+        CliLoggers.stopOutputRedirect();
+        CliLoggers.clearLoggers();
+    }
+
+    @Test
+    void addClient() {
+        CliLoggers.addApiClient("path", client);
+
+        assertThat(CliLoggers.isVerbose(), is(false));
+
+        assertThat(findLoggingInterceptor(), is(nullValue()));
+    }
+
+    private static List<Arguments> levels() {
+        return List.of(
+                arguments(new boolean[]{true}, BASIC),
+                arguments(new boolean[]{true, true}, HEADERS),
+                arguments(new boolean[]{true, true, true}, BODY),
+                arguments(new boolean[]{true, true, true, true}, BODY)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("levels")
+    void addClientStartLog(boolean[] verbose, Level level) {
+        CliLoggers.addApiClient("path", client);
+        CliLoggers.startOutputRedirect(new PrintWriter(System.out), verbose);
+
+        assertThat(CliLoggers.isVerbose(), is(true));
+
+        HttpLoggingInterceptor loggingInterceptor = findLoggingInterceptor();
+        assertThat(loggingInterceptor, is(notNullValue()));
+        assertThat(loggingInterceptor.getLevel(), is(level));
+    }
+
+    @ParameterizedTest
+    @MethodSource("levels")
+    void startLogAddClient(boolean[] verbose, Level level) {
+        CliLoggers.startOutputRedirect(new PrintWriter(System.out), verbose);
+        CliLoggers.addApiClient("path", client);
+
+        assertThat(CliLoggers.isVerbose(), is(true));
+
+        HttpLoggingInterceptor loggingInterceptor = findLoggingInterceptor();
+        assertThat(loggingInterceptor, is(notNullValue()));
+        assertThat(loggingInterceptor.getLevel(), is(level));
+    }
+
+    @Nullable
+    private HttpLoggingInterceptor findLoggingInterceptor() {
+        return client.getHttpClient().interceptors().stream()
+                .filter(HttpLoggingInterceptor.class::isInstance)
+                .map(HttpLoggingInterceptor.class::cast)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/modules/cli/src/test/java/org/apache/ignite/internal/cli/logger/CliLoggersTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/internal/cli/logger/CliLoggersTest.java
@@ -49,7 +49,7 @@ class CliLoggersTest {
 
     @Test
     void addClient() {
-        CliLoggers.addApiClient("path", client);
+        CliLoggers.addApiClient(client);
 
         assertThat(CliLoggers.isVerbose(), is(false));
 
@@ -68,7 +68,7 @@ class CliLoggersTest {
     @ParameterizedTest
     @MethodSource("levels")
     void addClientStartLog(boolean[] verbose, Level level) {
-        CliLoggers.addApiClient("path", client);
+        CliLoggers.addApiClient(client);
         CliLoggers.startOutputRedirect(new PrintWriter(System.out), verbose);
 
         assertThat(CliLoggers.isVerbose(), is(true));
@@ -82,7 +82,7 @@ class CliLoggersTest {
     @MethodSource("levels")
     void startLogAddClient(boolean[] verbose, Level level) {
         CliLoggers.startOutputRedirect(new PrintWriter(System.out), verbose);
-        CliLoggers.addApiClient("path", client);
+        CliLoggers.addApiClient(client);
 
         assertThat(CliLoggers.isVerbose(), is(true));
 

--- a/modules/cli/src/test/java/org/apache/ignite/internal/cli/logger/HttpLoggingTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/internal/cli/logger/HttpLoggingTest.java
@@ -38,6 +38,8 @@ class HttpLoggingTest {
 
     private HttpLogging logger;
 
+    private final boolean[] verbose = {true};
+
     @BeforeEach
     void setUp() {
         client = new ApiClient();
@@ -48,7 +50,7 @@ class HttpLoggingTest {
     void startAndStopLogging() {
         assertThat(client.getHttpClient().interceptors(), empty());
 
-        logger.startHttpLogging(WRITER);
+        logger.startHttpLogging(WRITER, verbose);
         assertThat(client.getHttpClient().interceptors(), not(empty()));
 
         logger.stopHttpLogging();
@@ -59,13 +61,13 @@ class HttpLoggingTest {
     void restartLogging() {
         assertThat(client.getHttpClient().interceptors(), empty());
 
-        logger.startHttpLogging(WRITER);
+        logger.startHttpLogging(WRITER, verbose);
         assertThat(client.getHttpClient().interceptors(), not(empty()));
 
         logger.stopHttpLogging();
         assertThat(client.getHttpClient().interceptors(), empty());
 
-        logger.startHttpLogging(WRITER);
+        logger.startHttpLogging(WRITER, verbose);
         assertThat(client.getHttpClient().interceptors(), not(empty()));
     }
 
@@ -76,7 +78,7 @@ class HttpLoggingTest {
         builder.interceptors().add(interceptor);
         client.setHttpClient(builder.build());
 
-        logger.startHttpLogging(WRITER);
+        logger.startHttpLogging(WRITER, verbose);
         logger.stopHttpLogging();
 
         assertThat(client.getHttpClient().interceptors(), contains(interceptor));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23938

Verbose option is extended so that a single option prints requests and responses, second one adds headers, third one adds bodies.
Also fixed an issue when verbose wasn't working in non-REPL mode.