### PR TITLE
IGNITE-23998. Disable releases for apache.snapshots repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ apply from: "$rootDir/buildscripts/javadoc.gradle"
 repositories {
     maven {
         url = uri('https://repository.apache.org/snapshots')
+        mavenContent {
+            snapshotsOnly()
+        }
     }
 
     maven {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Apache snapshot repository should be enabled only for snapshots.

https://issues.apache.org/jira/browse/IGNITE-23998

## How was this patch tested?

Local build.

```
$ ./gradlew compileJava
...
BUILD SUCCESSFUL in 2m 15s
83 actionable tasks: 83 executed
```