### PR TITLE
IGNITE-24294 IgniteCatalog API. Table's IndexDefinition reports incorrect name/sorting of index column

### DIFF
--- a/modules/catalog-dsl/src/integrationTest/java/org/apache/ignite/internal/catalog/ItCatalogDslTest.java
+++ b/modules/catalog-dsl/src/integrationTest/java/org/apache/ignite/internal/catalog/ItCatalogDslTest.java
@@ -429,7 +429,6 @@ class ItCatalogDslTest extends ClusterPerClassIntegrationTest {
         // sorted index
         {
             IndexDefinition index = indexMap.get("T_SORTED");
-            assertEquals("T_SORTED", index.name());
             assertEquals(IndexType.SORTED, index.type());
             assertEquals(List.of(
                             ColumnSorted.column("COL2", SortOrder.DESC_NULLS_FIRST),
@@ -441,7 +440,6 @@ class ItCatalogDslTest extends ClusterPerClassIntegrationTest {
         // hash index
         {
             IndexDefinition index = indexMap.get("T_HASH");
-            assertEquals("T_HASH", index.name());
             assertEquals(IndexType.HASH, index.type());
             assertEquals(List.of(ColumnSorted.column("COL1"), ColumnSorted.column("COL2")), index.columns());
         }

--- a/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/CreateTableImpl.java
+++ b/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/CreateTableImpl.java
@@ -118,6 +118,9 @@ class CreateTableImpl extends AbstractCatalogQuery<Name> {
     CreateTableImpl addIndex(String name, IndexType type, List<ColumnSorted> columns) {
         Objects.requireNonNull(name, "Index name must not be null.");
         Objects.requireNonNull(columns, "Index columns list must not be null.");
+        if (columns.isEmpty()) {
+            throw new IllegalArgumentException("Index columns list must not be empty.");
+        }
 
         indexes.add(new CreateIndexImpl(sql).ifNotExists().name(name).using(type).on(tableName, columns));
         return this;

--- a/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/CreateTableImpl.java
+++ b/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/CreateTableImpl.java
@@ -18,12 +18,12 @@
 package org.apache.ignite.internal.catalog.sql;
 
 import static java.util.Arrays.asList;
-import static org.apache.ignite.internal.catalog.sql.IndexColumnImpl.parseIndexColumnList;
 import static org.apache.ignite.internal.catalog.sql.QueryPartCollection.partsList;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.apache.ignite.catalog.ColumnSorted;
 import org.apache.ignite.catalog.ColumnType;
 import org.apache.ignite.catalog.IndexType;
@@ -86,12 +86,8 @@ class CreateTableImpl extends AbstractCatalogQuery<Name> {
         return this;
     }
 
-    CreateTableImpl primaryKey(String columnList) {
-        return primaryKey(IndexType.DEFAULT, columnList);
-    }
-
-    CreateTableImpl primaryKey(IndexType type, String columnList) {
-        return primaryKey(type, parseIndexColumnList(columnList));
+    CreateTableImpl primaryKey(List<String> columns) {
+        return primaryKey(IndexType.DEFAULT, columns.stream().map(ColumnSorted::column).collect(Collectors.toList()));
     }
 
     CreateTableImpl primaryKey(IndexType type, List<ColumnSorted> columns) {
@@ -99,10 +95,6 @@ class CreateTableImpl extends AbstractCatalogQuery<Name> {
 
         constraints.add(new Constraint().primaryKey(type, columns));
         return this;
-    }
-
-    CreateTableImpl colocateBy(String columnList) {
-        return colocateBy(QueryUtils.splitByComma(columnList));
     }
 
     CreateTableImpl colocateBy(String... columns) {
@@ -121,18 +113,6 @@ class CreateTableImpl extends AbstractCatalogQuery<Name> {
 
         this.zone = new Zone(zone.toUpperCase());
         return this;
-    }
-
-    CreateTableImpl addIndex(String name, String columnList) {
-        return addIndex(name, null, columnList);
-    }
-
-    CreateTableImpl addIndex(String name, IndexType type, String columnList) {
-        return addIndex(name, type, parseIndexColumnList(columnList));
-    }
-
-    CreateTableImpl addIndex(String name, IndexType type, ColumnSorted... columns) {
-        return addIndex(name, type, asList(columns));
     }
 
     CreateTableImpl addIndex(String name, IndexType type, List<ColumnSorted> columns) {

--- a/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/IgniteCatalogSqlImpl.java
+++ b/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/IgniteCatalogSqlImpl.java
@@ -91,12 +91,7 @@ public class IgniteCatalogSqlImpl implements IgniteCatalog {
     public CompletableFuture<TableDefinition> tableDefinitionAsync(QualifiedName tableName) {
         TableDefinitionCollector collector = new TableDefinitionCollector(tableName, sql);
 
-        return collector.collectDefinition().thenApply(builder -> {
-            if (builder != null) {
-                return builder.build();
-            }
-            return null;
-        });
+        return collector.collectDefinition();
     }
 
     @Override

--- a/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/IgniteCatalogSqlImpl.java
+++ b/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/IgniteCatalogSqlImpl.java
@@ -89,7 +89,7 @@ public class IgniteCatalogSqlImpl implements IgniteCatalog {
 
     @Override
     public CompletableFuture<TableDefinition> tableDefinitionAsync(QualifiedName tableName) {
-        TableDefinitionCollector collector = new TableDefinitionCollector(tableName.objectName(), sql);
+        TableDefinitionCollector collector = new TableDefinitionCollector(tableName, sql);
 
         return collector.collectDefinition().thenApply(builder -> {
             if (builder != null) {

--- a/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/IndexColumnImpl.java
+++ b/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/IndexColumnImpl.java
@@ -19,9 +19,7 @@ package org.apache.ignite.internal.catalog.sql;
 
 import static org.apache.ignite.catalog.ColumnSorted.column;
 
-import java.util.List;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.apache.ignite.catalog.ColumnSorted;
 import org.apache.ignite.catalog.SortOrder;
 
@@ -38,13 +36,8 @@ class IndexColumnImpl extends QueryPart {
         this.wrapped = wrapped;
     }
 
-    public static List<ColumnSorted> parseIndexColumnList(String columnList) {
-        return QueryUtils.splitByComma(columnList).stream()
-                .map(IndexColumnImpl::parseCol)
-                .collect(Collectors.toList());
-    }
-
-    private static ColumnSorted parseCol(String columnRaw) {
+    public static ColumnSorted parseColumn(String columnRaw) {
+        columnRaw = columnRaw.trim();
         String[] split = SPACES.split(columnRaw, 2);
         String columnName = split[0].trim();
         if (split.length < 2) {

--- a/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/Option.java
+++ b/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/Option.java
@@ -71,6 +71,10 @@ class Option extends QueryPart {
         return new Option("TABLE_NAME", tableName);
     }
 
+    public static Option schemaName(String tableName) {
+        return new Option("SCHEMA_NAME", tableName);
+    }
+
     public static Option zoneName(String zoneName) {
         return new Option("ZONE_NAME", zoneName);
     }

--- a/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/SelectFromView.java
+++ b/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/SelectFromView.java
@@ -57,7 +57,7 @@ class SelectFromView<T> extends AbstractCatalogQuery<List<T>> {
         });
     }
 
-    static <T> CompletableFuture<List<T>> collectResults(IgniteSql sql, String query, Function<SqlRow, T> mapper) {
+    static <T> CompletableFuture<List<T>> collectResults(IgniteSql sql, String query, Function<SqlRow, T> mapper, Object... params) {
         return sql.executeAsync(null, query).thenCompose(resultSet -> {
             List<T> result = new ArrayList<>();
             return iterate(resultSet, mapper, result).thenApply(unused -> result);

--- a/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/SelectFromView.java
+++ b/modules/catalog-dsl/src/main/java/org/apache/ignite/internal/catalog/sql/SelectFromView.java
@@ -58,7 +58,7 @@ class SelectFromView<T> extends AbstractCatalogQuery<List<T>> {
     }
 
     static <T> CompletableFuture<List<T>> collectResults(IgniteSql sql, String query, Function<SqlRow, T> mapper, Object... params) {
-        return sql.executeAsync(null, query).thenCompose(resultSet -> {
+        return sql.executeAsync(null, query, params).thenCompose(resultSet -> {
             List<T> result = new ArrayList<>();
             return iterate(resultSet, mapper, result).thenApply(unused -> result);
         });
@@ -87,7 +87,11 @@ class SelectFromView<T> extends AbstractCatalogQuery<List<T>> {
 
         if (!whereOptions.isEmpty()) {
             ctx.sql("WHERE ");
-            for (Option option : whereOptions) {
+            for (int i = 0; i < whereOptions.size(); i++) {
+                Option option = whereOptions.get(i);
+                if (i > 0) {
+                    ctx.sql(" AND ");
+                }
                 option.accept(ctx);
             }
         }

--- a/modules/catalog-dsl/src/test/java/org/apache/ignite/internal/catalog/sql/QueryPartTest.java
+++ b/modules/catalog-dsl/src/test/java/org/apache/ignite/internal/catalog/sql/QueryPartTest.java
@@ -38,10 +38,10 @@ import static org.apache.ignite.catalog.ColumnType.UUID;
 import static org.apache.ignite.catalog.ColumnType.VARBINARY;
 import static org.apache.ignite.catalog.ColumnType.VARCHAR;
 import static org.apache.ignite.internal.catalog.sql.ColumnTypeImpl.wrap;
-import static org.apache.ignite.internal.catalog.sql.IndexColumnImpl.parseIndexColumnList;
+import static org.apache.ignite.internal.catalog.sql.IndexColumnImpl.parseColumn;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -156,39 +156,33 @@ class QueryPartTest {
     }
 
     @Test
-    void indexColumnParseSimple() {
-        assertThat(parseIndexColumnList("col1"), contains(column("col1")));
-        assertThat(parseIndexColumnList("col1, col2"), contains(column("col1"), column("col2")));
-    }
-
-    @Test
     void indexColumnParseSorted() {
-        assertThat(parseIndexColumnList("col1"), contains(column("col1", SortOrder.DEFAULT)));
-        assertThat(parseIndexColumnList("COL2_UPPER_CASE ASC"), contains(column("COL2_UPPER_CASE", SortOrder.ASC)));
-        assertThat(parseIndexColumnList("col3 ASC    nUlls First  "), contains(column("col3", SortOrder.ASC_NULLS_FIRST)));
-        assertThat(parseIndexColumnList(" col4   asc  nulls  last "), contains(column("col4", SortOrder.ASC_NULLS_LAST)));
-        assertThat(parseIndexColumnList("col5 desc"), contains(column("col5", SortOrder.DESC)));
-        assertThat(parseIndexColumnList("col6 desc nulls first"), contains(column("col6", SortOrder.DESC_NULLS_FIRST)));
-        assertThat(parseIndexColumnList("col7 desc nulls last"), contains(column("col7", SortOrder.DESC_NULLS_LAST)));
-        assertThat(parseIndexColumnList("col8 nulls first"), contains(column("col8", SortOrder.NULLS_FIRST)));
-        assertThat(parseIndexColumnList("col9 nulls last"), contains(column("col9", SortOrder.NULLS_LAST)));
+        assertEquals(parseColumn("col1"), column("col1", SortOrder.DEFAULT));
+        assertEquals(parseColumn("COL2_UPPER_CASE ASC"), column("COL2_UPPER_CASE", SortOrder.ASC));
+        assertEquals(parseColumn("col3 ASC    nUlls First  "), column("col3", SortOrder.ASC_NULLS_FIRST));
+        assertEquals(parseColumn(" col4   asc  nulls  last "), column("col4", SortOrder.ASC_NULLS_LAST));
+        assertEquals(parseColumn("col5 desc"), column("col5", SortOrder.DESC));
+        assertEquals(parseColumn("col6 desc nulls first"), column("col6", SortOrder.DESC_NULLS_FIRST));
+        assertEquals(parseColumn("col7 desc nulls last"), column("col7", SortOrder.DESC_NULLS_LAST));
+        assertEquals(parseColumn("col8 nulls first"), column("col8", SortOrder.NULLS_FIRST));
+        assertEquals(parseColumn("col9 nulls last"), column("col9", SortOrder.NULLS_LAST));
     }
 
     @Test
     void indexColumnParseSortedWrongOrder() {
-        assertThat(parseIndexColumnList("col1 nulls first asc"), contains(column("col1", SortOrder.NULLS_FIRST)));
-        assertThat(parseIndexColumnList("col2 nulls last desc"), contains(column("col2", SortOrder.NULLS_LAST)));
-        assertThat(parseIndexColumnList("col3 desc nulls"), contains(column("col3", SortOrder.DESC)));
-        assertThat(parseIndexColumnList("col4 desc last nulls"), contains(column("col4", SortOrder.DESC)));
-        assertThat(parseIndexColumnList("col5 nulls asc first"), contains(column("col5")));
-        assertThat(parseIndexColumnList("col6 first nulls"), contains(column("col6")));
+        assertEquals(parseColumn("col1 nulls first asc"), column("col1", SortOrder.NULLS_FIRST));
+        assertEquals(parseColumn("col2 nulls last desc"), column("col2", SortOrder.NULLS_LAST));
+        assertEquals(parseColumn("col3 desc nulls"), column("col3", SortOrder.DESC));
+        assertEquals(parseColumn("col4 desc last nulls"), column("col4", SortOrder.DESC));
+        assertEquals(parseColumn("col5 nulls asc first"), column("col5"));
+        assertEquals(parseColumn("col6 first nulls"), column("col6"));
     }
 
     @Test
     void indexColumnPareIncorrectSortOrder() {
-        assertThat(parseIndexColumnList("col1 unexpectedKeyword"), contains(column("col1")));
-        assertThat(parseIndexColumnList("col2 nulls_first"), contains(column("col2")));
-        assertThat(parseIndexColumnList("col3 descnullslast"), contains(column("col3")));
+        assertEquals(parseColumn("col1 unexpectedKeyword"), column("col1"));
+        assertEquals(parseColumn("col2 nulls_first"), column("col2"));
+        assertEquals(parseColumn("col3 descnullslast"), column("col3"));
     }
 
     private static String sql(QueryPart part) {

--- a/modules/catalog-dsl/src/test/java/org/apache/ignite/internal/catalog/sql/QueryPartTest.java
+++ b/modules/catalog-dsl/src/test/java/org/apache/ignite/internal/catalog/sql/QueryPartTest.java
@@ -41,7 +41,6 @@ import static org.apache.ignite.internal.catalog.sql.ColumnTypeImpl.wrap;
 import static org.apache.ignite.internal.catalog.sql.IndexColumnImpl.parseColumn;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -157,32 +156,32 @@ class QueryPartTest {
 
     @Test
     void indexColumnParseSorted() {
-        assertEquals(parseColumn("col1"), column("col1", SortOrder.DEFAULT));
-        assertEquals(parseColumn("COL2_UPPER_CASE ASC"), column("COL2_UPPER_CASE", SortOrder.ASC));
-        assertEquals(parseColumn("col3 ASC    nUlls First  "), column("col3", SortOrder.ASC_NULLS_FIRST));
-        assertEquals(parseColumn(" col4   asc  nulls  last "), column("col4", SortOrder.ASC_NULLS_LAST));
-        assertEquals(parseColumn("col5 desc"), column("col5", SortOrder.DESC));
-        assertEquals(parseColumn("col6 desc nulls first"), column("col6", SortOrder.DESC_NULLS_FIRST));
-        assertEquals(parseColumn("col7 desc nulls last"), column("col7", SortOrder.DESC_NULLS_LAST));
-        assertEquals(parseColumn("col8 nulls first"), column("col8", SortOrder.NULLS_FIRST));
-        assertEquals(parseColumn("col9 nulls last"), column("col9", SortOrder.NULLS_LAST));
+        assertThat(parseColumn("col1"), is(column("col1", SortOrder.DEFAULT)));
+        assertThat(parseColumn("COL2_UPPER_CASE ASC"), is(column("COL2_UPPER_CASE", SortOrder.ASC)));
+        assertThat(parseColumn("col3 ASC    nUlls First  "), is(column("col3", SortOrder.ASC_NULLS_FIRST)));
+        assertThat(parseColumn(" col4   asc  nulls  last "), is(column("col4", SortOrder.ASC_NULLS_LAST)));
+        assertThat(parseColumn("col5 desc"), is(column("col5", SortOrder.DESC)));
+        assertThat(parseColumn("col6 desc nulls first"), is(column("col6", SortOrder.DESC_NULLS_FIRST)));
+        assertThat(parseColumn("col7 desc nulls last"), is(column("col7", SortOrder.DESC_NULLS_LAST)));
+        assertThat(parseColumn("col8 nulls first"), is(column("col8", SortOrder.NULLS_FIRST)));
+        assertThat(parseColumn("col9 nulls last"), is(column("col9", SortOrder.NULLS_LAST)));
     }
 
     @Test
     void indexColumnParseSortedWrongOrder() {
-        assertEquals(parseColumn("col1 nulls first asc"), column("col1", SortOrder.NULLS_FIRST));
-        assertEquals(parseColumn("col2 nulls last desc"), column("col2", SortOrder.NULLS_LAST));
-        assertEquals(parseColumn("col3 desc nulls"), column("col3", SortOrder.DESC));
-        assertEquals(parseColumn("col4 desc last nulls"), column("col4", SortOrder.DESC));
-        assertEquals(parseColumn("col5 nulls asc first"), column("col5"));
-        assertEquals(parseColumn("col6 first nulls"), column("col6"));
+        assertThat(parseColumn("col1 nulls first asc"), is(column("col1", SortOrder.NULLS_FIRST)));
+        assertThat(parseColumn("col2 nulls last desc"), is(column("col2", SortOrder.NULLS_LAST)));
+        assertThat(parseColumn("col3 desc nulls"), is(column("col3", SortOrder.DESC)));
+        assertThat(parseColumn("col4 desc last nulls"), is(column("col4", SortOrder.DESC)));
+        assertThat(parseColumn("col5 nulls asc first"), is(column("col5")));
+        assertThat(parseColumn("col6 first nulls"), is(column("col6")));
     }
 
     @Test
     void indexColumnPareIncorrectSortOrder() {
-        assertEquals(parseColumn("col1 unexpectedKeyword"), column("col1"));
-        assertEquals(parseColumn("col2 nulls_first"), column("col2"));
-        assertEquals(parseColumn("col3 descnullslast"), column("col3"));
+        assertThat(parseColumn("col1 unexpectedKeyword"), is(column("col1")));
+        assertThat(parseColumn("col2 nulls_first"), is(column("col2")));
+        assertThat(parseColumn("col3 descnullslast"), is(column("col3")));
     }
 
     private static String sql(QueryPart part) {


### PR DESCRIPTION
Use `system.index_columns` view in catalog dsl. 
Drop methods that parse column name/column definition lists from strings.

https://issues.apache.org/jira/browse/IGNITE-24294

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)