### PR TITLE
IGNITE-24047 Fixed flaky test CatalogCompactionRunnerSelfTest.rebalancePreventsCompaction

### DIFF
--- a/modules/catalog-compaction/build.gradle
+++ b/modules/catalog-compaction/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     testImplementation libs.mockito.junit
     testImplementation libs.mockito.core
     testImplementation libs.hamcrest.core
+    testImplementation libs.awaitility
 
     integrationTestImplementation libs.fastutil.core
     integrationTestImplementation libs.awaitility


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-24047

Need to conditionally wait until the versions map is truncated, similarly to other tests in `CatalogCompactionRunnerSelfTest`.