### PR TITLE
IGNITE-24228 .NET: Fix flaky tests on Windows

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
@@ -87,8 +87,12 @@ public class LoggingTests
             };
 
             using var server = new FakeServer();
-            using var client = await server.ConnectClientAsync(cfg);
-            await client.Tables.GetTablesAsync();
+            using (var client = await server.ConnectClientAsync(cfg))
+            {
+                await client.Tables.GetTablesAsync();
+            }
+
+            await textWriter.FlushAsync();
         }
         finally
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/LoggingTests.cs
@@ -22,6 +22,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
 using Internal;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using NUnit.Framework;
@@ -82,17 +83,22 @@ public class LoggingTests
             var cfg = new IgniteClientConfiguration
             {
                 LoggerFactory = LoggerFactory.Create(builder =>
-                    builder.AddSimpleConsole(opt => opt.ColorBehavior = LoggerColorBehavior.Disabled)
-                        .SetMinimumLevel(LogLevel.Trace))
+                {
+                    builder.AddConsole(opt =>
+                        {
+                            opt.MaxQueueLength = 1;
+                            opt.QueueFullMode = ConsoleLoggerQueueFullMode.Wait;
+                            opt.FormatterName = ConsoleFormatterNames.Simple;
+                        })
+                        .SetMinimumLevel(LogLevel.Trace);
+
+                    builder.Services.Configure((SimpleConsoleFormatterOptions opts) => opts.ColorBehavior = LoggerColorBehavior.Disabled);
+                })
             };
 
             using var server = new FakeServer();
-            using (var client = await server.ConnectClientAsync(cfg))
-            {
-                await client.Tables.GetTablesAsync();
-            }
-
-            await textWriter.FlushAsync();
+            using var client = await server.ConnectClientAsync(cfg);
+            await client.Tables.GetTablesAsync();
         }
         finally
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MultiClusterTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MultiClusterTest.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Internal.Common;
 using NUnit.Framework;
 
 /// <summary>
@@ -46,7 +47,11 @@ public class MultiClusterTest
 
         using var client = await IgniteClient.StartAsync(cfg);
 
-        TestUtils.WaitForCondition(() => log.Entries.Any(e => e.Message.Contains("Cluster ID mismatch")));
+        TestUtils.WaitForCondition(
+            () => log.Entries.Any(e => e.Message.Contains("Cluster ID mismatch")),
+            5000,
+            () => log.Entries.StringJoin());
+
         Assert.AreEqual(1, client.GetConnections().Count);
     }
 


### PR DESCRIPTION
Fix `TestClientDropsConnectionOnClusterIdMismatch`, `TestMicrosoftConsoleLogger`.