### PR TITLE
IGNITE-24112 Retry in RaftGroupServiceImpl on a RecipientLeftException

### DIFF
--- a/modules/raft/src/main/java/org/apache/ignite/internal/raft/RaftGroupServiceImpl.java
+++ b/modules/raft/src/main/java/org/apache/ignite/internal/raft/RaftGroupServiceImpl.java
@@ -63,6 +63,7 @@ import org.apache.ignite.internal.logger.IgniteLogger;
 import org.apache.ignite.internal.logger.Loggers;
 import org.apache.ignite.internal.network.ClusterService;
 import org.apache.ignite.internal.network.NetworkMessage;
+import org.apache.ignite.internal.network.RecipientLeftException;
 import org.apache.ignite.internal.raft.configuration.RaftConfiguration;
 import org.apache.ignite.internal.raft.service.LeaderWithTerm;
 import org.apache.ignite.internal.raft.service.RaftGroupService;
@@ -799,7 +800,10 @@ public class RaftGroupServiceImpl implements RaftGroupService {
     private static boolean recoverable(Throwable t) {
         t = unwrapCause(t);
 
-        return t instanceof TimeoutException || t instanceof IOException || t instanceof PeerUnavailableException;
+        return t instanceof TimeoutException
+                || t instanceof IOException
+                || t instanceof PeerUnavailableException
+                || t instanceof RecipientLeftException;
     }
 
     private Peer randomNode() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-24112