### PR TITLE
IGNITE-24687 Use integration test defaults for schema sync settings in colocation tests

### DIFF
--- a/modules/partition-replicator/src/integrationTest/java/org/apache/ignite/internal/partition/replicator/AbstractZoneReplicationTest.java
+++ b/modules/partition-replicator/src/integrationTest/java/org/apache/ignite/internal/partition/replicator/AbstractZoneReplicationTest.java
@@ -95,7 +95,7 @@ abstract class AbstractZoneReplicationTest extends IgniteAbstractTest {
     @InjectConfiguration
     private static ReplicationConfiguration replicationConfiguration;
 
-    @InjectConfiguration
+    @InjectConfiguration("mock.idleSyncTimeInterval = " + Node.METASTORAGE_IDLE_SYNC_TIME_INTERVAL_MS)
     private static MetaStorageConfiguration metaStorageConfiguration;
 
     @InjectConfiguration("mock.profiles = {" + DEFAULT_STORAGE_PROFILE + ".engine = aipersist, test.engine=test}")

--- a/modules/partition-replicator/src/integrationTest/java/org/apache/ignite/internal/partition/replicator/ItAbstractColocationTest.java
+++ b/modules/partition-replicator/src/integrationTest/java/org/apache/ignite/internal/partition/replicator/ItAbstractColocationTest.java
@@ -102,7 +102,7 @@ abstract class ItAbstractColocationTest extends IgniteAbstractTest {
     @InjectConfiguration("mock.profiles = {" + DEFAULT_STORAGE_PROFILE + ".engine = aipersist, test.engine=test}")
     private StorageConfiguration storageConfiguration;
 
-    @InjectConfiguration
+    @InjectConfiguration("mock.idleSyncTimeInterval = " + Node.METASTORAGE_IDLE_SYNC_TIME_INTERVAL_MS)
     private MetaStorageConfiguration metaStorageConfiguration;
 
     @InjectConfiguration

--- a/modules/partition-replicator/src/integrationTest/java/org/apache/ignite/internal/partition/replicator/fixtures/Node.java
+++ b/modules/partition-replicator/src/integrationTest/java/org/apache/ignite/internal/partition/replicator/fixtures/Node.java
@@ -193,6 +193,11 @@ import org.junit.jupiter.api.TestInfo;
 public class Node {
     private static final IgniteLogger LOG = Loggers.forClass(Node.class);
 
+    private static final int DELAY_DURATION_MS = 100;
+
+    /** The interval between two consecutive MS idle safe time syncs. */
+    public static final int METASTORAGE_IDLE_SYNC_TIME_INTERVAL_MS = DELAY_DURATION_MS / 2;
+
     public final String name;
 
     private final Loza raftManager;
@@ -590,7 +595,7 @@ public class Node {
                         .thenApply(Entry::value)
         );
 
-        LongSupplier delayDurationMsSupplier = () -> 10L;
+        LongSupplier delayDurationMsSupplier = () -> DELAY_DURATION_MS;
 
         catalogManager = new CatalogManagerImpl(
                 new UpdateLogImpl(metaStorageManager),


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-24687

1. Use delayDuration of 100ms
2. metaStorage.idleSyncTimeInterval must be twice as small, that is, 50ms, to prevent waits on schema syncs