### PR TITLE
IGNITE-24972 Flaky ItMulticastNodeFinderTest

### DIFF
--- a/modules/network/src/main/java/org/apache/ignite/internal/network/configuration/MulticastNodeFinderConfigurationSchema.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/configuration/MulticastNodeFinderConfigurationSchema.java
@@ -40,10 +40,10 @@ public class MulticastNodeFinderConfigurationSchema extends NodeFinderConfigurat
     @Range(min = 1, max = 65535)
     public int port = 47401;
 
-    /** Time to wait for multicast responses. */
+    /** Time to wait for multicast responses (m. */
     @Value(hasDefault = true)
     @Range(min = 0)
-    public int resultWaitTimeMillis = 500;
+    public int resultWaitTimeMillis = 1000;
 
     /** Time to live for multicast packets. Value {@link MulticastNodeFinder#UNSPECIFIED_TTL} corresponds to system default value. */
     @Value(hasDefault = true)

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/configuration/MulticastNodeFinderConfigurationSchema.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/configuration/MulticastNodeFinderConfigurationSchema.java
@@ -40,7 +40,7 @@ public class MulticastNodeFinderConfigurationSchema extends NodeFinderConfigurat
     @Range(min = 1, max = 65535)
     public int port = 47401;
 
-    /** Time to wait for multicast responses (m. */
+    /** Time to wait for multicast responses. */
     @Value(hasDefault = true)
     @Range(min = 0)
     public int resultWaitTimeMillis = 1000;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-24972

TC agents sometimes have problems with network latency, so resultWaitTime in test should be increased (1000ms is used in similar AI2 test)

It also won't hurt to have increased default in config also