### PR TITLE
IGNITE-24198 .NET: Fix locale-dependent Compute tests failures

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -713,7 +713,7 @@ namespace Apache.Ignite.Tests.Compute
             var res = await Client.Compute.SubmitAsync(await GetNodeAsync(1), DecimalJob, $"{number},{scale}");
             var resVal = await res.GetResultAsync();
 
-            var expected = decimal.Parse(number, NumberStyles.Float);
+            var expected = decimal.Parse(number, NumberStyles.Float, CultureInfo.InvariantCulture);
 
             if (scale > 0)
             {
@@ -938,7 +938,7 @@ namespace Apache.Ignite.Tests.Compute
         {
             public void Marshal(Nested obj, IBufferWriter<byte> writer)
             {
-                var str = obj.Id + ":" + obj.Price;
+                var str = obj.Id + ":" + obj.Price.ToString(CultureInfo.InvariantCulture);
                 Encoding.ASCII.GetBytes(str, writer);
             }
 
@@ -946,7 +946,7 @@ namespace Apache.Ignite.Tests.Compute
             {
                 var str = Encoding.ASCII.GetString(bytes);
                 var parts = str.Split(':');
-                return new(Guid.Parse(parts[0]), decimal.Parse(parts[1]));
+                return new(Guid.Parse(parts[0]), decimal.Parse(parts[1], CultureInfo.InvariantCulture));
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -270,8 +270,11 @@ namespace Apache.Ignite.Tests.Compute
                 var strExec = await Client.Compute.SubmitAsync(nodes, ToStringJob, val);
                 var str = await strExec.GetResultAsync();
 
-                var expectedStr0 = expectedStr ?? val.ToString()!.Replace("E+", "E");
-                Assert.AreEqual(expectedStr0, str);
+                expectedStr ??= val is IFormattable formattable
+                    ? formattable.ToString(null, CultureInfo.InvariantCulture).Replace("E+", "E")
+                    : val.ToString();
+
+                Assert.AreEqual(expectedStr, str);
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -19,9 +19,7 @@ namespace Apache.Ignite.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.Linq;
-    using System.Threading;
     using System.Threading.Tasks;
     using Ignite.Table;
     using Internal.Proto;
@@ -139,8 +137,6 @@ namespace Apache.Ignite.Tests
         {
             Console.WriteLine("SetUp: " + TestContext.CurrentContext.Test.Name);
             TestUtils.CheckByteArrayPoolLeak();
-
-            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("ru-RU");
         }
 
         [TearDown]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/IgniteTestsBase.cs
@@ -19,7 +19,9 @@ namespace Apache.Ignite.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Ignite.Table;
     using Internal.Proto;
@@ -137,6 +139,8 @@ namespace Apache.Ignite.Tests
         {
             Console.WriteLine("SetUp: " + TestContext.CurrentContext.Test.Name);
             TestUtils.CheckByteArrayPoolLeak();
+
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("ru-RU");
         }
 
         [TearDown]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/SqlTests.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Tests.Sql
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
     using System.Linq;
     using System.Threading.Tasks;
     using Ignite.Sql;
@@ -535,7 +536,7 @@ namespace Apache.Ignite.Tests.Sql
 
             Assert.AreEqual(32757, bigDecimal.Scale);
             Assert.AreEqual(13603, bigDecimal.UnscaledValue.GetByteCount());
-            StringAssert.StartsWith("3.3333333333", bigDecimal.ToString());
+            StringAssert.StartsWith("3.3333333333", bigDecimal.ToString(CultureInfo.InvariantCulture));
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite/BigDecimal.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/BigDecimal.cs
@@ -30,7 +30,7 @@ using Internal.Proto.BinaryTuple;
 /// .NET <see cref="decimal"/> has 28-29 digit precision and can not represent all values that Ignite supports.
 /// This type fills the gap.
 /// </summary>
-public readonly record struct BigDecimal : IComparable<BigDecimal>, IComparable
+public readonly record struct BigDecimal : IComparable<BigDecimal>, IComparable, IFormattable
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BigDecimal"/> struct.
@@ -134,6 +134,17 @@ public readonly record struct BigDecimal : IComparable<BigDecimal>, IComparable
 
     /// <inheritdoc />
     public override string ToString() => ToString(null);
+
+    /// <inheritdoc />
+    public string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        if (format != null)
+        {
+            throw new NotSupportedException("Format string is not supported.");
+        }
+
+        return ToString(formatProvider);
+    }
 
     /// <summary>
     /// Converts the numeric value of this object to its equivalent string representation.


### PR DESCRIPTION
* Implement `IFormattable` on `BigDecimal`
* Fix tests to use invariant culture for string conversions