### PR TITLE
IGNITE-24354 Move ChangePeersAndLearnersAsyncReplicaRequest processing to ZonePartitionReplicaListener

### DIFF
--- a/modules/distribution-zones/src/integrationTest/java/org/apache/ignite/internal/rebalance/ItRebalanceDistributedTest.java
+++ b/modules/distribution-zones/src/integrationTest/java/org/apache/ignite/internal/rebalance/ItRebalanceDistributedTest.java
@@ -1517,6 +1517,7 @@ public class ItRebalanceDistributedTest extends BaseIgniteAbstractTest {
                     new PartitionReplicaLifecycleManager(
                             catalogManager,
                             replicaManager,
+                            replicaSvc,
                             distributionZoneManager,
                             metaStorageManager,
                             clusterService.topologyService(),

--- a/modules/distribution-zones/src/main/java/org/apache/ignite/internal/distributionzones/rebalance/ZoneRebalanceRaftGroupEventsListener.java
+++ b/modules/distribution-zones/src/main/java/org/apache/ignite/internal/distributionzones/rebalance/ZoneRebalanceRaftGroupEventsListener.java
@@ -162,6 +162,7 @@ public class ZoneRebalanceRaftGroupEventsListener implements RaftGroupEventsList
     /** {@inheritDoc} */
     @Override
     public void onLeaderElected(long term) {
+        // TODO: remove the leader based failover https://issues.apache.org/jira/browse/IGNITE-24193
         if (!busyLock.enterBusy()) {
             return;
         }

--- a/modules/partition-replicator/src/integrationTest/java/org/apache/ignite/internal/partition/replicator/ItReplicaLifecycleTest.java
+++ b/modules/partition-replicator/src/integrationTest/java/org/apache/ignite/internal/partition/replicator/ItReplicaLifecycleTest.java
@@ -204,6 +204,9 @@ public class ItReplicaLifecycleTest extends IgniteAbstractTest {
         node0.cmgManager.initCluster(List.of(node0.name), List.of(node0.name), "cluster");
 
         placementDriver.setPrimary(node0.clusterService.topologyService().localMember());
+        // The exception for default zone: the zone initially will hadnle pending assignments equals to 0th node and while it's a primary
+        // colocated node, then primary-related requests will work correctly.
+        placementDriver.setDefaultZonePrimary(node0.clusterService.topologyService().localMember());
 
         nodes.values().forEach(Node::waitWatches);
 
@@ -514,6 +517,10 @@ public class ItReplicaLifecycleTest extends IgniteAbstractTest {
     }
 
     @Test
+    // Test is disabled because there is a possible race between a primary replica stopping process because of AFTER_REPLICA_DESTROYED and
+    // the primary replica weak stopping and peers set update in TableManager due to assignments stable switch if the primary colocated node
+    // is became outside of the stable assignments. It will be fixed if true PlacementDriver with replicas messaging will be used.
+    @Disabled("https://issues.apache.org/jira/browse/IGNITE-24374")
     void testTableReplicaListenersRemoveAfterRebalance(TestInfo testInfo) throws Exception {
         String zoneName = "TEST_ZONE";
         String tableName = "TEST_TABLE";

--- a/modules/partition-replicator/src/integrationTest/java/org/apache/ignite/internal/partition/replicator/fixtures/Node.java
+++ b/modules/partition-replicator/src/integrationTest/java/org/apache/ignite/internal/partition/replicator/fixtures/Node.java
@@ -601,6 +601,7 @@ public class Node {
         partitionReplicaLifecycleManager = new PartitionReplicaLifecycleManager(
                 catalogManager,
                 replicaManager,
+                replicaSvc,
                 distributionZoneManager,
                 metaStorageManager,
                 clusterService.topologyService(),

--- a/modules/partition-replicator/src/main/java/org/apache/ignite/internal/partition/replicator/ZonePartitionReplicaListener.java
+++ b/modules/partition-replicator/src/main/java/org/apache/ignite/internal/partition/replicator/ZonePartitionReplicaListener.java
@@ -18,23 +18,44 @@
 package org.apache.ignite.internal.partition.replicator;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+import static org.apache.ignite.internal.partitiondistribution.Assignments.fromBytes;
+import static org.apache.ignite.internal.raft.PeersAndLearners.fromAssignments;
+import static org.apache.ignite.internal.util.CompletableFutures.nullCompletedFuture;
+import static org.apache.ignite.internal.util.ExceptionUtils.unwrapCause;
+import static org.apache.ignite.lang.ErrorGroups.Common.INTERNAL_ERR;
 
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import org.apache.ignite.internal.catalog.CatalogService;
 import org.apache.ignite.internal.hlc.ClockService;
+import org.apache.ignite.internal.hlc.HybridTimestamp;
+import org.apache.ignite.internal.lang.IgniteBiTuple;
+import org.apache.ignite.internal.lang.IgniteInternalException;
 import org.apache.ignite.internal.logger.IgniteLogger;
 import org.apache.ignite.internal.logger.Loggers;
+import org.apache.ignite.internal.partition.replicator.network.replication.ChangePeersAndLearnersAsyncReplicaRequest;
+import org.apache.ignite.internal.partition.replicator.network.replication.ReadOnlyReplicaRequest;
 import org.apache.ignite.internal.partition.replicator.schema.ValidationSchemasSource;
+import org.apache.ignite.internal.partitiondistribution.Assignments;
+import org.apache.ignite.internal.placementdriver.PlacementDriver;
+import org.apache.ignite.internal.placementdriver.ReplicaMeta;
+import org.apache.ignite.internal.raft.ExecutorInclinedRaftCommandRunner;
+import org.apache.ignite.internal.raft.PeersAndLearners;
+import org.apache.ignite.internal.raft.service.LeaderWithTerm;
 import org.apache.ignite.internal.raft.service.RaftCommandRunner;
+import org.apache.ignite.internal.raft.service.RaftGroupService;
 import org.apache.ignite.internal.replicator.ReplicaResult;
 import org.apache.ignite.internal.replicator.ReplicationGroupId;
 import org.apache.ignite.internal.replicator.TablePartitionId;
 import org.apache.ignite.internal.replicator.ZonePartitionId;
+import org.apache.ignite.internal.replicator.exception.PrimaryReplicaMissException;
 import org.apache.ignite.internal.replicator.listener.ReplicaListener;
+import org.apache.ignite.internal.replicator.message.PrimaryReplicaRequest;
 import org.apache.ignite.internal.replicator.message.ReplicaRequest;
 import org.apache.ignite.internal.replicator.message.ReplicaSafeTimeSyncRequest;
 import org.apache.ignite.internal.replicator.message.TableAware;
@@ -42,6 +63,8 @@ import org.apache.ignite.internal.schema.SchemaSyncService;
 import org.apache.ignite.internal.tx.TxManager;
 import org.apache.ignite.internal.tx.message.TxFinishReplicaRequest;
 import org.apache.ignite.internal.tx.storage.state.TxStatePartitionStorage;
+import org.apache.ignite.network.ClusterNode;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
 /**
@@ -53,26 +76,51 @@ public class ZonePartitionReplicaListener implements ReplicaListener {
     // TODO: https://issues.apache.org/jira/browse/IGNITE-22624 await for the table replica listener if needed.
     private final Map<TablePartitionId, ReplicaListener> replicas = new ConcurrentHashMap<>();
 
-    private final RaftCommandRunner raftClient;
+    private final PlacementDriver placementDriver;
+
+    /** Instance of the local node. */
+    private final ClusterNode localNode;
+
+    /** Clock service. */
+    private final ClockService clockService;
+
+    private final RaftCommandRunner raftCommandRunner;
+
+    private final ZonePartitionId zoneReplicationGroupId;
 
     private final TxFinishReplicaRequestHandler txFinishReplicaRequestHandler;
 
     /**
      * The constructor.
      *
+     * @param txStatePartitionStorage Storage for transactions' states.
+     * @param placementDriver A component that provides primary replicas for a replication group.
+     * @param localNode An object that describe the local node in cluster context.
+     * @param clockService A component that provides hybrid Lamport's timestamp clocks.
+     * @param txManager Manager of transactions.
+     * @param validationSchemasSource Validator of tables' schemas.
+     * @param schemaSyncService Schema service for tables' metadata completeness checks.
+     * @param catalogService Service that provides zones' and tables' descriptors.
      * @param raftClient Raft client.
+     * @param zoneReplicationGroupId Identifier of the corresponding zone's replication group.
      */
     public ZonePartitionReplicaListener(
             TxStatePartitionStorage txStatePartitionStorage,
+            PlacementDriver placementDriver,
+            ClusterNode localNode,
             ClockService clockService,
             TxManager txManager,
             ValidationSchemasSource validationSchemasSource,
             SchemaSyncService schemaSyncService,
             CatalogService catalogService,
             RaftCommandRunner raftClient,
-            ZonePartitionId replicationGroupId
+            ZonePartitionId zoneReplicationGroupId
     ) {
-        this.raftClient = raftClient;
+        this.placementDriver = placementDriver;
+        this.localNode = localNode;
+        this.clockService = clockService;
+        this.raftCommandRunner = raftClient;
+        this.zoneReplicationGroupId = zoneReplicationGroupId;
 
         txFinishReplicaRequestHandler = new TxFinishReplicaRequestHandler(
                 txStatePartitionStorage,
@@ -82,23 +130,115 @@ public class ZonePartitionReplicaListener implements ReplicaListener {
                 schemaSyncService,
                 catalogService,
                 raftClient,
-                replicationGroupId
+                zoneReplicationGroupId
         );
     }
 
     @Override
     public CompletableFuture<ReplicaResult> invoke(ReplicaRequest request, UUID senderId) {
+        return ensureReplicaIsPrimary(request)
+                .thenCompose(res -> processRequest(request, res.get1(), senderId, res.get2()))
+                .thenApply(res -> {
+                    if (res instanceof ReplicaResult) {
+                        return (ReplicaResult) res;
+                    } else {
+                        return new ReplicaResult(res, null);
+                    }
+                });
+    }
+
+    /**
+     * Ensure that the primary replica was not changed.
+     *
+     * @param request Replica request.
+     * @return Future with {@link IgniteBiTuple} containing {@code boolean} (whether the replica is primary) and the start time of current
+     *     lease. The boolean is not {@code null} only for {@link ReadOnlyReplicaRequest}. If {@code true}, then replica is primary. The
+     *     lease start time is not {@code null} in case of {@link PrimaryReplicaRequest}.
+     */
+    private CompletableFuture<IgniteBiTuple<Boolean, Long>> ensureReplicaIsPrimary(ReplicaRequest request) {
+        HybridTimestamp current = clockService.current();
+
+        if (request instanceof PrimaryReplicaRequest) {
+            Long enlistmentConsistencyToken = ((PrimaryReplicaRequest) request).enlistmentConsistencyToken();
+
+            Function<ReplicaMeta, IgniteBiTuple<Boolean, Long>> validateClo = primaryReplicaMeta -> {
+                if (primaryReplicaMeta == null) {
+                    throw new PrimaryReplicaMissException(
+                            localNode.name(),
+                            null,
+                            localNode.id(),
+                            null,
+                            enlistmentConsistencyToken,
+                            null,
+                            null
+                    );
+                }
+
+                long currentEnlistmentConsistencyToken = primaryReplicaMeta.getStartTime().longValue();
+
+                if (enlistmentConsistencyToken != currentEnlistmentConsistencyToken
+                        || clockService.before(primaryReplicaMeta.getExpirationTime(), current)
+                        || !isLocalPeer(primaryReplicaMeta.getLeaseholderId())
+                ) {
+                    throw new PrimaryReplicaMissException(
+                            localNode.name(),
+                            primaryReplicaMeta.getLeaseholder(),
+                            localNode.id(),
+                            primaryReplicaMeta.getLeaseholderId(),
+                            enlistmentConsistencyToken,
+                            currentEnlistmentConsistencyToken,
+                            null);
+                }
+
+                return new IgniteBiTuple<>(null, primaryReplicaMeta.getStartTime().longValue());
+            };
+
+            ReplicaMeta meta = placementDriver.getCurrentPrimaryReplica(zoneReplicationGroupId, current);
+
+            if (meta != null) {
+                try {
+                    return completedFuture(validateClo.apply(meta));
+                } catch (Exception e) {
+                    return failedFuture(e);
+                }
+            }
+
+            return placementDriver.getPrimaryReplica(zoneReplicationGroupId, current).thenApply(validateClo);
+        } else if (request instanceof ReadOnlyReplicaRequest) {
+            return isLocalNodePrimaryReplicaAt(current);
+        } else if (request instanceof ReplicaSafeTimeSyncRequest) {
+            return isLocalNodePrimaryReplicaAt(current);
+        } else {
+            return completedFuture(new IgniteBiTuple<>(null, null));
+        }
+    }
+
+
+    private CompletableFuture<IgniteBiTuple<Boolean, Long>> isLocalNodePrimaryReplicaAt(HybridTimestamp timestamp) {
+        return placementDriver.getPrimaryReplica(zoneReplicationGroupId, timestamp)
+                .thenApply(primaryReplica -> new IgniteBiTuple<>(
+                        primaryReplica != null && isLocalPeer(primaryReplica.getLeaseholderId()),
+                        null
+                ));
+    }
+
+    private CompletableFuture<?> processRequest(
+            ReplicaRequest request,
+            @Nullable Boolean isPrimary,
+            UUID senderId,
+            @Nullable Long leaseStartTime
+    ) {
         if (!(request instanceof TableAware)) {
             // TODO: https://issues.apache.org/jira/browse/IGNITE-22620 implement ReplicaSafeTimeSyncRequest processing.
             if (request instanceof TxFinishReplicaRequest) {
                 return txFinishReplicaRequestHandler.handle((TxFinishReplicaRequest) request)
                         .thenApply(res -> new ReplicaResult(res, null));
+            } else if (request instanceof ChangePeersAndLearnersAsyncReplicaRequest) {
+                return processChangePeersAndLearnersReplicaRequest((ChangePeersAndLearnersAsyncReplicaRequest) request);
+            } else if (request instanceof ReplicaSafeTimeSyncRequest) {
+                LOG.debug("Non table request is not supported by the zone partition yet " + request);
             } else {
-                if (request instanceof ReplicaSafeTimeSyncRequest) {
-                    LOG.debug("Non table request is not supported by the zone partition yet " + request);
-                } else {
-                    LOG.warn("Non table request is not supported by the zone partition yet " + request);
-                }
+                LOG.warn("Non table request is not supported by the zone partition yet " + request);
             }
 
             return completedFuture(new ReplicaResult(null, null));
@@ -122,9 +262,75 @@ public class ZonePartitionReplicaListener implements ReplicaListener {
         }
     }
 
+    private CompletableFuture<Void> processChangePeersAndLearnersReplicaRequest(ChangePeersAndLearnersAsyncReplicaRequest request) {
+        ZonePartitionId replicaGrpId = (ZonePartitionId) request.groupId().asReplicationGroupId();
+
+        RaftGroupService raftClient = raftCommandRunner instanceof RaftGroupService
+                ? (RaftGroupService) raftCommandRunner
+                : ((RaftGroupService) ((ExecutorInclinedRaftCommandRunner) raftCommandRunner).decoratedCommandRunner());
+
+        return raftClient.refreshAndGetLeaderWithTerm()
+                .exceptionally(throwable -> {
+                    throwable = unwrapCause(throwable);
+
+                    if (throwable instanceof TimeoutException) {
+                        LOG.info(
+                                "Node couldn't get the leader within timeout so the changing peers is skipped [grp={}].",
+                                replicaGrpId
+                        );
+
+                        return LeaderWithTerm.NO_LEADER;
+                    }
+
+                    throw new IgniteInternalException(
+                            INTERNAL_ERR,
+                            "Failed to get a leader for the RAFT replication group [get=" + replicaGrpId + "].",
+                            throwable
+                    );
+                })
+                .thenCompose(leaderWithTerm -> {
+                    if (leaderWithTerm.isEmpty() || !isTokenStillValidPrimary(request.enlistmentConsistencyToken())) {
+                        return nullCompletedFuture();
+                    }
+
+                    // run update of raft configuration if this node is a leader
+                    LOG.debug("Current node={} is the leader of partition raft group={}. "
+                                    + "Initiate rebalance process for zone={}, partition={}",
+                            leaderWithTerm.leader(),
+                            replicaGrpId,
+                            replicaGrpId.zoneId(),
+                            replicaGrpId.partitionId()
+                    );
+
+                    return raftClient.changePeersAndLearnersAsync(peersConfigurationFromMessage(request), leaderWithTerm.term());
+                });
+    }
+
+    private boolean isTokenStillValidPrimary(long suspectedEnlistmentConsistencyToken) {
+        HybridTimestamp currentTime = clockService.current();
+
+        ReplicaMeta meta = placementDriver.getCurrentPrimaryReplica(zoneReplicationGroupId, currentTime);
+
+        return meta != null
+                && isLocalPeer(meta.getLeaseholderId())
+                && clockService.before(currentTime, meta.getExpirationTime())
+                && suspectedEnlistmentConsistencyToken == meta.getStartTime().longValue();
+    }
+
+    private boolean isLocalPeer(UUID nodeId) {
+        return localNode.id().equals(nodeId);
+    }
+
+
+    private static PeersAndLearners peersConfigurationFromMessage(ChangePeersAndLearnersAsyncReplicaRequest request) {
+        Assignments pendingAssignments = fromBytes(request.pendingAssignments());
+
+        return fromAssignments(pendingAssignments.nodes());
+    }
+
     @Override
     public RaftCommandRunner raftClient() {
-        return raftClient;
+        return raftCommandRunner;
     }
 
     /**
@@ -134,7 +340,7 @@ public class ZonePartitionReplicaListener implements ReplicaListener {
      * @param replicaListener Table replica listener.
      */
     public void addTableReplicaListener(TablePartitionId partitionId, Function<RaftCommandRunner, ReplicaListener> replicaListener) {
-        replicas.put(partitionId, replicaListener.apply(raftClient));
+        replicas.put(partitionId, replicaListener.apply(raftCommandRunner));
     }
 
     /**

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItIgniteNodeRestartTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/ItIgniteNodeRestartTest.java
@@ -757,6 +757,7 @@ public class ItIgniteNodeRestartTest extends BaseIgniteRestartTest {
                 new PartitionReplicaLifecycleManager(
                         catalogManager,
                         replicaMgr,
+                        replicaService,
                         distributionZoneManager,
                         metaStorageMgr,
                         clusterSvc.topologyService(),

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
@@ -1014,6 +1014,7 @@ public class IgniteImpl implements Ignite {
         partitionReplicaLifecycleManager = new PartitionReplicaLifecycleManager(
                 catalogManager,
                 replicaMgr,
+                replicaSvc,
                 distributionZoneManager,
                 metaStorageMgr,
                 clusterSvc.topologyService(),

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/TableManagerRecoveryTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/TableManagerRecoveryTest.java
@@ -384,6 +384,7 @@ public class TableManagerRecoveryTest extends IgniteAbstractTest {
                 new PartitionReplicaLifecycleManager(
                         catalogManager,
                         replicaMgr,
+                        null, // pass null there as TableManager
                         distributionZoneManager,
                         metaStorageManager,
                         topologyService,


### PR DESCRIPTION
JIRA Ticket: [IGNITE-24354](https://issues.apache.org/jira/browse/IGNITE-24354)

## The goal

The goal is to copy `ChangePeersAndLearnersAsyncReplicaRequest` logic from `TableManager` to `PartitionReplicaLifecycleManager` and from `PartitionReplicaListener` to `ZonePartitionReplicaListener`.

## The reason

During the colocation track we demand to move assignments logic from tables to zones so the rebalance process and the corresponding configuration change `ChangePeersAndLearnersAsyncReplicaRequest` request sending.

## The solution

The solution is straightforward to move the corresponding request sending and handling. The most issued place is default zone tests, but the solution is to set as a primary replica for default zone 0th node on the init, so the first assignments will be equal to 0th node and it will contains a started replica that is required for the request sending.