### PR TITLE
IGNITE-25161 Improve exception logging during node start

### DIFF
--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
@@ -1602,11 +1602,17 @@ public class IgniteImpl implements Ignite {
 
         var igniteException = new IgniteException(extractCodeFrom(e), errMsg, e);
 
+        // We log the exception as soon as possible to minimize the probability that it gets lost due to something like an OOM later.
+        LOG.error(errMsg, igniteException);
+
         ExecutorService lifecycleExecutor = stopExecutor();
 
         try {
             lifecycleManager.stopNode(new ComponentContext(lifecycleExecutor)).get();
-        } catch (Exception ex) {
+        } catch (Throwable ex) {
+            // We add ex as a suppressed subexception, but we don't know how the caller will handle it, so we also log it ourselves.
+            LOG.error("Node stop failed after node start failure", ex);
+
             igniteException.addSuppressed(ex);
         } finally {
             lifecycleExecutor.shutdownNow();


### PR DESCRIPTION
Explicitly log node start exception (and possible exception from node stop caused by failed start) to make sure they remain in logs even if the code attempting to start the node doesn't log them

https://issues.apache.org/jira/browse/IGNITE-25161