### PR TITLE
IGNITE-24968 Java thin: fix race on query cancellation

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/PayloadOutputChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/PayloadOutputChannel.java
@@ -32,6 +32,8 @@ public class PayloadOutputChannel implements AutoCloseable {
     /** Client request ID. */
     private final long requestId;
 
+    private Runnable onSent;
+
     /**
      * Constructor.
      *
@@ -76,5 +78,18 @@ public class PayloadOutputChannel implements AutoCloseable {
     @Override
     public void close() {
         out.close();
+    }
+
+    /**
+     * Sets the action to be executed when the payload is sent.
+     *
+     * @param onSent Action to be executed.
+     */
+    public void onSent(Runnable onSent) {
+        this.onSent = onSent;
+    }
+
+    public Runnable onSent() {
+        return onSent;
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/PayloadOutputChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/PayloadOutputChannel.java
@@ -33,7 +33,8 @@ public class PayloadOutputChannel implements AutoCloseable {
     /** Client request ID. */
     private final long requestId;
 
-    private volatile @Nullable Runnable onSent;
+    /** Action to be executed when the payload is sent. */
+    private volatile @Nullable Runnable onSentAction;
 
     /**
      * Constructor.
@@ -82,15 +83,16 @@ public class PayloadOutputChannel implements AutoCloseable {
     }
 
     /**
-     * Sets the action to be executed when the payload is sent.
+     * Sets the action to be executed when the payload is sent successfully.
      *
-     * @param onSent Action to be executed.
+     * @param action Action to be executed.
      */
-    public void onSent(Runnable onSent) {
-        this.onSent = onSent;
+    public void onSent(Runnable action) {
+        this.onSentAction = action;
     }
 
-    public @Nullable Runnable onSent() {
-        return onSent;
+    /** Returns an action, if any, that should be executed when the payload is sent successfully. */
+    @Nullable Runnable onSentAction() {
+        return onSentAction;
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/PayloadOutputChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/PayloadOutputChannel.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.client;
 
 import org.apache.ignite.internal.client.proto.ClientMessagePacker;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Thin client payload output channel.
@@ -32,7 +33,7 @@ public class PayloadOutputChannel implements AutoCloseable {
     /** Client request ID. */
     private final long requestId;
 
-    private Runnable onSent;
+    private volatile @Nullable Runnable onSent;
 
     /**
      * Constructor.
@@ -89,7 +90,7 @@ public class PayloadOutputChannel implements AutoCloseable {
         this.onSent = onSent;
     }
 
-    public Runnable onSent() {
+    public @Nullable Runnable onSent() {
         return onSent;
     }
 }

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -379,7 +379,11 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
                     onDisconnected(ex);
                 } else {
                     metrics.requestsSentIncrement();
-                    asyncContinuationExecutor.execute(payloadCh.onSent());
+
+                    Runnable onSent = payloadCh.onSent();
+                    if (onSent != null) {
+                        asyncContinuationExecutor.execute(onSent);
+                    }
                 }
             });
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -379,6 +379,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
                     onDisconnected(ex);
                 } else {
                     metrics.requestsSentIncrement();
+                    payloadCh.onSent().run();
                 }
             });
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -380,9 +380,9 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
                 } else {
                     metrics.requestsSentIncrement();
 
-                    Runnable onSent = payloadCh.onSent();
-                    if (onSent != null) {
-                        asyncContinuationExecutor.execute(onSent);
+                    Runnable action = payloadCh.onSentAction();
+                    if (action != null) {
+                        asyncContinuationExecutor.execute(action);
                     }
                 }
             });

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/TcpClientChannel.java
@@ -379,7 +379,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
                     onDisconnected(ex);
                 } else {
                     metrics.requestsSentIncrement();
-                    payloadCh.onSent().run();
+                    asyncContinuationExecutor.execute(payloadCh.onSent());
                 }
             });
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientSql.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientSql.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.ignite.internal.binarytuple.BinaryTupleBuilder;
+import org.apache.ignite.internal.client.ClientChannel;
 import org.apache.ignite.internal.client.PayloadOutputChannel;
 import org.apache.ignite.internal.client.PayloadReader;
 import org.apache.ignite.internal.client.PayloadWriter;
@@ -264,7 +265,7 @@ public class ClientSql implements IgniteSql {
             w.out().packLong(ch.observableTimestamp().get().longValue());
 
             if (cancellationToken != null) {
-                addCancelAction(cancellationToken, w.requestId());
+                addCancelAction(cancellationToken, w.requestId(), w.clientChannel());
             }
         };
 
@@ -351,21 +352,21 @@ public class ClientSql implements IgniteSql {
             w.out().packLong(ch.observableTimestamp().get().longValue());
 
             if (cancellationToken != null) {
-                addCancelAction(cancellationToken, w.requestId());
+                w.onSent(() -> addCancelAction(cancellationToken, w.requestId(), w.clientChannel()));
             }
         };
 
         return ch.serviceAsync(ClientOp.SQL_EXEC_SCRIPT, payloadWriter, null);
     }
 
-    private void addCancelAction(CancellationToken cancellationToken, long correlationToken) {
+    private static void addCancelAction(CancellationToken cancellationToken, long correlationToken, ClientChannel reqCh) {
         CompletableFuture<Void> cancelFuture = new CompletableFuture<>();
 
         if (CancelHandleHelper.isCancelled(cancellationToken)) {
             throw new SqlException(Sql.EXECUTION_CANCELLED_ERR, "The query was cancelled while executing.");
         }
 
-        Runnable cancelAction = () -> ch.serviceAsync(ClientOp.SQL_CANCEL_EXEC, w -> w.out().packLong(correlationToken), null)
+        Runnable cancelAction = () -> reqCh.serviceAsync(ClientOp.SQL_CANCEL_EXEC, w -> w.out().packLong(correlationToken), null)
                 .whenComplete((r, e) -> {
                     if (e != null) {
                         cancelFuture.completeExceptionally(e);

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientSql.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientSql.java
@@ -28,7 +28,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.ignite.internal.binarytuple.BinaryTupleBuilder;
-import org.apache.ignite.internal.client.ClientChannel;
 import org.apache.ignite.internal.client.PayloadOutputChannel;
 import org.apache.ignite.internal.client.PayloadReader;
 import org.apache.ignite.internal.client.PayloadWriter;
@@ -265,7 +264,7 @@ public class ClientSql implements IgniteSql {
             w.out().packLong(ch.observableTimestamp().get().longValue());
 
             if (cancellationToken != null) {
-                addCancelAction(cancellationToken, w.requestId(), w.clientChannel());
+                addCancelAction(cancellationToken, w);
             }
         };
 
@@ -352,21 +351,24 @@ public class ClientSql implements IgniteSql {
             w.out().packLong(ch.observableTimestamp().get().longValue());
 
             if (cancellationToken != null) {
-                w.onSent(() -> addCancelAction(cancellationToken, w.requestId(), w.clientChannel()));
+                addCancelAction(cancellationToken, w);
             }
         };
 
         return ch.serviceAsync(ClientOp.SQL_EXEC_SCRIPT, payloadWriter, null);
     }
 
-    private static void addCancelAction(CancellationToken cancellationToken, long correlationToken, ClientChannel reqCh) {
+    private static void addCancelAction(CancellationToken cancellationToken, PayloadOutputChannel ch) {
         CompletableFuture<Void> cancelFuture = new CompletableFuture<>();
 
         if (CancelHandleHelper.isCancelled(cancellationToken)) {
             throw new SqlException(Sql.EXECUTION_CANCELLED_ERR, "The query was cancelled while executing.");
         }
 
-        Runnable cancelAction = () -> reqCh.serviceAsync(ClientOp.SQL_CANCEL_EXEC, w -> w.out().packLong(correlationToken), null)
+        long correlationToken = ch.requestId();
+
+        Runnable cancelAction = () -> ch.clientChannel()
+                .serviceAsync(ClientOp.SQL_CANCEL_EXEC, w -> w.out().packLong(correlationToken), null)
                 .whenComplete((r, e) -> {
                     if (e != null) {
                         cancelFuture.completeExceptionally(e);
@@ -375,7 +377,7 @@ public class ClientSql implements IgniteSql {
                     }
                 });
 
-        CancelHandleHelper.addCancelAction(cancellationToken, cancelAction, cancelFuture);
+        ch.onSent(() -> CancelHandleHelper.addCancelAction(cancellationToken, cancelAction, cancelFuture));
     }
 
     private static void packProperties(

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlApiBaseTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlApiBaseTest.java
@@ -1286,25 +1286,19 @@ public abstract class ItSqlApiBaseTest extends BaseSqlIntegrationTest {
 
             startBarrier.await();
 
-            ResultSet<SqlRow> rs;
-
-            try {
-                rs = executeLazy(sql, token, query);
+            try (ResultSet<SqlRow> rs = executeLazy(sql, token, query)) {
+                expectQueryCancelled(() -> {
+                    while (rs.hasNext()) {
+                        rs.next();
+                    }
+                });
             } catch (SqlException e) {
                 assertEquals(Sql.EXECUTION_CANCELLED_ERR, e.code());
 
                 continue;
             }
 
-            expectQueryCancelled(() -> {
-                while (rs.hasNext()) {
-                    rs.next();
-                }
-            });
-
             await(cancelFut);
-
-            rs.close();
 
             startBarrier.reset();
         }

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlApiBaseTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/api/ItSqlApiBaseTest.java
@@ -1304,6 +1304,8 @@ public abstract class ItSqlApiBaseTest extends BaseSqlIntegrationTest {
 
             await(cancelFut);
 
+            rs.close();
+
             startBarrier.reset();
         }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-24968

The test fails due to a race between the token cancellation check and the cancellation request.

To fix this, `PayloadOutputChannel` now accepts a callback action that will be called when the payload is sent.