### PR TITLE
IGNITE-24876 Fix message reordering in network

### DIFF
--- a/modules/network/src/main/java/org/apache/ignite/internal/network/netty/NettySender.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/netty/NettySender.java
@@ -108,11 +108,9 @@ public class NettySender {
 
         // Write in event loop to make sure that, if a ClosedSocketException happens, we recover from it without exiting the event loop.
         // We need this to avoid message reordering due to switching from old channel to a new one.
-        if (channel.eventLoop().inEventLoop()) {
-            writeWithRecovery(obj, channel, triggerChannelRecreation);
-        } else {
-            channel.eventLoop().execute(() -> writeWithRecovery(obj, channel, triggerChannelRecreation));
-        }
+        // Also, we ALWAYS execute the writes on the event loop (by adding them to the event loop queue) even if we are on
+        // the event loop thread, to avoid another reordering.
+        channel.eventLoop().execute(() -> writeWithRecovery(obj, channel, triggerChannelRecreation));
 
         return obj.acknowledgedFuture();
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-24876

The reordering was happening because messages waiting for a sender to be opened (in the sender awaiting queue) would be written directly to the channel (when the sender was finally opened), bypassing the event loop queue.