### PR TITLE
IGNITE-24008 Properly cancel map reduce task

### DIFF
--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/task/TaskExecutionInternal.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/task/TaskExecutionInternal.java
@@ -209,8 +209,10 @@ public class TaskExecutionInternal<I, M, T, R> implements TaskExecution<R>, Mars
             return falseCompletedFuture();
         }
 
-        // If the split job is not complete, this will cancel the executions future.
+        // If the split job is not complete.
         if (splitExecution.cancel()) {
+            // The split job cancelled, but since it's not a direct chain of futures, we should cancel the next future in chain manually.
+            executionsFuture.cancel(true);
             return trueCompletedFuture();
         }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-24008

When cancelling map reduce task, we need to cancel dependent future manually, it might not be cancelled when we cancel the queue execution.