### PR TITLE
IGNITE-24302 .NET: Fix publicReleaseRefSpec

### DIFF
--- a/modules/platforms/dotnet/version.json
+++ b/modules/platforms/dotnet/version.json
@@ -3,7 +3,7 @@
     "version": "3.0.0-snapshot",
     "publicReleaseRefSpec": [
         "^refs/heads/main",
-        "^refs/heads/\\d+.*$"
+        "^refs/heads/ignite-3\\.\\d+.*$"
     ],
     "cloudBuild": {
         "setVersionVariables": false,


### PR DESCRIPTION
Enable public release builds from branches with `ignite-3.` prefix