### PR TITLE
IGNITE-24560 Sql. Result of script parsing with single statement is cached incorrectly

### DIFF
--- a/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/commands/sql/ItSqlCommandTest.java
+++ b/modules/cli/src/integrationTest/java/org/apache/ignite/internal/cli/commands/sql/ItSqlCommandTest.java
@@ -53,6 +53,27 @@ class ItSqlCommandTest extends CliSqlCommandTestBase {
     }
 
     @Test
+    @DisplayName("Should execute sequence of statements without error")
+    void createSelectAlterSelect() {
+        String[] statements = {
+                "CREATE TABLE test(id INT PRIMARY KEY, val1 INT, val2 INT)",
+                "SELECT * FROM test",
+                "ALTER TABLE test DROP COLUMN val2",
+                "SELECT * FROM test",
+        };
+
+        for (String statement : statements) {
+            execute("sql", statement, "--jdbc-url", JDBC_URL);
+
+            assertAll(
+                    this::assertExitCodeIsZero,
+                    this::assertOutputIsNotEmpty,
+                    this::assertErrOutputIsEmpty
+            );
+        }
+    }
+
+    @Test
     @DisplayName("Should display readable error when wrong jdbc is given")
     void wrongJdbcUrl() {
         execute("sql", "select * from person", "--jdbc-url", "jdbc:ignite:thin://no-such-host.com:10800");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-24560

----------
Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)