### PR TITLE
IGNITE-23939 Query cancellation should wait for the query termination phase only

### DIFF
--- a/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcKillCommandTest.java
+++ b/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcKillCommandTest.java
@@ -33,6 +33,8 @@ import org.apache.ignite.internal.app.IgniteImpl;
 import org.apache.ignite.internal.sql.engine.QueryCancelledException;
 import org.apache.ignite.internal.sql.engine.SqlQueryProcessor;
 import org.apache.ignite.internal.sql.engine.exec.fsm.QueryInfo;
+import org.apache.ignite.internal.sql.engine.util.SqlTestUtils;
+import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -113,7 +115,7 @@ public class ItJdbcKillCommandTest extends AbstractJdbcSelfTest {
 
                 // Actual kill.
                 assertThat(checker.check(existingQuery), is(0));
-                assertThat(runningQueries(), hasSize(0));
+                waitUntilRunningQueriesCount(is(0));
 
                 //noinspection ThrowableNotThrown
                 assertThrowsSqlException(
@@ -125,6 +127,12 @@ public class ItJdbcKillCommandTest extends AbstractJdbcSelfTest {
                 );
             }
         }
+    }
+
+    private static void waitUntilRunningQueriesCount(Matcher<Integer> count) {
+        IgniteImpl ignite = unwrapIgniteImpl(CLUSTER.node(0));
+        SqlQueryProcessor queryProcessor = (SqlQueryProcessor) ignite.queryEngine();
+        SqlTestUtils.waitUntilRunningQueriesCount(queryProcessor, is(count));
     }
 
     private static List<QueryInfo> runningQueries() {

--- a/modules/sql-engine/build.gradle
+++ b/modules/sql-engine/build.gradle
@@ -151,6 +151,7 @@ dependencies {
     testFixturesImplementation testFixtures(project(':ignite-runner'))
     testFixturesImplementation libs.jetbrains.annotations
     testFixturesImplementation libs.hamcrest.core
+    testFixturesImplementation libs.awaitility
 }
 
 integrationTest {

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItCancelQueryTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItCancelQueryTest.java
@@ -21,6 +21,7 @@ import static org.apache.ignite.internal.sql.engine.QueryProperty.ALLOWED_QUERY_
 import static org.apache.ignite.internal.sql.engine.util.SqlTestUtils.expectQueryCancelled;
 import static org.apache.ignite.internal.sql.engine.util.SqlTestUtils.expectQueryCancelledInternalException;
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.await;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
@@ -77,7 +78,7 @@ public class ItCancelQueryTest extends BaseSqlIntegrationTest {
                 query.toString()
         ));
 
-        assertEquals(1, qryProc.runningQueriesCount());
+        assertEquals(1, qryProc.runningQueries().size());
 
         // Request cancellation.
         CompletableFuture<Void> cancelled = cancelHandle.cancelAsync();
@@ -87,7 +88,7 @@ public class ItCancelQueryTest extends BaseSqlIntegrationTest {
 
         await(cancelled);
 
-        assertEquals(0, qryProc.runningQueriesCount());
+        waitUntilRunningQueriesCount(is(0));
     }
 
     /** Calling {@link CancelHandle#cancel()} should cancel execution of multiple queries. */
@@ -135,7 +136,7 @@ public class ItCancelQueryTest extends BaseSqlIntegrationTest {
                 query.toString()
         ));
 
-        assertEquals(2, qryProc.runningQueriesCount());
+        assertEquals(2, qryProc.runningQueries().size());
 
         // Request cancellation.
         CompletableFuture<Void> cancelled = cancelHandle.cancelAsync();
@@ -146,7 +147,7 @@ public class ItCancelQueryTest extends BaseSqlIntegrationTest {
 
         await(cancelled);
 
-        assertEquals(0, qryProc.runningQueriesCount());
+        waitUntilRunningQueriesCount(is(0));
     }
 
     /** Starting a query with a cancelled token should trigger query cancellation. */
