### PR TITLE
IGNITE-24122 Add -Xmx1g to defaultJvmArgs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,8 @@ ext {
     defaultJvmArgs = addOpens + [
             "-Dio.netty.tryReflectionSetAccessible=true",
             "-XX:+HeapDumpOnOutOfMemoryError",
-            "-ea"
+            "-ea",
+            "-Xmx1g"
     ]
 
     compilerArgs = [

--- a/buildscripts/java-junit5.gradle
+++ b/buildscripts/java-junit5.gradle
@@ -20,7 +20,7 @@ test {
     testLogging {
         events "passed", "skipped", "failed", "standard_error"
     }
-    maxHeapSize = '2g'
+    maxHeapSize = '1g'
 
     // Define default test timeouts to avoid everhanging tests.
     systemProperty 'junit.jupiter.execution.timeout.testable.method.default', '10m'


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-24122

Also, decrease default heap sizes for unit and integration tests to 1g and 2g, respectively