### PR TITLE
IGNITE-25178 .NET: Add synchronous Dispose method to ITransaction

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/LazyTransaction.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/LazyTransaction.cs
@@ -106,6 +106,9 @@ internal sealed class LazyTransaction : ITransaction
     public async ValueTask DisposeAsync() => await RollbackAsync().ConfigureAwait(false);
 
     /// <inheritdoc/>
+    public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+    /// <inheritdoc/>
     public override string ToString()
     {
         var builder = new IgniteToStringBuilder(typeof(Transaction));

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/LazyTransaction.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Transactions/LazyTransaction.cs
@@ -106,7 +106,12 @@ internal sealed class LazyTransaction : ITransaction
     public async ValueTask DisposeAsync() => await RollbackAsync().ConfigureAwait(false);
 
     /// <inheritdoc/>
-    public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
+    public void Dispose()
+    {
+        // It is recommended to implement IDisposable when IAsyncDisposable is implemented,
+        // so we have to do sync-over-async here.
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
 
     /// <inheritdoc/>
     public override string ToString()

--- a/modules/platforms/dotnet/Apache.Ignite/Transactions/ITransaction.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Transactions/ITransaction.cs
@@ -25,7 +25,7 @@ namespace Apache.Ignite.Transactions
     /// <para />
     /// Use <see cref="ITransactions.BeginAsync()"/> to start a new transaction.
     /// </summary>
-    public interface ITransaction : IAsyncDisposable
+    public interface ITransaction : IAsyncDisposable, IDisposable
     {
         /// <summary>
         /// Gets a value indicating whether this transaction is read-only.


### PR DESCRIPTION
Follow the recommendation to implement `IDisposable` when implementing `IAsyncDisposable`:
https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync
