### PR TITLE
IGNITE-25363 Sql. Delayed NODE_LEFT event processing may cause query to hang

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/SqlQueryProcessor.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/SqlQueryProcessor.java
@@ -108,6 +108,7 @@ import org.apache.ignite.internal.tx.impl.TransactionInflights;
 import org.apache.ignite.internal.util.ExceptionUtils;
 import org.apache.ignite.internal.util.IgniteSpinBusyLock;
 import org.apache.ignite.lang.CancellationToken;
+import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.sql.SqlException;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
@@ -255,7 +256,8 @@ public class SqlQueryProcessor implements QueryProcessor, SystemViewProvider {
     /** {@inheritDoc} */
     @Override
     public synchronized CompletableFuture<Void> startAsync(ComponentContext componentContext) {
-        var nodeName = clusterSrvc.topologyService().localMember().name();
+        ClusterNode localNode = clusterSrvc.topologyService().localMember();
+        String nodeName = localNode.name();
 
         taskExecutor = registerService(new QueryTaskExecutorImpl(nodeName, nodeCfg.execution().threadCount().value(), failureManager));
         var mailboxRegistry = registerService(new MailboxRegistryImpl());
@@ -275,7 +277,7 @@ public class SqlQueryProcessor implements QueryProcessor, SystemViewProvider {
         ));
 
         var msgSrvc = registerService(new MessageServiceImpl(
-                nodeName,
+                localNode,
                 clusterSrvc.messagingService(),
                 taskExecutor,
                 busyLock,

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExchangeServiceImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExchangeServiceImpl.java
@@ -38,6 +38,7 @@ import org.apache.ignite.internal.sql.engine.message.SqlQueryMessagesFactory;
 import org.apache.ignite.internal.util.ExceptionUtils;
 import org.apache.ignite.lang.IgniteException;
 import org.apache.ignite.lang.TraceableException;
+import org.apache.ignite.network.ClusterNode;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -142,7 +143,7 @@ public class ExchangeServiceImpl implements ExchangeService {
         );
     }
 
-    private void onMessage(String nodeName, QueryBatchRequestMessage msg) {
+    private void onMessage(ClusterNode node, QueryBatchRequestMessage msg) {
         ExecutionId executionId = new ExecutionId(msg.queryId(), msg.executionToken());
         CompletableFuture<Outbox<?>> outboxFut = mailboxRegistry.outbox(executionId, msg.exchangeId());
 
@@ -150,9 +151,9 @@ public class ExchangeServiceImpl implements ExchangeService {
             try {
                 SharedState state = msg.sharedState();
                 if (state != null) {
-                    outbox.onRewindRequest(nodeName, state, msg.amountOfBatches());
+                    outbox.onRewindRequest(node.name(), state, msg.amountOfBatches());
                 } else {
-                    outbox.onRequest(nodeName, msg.amountOfBatches());
+                    outbox.onRequest(node.name(), msg.amountOfBatches());
                 }
             } catch (Throwable e) {
                 outbox.onError(e);
@@ -168,13 +169,13 @@ public class ExchangeServiceImpl implements ExchangeService {
         }
     }
 
-    private void onMessage(String nodeName, QueryBatchMessage msg) {
+    private void onMessage(ClusterNode node, QueryBatchMessage msg) {
         ExecutionId executionId = new ExecutionId(msg.queryId(), msg.executionToken());
         Inbox<?> inbox = mailboxRegistry.inbox(executionId, msg.exchangeId());
 
         if (inbox != null) {
             try {
-                inbox.onBatchReceived(nodeName, msg.batchId(), msg.last(), msg.rows());
+                inbox.onBatchReceived(node.name(), msg.batchId(), msg.last(), msg.rows());
             } catch (Throwable e) {
                 inbox.onError(e);
 
@@ -186,7 +187,7 @@ public class ExchangeServiceImpl implements ExchangeService {
             }
         } else if (LOG.isDebugEnabled()) {
             LOG.debug("Stale batch message received: [nodeName={}, executionId={}, fragmentId={}, exchangeId={}, batchId={}]",
-                    nodeName, executionId, msg.fragmentId(), msg.exchangeId(), msg.batchId());
+                    node.name(), executionId, msg.fragmentId(), msg.exchangeId(), msg.batchId());
         }
     }
 

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionContext.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/ExecutionContext.java
@@ -80,6 +80,7 @@ public class ExecutionContext<RowT> implements DataContext {
     private final ClusterNode localNode;
 
     private final String originatingNodeName;
+    private final UUID originatingNodeId;
 
     private final RowHandler<RowT> handler;
 
@@ -128,6 +129,7 @@ public class ExecutionContext<RowT> implements DataContext {
             ExecutionId executionId,
             ClusterNode localNode,
             String originatingNodeName,
+            UUID originatingNodeId,
             FragmentDescription description,
             RowHandler<RowT> handler,
             Map<String, Object> params,
@@ -144,6 +146,7 @@ public class ExecutionContext<RowT> implements DataContext {
         this.params = params;
         this.localNode = localNode;
         this.originatingNodeName = originatingNodeName;
+        this.originatingNodeId = originatingNodeId;
         this.txAttributes = txAttributes;
         this.timeZoneId = timeZoneId;
         this.inBufSize = inBufSize < 0 ? Commons.IN_BUFFER_SIZE : inBufSize;
@@ -232,6 +235,13 @@ public class ExecutionContext<RowT> implements DataContext {
      */
     public String originatingNodeName() {
         return originatingNodeName;
+    }
+
+    /**
+     * Get originating node volatile ID.
+     */
+    public UUID originatingNodeId() {
+        return originatingNodeId;
     }
 
     /**

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/MailboxRegistryImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/MailboxRegistryImpl.java
@@ -137,8 +137,8 @@ public class MailboxRegistryImpl implements MailboxRegistry, TopologyEventHandle
     /** {@inheritDoc} */
     @Override
     public void onDisappeared(ClusterNode member) {
-        locals.values().forEach(fut -> fut.thenAccept(n -> n.onNodeLeft(member.name())));
-        remotes.values().forEach(n -> n.onNodeLeft(member.name()));
+        locals.values().forEach(fut -> fut.thenAccept(n -> n.onNodeLeft(member)));
+        remotes.values().forEach(n -> n.onNodeLeft(member));
     }
 
     private static class MailboxKey {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/rel/Outbox.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/exec/rel/Outbox.java
@@ -46,6 +46,7 @@ import org.apache.ignite.internal.sql.engine.trait.Destination;
 import org.apache.ignite.internal.sql.engine.util.Commons;
 import org.apache.ignite.internal.util.ExceptionUtils;
 import org.apache.ignite.lang.ErrorGroups.Common;
+import org.apache.ignite.network.ClusterNode;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
@@ -357,12 +358,9 @@ public class Outbox<RowT> extends AbstractNode<RowT> implements Mailbox<RowT>, S
         }
     }
 
-    /**
-     * OnNodeLeft.
-     * TODO Documentation https://issues.apache.org/jira/browse/IGNITE-15859
-     */
-    public void onNodeLeft(String nodeName) {
-        if (nodeName.equals(context().originatingNodeName())) {
+    /** Notifies the outbox that provided node has left the cluster. */
+    public void onNodeLeft(ClusterNode node) {
+        if (node.id().equals(context().originatingNodeId())) {
             this.execute(this::close);
         }
     }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/message/MessageListener.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/message/MessageListener.java
@@ -18,17 +18,18 @@
 package org.apache.ignite.internal.sql.engine.message;
 
 import org.apache.ignite.internal.network.NetworkMessage;
+import org.apache.ignite.network.ClusterNode;
 
 /**
- * MessageListener interface.
- * TODO Documentation https://issues.apache.org/jira/browse/IGNITE-15859
+ * Listener interface for receiving messages from other nodes in the cluster.
  */
+@FunctionalInterface
 public interface MessageListener {
     /**
-     * OnMessage.
+     * Callback invoked when a message is received from a remote cluster node.
      *
-     * @param nodeName Sender node consistent ID.
-     * @param msg Message.
+     * @param sender The cluster node that sent the message.
+     * @param msg The received message.
      */
-    void onMessage(String nodeName, NetworkMessage msg);
+    void onMessage(ClusterNode sender, NetworkMessage msg);
 }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/message/MessageServiceImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/message/MessageServiceImpl.java
@@ -43,7 +43,7 @@ import org.jetbrains.annotations.Nullable;
 public class MessageServiceImpl implements MessageService {
     private final MessagingService messagingSrvc;
 
-    private final String localNodeName;
+    private final ClusterNode localNode;
 
     private final QueryTaskExecutor taskExecutor;
 
@@ -54,17 +54,22 @@ public class MessageServiceImpl implements MessageService {
     private volatile Int2ObjectMap<MessageListener> lsnrs;
 
     /**
-     * Constructor.
-     * TODO Documentation https://issues.apache.org/jira/browse/IGNITE-15859
+     * Constructors the object.
+     *
+     * @param localNode The local node.
+     * @param messagingSrvc Actual service to send messages over network.
+     * @param taskExecutor An executor to delegate processing of received message.
+     * @param busyLock A lock to synchronize message processing and parent service stop.
+     * @param clockService A clock to propagate updated timestamp.
      */
     public MessageServiceImpl(
-            String localNodeName,
+            ClusterNode localNode,
             MessagingService messagingSrvc,
             QueryTaskExecutor taskExecutor,
             IgniteSpinBusyLock busyLock,
             ClockService clockService
     ) {
-        this.localNodeName = localNodeName;
+        this.localNode = localNode;
         this.messagingSrvc = messagingSrvc;
         this.taskExecutor = taskExecutor;
         this.busyLock = busyLock;
@@ -85,8 +90,8 @@ public class MessageServiceImpl implements MessageService {
         }
 
         try {
-            if (localNodeName.equals(nodeName)) {
-                onMessage(nodeName, msg);
+            if (localNode.name().equals(nodeName)) {
+                onMessage(localNode, msg);
 
                 return nullCompletedFuture();
             } else {
@@ -120,16 +125,16 @@ public class MessageServiceImpl implements MessageService {
         assert old == null : old;
     }
 
-    private void onMessage(String consistentId, NetworkMessage msg) {
+    private void onMessage(ClusterNode sender, NetworkMessage msg) {
         if (msg instanceof CancelOperationRequest) {
             return;
         }
 
         if (msg instanceof ExecutionContextAwareMessage) {
             ExecutionContextAwareMessage msg0 = (ExecutionContextAwareMessage) msg;
-            taskExecutor.execute(msg0.queryId(), msg0.fragmentId(), () -> onMessageInternal(consistentId, msg));
+            taskExecutor.execute(msg0.queryId(), msg0.fragmentId(), () -> onMessageInternal(sender, msg));
         } else {
-            taskExecutor.execute(() -> onMessageInternal(consistentId, msg));
+            taskExecutor.execute(() -> onMessageInternal(sender, msg));
         }
     }
 
@@ -146,13 +151,13 @@ public class MessageServiceImpl implements MessageService {
                 clockService.updateClock(((TimestampAware) msg).timestamp());
             }
 
-            onMessage(sender.name(), msg);
+            onMessage(sender, msg);
         } finally {
             busyLock.leaveBusy();
         }
     }
 
-    private void onMessageInternal(String consistentId, NetworkMessage msg) {
+    private void onMessageInternal(ClusterNode sender, NetworkMessage msg) {
         if (!busyLock.enterBusy()) {
             return;
         }
@@ -163,7 +168,7 @@ public class MessageServiceImpl implements MessageService {
                     "there is no listener for msgType=" + msg.messageType()
             );
 
-            lsnr.onMessage(consistentId, msg);
+            lsnr.onMessage(sender, msg);
         } finally {
             busyLock.leaveBusy();
         }

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImplTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImplTest.java
@@ -40,7 +40,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
@@ -83,8 +82,6 @@ import org.apache.ignite.internal.hlc.HybridClock;
 import org.apache.ignite.internal.hlc.HybridClockImpl;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.apache.ignite.internal.hlc.TestClockService;
-import org.apache.ignite.internal.lang.IgniteInternalException;
-import org.apache.ignite.internal.lang.RunnableX;
 import org.apache.ignite.internal.metrics.MetricManagerImpl;
 import org.apache.ignite.internal.network.ClusterNodeImpl;
 import org.apache.ignite.internal.network.MessagingService;
@@ -338,8 +335,9 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
 
         var expectedEx = new RuntimeException("Test error");
 
-        testCluster.node(nodeNames.get(2)).interceptor((nodeName, msg, original) -> {
+        testCluster.node(nodeNames.get(2)).interceptor((senderNode, msg, original) -> {
             if (msg instanceof QueryStartRequest) {
+                String nodeName = senderNode.name();
                 testCluster.node(nodeNames.get(2)).messageService().send(nodeName, new SqlQueryMessagesFactory().queryStartResponse()
                         .queryId(((QueryStartRequest) msg).queryId())
                         .fragmentId(((QueryStartRequest) msg).fragmentId())
@@ -347,7 +345,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
                         .build()
                 );
             } else {
-                original.onMessage(nodeName, msg);
+                original.onMessage(senderNode, msg);
             }
 
             return nullCompletedFuture();
@@ -414,8 +412,9 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
         CountDownLatch queryStartResponseBlockLatch = new CountDownLatch(nodeNames.size());
         CountDownLatch resumeMessagingLatch = new CountDownLatch(1);
 
-        testCluster.node(nodeNames.get(0)).interceptor((nodeName, msg, original) -> {
+        testCluster.node(nodeNames.get(0)).interceptor((senderNode, msg, original) -> {
             if (msg instanceof QueryStartRequest && ((QueryStartRequest) msg).fragmentDescription().target() == null) {
+                String nodeName = senderNode.name();
                 testCluster.node(nodeNames.get(0)).messageService().send(nodeName, new SqlQueryMessagesFactory().queryStartResponse()
                         .queryId(((QueryStartRequest) msg).queryId())
                         .fragmentId(((QueryStartRequest) msg).fragmentId())
@@ -437,7 +436,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
                 }
             }
 
-            original.onMessage(nodeName, msg);
+            original.onMessage(senderNode, msg);
 
             return nullCompletedFuture();
         });
@@ -546,8 +545,8 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
         // start response trigger
         CountDownLatch startResponse = new CountDownLatch(1);
 
-        nodeNames.stream().map(testCluster::node).forEach(node -> node.interceptor((senderNodeName, msg, original) -> {
-            if (node.nodeName.equals(nodeNames.get(0))) {
+        nodeNames.stream().map(testCluster::node).forEach(node -> node.interceptor((senderNode, msg, original) -> {
+            if (node.node.name().equals(nodeNames.get(0))) {
                 // On node_1, hang until an exception from another node fails the query to make sure that the root fragment does not execute
                 // before other fragments.
                 node.taskExecutor.execute(() -> {
@@ -563,12 +562,12 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
                         // No-op.
                     }
 
-                    original.onMessage(senderNodeName, msg);
+                    original.onMessage(senderNode, msg);
                 });
 
                 return nullCompletedFuture();
             } else {
-                original.onMessage(senderNodeName, msg);
+                original.onMessage(senderNode, msg);
 
                 return nullCompletedFuture();
             }
@@ -612,7 +611,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
         QueryPlan plan = prepare("SELECT * FROM test_tbl", ctx);
 
         nodeNames.stream().map(testCluster::node).forEach(node -> node.interceptor((senderNodeName, msg, original) -> {
-            if (node.nodeName.equals(nodeNames.get(0))) {
+            if (node.node.name().equals(nodeNames.get(0))) {
                 // On node_1, hang until an exception from another node fails the query to make sure that the root fragment does not execute
                 // before other fragments.
                 runAsync(() -> {
@@ -629,7 +628,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
                 return nullCompletedFuture();
             } else {
                 // On other nodes, simulate that the node has already gone.
-                return CompletableFuture.failedFuture(new NodeLeftException(node.nodeName));
+                return CompletableFuture.failedFuture(new NodeLeftException(node.node.name()));
             }
         }));
 
@@ -669,8 +668,9 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
         SqlException expectedException = new SqlException(Common.INTERNAL_ERR, "Expected exception");
         SqlOperationContext ctx = createContext();
 
-        testCluster.node(nodeNames.get(2)).interceptor((nodeName, msg, original) -> {
+        testCluster.node(nodeNames.get(2)).interceptor((senderNode, msg, original) -> {
             if (msg instanceof QueryStartRequest) {
+                String nodeName = senderNode.name();
                 testCluster.node(nodeNames.get(2)).messageService().send(nodeName, new SqlQueryMessagesFactory().queryStartResponse()
                         .queryId(((QueryStartRequest) msg).queryId())
                         .fragmentId(((QueryStartRequest) msg).fragmentId())
@@ -678,7 +678,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
                         .build()
                 );
             } else {
-                original.onMessage(nodeName, msg);
+                original.onMessage(senderNode, msg);
             }
 
             return nullCompletedFuture();
@@ -897,8 +897,9 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
         String expectedExceptionMessage = "This is expected";
 
         TestNode corruptedNode = testCluster.node(nodeNames.get(2));
-        corruptedNode.interceptor((nodeName, msg, original) -> {
+        corruptedNode.interceptor((senderNode, msg, original) -> {
             if (msg instanceof QueryBatchRequestMessage) {
+                String nodeName = senderNode.name();
                 corruptedNode.messageService().send(nodeName, new SqlQueryMessagesFactory().errorMessage()
                         .queryId(((QueryBatchRequestMessage) msg).queryId())
                         .executionToken(((QueryBatchRequestMessage) msg).executionToken())
@@ -909,7 +910,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
                         .build()
                 );
             } else {
-                original.onMessage(nodeName, msg);
+                original.onMessage(senderNode, msg);
             }
 
             return nullCompletedFuture();
@@ -956,6 +957,73 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
         }
     }
 
+    /**
+     * This test ensures that outdated NODE_LEFT event doesn't cause query to hang.
+     *
+     * <p>The sequence of events on real cluster is as follow:<ul>
+     * <li>Given: cluster of 3 nodes, distribution zone spans all these nodes.</li>
+     * <li>Node 1 has been restarted.</li>
+     * <li>Notification of org.apache.ignite.internal.network.TopologyEventHandler#onDisappeared handlers are delayed on node 2 (due to
+     * metastorage lagging or whatever reason).</li>
+     * <li>Query started from node 1.</li>
+     * <li>Root fragment processed locally, QueryBatchRequest came to node 2 before QueryStartRequest. This step
+     * is crucial since it puts not completed future to mailbox registry
+     * (org.apache.ignite.internal.sql.engine.exec.MailboxRegistryImpl#locals).</li>
+     * <li>TopologyEventHandler's are notified on node 2. This step
+     * causes onNodeLeft handler to be chained to the future from previous step. QueryStartRequest came to node 2. Query fragment is created
+     * an immediately closed by onNodeLeft handler.</li>
+     * </ul>
+     */
+    @Test
+    void outdatedNodeLeftEventDoesntCauseQueryToHang() {
+        QueryPlan plan = prepare("SELECT * FROM test_tbl", createContext());
+
+        // We need to emulate situation when QueryBatchRequest arrives before QueryStartRequest.
+        // For this, we introduce countDown latch that will be released when QueryBatchRequest is
+        // arrived. In the mean time, node-initiator will wait on this latch right after root
+        // fragment is initialized. This guarantees, that processing of non-root fragments will
+        // be postponed until root fragment requests batch from map node in question.
+        CountDownLatch requestBatchMessageArrived = new CountDownLatch(1);
+        testCluster.node(nodeNames.get(2)).interceptor((senderNode, msg, original) -> {
+            if (msg instanceof QueryBatchRequestMessage) {
+                requestBatchMessageArrived.countDown();
+            }
+
+            original.onMessage(senderNode, msg);
+
+            return nullCompletedFuture();
+        });
+        testCluster.node(nodeNames.get(0)).interceptor((senderNode, msg, original) -> {
+            original.onMessage(senderNode, msg);
+
+            if (msg instanceof QueryStartRequest
+                    // Fragment without target is a root.
+                    && ((QueryStartRequest) msg).fragmentDescription().target() == null) {
+
+                try {
+                    requestBatchMessageArrived.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+
+                ClusterNode sameNameDifferentIdNode = clusterNode(nodeNames.get(0));
+                // Fire NODE_LEFT event on map-node in question. This event contains
+                // cluster node with consistent ID equals to ID of node-initiator, but
+                // different volatile id. This emulates situation, when request prepared
+                // on newer topology outruns event processing from previous topology change.
+                testCluster.node(nodeNames.get(2)).notifyNodeLeft(sameNameDifferentIdNode);
+            }
+
+            return nullCompletedFuture();
+        });
+
+        SqlOperationContext ctx = createContext();
+
+        CompletableFuture<AsyncDataCursor<InternalSqlRow>> cursorFuture = executionServices.get(0).executePlan(plan, ctx);
+        // Request must not hung.
+        await(await(cursorFuture).requestNextAsync(100));
+    }
+
     @ParameterizedTest
     @MethodSource("txTypes")
     public void transactionRollbackOnError(NoOpTransaction tx) {
@@ -980,10 +1048,11 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
 
         var expectedEx = new RuntimeException("Test error");
 
-        testCluster.node(nodeNames.get(0)).interceptor((nodeName, msg, original) -> {
+        testCluster.node(nodeNames.get(0)).interceptor((senderNode, msg, original) -> {
             if (msg instanceof QueryStartRequest) {
                 QueryStartRequest queryStart = (QueryStartRequest) msg;
 
+                String nodeName = senderNode.name();
                 testCluster.node(nodeNames.get(0)).messageService().send(nodeName, new SqlQueryMessagesFactory().queryStartResponse()
                         .queryId(queryStart.queryId())
                         .fragmentId(queryStart.fragmentId())
@@ -991,7 +1060,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
                         .build()
                 );
             } else {
-                original.onMessage(nodeName, msg);
+                original.onMessage(senderNode, msg);
             }
 
             return nullCompletedFuture();
@@ -1049,20 +1118,20 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
 
         executers.add(taskExecutor);
 
-        var node = testCluster.addNode(nodeName, taskExecutor);
+        var clusterNode = clusterNode(nodeName);
+        var mailbox = new MailboxRegistryImpl();
+        var node = testCluster.addNode(clusterNode, taskExecutor, mailbox);
 
         node.dataset(dataPerNode.get(nodeName));
 
         var messageService = node.messageService();
-        var mailboxRegistry = new CapturingMailboxRegistry(new MailboxRegistryImpl());
-        mailboxes.add(mailboxRegistry);
+        var capturingMailbox = new CapturingMailboxRegistry(mailbox);
+        mailboxes.add(capturingMailbox);
 
         HybridClock clock = new HybridClockImpl();
         ClockService clockService = new TestClockService(clock);
 
-        var exchangeService = new ExchangeServiceImpl(mailboxRegistry, messageService, clockService);
-
-        var clusterNode = new ClusterNodeImpl(randomUUID(), nodeName, NetworkAddress.from("127.0.0.1:1111"));
+        var exchangeService = new ExchangeServiceImpl(capturingMailbox, messageService, clockService);
 
         if (nodeName.equals(nodeNames.get(0))) {
             firstNode = clusterNode;
@@ -1089,7 +1158,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
                 ArrayRowHandler.INSTANCE,
                 executableTableRegistry,
                 dependencyResolver,
-                (ctx, deps) -> node.implementor(ctx, mailboxRegistry, exchangeService, deps, tableFunctionRegistry),
+                (ctx, deps) -> node.implementor(ctx, capturingMailbox, exchangeService, deps, tableFunctionRegistry),
                 clockService,
                 killCommandHandler,
                 new ExpressionFactoryImpl<>(
@@ -1103,6 +1172,10 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
         executionService.start();
 
         return executionService;
+    }
+
+    private static ClusterNodeImpl clusterNode(String nodeName) {
+        return new ClusterNodeImpl(randomUUID(), nodeName, NetworkAddress.from("127.0.0.1:1111"));
     }
 
     private MappingServiceImpl createMappingService(
@@ -1168,65 +1241,11 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
         }
     }
 
-    private void awaitExecutionTimeout(
-            ExecutionService execService,
-            QueryPlan plan,
-            long deadlineMillis,
-            Class<? extends RuntimeException> errorClass
-    ) {
-        // operationContext uses explicit transaction by default.
-        Function<QueryCancel, SqlOperationContext> explicitTx = (cancel) -> operationContext()
-                .cancel(cancel)
-                .build();
-
-        awaitExecutionTimeout(execService, plan, explicitTx, deadlineMillis, errorClass);
-    }
-
-    private void awaitExecutionTimeout(
-            ExecutionService execService,
-            QueryPlan plan,
-            Function<QueryCancel, SqlOperationContext> execCtxFunc,
-            long deadlineMillis,
-            Class<? extends RuntimeException> errorClass
-    ) {
-        int attempts = 10;
-
-        for (int k = 0; k < attempts; k++) {
-            QueryCancel queryCancel = new QueryCancel();
-            CompletableFuture<Void> timeoutFut = setTimeout(queryCancel, deadlineMillis);
-
-            SqlOperationContext execCtx = execCtxFunc.apply(queryCancel);
-
-            AsyncCursor<InternalSqlRow> cursor;
-            try {
-                cursor = await(execService.executePlan(plan, execCtx));
-            } catch (QueryCancelledException e) {
-                // This might happen when initialization took longer than a time out,
-                // Retry to get a proper error.
-                continue;
-            }
-
-            CompletableFuture<?> batchFut = cursor.requestNextAsync(1);
-
-            timeoutFut.join();
-
-            IgniteTestUtils.assertThrowsWithCause(
-                    batchFut::join,
-                    errorClass,
-                    "Query timeout"
-            );
-
-            return;
-        }
-
-        fail("Failed to get query timeout error");
-    }
-
     static class TestCluster {
         private final Map<String, TestNode> nodes = new ConcurrentHashMap<>();
 
-        public TestNode addNode(String nodeName, QueryTaskExecutor taskExecutor) {
-            return nodes.computeIfAbsent(nodeName, key -> new TestNode(nodeName, taskExecutor));
+        public TestNode addNode(ClusterNode node, QueryTaskExecutor taskExecutor, MailboxRegistryImpl mailboxRegistry) {
+            return nodes.computeIfAbsent(node.name(), key -> new TestNode(node, taskExecutor, mailboxRegistry));
         }
 
         public TestNode node(String nodeName) {
@@ -1235,18 +1254,23 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
 
         class TestNode {
             private final Map<Short, MessageListener> msgListeners = new ConcurrentHashMap<>();
-            private final Queue<RunnableX> pending = new LinkedBlockingQueue<>();
             private volatile List<Object[]> dataset = List.of();
             private volatile MessageInterceptor interceptor = null;
 
             private final QueryTaskExecutor taskExecutor;
-            private final String nodeName;
+            private final ClusterNode node;
+            private final MailboxRegistryImpl mailboxRegistry;
 
-            private boolean scanPaused = false;
+            private volatile boolean scanPaused = false;
 
-            public TestNode(String nodeName, QueryTaskExecutor taskExecutor) {
-                this.nodeName = nodeName;
+            public TestNode(ClusterNode node, QueryTaskExecutor taskExecutor, MailboxRegistryImpl mailboxRegistry) {
+                this.node = node;
                 this.taskExecutor = taskExecutor;
+                this.mailboxRegistry = mailboxRegistry;
+            }
+
+            public void notifyNodeLeft(ClusterNode node) {
+                mailboxRegistry.onDisappeared(node);
             }
 
             public void dataset(List<Object[]> dataset) {
@@ -1258,28 +1282,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
             }
 
             public void pauseScan() {
-                synchronized (pending) {
-                    scanPaused = true;
-                }
-            }
-
-            public void resumeScan() {
-                synchronized (pending) {
-                    scanPaused = false;
-
-                    Throwable t = null;
-                    for (RunnableX runnableX : pending) {
-                        try {
-                            runnableX.run();
-                        } catch (Throwable t0) {
-                            if (t == null) {
-                                t = t0;
-                            } else {
-                                t.addSuppressed(t0);
-                            }
-                        }
-                    }
-                }
+                scanPaused = true;
             }
 
             public MessageService messageService() {
@@ -1289,7 +1292,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
                     public CompletableFuture<Void> send(String nodeName, NetworkMessage msg) {
                         TestNode node = nodes.get(nodeName);
 
-                        return node.onReceive(TestNode.this.nodeName, msg);
+                        return runAsync(() -> {}).thenCompose(none -> node.onReceive(TestNode.this.node, msg));
                     }
 
                     /** {@inheritDoc} */
@@ -1298,7 +1301,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
                         var old = msgListeners.put(msgId, lsnr);
 
                         if (old != null) {
-                            throw new RuntimeException(format("Listener was replaced [nodeName={}, msgId={}]", nodeName, msgId));
+                            throw new RuntimeException(format("Listener was replaced [nodeName={}, msgId={}]", node.name(), msgId));
                         }
                     }
 
@@ -1328,28 +1331,19 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
                     public Node<Object[]> visit(IgniteTableScan rel) {
                         return new ScanNode<>(ctx, dataset) {
                             @Override
-                            public void request(int rowsCnt) {
-                                RunnableX task = () -> super.request(rowsCnt);
-
-                                synchronized (pending) {
-                                    if (scanPaused) {
-                                        pending.add(task);
-                                    } else {
-                                        try {
-                                            task.run();
-                                        } catch (Throwable ex) {
-                                            // Error code is not used.
-                                            throw new IgniteInternalException(Common.INTERNAL_ERR, ex);
-                                        }
-                                    }
+                            public void request(int rowsCnt) throws Exception {
+                                if (scanPaused) {
+                                    return;
                                 }
+
+                                super.request(rowsCnt);
                             }
                         };
                     }
                 };
             }
 
-            private CompletableFuture<Void> onReceive(String senderNodeName, NetworkMessage message) {
+            private CompletableFuture<Void> onReceive(ClusterNode senderNode, NetworkMessage message) {
                 MessageListener original = (nodeName, msg) -> {
                     MessageListener listener = msgListeners.get(msg.messageType());
 
@@ -1369,10 +1363,10 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
                 MessageInterceptor interceptor = this.interceptor;
 
                 if (interceptor != null) {
-                    return interceptor.intercept(senderNodeName, message, original);
+                    return interceptor.intercept(senderNode, message, original);
                 }
 
-                original.onMessage(senderNodeName, message);
+                original.onMessage(senderNode, message);
 
                 return nullCompletedFuture();
             }
@@ -1380,7 +1374,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
 
         @FunctionalInterface
         interface MessageInterceptor {
-            CompletableFuture<Void> intercept(String senderNodeName, NetworkMessage msg, MessageListener original);
+            CompletableFuture<Void> intercept(ClusterNode senderNode, NetworkMessage msg, MessageListener original);
         }
     }
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/RuntimeSortedIndexTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/RuntimeSortedIndexTest.java
@@ -115,13 +115,15 @@ public class RuntimeSortedIndexTest extends IgniteAbstractTest {
     }
 
     private RuntimeSortedIndex<Object[]> generate(RelDataType rowType, final List<Integer> idxCols, int notUnique) {
+        ClusterNodeImpl node = new ClusterNodeImpl(randomUUID(), "fake-test-node", NetworkAddress.from("127.0.0.1:1111"));
         RuntimeSortedIndex<Object[]> idx = new RuntimeSortedIndex<>(
                 new ExecutionContext<>(
                         new ExpressionFactoryImpl<>(Commons.typeFactory(), 1024, CaffeineCacheFactory.INSTANCE),
                         null,
                         new ExecutionId(randomUUID(), 0),
-                        new ClusterNodeImpl(randomUUID(), "fake-test-node", NetworkAddress.from("127.0.0.1:1111")),
-                        "fake-test-node",
+                        node,
+                        node.name(),
+                        node.id(),
                         null,
                         ArrayRowHandler.INSTANCE,
                         Map.of(),

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/AbstractExecutionTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/AbstractExecutionTest.java
@@ -69,6 +69,7 @@ import org.apache.ignite.internal.thread.NamedThreadFactory;
 import org.apache.ignite.internal.thread.StripedThreadPoolExecutor;
 import org.apache.ignite.internal.util.ArrayUtils;
 import org.apache.ignite.internal.util.Pair;
+import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.NetworkAddress;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
@@ -138,14 +139,16 @@ public abstract class AbstractExecutionTest<T> extends IgniteAbstractTest {
 
         FragmentDescription fragmentDesc = getFragmentDescription();
 
+        ClusterNode node = new ClusterNodeImpl(randomUUID(), "fake-test-node", NetworkAddress.from("127.0.0.1:1111"));
         ExecutionContext<T> executionContext = new ExecutionContext<>(
                 new ExpressionFactoryImpl<>(
                         Commons.typeFactory(), 1024, CaffeineCacheFactory.INSTANCE
                 ),
                 taskExecutor,
                 new ExecutionId(randomUUID(), 0),
-                new ClusterNodeImpl(randomUUID(), "fake-test-node", NetworkAddress.from("127.0.0.1:1111")),
-                "fake-test-node",
+                node,
+                node.name(),
+                node.id(),
                 fragmentDesc,
                 rowHandler(),
                 Map.of(),

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/ExchangeExecutionTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/rel/ExchangeExecutionTest.java
@@ -625,7 +625,7 @@ public class ExchangeExecutionTest extends AbstractExecutionTest<Object[]> {
         ClockService clockService = new TestClockService(clock);
 
         MessageService messageService = new MessageServiceImpl(
-                clusterService.topologyService().localMember().name(),
+                clusterService.topologyService().localMember(),
                 clusterService.messagingService(),
                 taskExecutor,
                 new IgniteSpinBusyLock(),

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/TestBuilders.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/TestBuilders.java
@@ -647,6 +647,7 @@ public class TestBuilders {
                     new ExecutionId(queryId, 0),
                     Objects.requireNonNull(node, "node"),
                     node.name(),
+                    node.id(),
                     description,
                     ArrayRowHandler.INSTANCE,
                     Commons.parametersMap(dynamicParams),

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/TestNode.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/TestNode.java
@@ -166,7 +166,7 @@ public class TestNode implements LifecycleAware {
         holdLock = new IgniteSpinBusyLock();
 
         messageService = registerService(new MessageServiceImpl(
-                nodeName, messagingService, taskExecutor, holdLock, clockService
+                topologyService.localMember(), messagingService, taskExecutor, holdLock, clockService
         ));
         ExchangeService exchangeService = registerService(new ExchangeServiceImpl(
                 mailboxRegistry, messageService, clockService


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-25363

This patch addresses an issue causing query to hang in case NODE_LEFT event is delayed. The solution is to consider node ID which changes after the restart instead of consistent name.

----------
Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)