### PR TITLE
IGNITE-24318 Unify Tuple and SqlRow string representation

### DIFF
--- a/modules/api/src/main/java/org/apache/ignite/table/TupleImpl.java
+++ b/modules/api/src/main/java/org/apache/ignite/table/TupleImpl.java
@@ -399,12 +399,12 @@ class TupleImpl implements Tuple, Serializable {
         // Keep the same as IgniteToStringBuilder.toString().
         StringBuilder b = new StringBuilder();
 
-        b.append(Tuple.class.getSimpleName()).append(" [");
-        for (int i = 0; i < colNames.size(); i++) {
+        b.append(getClass().getSimpleName()).append(" [");
+        for (int i = 0; i < columnCount(); i++) {
             if (i > 0) {
                 b.append(", ");
             }
-            b.append(colNames.get(i)).append('=').append(colValues.get(i));
+            b.append(columnName(i)).append('=').append((Object) value(i));
         }
         b.append(']');
 

--- a/modules/api/src/main/java/org/apache/ignite/table/TupleImpl.java
+++ b/modules/api/src/main/java/org/apache/ignite/table/TupleImpl.java
@@ -396,6 +396,7 @@ class TupleImpl implements Tuple, Serializable {
     /** {@inheritDoc} */
     @Override
     public String toString() {
+        // Keep the same as IgniteToStringBuilder.toString().
         StringBuilder b = new StringBuilder();
 
         b.append(Tuple.class.getSimpleName()).append(" [");

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/table/MutableTupleBinaryTupleAdapter.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/table/MutableTupleBinaryTupleAdapter.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.UUID;
 import org.apache.ignite.internal.binarytuple.BinaryTupleContainer;
 import org.apache.ignite.internal.binarytuple.BinaryTupleReader;
+import org.apache.ignite.internal.tostring.S;
 import org.apache.ignite.lang.util.IgniteNameUtils;
 import org.apache.ignite.sql.ColumnType;
 import org.apache.ignite.table.Tuple;
@@ -548,5 +549,10 @@ public abstract class MutableTupleBinaryTupleAdapter implements Tuple, BinaryTup
             default:
                 throw new IllegalStateException("Unsupported type: " + type);
         }
+    }
+
+    @Override
+    public String toString() {
+        return S.tupleToString(this);
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientSqlRow.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientSqlRow.java
@@ -99,4 +99,21 @@ public class ClientSqlRow extends MutableTupleBinaryTupleAdapter implements SqlR
     public ResultSetMetadata metadata() {
         return metadata;
     }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        StringBuilder b = new StringBuilder();
+
+        b.append(SqlRow.class.getSimpleName()).append(" [");
+        for (int i = 0; i < columnCount(); i++) {
+            if (i > 0) {
+                b.append(", ");
+            }
+            b.append(columnName(i)).append('=').append((Object) value(i));
+        }
+        b.append(']');
+
+        return b.toString();
+    }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientSqlRow.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientSqlRow.java
@@ -27,7 +27,7 @@ import org.apache.ignite.table.Tuple;
 /**
  * Client SQL row.
  */
-public class ClientSqlRow extends MutableTupleBinaryTupleAdapter implements SqlRow {
+class ClientSqlRow extends MutableTupleBinaryTupleAdapter implements SqlRow {
     /** Meta. */
     private final ResultSetMetadata metadata;
 
@@ -98,22 +98,5 @@ public class ClientSqlRow extends MutableTupleBinaryTupleAdapter implements SqlR
     @Override
     public ResultSetMetadata metadata() {
         return metadata;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public String toString() {
-        StringBuilder b = new StringBuilder();
-
-        b.append(SqlRow.class.getSimpleName()).append(" [");
-        for (int i = 0; i < columnCount(); i++) {
-            if (i > 0) {
-                b.append(", ");
-            }
-            b.append(columnName(i)).append('=').append((Object) value(i));
-        }
-        b.append(']');
-
-        return b.toString();
     }
 }

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientTupleTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientTupleTest.java
@@ -303,7 +303,7 @@ public class ClientTupleTest extends AbstractMutableTupleTest {
         // Before mutation.
         assertEquals(
                 "ClientTuple [I8=1, \"i16\"=2, I32=3, \"i64\"=4, FLOAT=5.5, DOUBLE=6.6, "
-                        + "UUID=" + UUID_VALUE + ", STR=\uD83D\uDD25 Ignite, DATE=2025-02-20, "
+                        + "UUID=" + UUID_VALUE + ", STR=" + STRING_VALUE + ", DATE=" + DATE_VALUE + ", "
                         + "TIME=" + TIME_VALUE + ", DATETIME=" + DATETIME_VALUE + ", "
                         + "TIMESTAMP=" + TIMESTAMP_VALUE + ", BOOL=true, DECIMAL=1.234, "
                         + "BYTES=, PERIOD=P16D, DURATION=PT408H]",
@@ -314,7 +314,7 @@ public class ClientTupleTest extends AbstractMutableTupleTest {
 
         assertEquals(
                 "ClientTuple [I8=2, \"i16\"=2, I32=3, \"i64\"=4, FLOAT=5.5, DOUBLE=6.6, "
-                        + "UUID=" + UUID_VALUE + ", STR=\uD83D\uDD25 Ignite, DATE=2025-02-20, "
+                        + "UUID=" + UUID_VALUE + ", STR=" + STRING_VALUE + ", DATE=" + DATE_VALUE + ", "
                         + "TIME=" + TIME_VALUE + ", DATETIME=" + DATETIME_VALUE + ", "
                         + "TIMESTAMP=" + TIMESTAMP_VALUE + ", BOOL=true, DECIMAL=1.234, "
                         + "BYTES=null, PERIOD=P16D, DURATION=PT408H]",

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientTupleTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientTupleTest.java
@@ -295,6 +295,32 @@ public class ClientTupleTest extends AbstractMutableTupleTest {
         assertThrows(IllegalArgumentException.class, () -> valTupleWithFullRow.byteValue("\"STR\""), "Column doesn't exist [name=\"STR\"]");
     }
 
+    @SuppressWarnings("DynamicRegexReplaceableByCompiledPattern")
+    @Test
+    public void testToString() {
+        Tuple tuple = getTupleWithColumnOfAllTypes();
+
+        // Before mutation.
+        assertEquals(
+                "ClientTuple [I8=1, \"i16\"=2, I32=3, \"i64\"=4, FLOAT=5.5, DOUBLE=6.6, "
+                        + "UUID=" + UUID_VALUE + ", STR=\uD83D\uDD25 Ignite, DATE=2025-02-20, "
+                        + "TIME=" + TIME_VALUE + ", DATETIME=" + DATETIME_VALUE + ", "
+                        + "TIMESTAMP=" + TIMESTAMP_VALUE + ", BOOL=true, DECIMAL=1.234, "
+                        + "BYTES=, PERIOD=P16D, DURATION=PT408H]",
+                tuple.toString().replaceAll("\\[B@\\w+", ""));
+
+        // After mutation (different impl).
+        tuple.set("I8", 2).set("BYTES", null);
+
+        assertEquals(
+                "ClientTuple [I8=2, \"i16\"=2, I32=3, \"i64\"=4, FLOAT=5.5, DOUBLE=6.6, "
+                        + "UUID=" + UUID_VALUE + ", STR=\uD83D\uDD25 Ignite, DATE=2025-02-20, "
+                        + "TIME=" + TIME_VALUE + ", DATETIME=" + DATETIME_VALUE + ", "
+                        + "TIMESTAMP=" + TIMESTAMP_VALUE + ", BOOL=true, DECIMAL=1.234, "
+                        + "BYTES=null, PERIOD=P16D, DURATION=PT408H]",
+                tuple.toString());
+    }
+
     @Override
     protected Tuple createTuple(Function<Tuple, Tuple> transformer) {
         return transformer.apply(getTuple());

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientTupleTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientTupleTest.java
@@ -321,6 +321,16 @@ public class ClientTupleTest extends AbstractMutableTupleTest {
                 tuple.toString());
     }
 
+    @Test
+    public void testToStringMatchesTupleImpl() {
+        Tuple clientTuple = getTuple();
+        Tuple tupleImpl = Tuple.copy(clientTuple);
+
+        assertEquals(
+                tupleImpl.toString().replace("TupleImpl ", ""),
+                clientTuple.toString().replace("ClientTuple ", ""));
+    }
+
     @Override
     protected Tuple createTuple(Function<Tuple, Tuple> transformer) {
         return transformer.apply(getTuple());

--- a/modules/core/src/main/java/org/apache/ignite/internal/tostring/IgniteToStringBuilder.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/tostring/IgniteToStringBuilder.java
@@ -54,7 +54,6 @@ import org.apache.ignite.internal.lang.IgniteInternalException;
 import org.apache.ignite.internal.lang.IgniteStringBuilder;
 import org.apache.ignite.internal.lang.IgniteSystemProperties;
 import org.apache.ignite.internal.lang.IgniteTriConsumer;
-import org.apache.ignite.sql.SqlRow;
 import org.apache.ignite.table.Tuple;
 import org.jetbrains.annotations.Nullable;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/tostring/IgniteToStringBuilder.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/tostring/IgniteToStringBuilder.java
@@ -54,6 +54,8 @@ import org.apache.ignite.internal.lang.IgniteInternalException;
 import org.apache.ignite.internal.lang.IgniteStringBuilder;
 import org.apache.ignite.internal.lang.IgniteSystemProperties;
 import org.apache.ignite.internal.lang.IgniteTriConsumer;
+import org.apache.ignite.sql.SqlRow;
+import org.apache.ignite.table.Tuple;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -2212,6 +2214,28 @@ public class IgniteToStringBuilder {
                 ref.pos = pos + hashLen;
             }
         }
+    }
+
+    /**
+     * Converts Tuple to string representation.
+     *
+     * @param tuple Tuple.
+     * @return String.
+     */
+    public static String tupleToString(Tuple tuple) {
+        // Keep the same as TupleImpl.toString().
+        StringBuilder b = new StringBuilder();
+
+        b.append(tuple.getClass().getSimpleName()).append(" [");
+        for (int i = 0; i < tuple.columnCount(); i++) {
+            if (i > 0) {
+                b.append(", ");
+            }
+            b.append(tuple.columnName(i)).append('=').append((Object) tuple.value(i));
+        }
+        b.append(']');
+
+        return b.toString();
     }
 
     /**

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSqlTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSqlTest.java
@@ -521,6 +521,17 @@ public class ItThinClientSqlTest extends ItAbstractThinClientTest {
         assertThat(e.getMessage(), Matchers.containsString("Division by zero"));
     }
 
+    @Test
+    public void testClientSqlRowToString() {
+        AsyncResultSet<SqlRow> resultSet = client().sql()
+                .executeAsync(null, "select 1 as num, 'hello' as str")
+                .join();
+
+        SqlRow row = resultSet.currentPage().iterator().next();
+
+        assertEquals("ClientSqlRow [NUM=1, STR=hello]", row.toString());
+    }
+
     private static class Pojo {
         public int num;
 

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlApiBaseTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlApiBaseTest.java
@@ -1201,6 +1201,13 @@ public abstract class ItSqlApiBaseTest extends BaseSqlIntegrationTest {
         }
     }
 
+    @Test
+    public void rowToString() {
+        SqlRow row = executeForRead(igniteSql(), "SELECT 1 as COL_A, '2' as COL_B").next();
+
+        assertEquals("SqlRowImpl [COL_A=1, COL_B=2]", row.toString());
+    }
+
     protected ResultSet<SqlRow> executeForRead(IgniteSql sql, String query, Object... args) {
         return executeForRead(sql, null, query, args);
     }

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlApiBaseTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlApiBaseTest.java
@@ -1205,7 +1205,7 @@ public abstract class ItSqlApiBaseTest extends BaseSqlIntegrationTest {
     public void rowToString() {
         SqlRow row = executeForRead(igniteSql(), "SELECT 1 as COL_A, '2' as COL_B").next();
 
-        assertEquals("SqlRowImpl [COL_A=1, COL_B=2]", row.toString());
+        assertEquals(row.getClass().getSimpleName() + " [COL_A=1, COL_B=2]", row.toString());
     }
 
     protected ResultSet<SqlRow> executeForRead(IgniteSql sql, String query, Object... args) {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/api/AsyncResultSetImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/api/AsyncResultSetImpl.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.internal.sql.engine.AsyncSqlCursor;
 import org.apache.ignite.internal.sql.engine.InternalSqlRow;
 import org.apache.ignite.internal.sql.engine.SqlQueryType;
+import org.apache.ignite.internal.tostring.S;
 import org.apache.ignite.internal.util.AsyncCursor.BatchedResult;
 import org.apache.ignite.internal.util.TransformingIterator;
 import org.apache.ignite.sql.NoRowSetExpectedException;
@@ -396,9 +397,10 @@ public class AsyncResultSetImpl<T> implements AsyncResultSet<T> {
             return meta;
         }
 
+        /** {@inheritDoc} */
         @Override
         public String toString() {
-            return "Row " + row;
+            return S.tupleToString(this);
         }
     }
 }


### PR DESCRIPTION
Ensure consistent `toString` for `Tuple` and `SqlRow` (`extends Tuple`).