### PR TITLE
IGNITE-25007 Create JMH benchmark to test secondary indexes

### DIFF
--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/UpsertKvBenchmark.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/UpsertKvBenchmark.java
@@ -19,8 +19,8 @@ package org.apache.ignite.internal.benchmark;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.ignite.internal.lang.IgniteSystemProperties;
@@ -76,7 +76,6 @@ public class UpsertKvBenchmark extends AbstractMultiNodeBenchmark {
     private static final AtomicInteger COUNTER = new AtomicInteger();
 
     private static final ThreadLocal<Integer> GEN = ThreadLocal.withInitial(() -> COUNTER.getAndIncrement() * 20_000_000);
-    private static final ThreadLocal<Random> RANDOM = ThreadLocal.withInitial(Random::new);
 
     @Override
     public void nodeSetUp() throws Exception {
@@ -123,7 +122,7 @@ public class UpsertKvBenchmark extends AbstractMultiNodeBenchmark {
     }
 
     private Tuple valueTuple() {
-        String fieldVal = IgniteTestUtils.randomString(RANDOM.get(), fieldLength);
+        String fieldVal = IgniteTestUtils.randomString(ThreadLocalRandom.current(), fieldLength);
 
         return Tuple.create()
                 .set("field1", fieldVal)

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/UpsertKvBenchmark.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/UpsertKvBenchmark.java
@@ -19,15 +19,12 @@ package org.apache.ignite.internal.benchmark;
 
 import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.ignite.internal.lang.IgniteSystemProperties;
-import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.apache.ignite.internal.util.CompletableFutures;
 import org.apache.ignite.table.KeyValueView;
 import org.apache.ignite.table.Tuple;
@@ -75,7 +72,7 @@ public class UpsertKvBenchmark extends AbstractMultiNodeBenchmark {
     @Param({"0", "10"})
     private int idxes;
 
-    @Param({"10"})
+    @Param({"100"})
     private int fieldLength;
 
     @Param({"HASH", "SORTED"})
@@ -193,10 +190,5 @@ public class UpsertKvBenchmark extends AbstractMultiNodeBenchmark {
     @Override
     protected int replicaCount() {
         return 1;
-    }
-
-    @Override
-    protected Path workDir() throws Exception {
-        return Path.of("D:", "tmpDirPrefix" + ThreadLocalRandom.current().nextInt());
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-25007

Benchmark output
```
Benchmark                 (batch)  (fieldLength)  (fieldValueGeneration)  (fsync)  (idxes)  (indexType)  (partitionCount)   Mode  Cnt      Score     Error  Units
UpsertKvBenchmark.upsert        1            100            uniquePrefix    false        0         HASH                 8  thrpt   20  10357.167 ± 113.030  ops/s
UpsertKvBenchmark.upsert        1            100            uniquePrefix    false        0       SORTED                 8  thrpt   20  10412.456 ±  78.296  ops/s
UpsertKvBenchmark.upsert        1            100            uniquePrefix    false       10         HASH                 8  thrpt   20   6626.293 ±  57.927  ops/s
UpsertKvBenchmark.upsert        1            100            uniquePrefix    false       10       SORTED                 8  thrpt   20   4667.291 ±  94.643  ops/s
UpsertKvBenchmark.upsert        1            100           uniquePostfix    false        0         HASH                 8  thrpt   20  10388.310 ±  74.452  ops/s
UpsertKvBenchmark.upsert        1            100           uniquePostfix    false        0       SORTED                 8  thrpt   20  10249.812 ±  86.386  ops/s
UpsertKvBenchmark.upsert        1            100           uniquePostfix    false       10         HASH                 8  thrpt   20   6588.614 ±  54.229  ops/s
UpsertKvBenchmark.upsert        1            100           uniquePostfix    false       10       SORTED                 8  thrpt   20   3176.424 ±  68.222  ops/s
```