### PR TITLE
IGNITE-24701 Unhandled exception java.lang.UnsupportedOperationException for Reset Partitions

### DIFF
--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/disaster/GroupUpdateRequest.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/disaster/GroupUpdateRequest.java
@@ -443,7 +443,7 @@ class GroupUpdateRequest implements DisasterRecoveryRequest {
     }
 
     /**
-     * Returns a set of nodes that are both alive and either {@link LocalPartitionStateEnum#HEALTHY} or
+     * Returns a modifiable set of nodes that are both alive and either {@link LocalPartitionStateEnum#HEALTHY} or
      * {@link LocalPartitionStateEnum#CATCHING_UP}.
      */
     private static Set<Assignment> getAliveNodesWithData(
@@ -451,7 +451,7 @@ class GroupUpdateRequest implements DisasterRecoveryRequest {
             @Nullable LocalPartitionStateMessageByNode localPartitionStateMessageByNode
     ) {
         if (localPartitionStateMessageByNode == null) {
-            return Set.of();
+            return new HashSet<>();
         }
 
         var partAssignments = new HashSet<Assignment>();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-24701

result of getAliveNodesWithData is modified in enrichAssignments, so we can't return unmodifiable set there