### PR TITLE
IGNITE-24456: Sql. Unexpected SchemaNotFoundError when query does not access that schema

### DIFF
--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlApiBaseTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlApiBaseTest.java
@@ -640,8 +640,8 @@ public abstract class ItSqlApiBaseTest extends BaseSqlIntegrationTest {
 
         assertThrowsSqlException(
                 SqlBatchException.class,
-                Sql.SCHEMA_NOT_FOUND_ERR,
-                "Schema not found [schemaName=NON_EXISTING_SCHEMA]",
+                Sql.STMT_VALIDATION_ERR,
+                "Object 'TEST' not found",
                 () -> executeBatch(statement, args));
     }
 

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItPublicSchemaTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItPublicSchemaTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine;
+
+import static org.apache.ignite.internal.sql.engine.util.SqlTestUtils.assertThrowsSqlException;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.ignite.internal.ClusterPerTestIntegrationTest;
+import org.apache.ignite.internal.TestWrappers;
+import org.apache.ignite.internal.catalog.CatalogManager;
+import org.apache.ignite.lang.ErrorGroups.Sql;
+import org.apache.ignite.sql.IgniteSql;
+import org.apache.ignite.sql.ResultSet;
+import org.apache.ignite.sql.Statement;
+import org.junit.jupiter.api.Test;
+
+/**
+ * SQL tests for public schema.
+ */
+public class ItPublicSchemaTest extends ClusterPerTestIntegrationTest {
+
+    @Override
+    protected int initialNodes() {
+        return 1;
+    }
+
+    @Test
+    public void existsInEmptyCluster() {
+        CatalogManager catalogManager = TestWrappers.unwrapIgniteImpl(cluster.node(0)).catalogManager();
+        int version = catalogManager.latestCatalogVersion();
+
+        assertNotNull(catalogManager.catalog(version).schema("PUBLIC"));
+    }
+
+    @Test
+    public void dropCreatePublicSchema() {
+        sql("PUBLIC", "CREATE SCHEMA s2");
+        sql("S2", "CREATE TABLE t1 (id INT PRIMARY KEY, val VARCHAR)");
+
+        sql("PUBLIC", "DROP SCHEMA PUBLIC");
+
+        // Both should fail as PUBLIC schema has been dropped.
+        assertThrowsSqlException(
+                Sql.STMT_VALIDATION_ERR,
+                "Object 'T1' not found",
+                () -> sql("PUBLIC", "SELECT count(*) FROM t1")
+        );
+        assertThrowsSqlException(
+                Sql.STMT_VALIDATION_ERR,
+                "Object 'PUBLIC' not found",
+                () -> sql("PUBLIC", "SELECT count(*) FROM PUBLIC.t1")
+        );
+
+        // Non default schema
+        sql("S2", "SELECT count(*) FROM t1");
+        // Fully qualified table names also work.
+        sql("S2", "SELECT count(*) FROM S2.t1");
+
+        // Recreate public schema
+        sql("PUBLIC", "CREATE SCHEMA public");
+        sql("PUBLIC", "CREATE TABLE t1 (id INT PRIMARY KEY, val VARCHAR)");
+
+        sql("PUBLIC", "SELECT count(*) FROM t1");
+        sql("S2", "SELECT count(*) FROM public.t1");
+        sql("MISSING", "SELECT count(*) FROM public.t1");
+    }
+
+    private void sql(String defaultSchema, String stmt) {
+        IgniteSql sql = cluster.node(0).sql();
+        Statement statement = sql.statementBuilder().query(stmt)
+                .defaultSchema(defaultSchema)
+                .build();
+
+        try (ResultSet<?> rs = sql.execute(null, statement)) {
+            assertTrue(rs.hasRowSet() || rs.wasApplied());
+        }
+    }
+}

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSchemaTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSchemaTest.java
@@ -199,7 +199,7 @@ public class ItSchemaTest extends BaseSqlIntegrationTest {
                 .check();
 
         // Should work as wee, because we do not access the MISSING schema,
-        // but we get  Schema not found instead.
+        // Works fine because we do not access the MISSING schema.
         assertQuery("SELECT count(*) FROM s1.t1")
                 .withDefaultSchema("MISSING")
                 .returns(0L)

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImpl.java
@@ -114,6 +114,7 @@ import org.apache.ignite.internal.sql.engine.rel.IgniteRel;
 import org.apache.ignite.internal.sql.engine.rel.IgniteTableModify;
 import org.apache.ignite.internal.sql.engine.rel.IgniteTableScan;
 import org.apache.ignite.internal.sql.engine.rel.SourceAwareIgniteRel;
+import org.apache.ignite.internal.sql.engine.schema.IgniteSchemas;
 import org.apache.ignite.internal.sql.engine.schema.IgniteTable;
 import org.apache.ignite.internal.sql.engine.schema.SqlSchemaManager;
 import org.apache.ignite.internal.sql.engine.tx.QueryTransactionContext;
@@ -370,7 +371,8 @@ public class ExecutionServiceImpl<RowT> implements ExecutionService, TopologyEve
     }
 
     private IgniteRel relationalTreeFromJsonString(int catalogVersion, String jsonFragment) {
-        SchemaPlus rootSchema = sqlSchemaManager.schema(catalogVersion);
+        IgniteSchemas schemas = sqlSchemaManager.schemas(catalogVersion);
+        SchemaPlus rootSchema = schemas.root();
 
         return physNodesCache.computeIfAbsent(
                 new FragmentCacheKey(catalogVersion, jsonFragment),

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PrepareServiceImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PrepareServiceImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.sql.engine.prepare;
 
+import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
 import static org.apache.ignite.internal.sql.engine.prepare.CacheKey.EMPTY_CLASS_ARRAY;
 import static org.apache.ignite.internal.sql.engine.prepare.PlannerHelper.optimize;
 import static org.apache.ignite.internal.sql.engine.trait.TraitUtils.distributionPresent;
@@ -80,7 +81,6 @@ import org.apache.ignite.internal.thread.IgniteThreadFactory;
 import org.apache.ignite.internal.type.NativeTypeSpec;
 import org.apache.ignite.internal.util.ExceptionUtils;
 import org.apache.ignite.lang.ErrorGroups.Sql;
-import org.apache.ignite.lang.SchemaNotFoundException;
 import org.apache.ignite.sql.ColumnMetadata;
 import org.apache.ignite.sql.ColumnType;
 import org.apache.ignite.sql.ResultSetMetadata;
@@ -227,10 +227,9 @@ public class PrepareServiceImpl implements PrepareService {
 
         assert schemaName != null;
 
-        IgniteSchemas rootSchema = schemaManager.schemas(operationContext.operationTime().longValue());
-        if (rootSchema == null) {
-            return CompletableFuture.failedFuture(new SchemaNotFoundException("Root schema"));
-        }
+        long timestamp = operationContext.operationTime().longValue();
+        IgniteSchemas rootSchema = schemaManager.schemas(timestamp);
+        assert rootSchema != null : "Root schema does not exist";
 
         QueryCancel cancelHandler = operationContext.cancel();
         assert cancelHandler != null;

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PrepareServiceImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PrepareServiceImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.ignite.internal.sql.engine.prepare;
 
-import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
 import static org.apache.ignite.internal.sql.engine.prepare.CacheKey.EMPTY_CLASS_ARRAY;
 import static org.apache.ignite.internal.sql.engine.prepare.PlannerHelper.optimize;
 import static org.apache.ignite.internal.sql.engine.trait.TraitUtils.distributionPresent;

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PrepareServiceImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PrepareServiceImpl.java
@@ -237,7 +237,7 @@ public class PrepareServiceImpl implements PrepareService {
         SchemaPlus schemaPlus = rootSchema.root();
         SchemaPlus defaultSchema = schemaPlus.getSubSchema(schemaName);
         // If default schema does not exist or misconfigured, we should use the root schema as default one
-        // because if there is no other schema for the validator to use.
+        // because there is no other schema for the validator to use.
         if (defaultSchema == null) {
             defaultSchema = schemaPlus;
         }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/IgniteSchemas.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/IgniteSchemas.java
@@ -49,7 +49,7 @@ public final class IgniteSchemas {
     }
 
     /**
-     * Returns a catalog version this schema container belong to.
+     * Returns a catalog version this schema container belongs to.
      *
      * @return Catalog version.
      */

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/IgniteSchemas.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/IgniteSchemas.java
@@ -49,7 +49,7 @@ public final class IgniteSchemas {
     }
 
     /**
-     * Returns catalog version this schemas belong to.
+     * Returns catalog version this schema container belong to.
      *
      * @return Catalog version.
      */

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/IgniteSchemas.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/IgniteSchemas.java
@@ -17,35 +17,43 @@
 
 package org.apache.ignite.internal.sql.engine.schema;
 
-import java.util.concurrent.CompletableFuture;
+import org.apache.calcite.schema.SchemaPlus;
 
 /**
- * Sql schemas operations interface.
+ * Schema container.
  */
-public interface SqlSchemaManager {
-    /**
-     * Returns a schema container derived from catalog of the given version.
-     */
-    IgniteSchemas schemas(int catalogVersion);
+public final class IgniteSchemas {
+
+    private final SchemaPlus rootSchema;
+
+    private final int catalogVersion;
 
     /**
-     * Returns a schema container derived from catalog of version which was considered active at the given timestamp.
-     */
-    IgniteSchemas schemas(long timestamp);
-
-    /**
-     * Returns table by given id, which version correspond to the one from catalog of given version.
+     * Constructor.
      *
-     * @param catalogVersion Version of the catalog.
-     * @param tableId An identifier of a table of interest.
-     * @return A table.
+     * @param rootSchema Root schema.
+     * @param catalogVersion Catalog version.
      */
-    IgniteTable table(int catalogVersion, int tableId);
+    public IgniteSchemas(SchemaPlus rootSchema, int catalogVersion) {
+        this.rootSchema = rootSchema;
+        this.catalogVersion = catalogVersion;
+    }
 
     /**
-     * Returns a future to wait for given catalog version readiness.
+     * Returns a {@link SchemaPlus} that contains all catalog schemas.
      *
-     * @param catalogVersion version of the catalog to wait.
+     * @return Root schema.
      */
-    CompletableFuture<Void> schemaReadyFuture(int catalogVersion);
+    public SchemaPlus root() {
+        return rootSchema;
+    }
+
+    /**
+     * Returns catalog version this schemas belong to.
+     *
+     * @return Catalog version.
+     */
+    public int catalogVersion() {
+        return catalogVersion;
+    }
 }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/IgniteSchemas.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/IgniteSchemas.java
@@ -49,7 +49,7 @@ public final class IgniteSchemas {
     }
 
     /**
-     * Returns catalog version this schema container belong to.
+     * Returns a catalog version this schema container belong to.
      *
      * @return Catalog version.
      */

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/SqlSchemaManagerImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/schema/SqlSchemaManagerImpl.java
@@ -76,7 +76,7 @@ public class SqlSchemaManagerImpl implements SqlSchemaManager {
     private final CatalogManager catalogManager;
     private final SqlStatisticManager sqlStatisticManager;
 
-    private final Cache<Integer, SchemaPlus> schemaCache;
+    private final Cache<Integer, IgniteSchemas> schemaCache;
 
     /**
      * Table cache by (tableId, tableVersion).
@@ -107,7 +107,7 @@ public class SqlSchemaManagerImpl implements SqlSchemaManager {
 
     /** {@inheritDoc} */
     @Override
-    public SchemaPlus schema(int catalogVersion) {
+    public IgniteSchemas schemas(int catalogVersion) {
         return schemaCache.get(
                 catalogVersion,
                 version -> createRootSchema(catalogManager.catalog(version))
@@ -117,10 +117,10 @@ public class SqlSchemaManagerImpl implements SqlSchemaManager {
 
     /** {@inheritDoc} */
     @Override
-    public SchemaPlus schema(long timestamp) {
+    public IgniteSchemas schemas(long timestamp) {
         int catalogVersion = catalogManager.activeCatalogVersion(timestamp);
 
-        return schema(catalogVersion);
+        return schemas(catalogVersion);
     }
 
     /** {@inheritDoc} */
@@ -137,12 +137,14 @@ public class SqlSchemaManagerImpl implements SqlSchemaManager {
     @Override
     public IgniteTable table(int catalogVersion, int tableId) {
         return fullDataTableCache.get(cacheKey(catalogVersion, tableId), key -> {
-            SchemaPlus rootSchema = schemaCache.get(catalogVersion);
+            IgniteSchemas rootSchema = schemaCache.get(catalogVersion);
 
             // Retrieve table from the schema (if it exists).
             if (rootSchema != null) {
-                for (String name : rootSchema.getSubSchemaNames()) {
-                    SchemaPlus subSchema = rootSchema.getSubSchema(name);
+                SchemaPlus schemaPlus = rootSchema.root();
+
+                for (String name : schemaPlus.getSubSchemaNames()) {
+                    SchemaPlus subSchema = schemaPlus.getSubSchema(name);
 
                     assert subSchema != null : name;
 
@@ -195,7 +197,7 @@ public class SqlSchemaManagerImpl implements SqlSchemaManager {
         return cacheKey | part2;
     }
 
-    private SchemaPlus createRootSchema(Catalog catalog) {
+    private IgniteSchemas createRootSchema(Catalog catalog) {
         SchemaPlus rootSchema = Frameworks.createRootSchema(false);
 
         for (CatalogSchemaDescriptor schemaDescriptor : catalog.schemas()) {
@@ -203,7 +205,7 @@ public class SqlSchemaManagerImpl implements SqlSchemaManager {
             rootSchema.add(igniteSchema.getName(), igniteSchema);
         }
 
-        return rootSchema;
+        return new IgniteSchemas(rootSchema, catalog.version());
     }
 
     private IgniteSchema createSqlSchema(Catalog catalog, CatalogSchemaDescriptor schemaDescriptor) {

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/mapping/FragmentMappingTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/mapping/FragmentMappingTest.java
@@ -344,6 +344,7 @@ public class FragmentMappingTest extends AbstractPlannerTest {
                     .frameworkConfig(newConfigBuilder(FRAMEWORK_CONFIG)
                             .defaultSchema(createRootSchema(List.of(schema)).getSubSchema(schema.getName()))
                             .build())
+                    .defaultSchemaName(schema.getName())
                     .query(sqlStmt)
                     .build();
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/PredefinedSchemaManager.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/PredefinedSchemaManager.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.ignite.internal.sql.engine.schema.IgniteSchema;
+import org.apache.ignite.internal.sql.engine.schema.IgniteSchemas;
 import org.apache.ignite.internal.sql.engine.schema.IgniteTable;
 import org.apache.ignite.internal.sql.engine.schema.SqlSchemaManager;
 
@@ -42,7 +43,7 @@ import org.apache.ignite.internal.sql.engine.schema.SqlSchemaManager;
  * @see SqlSchemaManager
  */
 public class PredefinedSchemaManager implements SqlSchemaManager {
-    private final SchemaPlus root;
+    private final IgniteSchemas root;
     private final Int2ObjectMap<IgniteTable> tableById;
 
     /** Constructs schema manager from a single schema. */
@@ -51,12 +52,12 @@ public class PredefinedSchemaManager implements SqlSchemaManager {
     }
 
     /** Constructs schema manager from a collection of schemas. */
-    PredefinedSchemaManager(Collection<IgniteSchema> schemas) {
-        this.root = Frameworks.createRootSchema(false);
+    public PredefinedSchemaManager(Collection<IgniteSchema> schemas) {
+        SchemaPlus schemaPlus = Frameworks.createRootSchema(false);
         this.tableById = new Int2ObjectOpenHashMap<>();
 
         for (IgniteSchema schema : schemas) {
-            root.add(schema.getName(), schema);
+            schemaPlus.add(schema.getName(), schema);
 
             tableById.putAll(
                     schema.getTableNames().stream()
@@ -65,17 +66,19 @@ public class PredefinedSchemaManager implements SqlSchemaManager {
                             .collect(toIntMapCollector(IgniteTable::id, identity()))
             );
         }
+
+        root = new IgniteSchemas(schemaPlus, 0);
     }
 
     /** {@inheritDoc} */
     @Override
-    public SchemaPlus schema(int catalogVersion) {
+    public IgniteSchemas schemas(int catalogVersion) {
         return root;
     }
 
     /** {@inheritDoc} */
     @Override
-    public SchemaPlus schema(long timestamp) {
+    public IgniteSchemas schemas(long timestamp) {
         return root;
     }
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/AbstractPlannerTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/AbstractPlannerTest.java
@@ -278,6 +278,8 @@ public abstract class AbstractPlannerTest extends IgniteAbstractTest {
                                 .sqlToRelConverterConfig(relConvCfg)
                                 .build()
                 )
+                .catalogVersion(1)
+                .defaultSchemaName(defaultSchema.getName())
                 .query(sql)
                 .parameters(paramsMap)
                 // Assume that we use explicit transactions by default.

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/PlannerTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/PlannerTest.java
@@ -40,6 +40,7 @@ import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.hint.HintStrategyTable;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.CalciteContextException;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.util.ImmutableIntList;
@@ -59,9 +60,11 @@ import org.apache.ignite.internal.sql.engine.rel.IgniteRel;
 import org.apache.ignite.internal.sql.engine.rel.IgniteSort;
 import org.apache.ignite.internal.sql.engine.rel.IgniteTableScan;
 import org.apache.ignite.internal.sql.engine.schema.IgniteSchema;
+import org.apache.ignite.internal.sql.engine.schema.IgniteTable;
 import org.apache.ignite.internal.sql.engine.trait.IgniteDistribution;
 import org.apache.ignite.internal.sql.engine.trait.IgniteDistributions;
 import org.apache.ignite.internal.sql.engine.util.Commons;
+import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.internal.type.NativeTypes;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
@@ -136,6 +139,8 @@ public class PlannerTest extends AbstractPlannerTest {
                         .defaultSchema(schema)
                         .costFactory(new IgniteCostFactory(1, 100, 1, 1))
                         .build())
+                .catalogVersion(1)
+                .defaultSchemaName(publicSchema.getName())
                 .query(sql)
                 .build();
 
@@ -348,6 +353,59 @@ public class PlannerTest extends AbstractPlannerTest {
             assertNotNull(rex);
         } else {
             assertNull(rex);
+        }
+    }
+
+    @Test
+    public void testPlanningWhenDefaultSchemaIsMissing() throws Exception {
+        IgniteTable dept = departmentTable(IgniteDistributions.single())
+                .apply(TestBuilders.table())
+                .build();
+
+        IgniteTable emp = employerTable(IgniteDistributions.single())
+                .apply(TestBuilders.table())
+                .build();
+
+        IgniteSchema schema1 = new IgniteSchema("EMP_SCHEMA", 1, List.of(emp));
+        IgniteSchema schema2 = new IgniteSchema("DEPT_SCHEMA", 1, List.of(dept));
+        SchemaPlus schema = createRootSchema(List.of(schema1, schema2));
+
+        {
+            String sql = "SELECT d.*, e.* FROM dept_schema.dept d, emp_schema.emp e";
+
+            PlanningContext ctx = PlanningContext.builder()
+                    .frameworkConfig(newConfigBuilder(FRAMEWORK_CONFIG)
+                            .defaultSchema(schema)
+                            .costFactory(new IgniteCostFactory(1, 100, 1, 1))
+                            .build())
+                    .catalogVersion(1)
+                    .defaultSchemaName("MISSING_SCHEMA")
+                    .query(sql)
+                    .build();
+
+            IgniteRel plan = physicalPlan(ctx);
+            assertNotNull(plan);
+        }
+
+        // tables are not accessible w/o correct schemas.
+        {
+            String sql = "SELECT d.*, e.* FROM dept_schema.dept d, emp e";
+
+            PlanningContext ctx = PlanningContext.builder()
+                    .frameworkConfig(newConfigBuilder(FRAMEWORK_CONFIG)
+                            .defaultSchema(schema)
+                            .costFactory(new IgniteCostFactory(1, 100, 1, 1))
+                            .build())
+                    .catalogVersion(1)
+                    .defaultSchemaName("MISSING_SCHEMA")
+                    .query(sql)
+                    .build();
+
+            IgniteTestUtils.assertThrows(
+                    CalciteContextException.class,
+                    () -> physicalPlan(ctx),
+                    "Object 'EMP' not found"
+            );
         }
     }
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/PlannerTimeoutTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/PlannerTimeoutTest.java
@@ -100,6 +100,7 @@ public class PlannerTimeoutTest extends AbstractPlannerTest {
                 .frameworkConfig(newConfigBuilder(FRAMEWORK_CONFIG)
                         .defaultSchema(createRootSchema(List.of(schema)).getSubSchema(schema.getName()))
                         .build())
+                .defaultSchemaName(schema.getName())
                 .query(sql)
                 .build();
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/prepare/ddl/AbstractDdlSqlToCommandConverterTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/prepare/ddl/AbstractDdlSqlToCommandConverterTest.java
@@ -70,6 +70,8 @@ class AbstractDdlSqlToCommandConverterTest extends BaseIgniteAbstractTest {
                 .frameworkConfig(newConfigBuilder(FRAMEWORK_CONFIG)
                         .defaultSchema(schema)
                         .build())
+                .catalogVersion(1)
+                .defaultSchemaName(schemaName)
                 .query("")
                 .build();
     }

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/schema/SqlSchemaManagerImplTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/schema/SqlSchemaManagerImplTest.java
@@ -134,7 +134,7 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
         int versionAfter = catalogManager.latestCatalogVersion();
 
         // just to fill up cache
-        sqlSchemaManager.schema(versionAfter);
+        sqlSchemaManager.schemas(versionAfter);
 
         int nonExistingTableId = Integer.MAX_VALUE;
 
@@ -158,8 +158,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
         int versionAfter = catalogManager.latestCatalogVersion();
         assertThat(versionAfter, equalTo(versionBefore + 1));
 
-        SchemaPlus rootSchema = sqlSchemaManager.schema(versionAfter);
-        assertNotNull(rootSchema);
+        IgniteSchemas schemas = sqlSchemaManager.schemas(versionAfter);
+        assertNotNull(schemas);
+        SchemaPlus rootSchema = schemas.root();
 
         assertNotNull(rootSchema.getSubSchema(PUBLIC_SCHEMA_NAME));
         assertNotNull(rootSchema.getSubSchema(SYSTEM_SCHEMA_NAME));
@@ -177,8 +178,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
         int versionAfter = catalogManager.latestCatalogVersion();
         assertThat(versionAfter, equalTo(versionBefore + 1));
 
-        SchemaPlus rootSchema = sqlSchemaManager.schema(versionAfter);
-        assertNotNull(rootSchema);
+        IgniteSchemas schemas = sqlSchemaManager.schemas(versionAfter);
+        assertNotNull(schemas);
+        SchemaPlus rootSchema = schemas.root();
 
         SchemaPlus schemaPlus = rootSchema.getSubSchema(PUBLIC_SCHEMA_NAME);
         assertNotNull(schemaPlus);
@@ -235,8 +237,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
 
         int version = catalogManager.latestCatalogVersion();
 
-        SchemaPlus rootSchema = sqlSchemaManager.schema(version);
-        assertNotNull(rootSchema);
+        IgniteSchemas schemas = sqlSchemaManager.schemas(version);
+        assertNotNull(schemas);
+        SchemaPlus rootSchema = schemas.root();
 
         SchemaPlus schemaPlus = rootSchema.getSubSchema(PUBLIC_SCHEMA_NAME);
         assertNotNull(schemaPlus);
@@ -273,8 +276,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
         int versionAfter = catalogManager.latestCatalogVersion();
         assertThat(versionAfter, equalTo(versionBefore + 1));
 
-        SchemaPlus rootSchema = sqlSchemaManager.schema(versionAfter);
-        assertNotNull(rootSchema);
+        IgniteSchemas schemas = sqlSchemaManager.schemas(versionAfter);
+        assertNotNull(schemas);
+        SchemaPlus rootSchema = schemas.root();
 
         SchemaPlus schemaPlus = rootSchema.getSubSchema(PUBLIC_SCHEMA_NAME);
         assertNotNull(schemaPlus);
@@ -342,8 +346,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
         int versionAfter = catalogManager.latestCatalogVersion();
         assertThat(versionAfter, equalTo(versionBefore + 1));
 
-        SchemaPlus rootSchema = sqlSchemaManager.schema(versionAfter);
-        assertNotNull(rootSchema);
+        IgniteSchemas schemas = sqlSchemaManager.schemas(versionAfter);
+        assertNotNull(schemas);
+        SchemaPlus rootSchema = schemas.root();
 
         SchemaPlus schemaPlus = rootSchema.getSubSchema(PUBLIC_SCHEMA_NAME);
         assertNotNull(schemaPlus);
@@ -394,8 +399,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
         int versionAfter = catalogManager.latestCatalogVersion();
         assertThat(versionAfter, equalTo(versionBefore + 1));
 
-        SchemaPlus rootSchema = sqlSchemaManager.schema(versionAfter);
-        assertNotNull(rootSchema);
+        IgniteSchemas schemas = sqlSchemaManager.schemas(versionAfter);
+        assertNotNull(schemas);
+        SchemaPlus rootSchema = schemas.root();
 
         SchemaPlus schemaPlus = rootSchema.getSubSchema(PUBLIC_SCHEMA_NAME);
         assertNotNull(schemaPlus);
@@ -455,8 +461,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
         int versionAfter = catalogManager.latestCatalogVersion();
         assertThat(versionAfter, equalTo(versionBefore + 1));
 
-        SchemaPlus rootSchema = sqlSchemaManager.schema(versionAfter);
-        assertNotNull(rootSchema);
+        IgniteSchemas schemas = sqlSchemaManager.schemas(versionAfter);
+        assertNotNull(schemas);
+        SchemaPlus rootSchema = schemas.root();
 
         SchemaPlus schemaPlus = rootSchema.getSubSchema(PUBLIC_SCHEMA_NAME);
         assertNotNull(schemaPlus);
@@ -493,8 +500,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
             int versionAfter = catalogManager.latestCatalogVersion();
             assertThat(versionAfter, equalTo(versionBefore + 2));
 
-            SchemaPlus rootSchema = sqlSchemaManager.schema(versionAfter);
-            assertNotNull(rootSchema);
+            IgniteSchemas schemas = sqlSchemaManager.schemas(versionAfter);
+            assertNotNull(schemas);
+            SchemaPlus rootSchema = schemas.root();
 
             SchemaPlus schemaPlus = rootSchema.getSubSchema(PUBLIC_SCHEMA_NAME);
             assertNotNull(schemaPlus);
@@ -512,8 +520,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
             int versionAfter = catalogManager.latestCatalogVersion();
             assertThat(versionAfter, equalTo(versionBefore + 3));
 
-            SchemaPlus rootSchema = sqlSchemaManager.schema(versionAfter);
-            assertNotNull(rootSchema);
+            IgniteSchemas schemas = sqlSchemaManager.schemas(versionAfter);
+            assertNotNull(schemas);
+            SchemaPlus rootSchema = schemas.root();
 
             SchemaPlus schemaPlus = rootSchema.getSubSchema(PUBLIC_SCHEMA_NAME);
             assertNotNull(schemaPlus);
@@ -545,8 +554,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
         int versionAfter = catalogManager.latestCatalogVersion();
         assertThat(versionAfter, equalTo(versionBefore + 1));
 
-        SchemaPlus rootSchema = sqlSchemaManager.schema(versionAfter);
-        assertNotNull(rootSchema);
+        IgniteSchemas schemas = sqlSchemaManager.schemas(versionAfter);
+        assertNotNull(schemas);
+        SchemaPlus rootSchema = schemas.root();
 
         SchemaPlus schemaPlus = rootSchema.getSubSchema(PUBLIC_SCHEMA_NAME);
         assertNotNull(schemaPlus);
@@ -580,8 +590,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
             int versionAfter = catalogManager.latestCatalogVersion();
             assertThat(versionAfter, equalTo(versionBefore + 2));
 
-            SchemaPlus rootSchema = sqlSchemaManager.schema(versionAfter);
-            assertNotNull(rootSchema);
+            IgniteSchemas schemas = sqlSchemaManager.schemas(versionAfter);
+            assertNotNull(schemas);
+            SchemaPlus rootSchema = schemas.root();
 
             SchemaPlus schemaPlus = rootSchema.getSubSchema(PUBLIC_SCHEMA_NAME);
             assertNotNull(schemaPlus);
@@ -602,8 +613,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
             int versionAfter = catalogManager.latestCatalogVersion();
             assertThat(versionAfter, equalTo(versionBefore + 3));
 
-            SchemaPlus rootSchema = sqlSchemaManager.schema(versionAfter);
-            assertNotNull(rootSchema);
+            IgniteSchemas schemas = sqlSchemaManager.schemas(versionAfter);
+            assertNotNull(schemas);
+            SchemaPlus rootSchema = schemas.root();
 
             SchemaPlus schemaPlus = rootSchema.getSubSchema(PUBLIC_SCHEMA_NAME);
             assertNotNull(schemaPlus);
@@ -629,8 +641,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
             int versionAfter = catalogManager.latestCatalogVersion();
             assertThat(versionAfter, equalTo(versionBefore + 4));
 
-            SchemaPlus rootSchema = sqlSchemaManager.schema(versionAfter);
-            assertNotNull(rootSchema);
+            IgniteSchemas schemas = sqlSchemaManager.schemas(versionAfter);
+            assertNotNull(schemas);
+            SchemaPlus rootSchema = schemas.root();
 
             SchemaPlus schemaPlus = rootSchema.getSubSchema(PUBLIC_SCHEMA_NAME);
             assertNotNull(schemaPlus);
@@ -666,8 +679,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
         int versionAfter = catalogManager.latestCatalogVersion();
         assertThat(versionAfter, equalTo(versionBefore + 1));
 
-        SchemaPlus rootSchema = sqlSchemaManager.schema(versionAfter);
-        assertNotNull(rootSchema);
+        IgniteSchemas schemas = sqlSchemaManager.schemas(versionAfter);
+        assertNotNull(schemas);
+        SchemaPlus rootSchema = schemas.root();
 
         SchemaPlus schemaPlus = rootSchema.getSubSchema(PUBLIC_SCHEMA_NAME);
         assertNotNull(schemaPlus);
@@ -732,8 +746,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
         int versionAfter = catalogManager.latestCatalogVersion();
         assertThat(versionAfter, equalTo(versionBefore + 1));
 
-        SchemaPlus rootSchema = sqlSchemaManager.schema(versionAfter);
-        assertNotNull(rootSchema);
+        IgniteSchemas schemas = sqlSchemaManager.schemas(versionAfter);
+        assertNotNull(schemas);
+        SchemaPlus rootSchema = schemas.root();
 
         SchemaPlus schemaPlus = rootSchema.getSubSchema(SYSTEM_SCHEMA_NAME);
         assertNotNull(schemaPlus);
@@ -772,8 +787,9 @@ public class SqlSchemaManagerImplTest extends BaseIgniteAbstractTest {
         int versionAfter = catalogManager.latestCatalogVersion();
         assertThat(versionAfter, equalTo(versionBefore + 1));
 
-        SchemaPlus rootSchema = sqlSchemaManager.schema(versionAfter);
-        assertNotNull(rootSchema);
+        IgniteSchemas schemas = sqlSchemaManager.schemas(versionAfter);
+        assertNotNull(schemas);
+        SchemaPlus rootSchema = schemas.root();
 
         SchemaPlus schemaPlus = rootSchema.getSubSchema(SYSTEM_SCHEMA_NAME);
         assertNotNull(schemaPlus);


### PR DESCRIPTION
Introduces a schema contaner to resolve this issue - `SqlSchemaManager` now returns a top level schema container instead of a default schema.

The example illustrates resolution behaviour prior to this fix the second part was not possible due to `SchemaNotFoundError`:
```
// Root schema: [Schema1, Schema2]
// Schema S1. Tables: T1
// Schema S2. Tables: T1, T2
// Default schema: S1
//
// T1 resolves to S1.T1
// T2 does not exist.
// S2.T2 resolves to S2.T2
//
// When Default schema is not specified or refers to not existing schema:
//
// T1 does not exist.
// T2 does not exist.
// S1.T1 resolves to S1.T1
// S2.T2 resolves to S2.T2
// S2.T2 resolves to S2.T2
```

https://issues.apache.org/jira/browse/IGNITE-24456

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)