### PR TITLE
IGNITE-25354 .NET: Exclude tests and benchmarks from release

### DIFF
--- a/modules/platforms/build.gradle
+++ b/modules/platforms/build.gradle
@@ -138,7 +138,7 @@ def buildDotNet = tasks.register('buildDotNet', Exec) {
     dependsOn copyPlatformsHeaders
     workingDir "$projectDir/dotnet"
 
-    commandLine "dotnet", "build", ".",
+    commandLine "dotnet", "publish", ".",
             "--configuration", "Release",
             "--output", "$buildDir/dotnet"
     "/p:Version=${project.version}"

--- a/modules/platforms/dotnet/Apache.Extensions.Caching.Ignite.Tests/Apache.Extensions.Caching.Ignite.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Extensions.Caching.Ignite.Tests/Apache.Extensions.Caching.Ignite.Tests.csproj
@@ -6,6 +6,7 @@
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>
+        <IsPublishable>false</IsPublishable>
         <IsTestProject>true</IsTestProject>
         <RootNamespace>Apache.Extensions.Cache.Ignite.Tests</RootNamespace>
     </PropertyGroup>

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Apache.Ignite.Benchmarks.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Apache.Ignite.Benchmarks.csproj
@@ -24,6 +24,7 @@
         <AssemblyOriginatorKeyFile>Apache.Ignite.Benchmarks.snk</AssemblyOriginatorKeyFile>
         <ServerGarbageCollection>true</ServerGarbageCollection>
         <IsPackable>false</IsPackable>
+        <IsPublishable>false</IsPublishable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/Apache.Ignite.Internal.Generators.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Internal.Generators/Apache.Ignite.Internal.Generators.csproj
@@ -21,6 +21,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <IsPublishable>false</IsPublishable>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     </PropertyGroup>
     

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Apache.Ignite.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Apache.Ignite.Tests.csproj
@@ -20,6 +20,7 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
+        <IsPublishable>false</IsPublishable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>Apache.Ignite.Tests.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
* Use `dotnet publish` instead of `dotnet build` to prepare the release binaries
* Exclude tests and benchmarks with `IsPublishable` property