### PR TITLE
IGNITE-23935 Cluster init command use previous config

### DIFF
--- a/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/cluster/init/ClusterInitOptions.java
+++ b/modules/cli/src/main/java/org/apache/ignite/internal/cli/commands/cluster/init/ClusterInitOptions.java
@@ -91,14 +91,19 @@ public class ClusterInitOptions {
     private ClusterConfigOptions clusterConfigOptions;
 
     private static class ClusterConfigOptions {
-        @Option(names = CLUSTER_CONFIG_OPTION, order = 3, description = CLUSTER_CONFIG_OPTION_DESC)
+        @Option(names = CLUSTER_CONFIG_OPTION,
+                description = CLUSTER_CONFIG_OPTION_DESC,
+                order = 3,
+                defaultValue = Option.NULL_VALUE
+        )
         private String config;
 
         @Option(names = CLUSTER_CONFIG_FILE_OPTION,
                 description = CLUSTER_CONFIG_FILE_OPTION_DESC,
                 split = ",",
                 order = 4,
-                paramLabel = CLUSTER_CONFIG_FILE_PARAM_LABEL
+                paramLabel = CLUSTER_CONFIG_FILE_PARAM_LABEL,
+                defaultValue = Option.NULL_VALUE
         )
         private List<File> files;
     }

--- a/modules/cli/src/test/java/org/apache/ignite/internal/cli/commands/CliCommandTestBase.java
+++ b/modules/cli/src/test/java/org/apache/ignite/internal/cli/commands/CliCommandTestBase.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -40,6 +41,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 import org.apache.ignite.internal.cli.core.call.Call;
 import org.apache.ignite.internal.cli.core.call.CallInput;
 import org.apache.ignite.internal.cli.core.call.DefaultCallOutput;
@@ -49,6 +51,7 @@ import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentCaptor;
 import picocli.CommandLine;
 
@@ -66,6 +69,8 @@ public abstract class CliCommandTestBase extends BaseIgniteAbstractTest {
 
     private int exitCode = Integer.MIN_VALUE;
 
+    private CommandLine cmd;
+
     @BeforeAll
     static void setDumbTerminal() {
         System.setProperty("org.jline.terminal.dumb", "true");
@@ -73,20 +78,26 @@ public abstract class CliCommandTestBase extends BaseIgniteAbstractTest {
 
     protected abstract Class<?> getCommandClass();
 
+    @BeforeEach
+    void setUp() {
+        createCommand();
+    }
+
+    private void createCommand() {
+        cmd = new CommandLine(getCommandClass(), new MicronautFactory(context));
+        cmd.setExecutionExceptionHandler(new PicocliExecutionExceptionHandler());
+        CommandLineContextProvider.setCmd(cmd);
+    }
+
     protected void execute(String argsLine) {
         execute(argsLine.split(" "));
     }
 
     protected void execute(String... args) {
-        // Create command just before execution as some tests could register singletons which should be used by the command
-        CommandLine cmd = new CommandLine(getCommandClass(), new MicronautFactory(context));
-        cmd.setExecutionExceptionHandler(new PicocliExecutionExceptionHandler());
-
         sout = new StringWriter();
         serr = new StringWriter();
         cmd.setOut(new PrintWriter(sout));
         cmd.setErr(new PrintWriter(serr));
-        CommandLineContextProvider.setCmd(cmd);
 
         exitCode = cmd.execute(args);
     }
@@ -171,14 +182,62 @@ public abstract class CliCommandTestBase extends BaseIgniteAbstractTest {
         assertThat(reason, exp.lines().collect(toList()), contains(actual.lines().toArray(String[]::new)));
     }
 
-    protected <IT extends CallInput, OT, T extends Call<IT, OT>> T registerMockCall(Class<T> callClass) {
+    /**
+     * Runs the command with the mock call and verifies that the call was executed with the expected input.
+     *
+     * @param command Command string.
+     * @param callClass Call class.
+     * @param callInputClass Call input class.
+     * @param inputTransformer Function which transforms the call input to string.
+     * @param parameters Command arguments.
+     * @param expected Expected call input string.
+     * @param <IT> Input for the call.
+     * @param <OT> Output of the call.
+     * @param <T> Call type.
+     */
+    protected <IT extends CallInput, OT, T extends Call<IT, OT>> void checkParameters(
+            String command,
+            Class<T> callClass,
+            Class<IT> callInputClass,
+            Function<IT, String> inputTransformer,
+            String parameters,
+            String expected
+    ) {
+        T call = registerMockCall(callClass);
+        // Recreate the CommandLine object so that the registered mocks are available to this command.
+        createCommand();
+        execute(command + " " + parameters);
+        IT callInput = verifyCallInput(call, callInputClass);
+        assertEquals(expected, inputTransformer.apply(callInput));
+    }
+
+    /**
+     * Registers mock call of the specified class into the Micronaut's context. Mock returns empty output when executed.
+     *
+     * @param callClass Call class.
+     * @param <IT> Input for the call.
+     * @param <OT> Output of the call.
+     * @param <T> Call type.
+     * @return Created mock.
+     */
+    private <IT extends CallInput, OT, T extends Call<IT, OT>> T registerMockCall(Class<T> callClass) {
         T mock = mock(callClass);
         context.registerSingleton(mock);
         when(mock.execute(any())).thenReturn(DefaultCallOutput.empty());
         return mock;
     }
 
-    protected static <IT extends CallInput, OT, T extends Call<IT, OT>> IT verifyCallInput(T call, Class<IT> inputClass) {
+    /**
+     * Verifies that the call was executed and returns its input.
+     *
+     * @param call Call mock.
+     * @param inputClass Call input class.
+     * @param <IT> Input for the call.
+     * @param <OT> Output of the call.
+     * @param <T> Call type.
+     * @return Call input.
+     */
+    private static <IT extends CallInput, OT, T extends Call<IT, OT>> IT verifyCallInput(T call, Class<IT> inputClass) {
         ArgumentCaptor<IT> captor = ArgumentCaptor.forClass(inputClass);
         verify(call).execute(captor.capture());
         return captor.getValue();

--- a/modules/cli/src/test/java/org/apache/ignite/internal/cli/commands/ProfileMixinTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/internal/cli/commands/ProfileMixinTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.ignite.internal.cli.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.function.Function;
@@ -81,11 +80,9 @@ public class ProfileMixinTest extends CliCommandTestBase {
             String command,
             Class<T> callClass,
             Class<IT> callInputClass,
-            Function<IT, String> urlSupplier) {
-        T call = registerMockCall(callClass);
-        execute(command);
-        IT callInput = verifyCallInput(call, callInputClass);
-        assertEquals(DEFAULT_URL, urlSupplier.apply(callInput));
+            Function<IT, String> urlSupplier
+    ) {
+        checkParameters(command, callClass, callInputClass, urlSupplier, "", DEFAULT_URL);
     }
 
     @ParameterizedTest
@@ -95,11 +92,9 @@ public class ProfileMixinTest extends CliCommandTestBase {
             String command,
             Class<T> callClass,
             Class<IT> callInputClass,
-            Function<IT, String> urlSupplier) {
-        T call = registerMockCall(callClass);
-        execute(command + " --profile test");
-        IT callInput = verifyCallInput(call, callInputClass);
-        assertEquals(URL_FROM_PROFILE, urlSupplier.apply(callInput));
+            Function<IT, String> urlSupplier
+    ) {
+        checkParameters(command, callClass, callInputClass, urlSupplier, "--profile test", URL_FROM_PROFILE);
     }
 
     @ParameterizedTest
@@ -109,11 +104,9 @@ public class ProfileMixinTest extends CliCommandTestBase {
             String command,
             Class<T> callClass,
             Class<IT> callInputClass,
-            Function<IT, String> urlSupplier) {
-        T call = registerMockCall(callClass);
-        execute(command + " --url " + URL_FROM_CMD);
-        IT callInput = verifyCallInput(call, callInputClass);
-        assertEquals(URL_FROM_CMD, urlSupplier.apply(callInput));
+            Function<IT, String> urlSupplier
+    ) {
+        checkParameters(command, callClass, callInputClass, urlSupplier, "--url " + URL_FROM_CMD, URL_FROM_CMD);
     }
 
     @ParameterizedTest
@@ -123,11 +116,9 @@ public class ProfileMixinTest extends CliCommandTestBase {
             String command,
             Class<T> callClass,
             Class<IT> callInputClass,
-            Function<IT, String> urlSupplier) {
-        T call = registerMockCall(callClass);
-        execute(command + " --url " + URL_FROM_CMD);
-        IT callInput = verifyCallInput(call, callInputClass);
-        assertEquals(URL_FROM_CMD, urlSupplier.apply(callInput));
+            Function<IT, String> urlSupplier
+    ) {
+        checkParameters(command, callClass, callInputClass, urlSupplier, "--url " + URL_FROM_CMD, URL_FROM_CMD);
     }
 
     @ParameterizedTest
@@ -137,11 +128,9 @@ public class ProfileMixinTest extends CliCommandTestBase {
             String command,
             Class<T> callClass,
             Class<IT> callInputClass,
-            Function<IT, String> urlSupplier) {
-        T call = registerMockCall(callClass);
-        execute(command + " --profile test --url " + URL_FROM_CMD);
-        IT callInput = verifyCallInput(call, callInputClass);
-        assertEquals(URL_FROM_CMD, urlSupplier.apply(callInput));
+            Function<IT, String> urlSupplier
+    ) {
+        checkParameters(command, callClass, callInputClass, urlSupplier, "--profile test --url " + URL_FROM_CMD, URL_FROM_CMD);
     }
 
     @ParameterizedTest
@@ -151,11 +140,9 @@ public class ProfileMixinTest extends CliCommandTestBase {
             String command,
             Class<T> callClass,
             Class<IT> callInputClass,
-            Function<IT, String> urlSupplier) {
-        T call = registerMockCall(callClass);
-        execute(command + " --profile test --url " + URL_FROM_CMD);
-        IT callInput = verifyCallInput(call, callInputClass);
-        assertEquals(URL_FROM_CMD, urlSupplier.apply(callInput));
+            Function<IT, String> urlSupplier
+    ) {
+        checkParameters(command, callClass, callInputClass, urlSupplier, "--profile test --url " + URL_FROM_CMD, URL_FROM_CMD);
     }
 
     private static Stream<Arguments> nodeCallsProvider() {

--- a/modules/cli/src/test/java/org/apache/ignite/internal/cli/commands/cluster/ClusterInitTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/internal/cli/commands/cluster/ClusterInitTest.java
@@ -23,7 +23,6 @@ import static org.mockserver.matchers.MatchType.ONLY_MATCHING_FIELDS;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.HttpStatusCode.INTERNAL_SERVER_ERROR_500;
-import static org.mockserver.model.HttpStatusCode.OK_200;
 import static org.mockserver.model.JsonBody.json;
 
 import com.typesafe.config.ConfigFactory;
@@ -69,6 +68,8 @@ class ClusterInitTest extends IgniteCliInterfaceTestBase {
 
     @Test
     void wrongConfigFilePath() {
+        clientAndServer.when(request().withMethod("POST").withPath("/management/v1/cluster/init")).respond(response(null));
+
         execute(
                 "--url", mockUrl,
                 "--metastorage-group", "node1ConsistentId",
@@ -77,6 +78,14 @@ class ClusterInitTest extends IgniteCliInterfaceTestBase {
         );
 
         assertErrOutputIs("Couldn't read cluster configuration file wrong-path");
+
+        execute(
+                "--url", mockUrl,
+                "--metastorage-group", "node1ConsistentId",
+                "--name", "cluster"
+        );
+
+        assertSuccessfulOutputIs("Cluster was initialized successfully");
     }
 
     @Test
@@ -212,12 +221,7 @@ class ClusterInitTest extends IgniteCliInterfaceTestBase {
     @Test
     @DisplayName("--url http://localhost:10300 --metastorage-group node2ConsistentId, node3ConsistentId")
     void cmgNodesAreNotMandatoryForInit() {
-        clientAndServer
-                .when(request()
-                        .withMethod("POST")
-                        .withPath("/management/v1/cluster/init")
-                )
-                .respond(response().withStatusCode(OK_200.code()));
+        clientAndServer.when(request().withMethod("POST").withPath("/management/v1/cluster/init")).respond(response(null));
 
         execute(
                 "--url", mockUrl,

--- a/modules/cli/src/test/java/org/apache/ignite/internal/cli/commands/cluster/config/ConfigUpdateCommandTest.java
+++ b/modules/cli/src/test/java/org/apache/ignite/internal/cli/commands/cluster/config/ConfigUpdateCommandTest.java
@@ -18,7 +18,6 @@
 package org.apache.ignite.internal.cli.commands.cluster.config;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.function.Function;
@@ -113,19 +112,5 @@ class ConfigUpdateCommandTest extends CliCommandTestBase {
             Function<IT, String> configFunction
     ) {
         checkParameters(command, callClass, callInputClass, configFunction, "\"test1\" \"test2\"", "test1 test2");
-    }
-
-    private <IT extends CallInput, OT, T extends Call<IT, OT>> void checkParameters(
-            String command,
-            Class<T> callClass,
-            Class<IT> callInputClass,
-            Function<IT, String> configFunction,
-            String parameters,
-            String expected
-    ) {
-        T call = registerMockCall(callClass);
-        execute(command + " " + parameters);
-        IT callInput = verifyCallInput(call, callInputClass);
-        assertEquals(expected, configFunction.apply(callInput));
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23935

Options in the mixin classes should use `NULL_VALUE` default value.
The tests are refactored so that the command line object is not recreated on each execution so that the added tests are actually fail without the fix.