### PR TITLE
IGNITE-23888 Thin client: add config argument validation

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/IgniteClient.java
@@ -241,6 +241,11 @@ public interface IgniteClient extends Ignite, AutoCloseable {
          * @return This instance.
          */
         public Builder heartbeatInterval(long heartbeatInterval) {
+            if (heartbeatInterval < 0) {
+                throw new IllegalArgumentException("Heartbeat interval [" + heartbeatInterval + "] "
+                        + "must be a non-negative integer value.");
+            }
+
             this.heartbeatInterval = heartbeatInterval;
 
             return this;
@@ -255,6 +260,11 @@ public interface IgniteClient extends Ignite, AutoCloseable {
          * @return This instance.
          */
         public Builder heartbeatTimeout(long heartbeatTimeout) {
+            if (heartbeatTimeout < 0) {
+                throw new IllegalArgumentException("Heartbeat timeout [" + heartbeatTimeout + "] "
+                        + "must be a non-negative integer value.");
+            }
+
             this.heartbeatTimeout = heartbeatTimeout;
 
             return this;

--- a/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/HeartbeatTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.ignite.client;
 
-import static org.apache.ignite.internal.testframework.IgniteTestUtils.assertThrowsWithCause;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -67,19 +66,6 @@ public class HeartbeatTest extends BaseIgniteAbstractTest {
 
                 assertEquals(0, client.tables().tables().size());
             }
-        }
-    }
-
-    @SuppressWarnings("ThrowableNotThrown")
-    @Test
-    public void testInvalidHeartbeatIntervalThrows() {
-        try (var srv = new TestServer(300, new FakeIgnite())) {
-
-            Builder builder = IgniteClient.builder()
-                    .addresses("127.0.0.1:" + srv.port())
-                    .heartbeatInterval(-50);
-
-            assertThrowsWithCause(builder::build, IllegalArgumentException.class, "Negative delay.");
         }
     }
 


### PR DESCRIPTION
All config properties reviewed:
* Negative values are not allowed
* In some cases, `0` means disabled timeout (when stated in the javadoc)