### PR TITLE
IGNITE-24658 Sql. Fix NPE in ReadWriteTransactionImpl#enlist

### DIFF
--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeTxManager.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeTxManager.java
@@ -39,7 +39,6 @@ import org.apache.ignite.internal.tx.TxManager;
 import org.apache.ignite.internal.tx.TxState;
 import org.apache.ignite.internal.tx.TxStateMeta;
 import org.apache.ignite.internal.tx.impl.EnlistedPartitionGroup;
-import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.tx.TransactionException;
 import org.jetbrains.annotations.Nullable;
 
@@ -110,7 +109,7 @@ public class FakeTxManager implements TxManager {
             public void enlist(
                     ReplicationGroupId replicationGroupId,
                     int tableId,
-                    ClusterNode primaryNode,
+                    String primaryNodeConsistentId,
                     long consistencyToken
             ) {
                 // No-op.

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/table/ItTableScanTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/table/ItTableScanTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.table;
 
+import static java.util.Objects.requireNonNull;
 import static org.apache.ignite.internal.TestWrappers.unwrapIgniteImpl;
 import static org.apache.ignite.internal.TestWrappers.unwrapTableViewInternal;
 import static org.apache.ignite.internal.partitiondistribution.PartitionDistributionUtils.calculateAssignmentForPartition;
@@ -1052,8 +1053,7 @@ public class ItTableScanTest extends BaseSqlIntegrationTest {
         tx.enlist(
                 tblPartId,
                 tblPartId.tableId(),
-                ignite.clusterNodes().stream().filter(n -> n.name().equals(primaryReplica.getLeaseholder()))
-                        .findFirst().orElseThrow(),
+                requireNonNull(primaryReplica.getLeaseholder(), "primaryReplica#getLeaseholder"),
                 primaryReplica.getStartTime().longValue()
         );
 

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImpl.java
@@ -154,8 +154,6 @@ public class ExecutionServiceImpl<RowT> implements ExecutionService, TopologyEve
 
     private final MessageService messageService;
 
-    private final TopologyService topSrvc;
-
     private final ClusterNode localNode;
 
     private final SqlSchemaManager sqlSchemaManager;
@@ -221,7 +219,6 @@ public class ExecutionServiceImpl<RowT> implements ExecutionService, TopologyEve
         this.handler = handler;
         this.messageService = messageService;
         this.mappingService = mappingService;
-        this.topSrvc = topSrvc;
         this.sqlSchemaManager = sqlSchemaManager;
         this.taskExecutor = taskExecutor;
         this.ddlCmdHnd = ddlCmdHnd;
@@ -1163,7 +1160,7 @@ public class ExecutionServiceImpl<RowT> implements ExecutionService, TopologyEve
                         tx.enlist(
                                 replicationGroupId,
                                 tableId,
-                                topSrvc.getByConsistentId(assignment.name()),
+                                assignment.name(),
                                 assignment.enlistmentConsistencyToken()
                         );
                     }

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/ClusterServiceFactory.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/ClusterServiceFactory.java
@@ -28,8 +28,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.ignite.internal.manager.ComponentContext;
 import org.apache.ignite.internal.network.AbstractMessagingService;
 import org.apache.ignite.internal.network.AbstractTopologyService;
@@ -131,9 +129,8 @@ public class ClusterServiceFactory {
                     messagingServicesByNode.remove(nodeName);
                     topologyServicesByNode.remove(nodeName);
 
-                    topologyServicesByNode.values().stream()
-                            .flatMap(topSrvc -> topSrvc.getEventHandlers().stream())
-                            .forEach(eventHandler -> eventHandler.onDisappeared(node));
+                    topologyServicesByNode.values()
+                            .forEach(topologyService -> topologyService.evictNode(nodeName));
                 }
 
                 return nullCompletedFuture();
@@ -149,9 +146,11 @@ public class ClusterServiceFactory {
         private final Map<NetworkAddress, ClusterNode> allMembersByAddress;
 
         private LocalTopologyService(String localMember, List<String> allMembers) {
-            this.allMembers = allMembers.stream()
+            this.allMembers = new ConcurrentHashMap<>();
+
+            allMembers.stream()
                     .map(LocalTopologyService::nodeFromName)
-                    .collect(Collectors.toMap(ClusterNode::name, Function.identity()));
+                    .forEach(node -> this.allMembers.put(node.name(), node));
 
             this.localMember = this.allMembers.get(localMember);
 
@@ -162,6 +161,14 @@ public class ClusterServiceFactory {
             this.allMembersByAddress = new HashMap<>();
 
             this.allMembers.forEach((ignored, member) -> allMembersByAddress.put(member.address(), member));
+        }
+
+        private void evictNode(String nodeName) {
+            ClusterNode nodeToEvict = allMembers.remove(nodeName);
+
+            if (nodeToEvict != null) {
+                getEventHandlers().forEach(handler -> handler.onDisappeared(nodeToEvict));
+            }
         }
 
         private static ClusterNode nodeFromName(String name) {

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/NoOpTransaction.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/NoOpTransaction.java
@@ -195,11 +195,11 @@ public final class NoOpTransaction implements InternalTransaction {
     public void enlist(
             ReplicationGroupId replicationGroupId,
             int tableId,
-            ClusterNode primaryNode,
+            String primaryNodeConsistentId,
             long consistencyToken
     ) {
         requireNonNull(replicationGroupId, "replicationGroupId");
-        requireNonNull(primaryNode, "primaryNode");
+        requireNonNull(primaryNodeConsistentId, "primaryNodeConsistentId");
 
         // No-op.
     }

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/NoOpTransaction.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/NoOpTransaction.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.sql.engine.framework;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static org.apache.ignite.internal.hlc.HybridTimestamp.NULL_HYBRID_TIMESTAMP;
 import static org.apache.ignite.internal.hlc.HybridTimestamp.nullableHybridTimestamp;
@@ -197,6 +198,9 @@ public final class NoOpTransaction implements InternalTransaction {
             ClusterNode primaryNode,
             long consistencyToken
     ) {
+        requireNonNull(replicationGroupId, "replicationGroupId");
+        requireNonNull(primaryNode, "primaryNode");
+
         // No-op.
     }
 

--- a/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItInternalTableReadWriteScanTest.java
+++ b/modules/table/src/integrationTest/java/org/apache/ignite/distributed/ItInternalTableReadWriteScanTest.java
@@ -87,7 +87,7 @@ public class ItInternalTableReadWriteScanTest extends ItAbstractInternalTableSca
 
         ClusterNode primaryReplicaNode = getPrimaryReplica(tblPartId);
 
-        tx.enlist(tblPartId, internalTbl.tableId(), primaryReplicaNode, term);
+        tx.enlist(tblPartId, internalTbl.tableId(), primaryReplicaNode.name(), term);
 
         return tx;
     }

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/storage/InternalTableImpl.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/storage/InternalTableImpl.java
@@ -1997,7 +1997,11 @@ public class InternalTableImpl implements InternalTable {
         Function<ReplicaMeta, PendingTxPartitionEnlistment> enlistClo = replicaMeta -> {
             ReplicationGroupId partGroupId = targetReplicationGroupId(partId);
 
-            tx.enlist(partGroupId, tableId, getClusterNode(replicaMeta).name(), enlistmentConsistencyToken(replicaMeta));
+            String leaseHolderNodeId = replicaMeta.getLeaseholder();
+
+            assert leaseHolderNodeId != null;
+
+            tx.enlist(partGroupId, tableId, leaseHolderNodeId, enlistmentConsistencyToken(replicaMeta));
 
             return tx.enlistedPartition(partGroupId);
         };

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/storage/InternalTableImpl.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/storage/InternalTableImpl.java
@@ -1997,7 +1997,7 @@ public class InternalTableImpl implements InternalTable {
         Function<ReplicaMeta, PendingTxPartitionEnlistment> enlistClo = replicaMeta -> {
             ReplicationGroupId partGroupId = targetReplicationGroupId(partId);
 
-            tx.enlist(partGroupId, tableId, getClusterNode(replicaMeta), enlistmentConsistencyToken(replicaMeta));
+            tx.enlist(partGroupId, tableId, getClusterNode(replicaMeta).name(), enlistmentConsistencyToken(replicaMeta));
 
             return tx.enlistedPartition(partGroupId);
         };

--- a/modules/transactions/src/jmh/java/org/apache/ignite/internal/tx/impl/TransactionExpirationRegistryBenchmark.java
+++ b/modules/transactions/src/jmh/java/org/apache/ignite/internal/tx/impl/TransactionExpirationRegistryBenchmark.java
@@ -27,7 +27,6 @@ import org.apache.ignite.internal.replicator.TablePartitionId;
 import org.apache.ignite.internal.tx.InternalTransaction;
 import org.apache.ignite.internal.tx.PendingTxPartitionEnlistment;
 import org.apache.ignite.internal.tx.TxState;
-import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.tx.TransactionException;
 import org.jetbrains.annotations.Nullable;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -118,7 +117,7 @@ public class TransactionExpirationRegistryBenchmark {
         public void enlist(
                 ReplicationGroupId replicationGroupId,
                 int tableId,
-                ClusterNode primaryNode,
+                String primaryNodeConsistentId,
                 long consistencyToken
         ) {
             // No-op.

--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/InternalTransaction.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/InternalTransaction.java
@@ -21,7 +21,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.apache.ignite.internal.replicator.ReplicationGroupId;
-import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.tx.Transaction;
 import org.jetbrains.annotations.Nullable;
 
@@ -71,13 +70,13 @@ public interface InternalTransaction extends Transaction {
      *
      * @param replicationGroupId Replication group id to enlist.
      * @param tableId Table ID for enlistment.
-     * @param primaryNode Primary replica cluster node.
+     * @param primaryNodeConsistentId Consistent node id of primary replica.
      * @param consistencyToken Consistency token to enlist for given replication group.
      */
     void enlist(
             ReplicationGroupId replicationGroupId,
             int tableId,
-            ClusterNode primaryNode,
+            String primaryNodeConsistentId,
             long consistencyToken
     );
 

--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/PublicApiThreadingTransaction.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/PublicApiThreadingTransaction.java
@@ -31,7 +31,6 @@ import org.apache.ignite.internal.tx.InternalTransaction;
 import org.apache.ignite.internal.tx.PendingTxPartitionEnlistment;
 import org.apache.ignite.internal.tx.TxState;
 import org.apache.ignite.internal.wrapper.Wrapper;
-import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.tx.Transaction;
 import org.apache.ignite.tx.TransactionException;
 import org.jetbrains.annotations.Nullable;
@@ -109,10 +108,10 @@ public class PublicApiThreadingTransaction implements InternalTransaction, Wrapp
     public void enlist(
             ReplicationGroupId replicationGroupId,
             int tableId,
-            ClusterNode primaryNode,
+            String primaryNodeConsistentId,
             long consistencyToken
     ) {
-        transaction.enlist(replicationGroupId, tableId, primaryNode, consistencyToken);
+        transaction.enlist(replicationGroupId, tableId, primaryNodeConsistentId, consistencyToken);
     }
 
     @Override

--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/ReadOnlyTransactionImpl.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/ReadOnlyTransactionImpl.java
@@ -29,7 +29,6 @@ import org.apache.ignite.internal.hlc.HybridTimestampTracker;
 import org.apache.ignite.internal.replicator.ReplicationGroupId;
 import org.apache.ignite.internal.replicator.TablePartitionId;
 import org.apache.ignite.internal.tx.PendingTxPartitionEnlistment;
-import org.apache.ignite.network.ClusterNode;
 
 /**
  * The read-only implementation of an internal transaction.
@@ -89,7 +88,7 @@ public class ReadOnlyTransactionImpl extends IgniteAbstractTransactionImpl {
     public void enlist(
             ReplicationGroupId replicationGroupId,
             int tableId,
-            ClusterNode primaryNode,
+            String primaryNodeConsistentId,
             long consistencyToken
     ) {
         // No-op.

--- a/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/ReadWriteTransactionImpl.java
+++ b/modules/transactions/src/main/java/org/apache/ignite/internal/tx/impl/ReadWriteTransactionImpl.java
@@ -36,7 +36,6 @@ import org.apache.ignite.internal.replicator.ReplicationGroupId;
 import org.apache.ignite.internal.tx.PendingTxPartitionEnlistment;
 import org.apache.ignite.internal.tx.TransactionIds;
 import org.apache.ignite.internal.tx.TxManager;
-import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.tx.TransactionException;
 import org.jetbrains.annotations.Nullable;
 
@@ -105,7 +104,7 @@ public class ReadWriteTransactionImpl extends IgniteAbstractTransactionImpl {
     public void enlist(
             ReplicationGroupId replicationGroupId,
             int tableId,
-            ClusterNode primaryNode,
+            String primaryNodeConsistentId,
             long consistencyToken
     ) {
         // No need to wait for lock if commit is in progress.
@@ -119,7 +118,7 @@ public class ReadWriteTransactionImpl extends IgniteAbstractTransactionImpl {
 
             PendingTxPartitionEnlistment enlistment = enlisted.computeIfAbsent(
                     replicationGroupId,
-                    k -> new PendingTxPartitionEnlistment(primaryNode.name(), consistencyToken)
+                    k -> new PendingTxPartitionEnlistment(primaryNodeConsistentId, consistencyToken)
             );
 
             enlistment.addTableId(tableId);

--- a/modules/transactions/src/test/java/org/apache/ignite/internal/tx/TxManagerTest.java
+++ b/modules/transactions/src/test/java/org/apache/ignite/internal/tx/TxManagerTest.java
@@ -231,7 +231,7 @@ public class TxManagerTest extends IgniteAbstractTest {
 
         ReplicationGroupId partitionIdForEnlistment = new ZonePartitionId(1, 0);
 
-        tx.enlist(partitionIdForEnlistment, 10, REMOTE_NODE, 1L);
+        tx.enlist(partitionIdForEnlistment, 10, REMOTE_NODE.name(), 1L);
 
         PendingTxPartitionEnlistment actual = tx.enlistedPartition(partitionIdForEnlistment);
         assertEquals(REMOTE_NODE.name(), actual.primaryNodeConsistentId());
@@ -314,7 +314,7 @@ public class TxManagerTest extends IgniteAbstractTest {
 
         ZonePartitionId replicationGroupId = new ZonePartitionId(1, 0);
 
-        tx.enlist(replicationGroupId, 10, REMOTE_NODE, 1L);
+        tx.enlist(replicationGroupId, 10, REMOTE_NODE.name(), 1L);
         tx.assignCommitPartition(replicationGroupId);
 
         tx.commit();
@@ -335,7 +335,7 @@ public class TxManagerTest extends IgniteAbstractTest {
 
         ZonePartitionId replicationGroupId = new ZonePartitionId(1, 0);
 
-        tx.enlist(replicationGroupId, 10, REMOTE_NODE, 1L);
+        tx.enlist(replicationGroupId, 10, REMOTE_NODE.name(), 1L);
         tx.assignCommitPartition(replicationGroupId);
 
         tx.rollback();
@@ -363,7 +363,7 @@ public class TxManagerTest extends IgniteAbstractTest {
 
         ZonePartitionId replicationGroupId = new ZonePartitionId(1, 0);
 
-        tx.enlist(replicationGroupId, 10, REMOTE_NODE, 1L);
+        tx.enlist(replicationGroupId, 10, REMOTE_NODE.name(), 1L);
         tx.assignCommitPartition(replicationGroupId);
 
         TransactionException transactionException = assertThrows(TransactionException.class, tx::commit);
@@ -391,7 +391,7 @@ public class TxManagerTest extends IgniteAbstractTest {
 
         ZonePartitionId replicationGroupId = new ZonePartitionId(1, 0);
 
-        tx.enlist(replicationGroupId, 10, REMOTE_NODE, 1L);
+        tx.enlist(replicationGroupId, 10, REMOTE_NODE.name(), 1L);
         tx.assignCommitPartition(replicationGroupId);
 
         TransactionException transactionException = assertThrows(TransactionException.class, tx::rollback);
@@ -628,14 +628,14 @@ public class TxManagerTest extends IgniteAbstractTest {
         // Prepare transaction.
         InternalTransaction tx = txManager.beginExplicitRw(hybridTimestampTracker, InternalTxOptions.defaults());
 
-        ClusterNode node = mock(ClusterNode.class);
+        String nodeName = "SomeNode";
 
         ZonePartitionId partitionIdForEnlistment1 = new ZonePartitionId(1, 0);
-        tx.enlist(partitionIdForEnlistment1, 10, node, 1L);
+        tx.enlist(partitionIdForEnlistment1, 10, nodeName, 1L);
         tx.assignCommitPartition(partitionIdForEnlistment1);
 
         ReplicationGroupId partitionIdForEnlistment2 = new ZonePartitionId(2, 0);
-        tx.enlist(partitionIdForEnlistment2, 20, node, 1L);
+        tx.enlist(partitionIdForEnlistment2, 20, nodeName, 1L);
 
         when(placementDriver.getPrimaryReplica(eq(partitionIdForEnlistment1), any()))
                 .thenReturn(completedFuture(
@@ -772,7 +772,7 @@ public class TxManagerTest extends IgniteAbstractTest {
 
         ZonePartitionId replicationGroupId = new ZonePartitionId(1, 0);
 
-        tx.enlist(replicationGroupId, 10, REMOTE_NODE, 1L);
+        tx.enlist(replicationGroupId, 10, REMOTE_NODE.name(), 1L);
         tx.assignCommitPartition(replicationGroupId);
 
         return tx;

--- a/modules/transactions/src/test/java/org/apache/ignite/internal/tx/impl/ReadWriteTransactionImplTest.java
+++ b/modules/transactions/src/test/java/org/apache/ignite/internal/tx/impl/ReadWriteTransactionImplTest.java
@@ -35,7 +35,6 @@ import org.apache.ignite.internal.hlc.HybridClock;
 import org.apache.ignite.internal.hlc.HybridClockImpl;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.apache.ignite.internal.hlc.HybridTimestampTracker;
-import org.apache.ignite.internal.lang.IgniteBiTuple;
 import org.apache.ignite.internal.network.ClusterNodeImpl;
 import org.apache.ignite.internal.replicator.ZonePartitionId;
 import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
@@ -59,8 +58,6 @@ class ReadWriteTransactionImplTest extends BaseIgniteAbstractTest {
             "test-node",
             new NetworkAddress("localhost", 1234)
     );
-
-    private static final IgniteBiTuple NODE_AND_TOKEN = new IgniteBiTuple(CLUSTER_NODE, 0L);
 
     private static final int TABLE_ID = 1;
     private static final int ZONE_ID = 2;
@@ -121,8 +118,8 @@ class ReadWriteTransactionImplTest extends BaseIgniteAbstractTest {
 
         tx.assignCommitPartition(TX_COMMIT_PART);
 
-        tx.enlist(new ZonePartitionId(ZONE_ID, 0), TABLE_ID, CLUSTER_NODE, 0L);
-        tx.enlist(new ZonePartitionId(ZONE_ID, 2), TABLE_ID, CLUSTER_NODE, 0L);
+        tx.enlist(new ZonePartitionId(ZONE_ID, 0), TABLE_ID, CLUSTER_NODE.name(), 0L);
+        tx.enlist(new ZonePartitionId(ZONE_ID, 2), TABLE_ID, CLUSTER_NODE.name(), 0L);
 
         if (commit) {
             if (txState == null) {
@@ -139,11 +136,11 @@ class ReadWriteTransactionImplTest extends BaseIgniteAbstractTest {
         }
 
         TransactionException ex = assertThrows(TransactionException.class,
-                () -> tx.enlist(new ZonePartitionId(ZONE_ID, 5), TABLE_ID, CLUSTER_NODE, 0L));
+                () -> tx.enlist(new ZonePartitionId(ZONE_ID, 5), TABLE_ID, CLUSTER_NODE.name(), 0L));
 
         assertTrue(ex.getMessage().contains(txState.toString()));
 
-        ex = assertThrows(TransactionException.class, () -> tx.enlist(new ZonePartitionId(ZONE_ID, 0), TABLE_ID, CLUSTER_NODE, 0L));
+        ex = assertThrows(TransactionException.class, () -> tx.enlist(new ZonePartitionId(ZONE_ID, 0), TABLE_ID, CLUSTER_NODE.name(), 0L));
 
         assertTrue(ex.getMessage().contains(txState.toString()));
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-24658

The patch is split on 2 commits: first one adjust test framework (adds node eviction from physical topology) to highlight original issue (highlighted by `QueryRecoveryTest#queryWithImplicitTxRecoversWhenNodeLeftClusterBeforeFragmentHasBeenSent`); the second commit addresses the issue.

-----------
Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)