### PR TITLE
IGNITE-24469 Add tuple support to data streamer with receiver

### DIFF
--- a/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/inlineschema/TupleWithSchemaMarshalling.java
+++ b/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/inlineschema/TupleWithSchemaMarshalling.java
@@ -40,7 +40,7 @@ import org.jetbrains.annotations.Nullable;
 public final class TupleWithSchemaMarshalling {
     private static final ByteOrder BYTE_ORDER = ByteOrder.LITTLE_ENDIAN;
 
-    private static final int NESTED_TUPLE_FLAG = -1;
+    public static final int TYPE_ID_TUPLE = -1;
 
     /**
      * Marshal tuple in the following format (LITTLE_ENDIAN).
@@ -255,7 +255,7 @@ public final class TupleWithSchemaMarshalling {
 
     private static int getColumnTypeId(@Nullable Object value) {
         if (value instanceof Tuple) {
-            return NESTED_TUPLE_FLAG;
+            return TYPE_ID_TUPLE;
         } else {
             return inferType(value).id();
         }
@@ -321,7 +321,7 @@ public final class TupleWithSchemaMarshalling {
 
 
     private static void setColumnValue(BinaryTupleReader reader, Tuple tuple, String colName, int colTypeId, int i) {
-        if (colTypeId == NESTED_TUPLE_FLAG) {
+        if (colTypeId == TYPE_ID_TUPLE) {
             byte[] nestedTupleBytes = reader.bytesValue(i);
             Tuple nestedTuple = unmarshal(nestedTupleBytes);
             tuple.set(colName, nestedTuple);

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientBinaryTupleUtils.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientBinaryTupleUtils.java
@@ -27,13 +27,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
-import java.util.function.Consumer;
-import java.util.function.Function;
 import org.apache.ignite.internal.binarytuple.BinaryTupleBuilder;
 import org.apache.ignite.internal.binarytuple.BinaryTupleReader;
 import org.apache.ignite.internal.type.NativeType;
@@ -122,64 +116,6 @@ public class ClientBinaryTupleUtils {
         }
     }
 
-    private static Function<Integer, Object> readerForType(BinaryTupleReader binTuple, ColumnType type) {
-        switch (type) {
-            case INT8:
-                return binTuple::byteValue;
-
-            case INT16:
-                return binTuple::shortValue;
-
-            case INT32:
-                return binTuple::intValue;
-
-            case INT64:
-                return binTuple::longValue;
-
-            case FLOAT:
-                return binTuple::floatValue;
-
-            case DOUBLE:
-                return binTuple::doubleValue;
-
-            case DECIMAL:
-                return idx -> binTuple.decimalValue(idx, -1);
-
-            case UUID:
-                return binTuple::uuidValue;
-
-            case STRING:
-                return binTuple::stringValue;
-
-            case BYTE_ARRAY:
-                return binTuple::bytesValue;
-
-            case DATE:
-                return binTuple::dateValue;
-
-            case TIME:
-                return binTuple::timeValue;
-
-            case DATETIME:
-                return binTuple::dateTimeValue;
-
-            case TIMESTAMP:
-                return binTuple::timestampValue;
-
-            case BOOLEAN:
-                return idx -> binTuple.byteValue(idx) != 0;
-
-            case DURATION:
-                return binTuple::durationValue;
-
-            case PERIOD:
-                return binTuple::periodValue;
-
-            default:
-                throw unsupportedTypeException(type.id());
-        }
-    }
-
     /**
      * Writes an object with type info to the binary tuple.
      *
@@ -243,114 +179,6 @@ public class ClientBinaryTupleUtils {
         } else if (obj instanceof Period) {
             appendTypeAndScale(builder, ColumnType.PERIOD);
             builder.appendPeriod((Period) obj);
-        } else {
-            throw unsupportedTypeException(obj.getClass());
-        }
-    }
-
-    /**
-     * Packs an array of objects in BinaryTuple format.
-     *
-     * @param builder Target builder.
-     * @param items Items.
-     */
-    static <T> void appendCollectionToBinaryTuple(BinaryTupleBuilder builder, Collection<T> items) {
-        assert items != null : "items can't be null";
-        assert !items.isEmpty() : "items can't be empty";
-        assert builder != null : "builder can't be null";
-
-        T firstItem = items.iterator().next();
-        Objects.requireNonNull(firstItem);
-        Class<?> type = firstItem.getClass();
-
-        Consumer<T> appender = appendTypeAndGetAppender(builder, firstItem);
-        builder.appendInt(items.size());
-
-        for (T item : items) {
-            Objects.requireNonNull(item);
-            if (!type.equals(item.getClass())) {
-                throw new IllegalArgumentException(
-                        "All items must have the same type. First item: " + type + ", current item: " + item.getClass());
-            }
-
-            appender.accept(item);
-        }
-    }
-
-    static <R> List<R> readCollectionFromBinaryTuple(BinaryTupleReader reader, int readerIndex) {
-        int typeId = reader.intValue(readerIndex++);
-        ColumnType type = ColumnTypeConverter.fromIdOrThrow(typeId);
-        Function<Integer, Object> itemReader = readerForType(reader, type);
-        int itemsCount = reader.intValue(readerIndex++);
-
-        List<R> items = new ArrayList<>(itemsCount);
-        for (int i = 0; i < itemsCount; i++) {
-            items.add((R) itemReader.apply(readerIndex++));
-        }
-
-        return items;
-    }
-
-    /**
-     * Writes type id to the specified packer and returns a consumer that writes the value to the binary tuple.
-     *
-     * @param builder Builder.
-     * @param obj Object.
-     */
-    private static <T> Consumer<T> appendTypeAndGetAppender(BinaryTupleBuilder builder, Object obj) {
-        assert obj != null : "Object is null";
-
-        if (obj instanceof Boolean) {
-            builder.appendInt(ColumnType.BOOLEAN.id());
-            return (T v) -> builder.appendBoolean((Boolean) v);
-        } else if (obj instanceof Byte) {
-            builder.appendInt(ColumnType.INT8.id());
-            return (T v) -> builder.appendByte((Byte) v);
-        } else if (obj instanceof Short) {
-            builder.appendInt(ColumnType.INT16.id());
-            return (T v) -> builder.appendShort((Short) v);
-        } else if (obj instanceof Integer) {
-            builder.appendInt(ColumnType.INT32.id());
-            return (T v) -> builder.appendInt((Integer) v);
-        } else if (obj instanceof Long) {
-            builder.appendInt(ColumnType.INT64.id());
-            return (T v) -> builder.appendLong((Long) v);
-        } else if (obj instanceof Float) {
-            builder.appendInt(ColumnType.FLOAT.id());
-            return (T v) -> builder.appendFloat((Float) v);
-        } else if (obj instanceof Double) {
-            builder.appendInt(ColumnType.DOUBLE.id());
-            return (T v) -> builder.appendDouble((Double) v);
-        } else if (obj instanceof BigDecimal) {
-            builder.appendInt(ColumnType.DECIMAL.id());
-            return (T v) -> builder.appendDecimal((BigDecimal) v, ((BigDecimal) v).scale());
-        } else if (obj instanceof UUID) {
-            builder.appendInt(ColumnType.UUID.id());
-            return (T v) -> builder.appendUuid((UUID) v);
-        } else if (obj instanceof String) {
-            builder.appendInt(ColumnType.STRING.id());
-            return (T v) -> builder.appendString((String) v);
-        } else if (obj instanceof byte[]) {
-            builder.appendInt(ColumnType.BYTE_ARRAY.id());
-            return (T v) -> builder.appendBytes((byte[]) v);
-        } else if (obj instanceof LocalDate) {
-            builder.appendInt(ColumnType.DATE.id());
-            return (T v) -> builder.appendDate((LocalDate) v);
-        } else if (obj instanceof LocalTime) {
-            builder.appendInt(ColumnType.TIME.id());
-            return (T v) -> builder.appendTime((LocalTime) v);
-        } else if (obj instanceof LocalDateTime) {
-            builder.appendInt(ColumnType.DATETIME.id());
-            return (T v) -> builder.appendDateTime((LocalDateTime) v);
-        } else if (obj instanceof Instant) {
-            builder.appendInt(ColumnType.TIMESTAMP.id());
-            return (T v) -> builder.appendTimestamp((Instant) v);
-        } else if (obj instanceof Duration) {
-            builder.appendInt(ColumnType.DURATION.id());
-            return (T v) -> builder.appendDuration((Duration) v);
-        } else if (obj instanceof Period) {
-            builder.appendInt(ColumnType.PERIOD.id());
-            return (T v) -> builder.appendPeriod((Period) v);
         } else {
             throw unsupportedTypeException(obj.getClass());
         }
@@ -475,11 +303,11 @@ public class ClientBinaryTupleUtils {
         builder.appendInt(0);
     }
 
-    private static IgniteException unsupportedTypeException(int dataType) {
+    static IgniteException unsupportedTypeException(int dataType) {
         return new IgniteException(PROTOCOL_ERR, "Unsupported type: " + dataType);
     }
 
-    private static IgniteException unsupportedTypeException(Class<?> cls) {
+    static IgniteException unsupportedTypeException(Class<?> cls) {
         return new IgniteException(PROTOCOL_ERR, "Unsupported type: " + cls);
     }
 }

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/StreamerReceiverSerializer.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/StreamerReceiverSerializer.java
@@ -56,8 +56,6 @@ import org.jetbrains.annotations.Nullable;
  * No intermediate steps, trivial serialize/deserialize.
  */
 public class StreamerReceiverSerializer {
-    private static final int TYPE_ID_TUPLE = -1;
-
     /**
      * Serializes streamer receiver info.
      *
@@ -330,7 +328,7 @@ public class StreamerReceiverSerializer {
             builder.appendInt(ColumnType.PERIOD.id());
             return (T v) -> builder.appendPeriod((Period) v);
         } else if (obj instanceof Tuple) {
-            builder.appendInt(TYPE_ID_TUPLE);
+            builder.appendInt(TupleWithSchemaMarshalling.TYPE_ID_TUPLE);
             return (T v) -> appendTuple(builder, (Tuple) v);
         } else {
             throw unsupportedTypeException(obj.getClass());
@@ -338,7 +336,7 @@ public class StreamerReceiverSerializer {
     }
 
     private static Function<Integer, Object> readerForType(BinaryTupleReader binTuple, int typeId) {
-        if (typeId == TYPE_ID_TUPLE) {
+        if (typeId == TupleWithSchemaMarshalling.TYPE_ID_TUPLE) {
             return idx -> readTuple(binTuple, idx);
         }
 
@@ -403,7 +401,7 @@ public class StreamerReceiverSerializer {
 
     private static <T> void appendArg(BinaryTupleBuilder builder, @Nullable T arg) {
         if (arg instanceof Tuple) {
-            builder.appendInt(TYPE_ID_TUPLE);
+            builder.appendInt(TupleWithSchemaMarshalling.TYPE_ID_TUPLE);
             builder.appendInt(0); // Scale.
             appendTuple(builder, (Tuple) arg);
 
@@ -418,7 +416,7 @@ public class StreamerReceiverSerializer {
             return null;
         }
 
-        if (reader.intValue(index) == TYPE_ID_TUPLE) {
+        if (reader.intValue(index) == TupleWithSchemaMarshalling.TYPE_ID_TUPLE) {
             return readTuple(reader, index + 2);
         }
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/StreamerReceiverSerializer.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/StreamerReceiverSerializer.java
@@ -67,19 +67,19 @@ public class StreamerReceiverSerializer {
      * Serializes streamer receiver info.
      *
      * @param receiver Receiver descriptor.
-     * @param receiverArgs Receiver arguments.
+     * @param receiverArg Receiver arguments.
      * @param items Items.
      */
     public static <A> byte[] serializeReceiverInfoWithElementCount(
             ReceiverDescriptor<A> receiver,
-            @Nullable A receiverArgs,
+            @Nullable A receiverArg,
             Collection<?> items) {
         // className + arg + items size + item type + items.
         int binaryTupleSize = 1 + 3 + 1 + 1 + items.size();
         var builder = new BinaryTupleBuilder(binaryTupleSize);
         builder.appendString(receiver.receiverClassName());
 
-        ClientBinaryTupleUtils.appendObject(builder, receiverArgs);
+        ClientBinaryTupleUtils.appendObject(builder, receiverArg);
 
         ClientBinaryTupleUtils.appendCollectionToBinaryTuple(builder, items);
 

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/StreamerReceiverSerializer.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/StreamerReceiverSerializer.java
@@ -77,9 +77,7 @@ public class StreamerReceiverSerializer {
         var builder = new BinaryTupleBuilder(binaryTupleSize);
         builder.appendString(receiverClassName);
 
-        // TODO: Use SharedComputeUtils for arg and items.
-        ClientBinaryTupleUtils.appendObject(builder, receiverArg);
-
+        appendArg(builder, receiverArg);
         appendCollectionToBinaryTuple(builder, items);
 
         w.packInt(binaryTupleSize);
@@ -102,9 +100,7 @@ public class StreamerReceiverSerializer {
         var builder = new BinaryTupleBuilder(binaryTupleSize);
         builder.appendString(receiver.receiverClassName());
 
-        // TODO: Use SharedComputeUtils for arg and items.
-        ClientBinaryTupleUtils.appendObject(builder, receiverArg);
-
+        appendArg(builder, receiverArg);
         appendCollectionToBinaryTuple(builder, items);
 
         ByteBuffer buf = builder.build();
@@ -134,7 +130,7 @@ public class StreamerReceiverSerializer {
             throw new IgniteException(PROTOCOL_ERR, "Receiver class name is null");
         }
 
-        Object receiverArg = ClientBinaryTupleUtils.readObject(reader, readerIndex);
+        Object receiverArg = readArg(reader, readerIndex);
 
         readerIndex += 3;
 
@@ -406,6 +402,16 @@ public class StreamerReceiverSerializer {
             default:
                 throw unsupportedTypeException(type.id());
         }
+    }
+
+    private static <T> void appendArg(BinaryTupleBuilder builder, @Nullable T arg) {
+        // TODO: Support Tuple
+        ClientBinaryTupleUtils.appendObject(builder, arg);
+    }
+
+    private static @Nullable Object readArg(BinaryTupleReader reader, int readerIndex) {
+        // TODO: Support Tuple
+        return ClientBinaryTupleUtils.readObject(reader, readerIndex);
     }
 
     /**

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/StreamerReceiverSerializer.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/StreamerReceiverSerializer.java
@@ -17,16 +17,30 @@
 
 package org.apache.ignite.internal.client.proto;
 
+import static org.apache.ignite.internal.client.proto.ClientBinaryTupleUtils.unsupportedTypeException;
 import static org.apache.ignite.lang.ErrorGroups.Client.PROTOCOL_ERR;
 
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Period;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import org.apache.ignite.internal.binarytuple.BinaryTupleBuilder;
 import org.apache.ignite.internal.binarytuple.BinaryTupleReader;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.marshalling.Marshaller;
+import org.apache.ignite.sql.ColumnType;
 import org.apache.ignite.table.ReceiverDescriptor;
 import org.jetbrains.annotations.Nullable;
 
@@ -62,7 +76,7 @@ public class StreamerReceiverSerializer {
         // TODO: Use SharedComputeUtils for arg and items.
         ClientBinaryTupleUtils.appendObject(builder, receiverArg);
 
-        ClientBinaryTupleUtils.appendCollectionToBinaryTuple(builder, items);
+        appendCollectionToBinaryTuple(builder, items);
 
         w.packInt(binaryTupleSize);
         w.packBinaryTuple(builder);
@@ -87,7 +101,7 @@ public class StreamerReceiverSerializer {
         // TODO: Use SharedComputeUtils for arg and items.
         ClientBinaryTupleUtils.appendObject(builder, receiverArg);
 
-        ClientBinaryTupleUtils.appendCollectionToBinaryTuple(builder, items);
+        appendCollectionToBinaryTuple(builder, items);
 
         ByteBuffer buf = builder.build();
         int bufSize = buf.limit() - buf.position();
@@ -120,7 +134,7 @@ public class StreamerReceiverSerializer {
 
         readerIndex += 3;
 
-        List<Object> items = ClientBinaryTupleUtils.readCollectionFromBinaryTuple(reader, readerIndex);
+        List<Object> items = readCollectionFromBinaryTuple(reader, readerIndex);
 
         return new SteamerReceiverInfo(receiverClassName, receiverArg, items);
     }
@@ -137,7 +151,7 @@ public class StreamerReceiverSerializer {
 
         int numElements = 2 + receiverResults.size();
         var builder = new BinaryTupleBuilder(numElements);
-        ClientBinaryTupleUtils.appendCollectionToBinaryTuple(builder, receiverResults);
+        appendCollectionToBinaryTuple(builder, receiverResults);
 
         ByteBuffer res = builder.build();
 
@@ -170,8 +184,7 @@ public class StreamerReceiverSerializer {
 
         var reader = new BinaryTupleReader(numElements, buf.slice().order(ByteOrder.LITTLE_ENDIAN));
 
-        // TODO: Use SharedComputeUtils for results.
-        return ClientBinaryTupleUtils.readCollectionFromBinaryTuple(reader, 0);
+        return readCollectionFromBinaryTuple(reader, 0);
     }
 
     /**
@@ -211,8 +224,173 @@ public class StreamerReceiverSerializer {
         byte[] bytes = r.readBinary();
         var reader = new BinaryTupleReader(numElements, bytes);
 
-        // TODO: Use SharedComputeUtils for results.
-        return ClientBinaryTupleUtils.readCollectionFromBinaryTuple(reader, 0);
+        return readCollectionFromBinaryTuple(reader, 0);
+    }
+
+    /**
+     * Packs an array of objects in BinaryTuple format.
+     *
+     * @param builder Target builder.
+     * @param items Items.
+     */
+    private static <T> void appendCollectionToBinaryTuple(BinaryTupleBuilder builder, Collection<T> items) {
+        assert items != null : "items can't be null";
+        assert !items.isEmpty() : "items can't be empty";
+        assert builder != null : "builder can't be null";
+
+        T firstItem = items.iterator().next();
+        Objects.requireNonNull(firstItem);
+        Class<?> type = firstItem.getClass();
+
+        Consumer<T> appender = appendTypeAndGetAppender(builder, firstItem);
+        builder.appendInt(items.size());
+
+        for (T item : items) {
+            Objects.requireNonNull(item);
+            if (!type.equals(item.getClass())) {
+                throw new IllegalArgumentException(
+                        "All items must have the same type. First item: " + type + ", current item: " + item.getClass());
+            }
+
+            appender.accept(item);
+        }
+    }
+
+    private static <R> List<R> readCollectionFromBinaryTuple(BinaryTupleReader reader, int readerIndex) {
+        int typeId = reader.intValue(readerIndex++);
+        ColumnType type = ColumnTypeConverter.fromIdOrThrow(typeId);
+        Function<Integer, Object> itemReader = readerForType(reader, type);
+        int itemsCount = reader.intValue(readerIndex++);
+
+        List<R> items = new ArrayList<>(itemsCount);
+        for (int i = 0; i < itemsCount; i++) {
+            items.add((R) itemReader.apply(readerIndex++));
+        }
+
+        return items;
+    }
+
+    /**
+     * Writes type id to the specified packer and returns a consumer that writes the value to the binary tuple.
+     *
+     * @param builder Builder.
+     * @param obj Object.
+     */
+    private static <T> Consumer<T> appendTypeAndGetAppender(BinaryTupleBuilder builder, Object obj) {
+        assert obj != null : "Object is null";
+
+        if (obj instanceof Boolean) {
+            builder.appendInt(ColumnType.BOOLEAN.id());
+            return (T v) -> builder.appendBoolean((Boolean) v);
+        } else if (obj instanceof Byte) {
+            builder.appendInt(ColumnType.INT8.id());
+            return (T v) -> builder.appendByte((Byte) v);
+        } else if (obj instanceof Short) {
+            builder.appendInt(ColumnType.INT16.id());
+            return (T v) -> builder.appendShort((Short) v);
+        } else if (obj instanceof Integer) {
+            builder.appendInt(ColumnType.INT32.id());
+            return (T v) -> builder.appendInt((Integer) v);
+        } else if (obj instanceof Long) {
+            builder.appendInt(ColumnType.INT64.id());
+            return (T v) -> builder.appendLong((Long) v);
+        } else if (obj instanceof Float) {
+            builder.appendInt(ColumnType.FLOAT.id());
+            return (T v) -> builder.appendFloat((Float) v);
+        } else if (obj instanceof Double) {
+            builder.appendInt(ColumnType.DOUBLE.id());
+            return (T v) -> builder.appendDouble((Double) v);
+        } else if (obj instanceof BigDecimal) {
+            builder.appendInt(ColumnType.DECIMAL.id());
+            return (T v) -> builder.appendDecimal((BigDecimal) v, ((BigDecimal) v).scale());
+        } else if (obj instanceof UUID) {
+            builder.appendInt(ColumnType.UUID.id());
+            return (T v) -> builder.appendUuid((UUID) v);
+        } else if (obj instanceof String) {
+            builder.appendInt(ColumnType.STRING.id());
+            return (T v) -> builder.appendString((String) v);
+        } else if (obj instanceof byte[]) {
+            builder.appendInt(ColumnType.BYTE_ARRAY.id());
+            return (T v) -> builder.appendBytes((byte[]) v);
+        } else if (obj instanceof LocalDate) {
+            builder.appendInt(ColumnType.DATE.id());
+            return (T v) -> builder.appendDate((LocalDate) v);
+        } else if (obj instanceof LocalTime) {
+            builder.appendInt(ColumnType.TIME.id());
+            return (T v) -> builder.appendTime((LocalTime) v);
+        } else if (obj instanceof LocalDateTime) {
+            builder.appendInt(ColumnType.DATETIME.id());
+            return (T v) -> builder.appendDateTime((LocalDateTime) v);
+        } else if (obj instanceof Instant) {
+            builder.appendInt(ColumnType.TIMESTAMP.id());
+            return (T v) -> builder.appendTimestamp((Instant) v);
+        } else if (obj instanceof Duration) {
+            builder.appendInt(ColumnType.DURATION.id());
+            return (T v) -> builder.appendDuration((Duration) v);
+        } else if (obj instanceof Period) {
+            builder.appendInt(ColumnType.PERIOD.id());
+            return (T v) -> builder.appendPeriod((Period) v);
+        } else {
+            throw unsupportedTypeException(obj.getClass());
+        }
+    }
+
+    private static Function<Integer, Object> readerForType(BinaryTupleReader binTuple, ColumnType type) {
+        switch (type) {
+            case INT8:
+                return binTuple::byteValue;
+
+            case INT16:
+                return binTuple::shortValue;
+
+            case INT32:
+                return binTuple::intValue;
+
+            case INT64:
+                return binTuple::longValue;
+
+            case FLOAT:
+                return binTuple::floatValue;
+
+            case DOUBLE:
+                return binTuple::doubleValue;
+
+            case DECIMAL:
+                return idx -> binTuple.decimalValue(idx, -1);
+
+            case UUID:
+                return binTuple::uuidValue;
+
+            case STRING:
+                return binTuple::stringValue;
+
+            case BYTE_ARRAY:
+                return binTuple::bytesValue;
+
+            case DATE:
+                return binTuple::dateValue;
+
+            case TIME:
+                return binTuple::timeValue;
+
+            case DATETIME:
+                return binTuple::dateTimeValue;
+
+            case TIMESTAMP:
+                return binTuple::timestampValue;
+
+            case BOOLEAN:
+                return idx -> binTuple.byteValue(idx) != 0;
+
+            case DURATION:
+                return binTuple::durationValue;
+
+            case PERIOD:
+                return binTuple::periodValue;
+
+            default:
+                throw unsupportedTypeException(type.id());
+        }
     }
 
     /**

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/StreamerReceiverSerializer.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/StreamerReceiverSerializer.java
@@ -45,17 +45,22 @@ public class StreamerReceiverSerializer {
      *
      * @param w Writer.
      * @param receiverClassName Receiver class name.
-     * @param receiverArgs Receiver arguments.
+     * @param receiverArg Receiver arguments.
      * @param items Items.
      */
-    public static <A> void serializeReceiverInfoOnClient(ClientMessagePacker w, String receiverClassName, A receiverArgs,
-            @Nullable Marshaller<A, byte[]> receiverArgsMarshaller, Collection<?> items) {
+    public static <A> void serializeReceiverInfoOnClient(
+            ClientMessagePacker w,
+            String receiverClassName,
+            A receiverArg,
+            @Nullable Marshaller<A, byte[]> receiverArgsMarshaller,
+            Collection<?> items) {
         // className + arg + items size + item type + items.
         int binaryTupleSize = 1 + 3 + 1 + 1 + items.size();
         var builder = new BinaryTupleBuilder(binaryTupleSize);
         builder.appendString(receiverClassName);
 
-        ClientBinaryTupleUtils.appendObject(builder, receiverArgs);
+        // TODO: Use SharedComputeUtils for arg and items.
+        ClientBinaryTupleUtils.appendObject(builder, receiverArg);
 
         ClientBinaryTupleUtils.appendCollectionToBinaryTuple(builder, items);
 
@@ -79,6 +84,7 @@ public class StreamerReceiverSerializer {
         var builder = new BinaryTupleBuilder(binaryTupleSize);
         builder.appendString(receiver.receiverClassName());
 
+        // TODO: Use SharedComputeUtils for arg and items.
         ClientBinaryTupleUtils.appendObject(builder, receiverArg);
 
         ClientBinaryTupleUtils.appendCollectionToBinaryTuple(builder, items);
@@ -164,6 +170,7 @@ public class StreamerReceiverSerializer {
 
         var reader = new BinaryTupleReader(numElements, buf.slice().order(ByteOrder.LITTLE_ENDIAN));
 
+        // TODO: Use SharedComputeUtils for results.
         return ClientBinaryTupleUtils.readCollectionFromBinaryTuple(reader, 0);
     }
 
@@ -204,6 +211,7 @@ public class StreamerReceiverSerializer {
         byte[] bytes = r.readBinary();
         var reader = new BinaryTupleReader(numElements, bytes);
 
+        // TODO: Use SharedComputeUtils for results.
         return ClientBinaryTupleUtils.readCollectionFromBinaryTuple(reader, 0);
     }
 

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeImpl.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeImpl.java
@@ -588,7 +588,7 @@ public class IgniteComputeImpl implements IgniteComputeInternal, StreamerReceive
             Collection<I> items,
             ClusterNode node,
             List<DeploymentUnit> deploymentUnits) {
-        var payload = StreamerReceiverSerializer.serializeReceiverInfoWithElementCount(receiver, receiverArg, items);
+        byte[] payload = StreamerReceiverSerializer.serializeReceiverInfoWithElementCount(receiver, receiverArg, items);
 
         return runReceiverAsync(payload, node, deploymentUnits)
                 .thenApply(StreamerReceiverSerializer::deserializeReceiverJobResults);

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeImpl.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/IgniteComputeImpl.java
@@ -588,7 +588,7 @@ public class IgniteComputeImpl implements IgniteComputeInternal, StreamerReceive
             Collection<I> items,
             ClusterNode node,
             List<DeploymentUnit> deploymentUnits) {
-        byte[] payload = StreamerReceiverSerializer.serializeReceiverInfoWithElementCount(receiver, receiverArg, items);
+        var payload = StreamerReceiverSerializer.serializeReceiverInfoWithElementCount(receiver, receiverArg, items);
 
         return runReceiverAsync(payload, node, deploymentUnits)
                 .thenApply(StreamerReceiverSerializer::deserializeReceiverJobResults);

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItAbstractDataStreamerTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItAbstractDataStreamerTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -641,7 +642,14 @@ public abstract class ItAbstractDataStreamerTest extends ClusterPerClassIntegrat
         Tuple resTuple = resultSubscriber.items.get(0);
 
         for (int i = 0; i < tuple.columnCount(); i++) {
-            assertEquals(tuple.value(i), (Object) resTuple.value(i));
+            Object origVal = tuple.value(i);
+            Object resVal = resTuple.value(i);
+
+            if (origVal instanceof byte[]) {
+                assertArrayEquals((byte[]) origVal, (byte[]) resVal);
+            } else {
+                assertEquals(origVal, resVal);
+            }
         }
     }
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItAbstractDataStreamerTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItAbstractDataStreamerTest.java
@@ -559,6 +559,7 @@ public abstract class ItAbstractDataStreamerTest extends ClusterPerClassIntegrat
         var resultSubscriber = new TestSubscriber<Tuple>();
 
         try (var publisher = new SubmissionPublisher<Tuple>()) {
+            // Tuple argument.
             Tuple receiverArg = Tuple.create().set("arg1", "val1").set("arg2", 2);
 
             streamerFut = defaultTable().recordView().streamData(
@@ -571,6 +572,7 @@ public abstract class ItAbstractDataStreamerTest extends ClusterPerClassIntegrat
                     receiverArg
             );
 
+            // Tuple payload.
             publisher.submit(tuple(1, "foo1"));
             publisher.submit(tuple(2, "foo2"));
         }
@@ -578,6 +580,7 @@ public abstract class ItAbstractDataStreamerTest extends ClusterPerClassIntegrat
         assertThat(streamerFut, willCompleteSuccessfully());
         assertEquals(2, resultSubscriber.items.size());
 
+        // Tuple results.
         for (Tuple item : resultSubscriber.items) {
             assertEquals("foo" + item.intValue(0), item.stringValue(1));
             assertEquals("val1", item.stringValue("arg1"));

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItAbstractDataStreamerTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/streamer/ItAbstractDataStreamerTest.java
@@ -672,8 +672,7 @@ public abstract class ItAbstractDataStreamerTest extends ClusterPerClassIntegrat
         assertThat(streamerFut, willCompleteSuccessfully());
         assertEquals(1, resultSubscriber.items.size());
 
-        Tuple resTuple = resultSubscriber.items.get(0);
-        return resTuple;
+        return resultSubscriber.items.get(0);
     }
 
     private void waitForKey(RecordView<Tuple> view, Tuple key) throws InterruptedException {


### PR DESCRIPTION
Allow Tuple as a data streamer payload, argument, and result.
* Reuse `TupleWithSchemaMarshalling` from Compute (allows nested Tuples as well)
* Move streamer-specific logic from `ClientBinaryTupleUtils` to `StreamerReceiverSerializer`