@@ -177,7 +178,7 @@ public class ItCancelQueryTest extends BaseSqlIntegrationTest {
 
         expectQueryCancelledInternalException(run);
 
-        assertEquals(0, qryProc.runningQueriesCount());
+        waitUntilRunningQueriesCount(is(0));
     }
 
     /** Calling {@link CancelHandle#cancel()} should cancel execution of queries that use executable plans. */
@@ -219,6 +220,6 @@ public class ItCancelQueryTest extends BaseSqlIntegrationTest {
 
         await(f);
 
-        assertEquals(0, qryProc.runningQueriesCount());
+        waitUntilRunningQueriesCount(is(0));
     }
 }

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItCancelScriptTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItCancelScriptTest.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import org.apache.ignite.lang.CancelHandle;
 import org.apache.ignite.lang.CancellationToken;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -50,7 +49,7 @@ public class ItCancelScriptTest extends BaseSqlMultiStatementTest {
     void cleanup() {
         sql("DELETE FROM TEST");
 
-        Awaitility.await().untilAsserted(() -> assertThat(queryProcessor().runningQueriesCount(), is(0)));
+        waitUntilRunningQueriesCount(is(0));
     }
 
     @Test
@@ -69,7 +68,7 @@ public class ItCancelScriptTest extends BaseSqlMultiStatementTest {
         List<AsyncSqlCursor<InternalSqlRow>> allCursors = fetchAllCursors(runScript(token, query.toString()));
 
         assertThat(allCursors, hasSize(statementsCount));
-        assertThat(queryProcessor().runningQueriesCount(), is(statementsCount + /* SCRIPT */ 1));
+        assertThat(queryProcessor().runningQueries().size(), is(statementsCount + /* SCRIPT */ 1));
 
         cancelHandle.cancel();
 
@@ -100,8 +99,7 @@ public class ItCancelScriptTest extends BaseSqlMultiStatementTest {
         cancelHandle.cancel();
 
         assertThat(queryProcessor().openedCursors(), is(0));
-        // TODO https://issues.apache.org/jira/browse/IGNITE-23939 Remove busy wait.
-        Awaitility.await().untilAsserted(() -> assertThat(queryProcessor().runningQueriesCount(), is(0)));
+        waitUntilRunningQueriesCount(is(0));
         assertEquals(0, txManager().pending());
 
         assertTrue(cursors.get(2).hasNextResult());

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlQueriesSystemViewTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlQueriesSystemViewTest.java
@@ -21,7 +21,6 @@ import static org.apache.ignite.internal.TestWrappers.unwrapIgniteImpl;
 import static org.apache.ignite.internal.sql.engine.SqlQueriesViewProvider.SCRIPT_QUERY_TYPE;
 import static org.apache.ignite.internal.sql.engine.util.SqlTestUtils.assertThrowsSqlException;
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.await;
-import static org.apache.ignite.internal.testframework.IgniteTestUtils.waitForCondition;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -40,10 +39,10 @@ import org.apache.ignite.Ignite;
 import org.apache.ignite.internal.hlc.ClockService;
 import org.apache.ignite.internal.sql.SqlCommon;
 import org.apache.ignite.internal.sql.engine.util.MetadataMatcher;
+import org.apache.ignite.internal.sql.engine.util.SqlTestUtils;
 import org.apache.ignite.internal.tx.InternalTransaction;
 import org.apache.ignite.lang.ErrorGroups.Sql;
 import org.apache.ignite.sql.ColumnType;
-import org.awaitility.Awaitility;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.jetbrains.annotations.Nullable;
@@ -153,7 +152,7 @@ public class ItSqlQueriesSystemViewTest extends BaseSqlMultiStatementTest {
         long timeAfter = clockService.now().getPhysical();
 
         assertThat(cursors, hasSize(3));
-        assertThat(queryProcessor().runningQueriesCount(), is(4));
+        assertThat(queryProcessor().runningQueries().size(), is(4));
 
         // Verify script query info.
         {
@@ -198,10 +197,10 @@ public class ItSqlQueriesSystemViewTest extends BaseSqlMultiStatementTest {
 
         // Closing cursors.
         await(cursors.get(0).closeAsync());
-        Awaitility.await().untilAsserted(() -> assertThat(queryProcessor().runningQueriesCount(), is(3)));
+        waitUntilRunningQueriesCount(is(3));
 
         await(cursors.get(1).closeAsync());
-        Awaitility.await().untilAsserted(() -> assertThat(queryProcessor().runningQueriesCount(), is(2)));
+        waitUntilRunningQueriesCount(is(2));
 
         await(cursors.get(2).closeAsync());
         checkNoPendingQueries();
@@ -224,8 +223,7 @@ public class ItSqlQueriesSystemViewTest extends BaseSqlMultiStatementTest {
         long timeAfter = clockService.now().getPhysical();
 
         // "DDL" and "EXPLAIN" queries close cursor automatically.
-        waitForCondition(() -> queryProcessor().runningQueriesCount() == 4, 5_000);
-        assertThat(queryProcessor().runningQueriesCount(), is(4));
+        waitUntilRunningQueriesCount(is(4));
 
         String sql = "SELECT * FROM SYSTEM.SQL_QUERIES "
                 + "WHERE PARENT_ID=(SELECT ID FROM SYSTEM.SQL_QUERIES WHERE TYPE='SCRIPT') "
@@ -308,7 +306,7 @@ public class ItSqlQueriesSystemViewTest extends BaseSqlMultiStatementTest {
         for (Ignite node : nodes) {
             SqlQueryProcessor queryProcessor = (SqlQueryProcessor) unwrapIgniteImpl(node).queryEngine();
 
-            Awaitility.await().untilAsserted(() -> assertThat(queryProcessor.runningQueriesCount(), is(0)));
+            SqlTestUtils.waitUntilRunningQueriesCount(queryProcessor, is(0));
         }
     }
 

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/SqlQueryProcessor.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/SqlQueryProcessor.java
@@ -559,12 +559,6 @@ public class SqlQueryProcessor implements QueryProcessor, SystemViewProvider {
                 .count();
     }
 
-    /** Returns the number of running queries. */
-    @TestOnly
-    public int runningQueriesCount() {
-        return runningQueries().size();
-    }
-
     /** Returns the list of running queries. */
     @TestOnly
     public List<QueryInfo> runningQueries() {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/fsm/QueryExecutor.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/fsm/QueryExecutor.java
@@ -312,10 +312,16 @@ public class QueryExecutor implements LifecycleAware {
     }
 
     private void trackQuery(Query query, @Nullable CancellationToken cancellationToken) {
-        CompletableFuture<?> unregisterFuture = query.register(runningQueries);
+        Query old = runningQueries.put(query.id, query);
+
+        assert old == null : "Query with the same id already registered";
+
+        CompletableFuture<Void> queryTerminationFut = query.onPhaseStarted(ExecutionPhase.TERMINATED);
+
+        queryTerminationFut.whenComplete((ignored, ex) -> runningQueries.remove(query.id));
 
         if (cancellationToken != null) {
-            CancelHandleHelper.addCancelAction(cancellationToken, query::cancel, unregisterFuture);
+            CancelHandleHelper.addCancelAction(cancellationToken, query::cancel, queryTerminationFut);
         }
     }
 

--- a/modules/sql-engine/src/testFixtures/java/org/apache/ignite/internal/sql/BaseSqlIntegrationTest.java
+++ b/modules/sql-engine/src/testFixtures/java/org/apache/ignite/internal/sql/BaseSqlIntegrationTest.java
@@ -35,6 +35,7 @@ import org.apache.ignite.internal.sql.engine.util.InjectQueryCheckerFactory;
 import org.apache.ignite.internal.sql.engine.util.QueryChecker;
 import org.apache.ignite.internal.sql.engine.util.QueryCheckerExtension;
 import org.apache.ignite.internal.sql.engine.util.QueryCheckerFactory;
+import org.apache.ignite.internal.sql.engine.util.SqlTestUtils;
 import org.apache.ignite.internal.systemview.SystemViewManagerImpl;
 import org.apache.ignite.internal.tx.HybridTimestampTracker;
 import org.apache.ignite.internal.tx.InternalTransaction;
@@ -44,6 +45,7 @@ import org.apache.ignite.sql.ColumnMetadata;
 import org.apache.ignite.sql.IgniteSql;
 import org.apache.ignite.table.Table;
 import org.apache.ignite.tx.IgniteTransactions;
+import org.hamcrest.Matcher;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
@@ -257,6 +259,16 @@ public abstract class BaseSqlIntegrationTest extends ClusterPerClassIntegrationT
      */
     protected SystemViewManagerImpl systemViewManager() {
         return (SystemViewManagerImpl) unwrapIgniteImpl(CLUSTER.aliveNode()).systemViewManager();
+    }
+
+    /**
+     * Waits until the number of running queries matches the specified matcher.
+     *
+     * @param matcher Matcher to check the number of running queries.
+     * @throws AssertionError If after waiting the number of running queries still does not match the specified matcher.
+     */
+    protected void waitUntilRunningQueriesCount(Matcher<Integer> matcher) {
+        SqlTestUtils.waitUntilRunningQueriesCount(queryProcessor(), matcher);
     }
 
     /** An executable that retrieves the data from the specified cursor. */

--- a/modules/sql-engine/src/testFixtures/java/org/apache/ignite/internal/sql/engine/util/SqlTestUtils.java
+++ b/modules/sql-engine/src/testFixtures/java/org/apache/ignite/internal/sql/engine/util/SqlTestUtils.java
@@ -65,6 +65,7 @@ import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
 import org.apache.ignite.internal.sql.engine.InternalSqlRow;
 import org.apache.ignite.internal.sql.engine.QueryCancelledException;
+import org.apache.ignite.internal.sql.engine.SqlQueryProcessor;
 import org.apache.ignite.internal.sql.engine.type.IgniteCustomType;
 import org.apache.ignite.internal.sql.engine.type.IgniteTypeFactory;
 import org.apache.ignite.internal.sql.engine.type.IgniteTypeSystem;
@@ -84,7 +85,9 @@ import org.apache.ignite.sql.IgniteSql;
 import org.apache.ignite.sql.ResultSet;
 import org.apache.ignite.sql.SqlException;
 import org.apache.ignite.tx.Transaction;
+import org.awaitility.Awaitility;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.function.Executable;
@@ -579,5 +582,17 @@ public class SqlTestUtils {
                 action,
                 CANCEL_MSG
         );
+    }
+
+    /**
+     * Waits until the number of running queries matches the specified matcher.
+     *
+     * @param queryProcessor Query processor.
+     * @param matcher Matcher to check the number of running queries.
+     * @throws AssertionError If after waiting the number of running queries still does not match the specified matcher.
+     */
+    public static void waitUntilRunningQueriesCount(SqlQueryProcessor queryProcessor, Matcher<Integer> matcher) {
+        //noinspection TestOnlyProblems
+        Awaitility.await().untilAsserted(() -> assertThat(queryProcessor.runningQueries().size(), matcher));
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-23939

To achieve consistent behavior between query cancellation and script cancellation, query cancellation should only wait the termination phase and don't wait until the query is removed from the running queries registry.

Note: fixed tests to conditionally wait until the query is removed from the registry.

p.s. the main change have been made in `Query` and `QueryExecutor` classes.