### PR TITLE
IGNITE-24612 .NET: Fix streamer schema update

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/DataStreamerTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/DataStreamerTests.cs
@@ -407,7 +407,7 @@ public class DataStreamerTests : IgniteTestsBase
     [Test]
     public async Task TestManyItemsWithDisconnectAndRetry([Values(true, false)] bool withReceiver)
     {
-        const int count = 100_000;
+        const int count = 10_000;
         int upsertIdx = 0;
 
         using var server = new FakeServer(

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/DataStreamerTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/DataStreamerTests.cs
@@ -407,7 +407,7 @@ public class DataStreamerTests : IgniteTestsBase
     [Test]
     public async Task TestManyItemsWithDisconnectAndRetry([Values(true, false)] bool withReceiver)
     {
-        const int count = 10_000;
+        const int count = 100_000;
         int upsertIdx = 0;
 
         using var server = new FakeServer(

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/SchemaSynchronizationTest.cs
@@ -344,14 +344,15 @@ public class SchemaSynchronizationTest : IgniteTestsBase
     [SuppressMessage("ReSharper", "AccessToDisposedClosure", Justification = "Reviewed")]
     public async Task TestSchemaUpdateWhileStreaming(
         [Values(true, false)] bool insertNewColumn,
-        [Values(true, false)] bool withRemove)
+        [Values(true, false)] bool withRemove,
+        [Values(1, 2, 10)] int pageSize)
     {
         await Client.Sql.ExecuteAsync(null, $"CREATE TABLE {TestTableName} (KEY bigint PRIMARY KEY)");
 
         var table = await Client.Tables.GetTableAsync(TestTableName);
         var view = table!.RecordBinaryView;
 
-        var options = DataStreamerOptions.Default with { PageSize = 2 };
+        var options = DataStreamerOptions.Default with { PageSize = pageSize };
         await view.StreamDataAsync(GetData(), options);
 
         // Inserted with old schema.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
@@ -318,6 +318,7 @@ internal static class DataStreamer
                         if (schemaVersion is { })
                         {
                             // Serialize again with the new schema.
+                            // TODO: Update global schema atomically.
                             schema0 = await table.GetSchemaAsync(schemaVersion).ConfigureAwait(false);
                             ReWriteBatch(buf, partitionId, schema0, items.AsSpan(0, count), writer);
                         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
@@ -283,7 +283,7 @@ internal static class DataStreamer
 
                 FinalizeBatchHeader(batch);
                 batch.Task = SendAndDisposeBufAsync(
-                    batch.Buffer, batch.PartitionId, batch.Task, batch.Items, batch.Count, batch.SchemaOutdated);
+                    batch.Buffer, batch.PartitionId, batch.Task, batch.Items, batch.Count, batch.SchemaOutdated, batch.Schema.Version);
 
                 batch.Items = GetPool<T>().Rent(options.PageSize);
                 batch.Count = 0;
@@ -303,12 +303,13 @@ internal static class DataStreamer
             Task oldTask,
             DataStreamerItem<T>[] items,
             int count,
-            bool batchSchemaOutdated)
+            bool batchSchemaOutdated,
+            int batchSchemaVer)
         {
             Debug.Assert(items.Length > 0, "items.Length > 0");
             var schema0 = schema;
 
-            if (batchSchemaOutdated)
+            if (batchSchemaOutdated || batchSchemaVer < schema0.Version)
             {
                 // Schema update was detected while the batch was being filled.
                 // Re-serialize the whole batch.

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
@@ -327,6 +327,9 @@ internal static class DataStreamer
                                 schema = await table.GetSchemaAsync(schemaVersion).ConfigureAwait(false);
                             }
 
+                            // Always rewrite.
+                            ReWriteBatch(buf, partitionId, schema, items.AsSpan(0, count), writer);
+
                             // Serialize again with the new schema.
                             ReWriteBatch(buf, partitionId, schema, items.AsSpan(0, count), writer);
                         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
@@ -282,11 +282,11 @@ internal static class DataStreamer
 
                 batch.Items = GetPool<T>().Rent(options.PageSize);
                 batch.Count = 0;
-                batch.Buffer = ProtoCommon.GetMessageWriter(); // Prev buf will be disposed in SendAndDisposeBufAsync.
-                InitBuffer(batch, schema);
-                batch.LastFlush = Stopwatch.GetTimestamp();
                 batch.Schema = schema;
                 batch.SchemaOutdated = false;
+                batch.Buffer = ProtoCommon.GetMessageWriter(); // Prev buf will be disposed in SendAndDisposeBufAsync.
+                InitBuffer(batch, batch.Schema);
+                batch.LastFlush = Stopwatch.GetTimestamp();
 
                 Metrics.StreamerBatchesActiveIncrement();
             }
@@ -324,6 +324,7 @@ internal static class DataStreamer
                             // Might be updated by another batch.
                             if (schema.Version != schemaVersion)
                             {
+                                // TODO: Race condition?
                                 schema = await table.GetSchemaAsync(schemaVersion).ConfigureAwait(false);
                             }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
@@ -335,8 +335,6 @@ internal static class DataStreamer
                         // Wait for the previous batch for this node to preserve item order.
                         await oldTask.ConfigureAwait(false);
 
-                        // Always rewrite before send.
-                        ReWriteBatch(buf, partitionId, schema, items.AsSpan(0, count), writer);
                         await SendBatchAsync(table, buf, count, preferredNode, retryPolicy).ConfigureAwait(false);
 
                         return;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
@@ -400,7 +400,7 @@ internal static class DataStreamer
 
             try
             {
-                if (schema.Version >= ver)
+                if (ver != Table.SchemaVersionForceLatest && schema.Version >= ver)
                 {
                     return schema;
                 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
@@ -306,21 +306,21 @@ internal static class DataStreamer
             bool batchSchemaOutdated,
             int batchSchemaVer)
         {
-            Debug.Assert(items.Length > 0, "items.Length > 0");
-            var schema0 = schema;
-
-            if (batchSchemaOutdated || batchSchemaVer < schema0.Version)
-            {
-                // Schema update was detected while the batch was being filled.
-                // Re-serialize the whole batch.
-                ReWriteBatch(buf, partitionId, schema0, items.AsSpan(0, count), writer);
-            }
-
-            // ReSharper disable once AccessToModifiedClosure
-            var preferredNode = PreferredNode.FromName(partitionAssignment[partitionId] ?? string.Empty);
-
             try
             {
+                Debug.Assert(items.Length > 0, "items.Length > 0");
+                var schema0 = schema;
+
+                if (batchSchemaOutdated || batchSchemaVer < schema0.Version)
+                {
+                    // Schema update was detected while the batch was being filled.
+                    // Re-serialize the whole batch.
+                    ReWriteBatch(buf, partitionId, schema0, items.AsSpan(0, count), writer);
+                }
+
+                // ReSharper disable once AccessToModifiedClosure
+                var preferredNode = PreferredNode.FromName(partitionAssignment[partitionId] ?? string.Empty);
+
                 int? schemaVersion = null;
                 while (true)
                 {

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
@@ -327,15 +327,15 @@ internal static class DataStreamer
                                 schema = await table.GetSchemaAsync(schemaVersion).ConfigureAwait(false);
                             }
 
-                            // Always rewrite.
-                            ReWriteBatch(buf, partitionId, schema, items.AsSpan(0, count), writer);
-
                             // Serialize again with the new schema.
                             ReWriteBatch(buf, partitionId, schema, items.AsSpan(0, count), writer);
                         }
 
                         // Wait for the previous batch for this node to preserve item order.
                         await oldTask.ConfigureAwait(false);
+
+                        // Always rewrite before send.
+                        ReWriteBatch(buf, partitionId, schema, items.AsSpan(0, count), writer);
                         await SendBatchAsync(table, buf, count, preferredNode, retryPolicy).ConfigureAwait(false);
 
                         return;


### PR DESCRIPTION
Fix invalid batch situation causing `IndexOutOfBoundsException` on the server: batch header contains new schema version, while one of the tuples is written with old schema version.
* Update streamer schema under lock
* Add batch schema version check