### PR TITLE
IGNITE-24134 Sql. Improve performance of KV plan in SQL

### DIFF
--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlUsesKeyValueGetTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlUsesKeyValueGetTest.java
@@ -32,7 +32,7 @@ public class ItSqlUsesKeyValueGetTest extends BaseSqlIntegrationTest {
     private static final int TABLE_SIZE = 10;
 
     @BeforeAll
-    @SuppressWarnings({"ConcatenationWithEmptyString", "resource"})
+    @SuppressWarnings("ConcatenationWithEmptyString")
     static void initSchema() {
         CLUSTER.aliveNode().sql().executeScript(""
                 + "CREATE TABLE simple_key (id INT PRIMARY KEY, val INT);"

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlUsesSelectCountOptimizedTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlUsesSelectCountOptimizedTest.java
@@ -44,7 +44,8 @@ public class ItSqlUsesSelectCountOptimizedTest extends BaseSqlIntegrationTest {
     @BeforeEach
     @AfterEach
     public void resetFastOpt() {
-        System.setProperty("FAST_QUERY_OPTIMIZATION_ENABLED", String.valueOf(Commons.fastQueryOptimizationEnabled()));
+        System.clearProperty("FAST_QUERY_OPTIMIZATION_ENABLED");
+        Commons.resetFastQueryOptimizationFlag();
     }
 
     @Test
@@ -119,6 +120,7 @@ public class ItSqlUsesSelectCountOptimizedTest extends BaseSqlIntegrationTest {
         // Disable fast query optimization
         // TODO: https://issues.apache.org/jira/browse/IGNITE-22821 replace with feature toggle
         System.setProperty("FAST_QUERY_OPTIMIZATION_ENABLED", "false");
+        Commons.resetFastQueryOptimizationFlag();
 
         assertQuery("SELECT COUNT(*) FROM test")
                 .matches(QueryChecker.containsSubPlan("Aggregate"))

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/datatypes/ItCastToIntWithoutFastQueryOptimizationTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/datatypes/ItCastToIntWithoutFastQueryOptimizationTest.java
@@ -19,6 +19,8 @@ package org.apache.ignite.internal.sql.engine.datatypes;
 
 import org.apache.ignite.internal.sql.engine.util.Commons;
 import org.apache.ignite.internal.testframework.WithSystemProperty;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * Set of tests to ensure correctness of CAST expression to INTEGER
@@ -29,4 +31,9 @@ import org.apache.ignite.internal.testframework.WithSystemProperty;
  */
 @WithSystemProperty(key = "FAST_QUERY_OPTIMIZATION_ENABLED", value = "false")
 public class ItCastToIntWithoutFastQueryOptimizationTest extends ItCastToIntTest {
+    @BeforeAll
+    @AfterAll
+    public static void resetFlag() {
+        Commons.resetFastQueryOptimizationFlag();
+    }
 }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/CacheKey.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/CacheKey.java
@@ -39,6 +39,8 @@ public class CacheKey {
 
     private final Object[] paramTypes;
 
+    private int hashCode = 0;
+
     /**
      * Constructor.
      *
@@ -87,11 +89,16 @@ public class CacheKey {
 
     @Override
     public int hashCode() {
-        int result = catalogVersion;
-        result = 31 * result + schemaName.hashCode();
-        result = 31 * result + query.hashCode();
-        result = 31 * result + (contextKey != null ? contextKey.hashCode() : 0);
-        result = 31 * result + Arrays.deepHashCode(paramTypes);
-        return result;
+        if (hashCode == 0) {
+            int result = catalogVersion;
+            result = 31 * result + schemaName.hashCode();
+            result = 31 * result + query.hashCode();
+            result = 31 * result + (contextKey != null ? contextKey.hashCode() : 0);
+            result = 31 * result + Arrays.deepHashCode(paramTypes);
+
+            hashCode = result;
+        }
+
+        return hashCode;
     }
 }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/Commons.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/Commons.java
@@ -122,6 +122,7 @@ import org.codehaus.commons.compiler.CompilerFactoryFactory;
 import org.codehaus.commons.compiler.IClassBodyEvaluator;
 import org.codehaus.commons.compiler.ICompilerFactory;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 /**
  * Utility methods.
@@ -190,6 +191,8 @@ public final class Commons {
             .typeSystem(IgniteTypeSystem.INSTANCE)
             .traitDefs(DISTRIBUTED_TRAITS_SET)
             .build();
+
+    private static volatile @Nullable Boolean fastOptimizationsEnabled = null;
 
     private Commons() {
     }
@@ -771,8 +774,21 @@ public final class Commons {
      * @return A {@code true} if fast path optimizations are enabled, {@code false} otherwise.
      */
     public static boolean fastQueryOptimizationEnabled() {
-        // TODO: https://issues.apache.org/jira/browse/IGNITE-22821 replace with feature toggle
-        return IgniteSystemProperties.getBoolean("FAST_QUERY_OPTIMIZATION_ENABLED", true);
+        Boolean enabled = fastOptimizationsEnabled;
+
+        if (enabled == null) {
+            // TODO: https://issues.apache.org/jira/browse/IGNITE-22821 replace with feature toggle
+            enabled = IgniteSystemProperties.getBoolean("FAST_QUERY_OPTIMIZATION_ENABLED", true);
+
+            fastOptimizationsEnabled = enabled;
+        }
+
+        return enabled;
+    }
+
+    @TestOnly
+    public static void resetFastQueryOptimizationFlag() {
+        fastOptimizationsEnabled = null;
     }
 
     /**

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/DmlPlannerTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/DmlPlannerTest.java
@@ -43,6 +43,8 @@ import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.internal.testframework.WithSystemProperty;
 import org.apache.ignite.internal.type.NativeType;
 import org.apache.ignite.internal.type.NativeTypes;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -52,6 +54,12 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 @WithSystemProperty(key = "FAST_QUERY_OPTIMIZATION_ENABLED", value = "false")
 public class DmlPlannerTest extends AbstractPlannerTest {
+    @BeforeAll
+    @AfterAll
+    public static void resetFlag() {
+        Commons.resetFastQueryOptimizationFlag();
+    }
+
     /**
      * Test for INSERT .. VALUES when table has a single distribution.
      */

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/DynamicParametersTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/DynamicParametersTest.java
@@ -36,6 +36,8 @@ import org.apache.ignite.internal.type.NativeType;
 import org.apache.ignite.internal.type.NativeTypes;
 import org.apache.ignite.internal.type.VarlenNativeType;
 import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
@@ -45,6 +47,11 @@ import org.junit.jupiter.api.TestFactory;
  */
 @WithSystemProperty(key = "FAST_QUERY_OPTIMIZATION_ENABLED", value = "false")
 public class DynamicParametersTest extends AbstractPlannerTest {
+    @BeforeAll
+    @AfterAll
+    public static void resetFlag() {
+        Commons.resetFastQueryOptimizationFlag();
+    }
 
     /**
      * This test case triggers "Conversion to relational algebra failed to preserve datatypes" assertion,

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/ImplicitCastsTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/ImplicitCastsTest.java
@@ -50,11 +50,14 @@ import org.apache.ignite.internal.sql.engine.schema.IgniteSchema;
 import org.apache.ignite.internal.sql.engine.schema.IgniteTable;
 import org.apache.ignite.internal.sql.engine.trait.IgniteDistributions;
 import org.apache.ignite.internal.sql.engine.type.IgniteTypeFactory;
+import org.apache.ignite.internal.sql.engine.util.Commons;
 import org.apache.ignite.internal.sql.engine.util.NativeTypeValues;
 import org.apache.ignite.internal.sql.engine.util.StatementChecker;
 import org.apache.ignite.internal.testframework.WithSystemProperty;
 import org.apache.ignite.internal.type.NativeTypes;
 import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -151,6 +154,12 @@ public class ImplicitCastsTest extends AbstractPlannerTest {
         });
 
         return result.stream();
+    }
+
+    @BeforeAll
+    @AfterAll
+    public static void resetFlag() {
+        Commons.resetFastQueryOptimizationFlag();
     }
 
     /** MergeSort join - casts are pushed down to children. **/

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/PartitionPruningMetadataTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/PartitionPruningMetadataTest.java
@@ -40,8 +40,11 @@ import org.apache.ignite.internal.sql.engine.schema.IgniteSchema;
 import org.apache.ignite.internal.sql.engine.schema.IgniteTable;
 import org.apache.ignite.internal.sql.engine.schema.TableDescriptor;
 import org.apache.ignite.internal.sql.engine.trait.IgniteDistributions;
+import org.apache.ignite.internal.sql.engine.util.Commons;
 import org.apache.ignite.internal.testframework.WithSystemProperty;
 import org.apache.ignite.internal.type.NativeTypes;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -109,6 +112,12 @@ public class PartitionPruningMetadataTest extends AbstractPlannerTest {
             .addColumn("C2", NativeTypes.BOOLEAN, false)
             .distribution(IgniteDistributions.affinity(List.of(0), 1, 2))
             .build());
+
+    @BeforeAll
+    @AfterAll
+    public static void resetFlag() {
+        Commons.resetFastQueryOptimizationFlag();
+    }
 
     /** Basic test cases for partition pruning metadata extractor, select case. */
     @ParameterizedTest(name = "SELECT: {0}")

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/SelectCountPlannerTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/SelectCountPlannerTest.java
@@ -44,6 +44,7 @@ import org.apache.ignite.internal.sql.engine.prepare.ExplainPlan;
 import org.apache.ignite.internal.sql.engine.prepare.QueryPlan;
 import org.apache.ignite.internal.sql.engine.prepare.SelectCountPlan;
 import org.apache.ignite.internal.sql.engine.tx.QueryTransactionContext;
+import org.apache.ignite.internal.sql.engine.util.Commons;
 import org.apache.ignite.internal.testframework.SystemPropertiesExtension;
 import org.apache.ignite.internal.testframework.WithSystemProperty;
 import org.junit.jupiter.api.AfterAll;
@@ -78,6 +79,8 @@ public class SelectCountPlannerTest extends AbstractPlannerTest {
 
     @AfterEach
     void clearCatalog() {
+        Commons.resetFastQueryOptimizationFlag();
+
         int version = CLUSTER.catalogManager().latestCatalogVersion();
 
         List<CatalogCommand> commands = new ArrayList<>();

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/QueryCheckerTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/QueryCheckerTest.java
@@ -67,6 +67,12 @@ public class QueryCheckerTest extends BaseIgniteAbstractTest {
             .build();
 
     @BeforeAll
+    @AfterAll
+    public static void resetFlag() {
+        Commons.resetFastQueryOptimizationFlag();
+    }
+
+    @BeforeAll
     static void startCluster() {
         CLUSTER.start();
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-24134

Results as follow:
```
Before
Benchmark               (clusterSize)  (fsync)  Mode  Cnt  Score   Error  Units
SelectBenchmark.kvGet               1    false  avgt   20  3.238 ± 0.185  us/op
SelectBenchmark.sqlGet              1    false  avgt   20  5.889 ± 0.143  us/op

After
SelectBenchmark.sqlGet              1    false  avgt   20  4.805 ± 0.068  us/op


Before
Benchmark                          (clusterSize)  (fsync)  (partitionCount)  (replicaCount)  Mode  Cnt   Score   Error  Units
InsertBenchmark.kvInsert                       1    false                24               1  avgt   20  38.814 ± 9.475  us/op
InsertBenchmark.sqlPreparedInsert              1    false                24               1  avgt   20  45.951 ± 7.650  us/op

After
Benchmark                          (clusterSize)  (fsync)  (partitionCount)  (replicaCount)  Mode  Cnt   Score   Error  Units
InsertBenchmark.sqlPreparedInsert              1    false                24               1  avgt   20  40.862 ± 7.930  us/op
```
--------------
Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)