### PR TITLE
IGNITE-24840: Sql. Extend SQL logic test coverage for TIME types

### DIFF
--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/sqllogic/Statement.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/sqllogic/Statement.java
@@ -118,6 +118,7 @@ final class Statement extends Command {
                 IgniteStringBuilder detailsBuilder = new IgniteStringBuilder("Not expected result at: ")
                         .app(posDesc).app('.').nl()
                         .app('\t').app("Statement: ").app(qry).app('.').nl()
+                        .app('\t').app("Loop variables: ").app(ctx.loopVars).nl()
                         .app('\t').app("Expected: ");
 
                 Throwable err = Assertions.assertThrows(

--- a/modules/sql-engine/src/integrationTest/sql/group1/types/time/test_time.test
+++ b/modules/sql-engine/src/integrationTest/sql/group1/types/time/test_time.test
@@ -156,6 +156,7 @@ INSERT INTO times_sub_ms VALUES(5, '00:00:00.999999'::${type}, '00:00:00.999999'
 statement ok
 INSERT INTO times_sub_ms VALUES(6, '00:00:00.999999999'::${type}, '00:00:00.999999999'::${type}, '00:00:00.999999999'::${type}, '00:00:00.999999999'::${type})
 
+# TODO https://issues.apache.org/jira/browse/IGNITE-24934 Make behavior consistent for truncated values
 query TTTT
 SELECT t1_0::VARCHAR, t1_1::VARCHAR, t1_2::VARCHAR, t1_3::VARCHAR FROM times_sub_ms ORDER BY id ASC
 ----

--- a/modules/sql-engine/src/integrationTest/sql/group1/types/time/test_time.test
+++ b/modules/sql-engine/src/integrationTest/sql/group1/types/time/test_time.test
@@ -28,3 +28,145 @@ SELECT cast(t1 AS VARCHAR), cast(t2 AS VARCHAR) FROM times ORDER by t1
 20:08:10.33	20:08:10.33
 20:08:10.998	20:08:10.998
 NULL	NULL
+
+# A cast operation to a time data type that reduce precision behave the same way as such cast to a decimal
+# SELECT '20.999'::DECIMAL(4,2) produces 20.99
+
+# TIME
+
+# Literals
+
+statement ok
+CREATE TABLE times2(id INT PRIMARY KEY, t1_0 TIME(0), t1_1 TIME(1), t1_2 TIME(2), t1_3 TIME(3))
+
+statement ok
+INSERT INTO times2 VALUES(1, TIME '00:00:00.333', TIME '00:00:00.333',  TIME '00:00:00.333', TIME '00:00:00.333')
+
+statement ok
+INSERT INTO times2 VALUES(2, TIME '00:00:00.999', TIME '00:00:00.999',  TIME '00:00:00.999', TIME '00:00:00.999')
+
+statement ok
+INSERT INTO times2 VALUES(3, TIME '00:00:59.333', TIME '00:00:59.333',  TIME '00:00:59.333', TIME '00:00:59.333')
+
+statement ok
+INSERT INTO times2 VALUES(4, TIME '00:00:59.999', TIME '00:00:59.999',  TIME '00:00:59.999', TIME '00:00:59.999')
+
+query TTTT
+SELECT t1_0::VARCHAR, t1_1::VARCHAR, t1_2::VARCHAR, t1_3::VARCHAR FROM times2 ORDER BY id ASC
+----
+00:00:00	00:00:00.3	00:00:00.33	00:00:00.333
+00:00:00	00:00:00.9	00:00:00.99	00:00:00.999
+00:00:59	00:00:59.3	00:00:59.33	00:00:59.333
+00:00:59	00:00:59.9	00:00:59.99	00:00:59.999
+
+# same as above but with CAST to TIME, TIME(3)
+
+# Cast to time instead of literals
+
+for type in [TIME, TIME(3)]
+
+statement ok
+CREATE TABLE times3(id INT PRIMARY KEY, t1_0 TIME(0), t1_1 TIME(1), t1_2 TIME(2), t1_3 TIME(3))
+
+statement ok
+INSERT INTO times3 VALUES(1, '00:00:00.333'::${type}, '00:00:00.333'::${type}, '00:00:00.333'::${type}, '00:00:00.333'::${type})
+
+statement ok
+INSERT INTO times3 VALUES(2, '00:00:00.999'::${type}, '00:00:00.999'::${type}, '00:00:00.999'::${type}, '00:00:00.999'::${type})
+
+statement ok
+INSERT INTO times3 VALUES(3, '00:00:59.333'::${type}, '00:00:59.333'::${type}, '00:00:59.333'::${type}, '00:00:59.333'::${type})
+
+statement ok
+INSERT INTO times3 VALUES(4, '00:00:59.999'::${type}, '00:00:59.999'::${type}, '00:00:59.999'::${type}, '00:00:59.999'::${type})
+
+query TTTT
+SELECT t1_0::VARCHAR, t1_1::VARCHAR, t1_2::VARCHAR, t1_3::VARCHAR FROM times3 ORDER BY id ASC
+----
+00:00:00	00:00:00.3	00:00:00.33	00:00:00.333
+00:00:00	00:00:00.9	00:00:00.99	00:00:00.999
+00:00:59	00:00:59.3	00:00:59.33	00:00:59.333
+00:00:59	00:00:59.9	00:00:59.99	00:00:59.999
+
+statement ok
+DROP TABLE times3
+
+endfor
+
+# Sub-millisecond precision time
+
+statement ok
+CREATE TABLE times_sub_ms(id INT PRIMARY KEY, t1_0 TIME(6), t1_1 TIME(7), t1_2 TIME(8), t1_3 TIME(9))
+
+# Literals
+
+statement ok
+INSERT INTO times_sub_ms VALUES(1, TIME '00:00:00.333333', TIME '00:00:00.333333',  TIME '00:00:00.333333', TIME '00:00:00.333333')
+
+statement ok
+INSERT INTO times_sub_ms VALUES(2, TIME '00:00:00.999999', TIME '00:00:00.999999',  TIME '00:00:00.999999', TIME '00:00:00.999999')
+
+statement ok
+INSERT INTO times_sub_ms VALUES(3, TIME '00:00:59.333333', TIME '00:00:59.333333',  TIME '00:00:59.333', TIME '00:00:59.333333')
+
+statement ok
+INSERT INTO times_sub_ms VALUES(4, TIME '00:00:58.999999', TIME '00:00:58.999999', TIME '00:00:58.999999', TIME '00:00:58.999999')
+
+statement ok
+INSERT INTO times_sub_ms VALUES(5, TIME '00:00:00.999999', TIME '00:00:00.999999', TIME '00:00:00.999999', TIME '00:00:00.999999')
+
+statement ok
+INSERT INTO times_sub_ms VALUES(6, TIME '00:00:00.999999999', TIME '00:00:00.999999999', TIME '00:00:00.999999999', TIME '00:00:00.999999999')
+
+query TTTT
+SELECT t1_0::VARCHAR, t1_1::VARCHAR, t1_2::VARCHAR, t1_3::VARCHAR FROM times_sub_ms ORDER BY id ASC
+----
+00:00:00.333	00:00:00.333	00:00:00.333	00:00:00.333
+00:00:00.999	00:00:00.999	00:00:00.999	00:00:00.999
+00:00:59.333	00:00:59.333	00:00:59.333	00:00:59.333
+00:00:58.999	00:00:58.999	00:00:58.999	00:00:58.999
+00:00:00.999	00:00:00.999	00:00:00.999	00:00:00.999
+00:00:00.999	00:00:00.999	00:00:00.999	00:00:00.999
+
+statement ok
+DROP TABLE times_sub_ms
+
+# Cast to time instead of literals
+
+for type in [TIME(6), TIME(7), TIME(8), TIME(9)]
+
+statement ok
+CREATE TABLE times_sub_ms(id INT PRIMARY KEY, t1_0 TIME(6), t1_1 TIME(7), t1_2 TIME(8), t1_3 TIME(9))
+
+statement ok
+INSERT INTO times_sub_ms VALUES(1, '00:00:00.333333'::${type}, '00:00:00.333333'::${type}, '00:00:00.333333'::${type}, '00:00:00.333333'::${type})
+
+statement ok
+INSERT INTO times_sub_ms VALUES(2, '00:00:00.999999'::${type}, '00:00:00.999999'::${type}, '00:00:00.999999'::${type}, '00:00:00.999999'::${type})
+
+statement ok
+INSERT INTO times_sub_ms VALUES(3, '00:00:59.333333'::${type}, '00:00:59.333333'::${type}, '00:00:59.333333'::${type}, '00:00:59.333333'::${type})
+
+statement ok
+INSERT INTO times_sub_ms VALUES(4, '00:00:58.999999'::${type}, '00:00:58.999999'::${type}, '00:00:58.999999'::${type}, '00:00:58.999999'::${type})
+
+statement ok
+INSERT INTO times_sub_ms VALUES(5, '00:00:00.999999'::${type}, '00:00:00.999999'::${type}, '00:00:00.999999'::${type}, '00:00:00.999999'::${type})
+
+statement ok
+INSERT INTO times_sub_ms VALUES(6, '00:00:00.999999999'::${type}, '00:00:00.999999999'::${type}, '00:00:00.999999999'::${type}, '00:00:00.999999999'::${type})
+
+query TTTT
+SELECT t1_0::VARCHAR, t1_1::VARCHAR, t1_2::VARCHAR, t1_3::VARCHAR FROM times_sub_ms ORDER BY id ASC
+----
+00:00:00.333	00:00:00.333	00:00:00.333	00:00:00.333
+00:00:01	00:00:01	00:00:01	00:00:01
+00:00:59.333	00:00:59.333	00:00:59.333	00:00:59.333
+00:00:59	00:00:59	00:00:59	00:00:59
+00:00:01	00:00:01	00:00:01	00:00:01
+00:00:01	00:00:01	00:00:01	00:00:01
+
+statement ok
+DROP TABLE times_sub_ms
+
+endfor

--- a/modules/sql-engine/src/integrationTest/sql/group1/types/time/time_parsing.test
+++ b/modules/sql-engine/src/integrationTest/sql/group1/types/time/time_parsing.test
@@ -27,3 +27,85 @@ query I
 SELECT '14:42:04.999000'::TIME(6)::VARCHAR
 ----
 14:42:04.999
+
+query T
+SELECT '1'::TIME
+----
+01:00:00
+
+query T
+SELECT '11'::TIME
+----
+11:00:00
+
+statement error
+SELECT '11:'::TIME
+
+query T
+SELECT '11:1'::TIME
+----
+11:01:00
+
+statement error
+SELECT '23:60:00'::TIME
+----
+
+# https://issues.apache.org/jira/browse/IGNITE-25000 Negative time components / out of range values
+skipif ignite3
+statement error
+SELECT '23:00:60'::TIME
+
+# https://issues.apache.org/jira/browse/IGNITE-25000 Negative time components / out of range values
+skipif ignite3
+statement error
+SELECT '22:60:60'::TIME
+
+statement error
+SELECT '23:59:60'::TIME
+----
+
+# https://issues.apache.org/jira/browse/IGNITE-25000 Negative time components / out of range values
+skipif ignite3
+statement error
+SELECT '-00:00:00'::TIME
+----
+
+statement error
+SELECT '-1:00:00'::TIME
+----
+
+# https://issues.apache.org/jira/browse/IGNITE-25000 Negative time components / out of range values
+skipif ignite3
+statement error
+SELECT '1:-00:00'::TIME
+----
+
+# https://issues.apache.org/jira/browse/IGNITE-25000 Negative time components / out of range values
+skipif ignite3
+statement error
+SELECT '1:-01:00'::TIME
+----
+
+# https://issues.apache.org/jira/browse/IGNITE-25000 Negative time components / out of range values
+skipif ignite3
+statement error
+SELECT '10:-01:00'::TIME
+----
+
+# https://issues.apache.org/jira/browse/IGNITE-25000 Negative time components / out of range values
+skipif ignite3
+statement error
+SELECT '1:01:-00'::TIME
+----
+
+# https://issues.apache.org/jira/browse/IGNITE-25000 Negative time components / out of range values
+skipif ignite3
+statement error
+SELECT '1:01:-01'::TIME
+----
+
+# https://issues.apache.org/jira/browse/IGNITE-25000 Negative time components / out of range values
+skipif ignite3
+statement error
+SELECT '1:10:-01'::TIME
+----


### PR DESCRIPTION
Add tests that document current behaviour of TIME literals/ CAST to TIME.

- Casts with precision loss in precision supported precision range behave the same way as casts to decimals: ` SELECT '20.999'::DECIMAL(4,2) produces 20.99` and `SELECT '01:01:01.999'::TIME(2) ` produces  01:01:01.990 

- Documents the behaviour of casts with precision on with on time types with sub-millisecond precision - the behaviour is inconsistent between TIME literals and CASTs but that is OK for now since sub-millisecond precision is not fully supported yet.

https://issues.apache.org/jira/browse/IGNITE-24840

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)