### PR TITLE
IGNITE-23965 Sql.  JDBC update counter for DDL/KILL statements must always be zero.

### DIFF
--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/commands/sql/ItSqlMultistatementTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/commands/sql/ItSqlMultistatementTest.java
@@ -118,8 +118,8 @@ public class ItSqlMultistatementTest extends CliSqlCommandTestBase {
     @Test
     void sequentialCreateTable() {
         String testQuery = "create table mytable1(id int primary key); create table mytable2(id int primary key)";
-        String expectedOutput = "Updated 1 rows.\n"
-                + "Updated 1 rows.";
+        String expectedOutput = "Updated 0 rows.\n"
+                + "Updated 0 rows.";
 
         execute("sql", testQuery, "--jdbc-url", JDBC_URL);
 

--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/commands/sql/ItSqlReplCommandTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/commands/sql/ItSqlReplCommandTest.java
@@ -50,7 +50,7 @@ class ItSqlReplCommandTest extends CliIntegrationTest {
         execute("CREATE TABLE T(K INT PRIMARY KEY)", "--jdbc-url", JDBC_URL);
 
         assertAll(
-                () -> assertOutputContains("Updated 1 rows."),
+                () -> assertOutputContains("Updated 0 rows."),
                 this::assertErrOutputIsEmpty
         );
 
@@ -68,7 +68,7 @@ class ItSqlReplCommandTest extends CliIntegrationTest {
 
         assertAll(
                 // The output from CREATE TABLE is: Updated 0 rows.
-                () -> assertOutputContains("Updated 1 rows."),
+                () -> assertOutputContains("Updated 0 rows."),
                 this::assertErrOutputIsEmpty
         );
 

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/JdbcHandlerBase.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/JdbcHandlerBase.java
@@ -108,13 +108,7 @@ abstract class JdbcHandlerBase {
                     return new JdbcQuerySingleResult(cursorId, updCount, cur.hasNextResult());
                 }
                 case DDL:
-                case KILL: {
-                    assert batch.items().get(0).get(0) instanceof Boolean : "Invalid DDL/KILL result: " + batch.items();
-
-                    boolean applied = (boolean) batch.items().get(0).get(0);
-
-                    return new JdbcQuerySingleResult(cursorId, applied ? 1 : 0, cur.hasNextResult());
-                }
+                case KILL:
                 case TX_CONTROL:
                     return new JdbcQuerySingleResult(cursorId, 0, cur.hasNextResult());
                 default:

--- a/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcComplexDmlDdlSelfTest.java
+++ b/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcComplexDmlDdlSelfTest.java
@@ -50,11 +50,11 @@ public class ItJdbcComplexDmlDdlSelfTest extends AbstractJdbcSelfTest {
      */
     @Test
     public void testCreateSelectDrop() throws Exception {
-        sql(new UpdateChecker(1),
+        sql(new UpdateChecker(0),
                 "CREATE TABLE person_t (ID int, NAME varchar, AGE int, COMPANY varchar, CITY varchar, "
                         + "primary key (ID, NAME, CITY))");
 
-        sql(new UpdateChecker(1), "CREATE TABLE city_t (name varchar, population int, primary key (name))");
+        sql(new UpdateChecker(0), "CREATE TABLE city_t (name varchar, population int, primary key (name))");
 
         sql(new UpdateChecker(3),
                 "INSERT INTO city_t (name, population) values(?, ?), (?, ?), (?, ?)",
@@ -131,9 +131,6 @@ public class ItJdbcComplexDmlDdlSelfTest extends AbstractJdbcSelfTest {
         }), "SELECT * FROM person_t where company = 'New Company'");
 
         assertEquals(cnt[0], 34, "Invalid rows count");
-
-        sql(new UpdateChecker(1), "DROP TABLE IF EXISTS city_t");
-        sql(new UpdateChecker(1), "DROP TABLE IF EXISTS person_t");
 
         sql(new UpdateChecker(0), "DROP TABLE IF EXISTS city_t");
         sql(new UpdateChecker(0), "DROP TABLE IF EXISTS person_t");

--- a/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcKillCommandTest.java
+++ b/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcKillCommandTest.java
@@ -112,7 +112,7 @@ public class ItJdbcKillCommandTest extends AbstractJdbcSelfTest {
                 assertThat(runningQueries(), hasSize(1));
 
                 // Actual kill.
-                assertThat(checker.check(existingQuery), is(1));
+                assertThat(checker.check(existingQuery), is(0));
                 assertThat(runningQueries(), hasSize(0));
 
                 //noinspection ThrowableNotThrown

--- a/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcMultiStatementSelfTest.java
+++ b/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcMultiStatementSelfTest.java
@@ -272,13 +272,13 @@ public class ItJdbcMultiStatementSelfTest extends AbstractJdbcSelfTest {
     public void testMiscDmlExecute() throws Exception {
         boolean res = stmt.execute("DROP TABLE IF EXISTS TEST_TX; DROP TABLE IF EXISTS SOME_UNEXISTING_TBL;");
         assertFalse(res);
-        assertEquals(1, stmt.getUpdateCount());
+        assertEquals(0, stmt.getUpdateCount());
         assertFalse(stmt.getMoreResults());
         assertEquals(0, stmt.getUpdateCount());
 
         res = stmt.execute("CREATE TABLE TEST_TX (ID INT PRIMARY KEY, AGE INT, NAME VARCHAR) ");
         assertFalse(res);
-        assertEquals(1, stmt.getUpdateCount());
+        assertEquals(0, stmt.getUpdateCount());
         assertFalse(stmt.getMoreResults());
         assertNull(stmt.getResultSet());
 
@@ -556,10 +556,10 @@ public class ItJdbcMultiStatementSelfTest extends AbstractJdbcSelfTest {
         assertEquals(-1, stmt.getUpdateCount());
 
         stmt.execute("DROP TABLE IF EXISTS TEST_TX; DROP TABLE IF EXISTS PUBLIC.TRANSACTIONS;");
-        assertEquals(1, stmt.getUpdateCount());
+        assertEquals(0, stmt.getUpdateCount());
 
         stmt.execute("CREATE TABLE TEST_TX (ID INT PRIMARY KEY, AGE INT, NAME VARCHAR) ");
-        assertEquals(1, stmt.getUpdateCount());
+        assertEquals(0, stmt.getUpdateCount());
     }
 
     @Test

--- a/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcStatementSelfTest.java
+++ b/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcStatementSelfTest.java
@@ -429,13 +429,13 @@ public class ItJdbcStatementSelfTest extends ItJdbcAbstractStatementSelfTest {
 
         // DROP TABLE statement
         assertNull(stmt0.getResultSet());
-        assertEquals(1, stmt0.getUpdateCount());
+        assertEquals(0, stmt0.getUpdateCount());
 
         stmt0.getMoreResults();
 
         // CREATE TABLE statement
         assertNull(stmt0.getResultSet());
-        assertEquals(1, stmt0.getUpdateCount());
+        assertEquals(0, stmt0.getUpdateCount());
 
         for (int i = 0; i < stmtCnt; ++i) {
             assertFalse(stmt0.getMoreResults());
@@ -465,14 +465,14 @@ public class ItJdbcStatementSelfTest extends ItJdbcAbstractStatementSelfTest {
 
         // DROP TABLE statement
         assertNull(stmt.getResultSet());
-        assertEquals(1, stmt.getUpdateCount());
+        assertEquals(0, stmt.getUpdateCount());
 
         // DROP TABLE
         assertFalse(stmt.getMoreResults(), "Result set doesn't have more results.");
 
         // CREATE TABLE statement
         assertNull(stmt.getResultSet());
-        assertEquals(1, stmt.getUpdateCount());
+        assertEquals(0, stmt.getUpdateCount());
 
         for (int i = 0; i < stmtCnt; ++i) {
             if (i % 2 == 0) {

--- a/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcUpdateStatementSelfTest.java
+++ b/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcUpdateStatementSelfTest.java
@@ -61,7 +61,7 @@ public class ItJdbcUpdateStatementSelfTest extends AbstractJdbcSelfTest {
 
         final String q4 = "DROP TABLE usertable;";
 
-        assertEquals(1, stmt.executeUpdate(q1));
+        assertEquals(0, stmt.executeUpdate(q1));
         assertEquals(1, stmt.executeUpdate(q2));
         assertEquals(1, stmt.executeUpdate(q3));
 
@@ -75,7 +75,7 @@ public class ItJdbcUpdateStatementSelfTest extends AbstractJdbcSelfTest {
             assertEquals("b" + i, resultSet.getString(i + 2));
         }
 
-        assertEquals(1, stmt.executeUpdate(q4));
+        assertEquals(0, stmt.executeUpdate(q4));
     }
 
     /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23965