### PR TITLE
IGNITE-25525 ExceptionInInitializerError in BinaryTupleParser since JDK 17

### DIFF
--- a/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/BinaryTupleParser.java
+++ b/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/BinaryTupleParser.java
@@ -30,7 +30,6 @@ import java.time.Period;
 import java.util.UUID;
 import java.util.function.Function;
 import org.apache.ignite.internal.util.ByteUtils;
-import org.apache.ignite.internal.util.GridUnsafe;
 
 /**
  * Binary tuple parser allows to get bytes of individual elements from entirety of tuple bytes.
@@ -52,9 +51,6 @@ public class BinaryTupleParser {
 
     /** Byte order of ByteBuffers that contain the tuple. */
     public static final ByteOrder ORDER = ByteOrder.LITTLE_ENDIAN;
-
-    /** Whether the byte order of the underlying buffer is reversed compared to the native byte order. */
-    private static final boolean REVERSE_BYTE_ORDER = GridUnsafe.NATIVE_BYTE_ORDER != ORDER;
 
     /** UUID size in bytes. */
     private static final int UUID_SIZE = 16;

--- a/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/BinaryTupleReader.java
+++ b/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/BinaryTupleReader.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
 import java.util.UUID;
+import java.util.function.Function;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -58,6 +59,17 @@ public class BinaryTupleReader extends BinaryTupleParser implements BinaryTupleP
      */
     public BinaryTupleReader(int numElements, ByteBuffer buffer) {
         super(numElements, buffer);
+    }
+
+    /**
+     * Constructor with a specific factory function for creating a `ByteBufferAccessor`.
+     *
+     * @param numElements Number of tuple elements.
+     * @param buffer Buffer with a binary tuple.
+     * @param byteBufferAccessorFactory A factory function to create a `ByteBufferAccessor` for accessing the buffer.
+     */
+    public BinaryTupleReader(int numElements, ByteBuffer buffer, Function<ByteBuffer, ByteBufferAccessor> byteBufferAccessorFactory) {
+        super(numElements, buffer, byteBufferAccessorFactory);
     }
 
     /** {@inheritDoc} */

--- a/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/ByteBufferAccessor.java
+++ b/modules/binary-tuple/src/main/java/org/apache/ignite/internal/binarytuple/ByteBufferAccessor.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.binarytuple;
+
+/**
+ * An interface for accessing a byte buffer with methods to read various data types
+ * at specific positions. This interface abstracts the underlying implementation
+ * for handling data in either direct or heap-based byte buffers.
+ */
+public interface ByteBufferAccessor {
+    /**
+     * Retrieves the byte value from the underlying byte buffer at the specified index.
+     *
+     * @param p the index in the underlying byte buffer to retrieve the byte from.
+     * @return the byte value located at the specified index in the byte buffer.
+     */
+    byte get(int p);
+
+    /**
+     * Reads a 32-bit integer value from the underlying byte buffer at the specified index.
+     *
+     * @param p the index in the underlying byte buffer to start reading the 32-bit integer value from.
+     * @return the 32-bit integer value located at the specified index in the byte buffer.
+     */
+    int getInt(int p);
+
+    /**
+     * Reads a 64-bit long value from the underlying byte buffer at the specified index.
+     *
+     * @param p the index in the underlying byte buffer to start reading the 64-bit long value from.
+     * @return the 64-bit long value located at the specified index in the byte buffer.
+     */
+    long getLong(int p);
+
+    /**
+     * Reads a 16-bit short value from the underlying byte buffer at the specified index.
+     *
+     * @param p the index in the underlying byte buffer to start reading the 16-bit short value from.
+     * @return the 16-bit short value located at the specified index in the byte buffer.
+     */
+    short getShort(int p);
+
+    /**
+     * Reads a 32-bit floating-point value from the underlying byte buffer at the specified index.
+     *
+     * @param p the index in the underlying byte buffer to start reading the 32-bit floating-point value from.
+     * @return the 32-bit floating-point value located at the specified index in the byte buffer.
+     */
+    float getFloat(int p);
+
+    /**
+     * Reads a 64-bit double-precision floating-point value from the underlying
+     * byte buffer at the specified index.
+     *
+     * @param p the index in the underlying byte buffer to start reading the
+     *          64-bit double-precision floating-point value from.
+     * @return the 64-bit double-precision floating-point value located at
+     *         the specified index in the byte buffer.
+     */
+    double getDouble(int p);
+
+    /**
+     * Returns the capacity of the underlying byte buffer, representing the total number of bytes it can hold.
+     *
+     * @return the total capacity of the byte buffer.
+     */
+    int capacity();
+}

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/BinaryTuple.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/BinaryTuple.java
@@ -18,8 +18,10 @@
 package org.apache.ignite.internal.schema;
 
 import java.nio.ByteBuffer;
+import java.util.function.Function;
 import org.apache.ignite.internal.binarytuple.BinaryTupleBuilder;
 import org.apache.ignite.internal.binarytuple.BinaryTupleReader;
+import org.apache.ignite.internal.binarytuple.ByteBufferAccessor;
 
 /**
  * Utility for access to binary tuple elements as typed values and with schema knowledge that allows to read
@@ -44,6 +46,17 @@ public class BinaryTuple extends BinaryTupleReader implements InternalTupleEx {
      */
     public BinaryTuple(int elementCount, ByteBuffer buffer) {
         super(elementCount, buffer);
+    }
+
+    /**
+     * Constructor with a specific factory function for creating a `ByteBufferAccessor`.
+     *
+     * @param elementCount Number of tuple elements.
+     * @param buffer Buffer with a binary tuple.
+     * @param accessorFactory A factory function to create a `ByteBufferAccessor` for accessing the buffer.
+     */
+    public BinaryTuple(int elementCount, ByteBuffer buffer, Function<ByteBuffer, ByteBufferAccessor> accessorFactory) {
+        super(elementCount, buffer, accessorFactory);
     }
 
     @Override

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/BinaryTupleComparator.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/BinaryTupleComparator.java
@@ -66,8 +66,10 @@ public class BinaryTupleComparator implements Comparator<ByteBuffer> {
 
         int numElements = columnTypes.size();
 
-        BinaryTupleReader tuple1 = isBuffer1Prefix ? new BinaryTuplePrefix(numElements, buffer1) : new BinaryTuple(numElements, buffer1);
-        BinaryTupleReader tuple2 = isBuffer2Prefix ? new BinaryTuplePrefix(numElements, buffer2) : new BinaryTuple(numElements, buffer2);
+        BinaryTupleReader tuple1 = isBuffer1Prefix ? new BinaryTuplePrefix(numElements, buffer1)
+                : new BinaryTuple(numElements, buffer1, UnsafeByteBufferAccessor::new);
+        BinaryTupleReader tuple2 = isBuffer2Prefix ? new BinaryTuplePrefix(numElements, buffer2)
+                : new BinaryTuple(numElements, buffer2, UnsafeByteBufferAccessor::new);
 
         int columnsToCompare = Math.min(tuple1.elementCount(), tuple2.elementCount());
 

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/BinaryTupleComparatorUtils.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/BinaryTupleComparatorUtils.java
@@ -24,8 +24,8 @@ import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import org.apache.ignite.internal.binarytuple.BinaryTupleCommon;
-import org.apache.ignite.internal.binarytuple.BinaryTupleParser.ByteBufferAccessor;
 import org.apache.ignite.internal.binarytuple.BinaryTupleReader;
+import org.apache.ignite.internal.binarytuple.ByteBufferAccessor;
 import org.apache.ignite.sql.ColumnType;
 
 /**

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/PartialBinaryTupleMatcher.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/PartialBinaryTupleMatcher.java
@@ -84,9 +84,10 @@ public class PartialBinaryTupleMatcher {
 
         assert !isBuffer1Prefix : "An inline tuple must not contain a prefix.";
 
-        BinaryTupleReader tuple1 = new BinaryTuple(numElements, buffer1);
+        BinaryTupleReader tuple1 = new BinaryTuple(numElements, buffer1, UnsafeByteBufferAccessor::new);
 
-        BinaryTupleReader tuple2 = isBuffer2Prefix ? new BinaryTuplePrefix(numElements, buffer2) : new BinaryTuple(numElements, buffer2);
+        BinaryTupleReader tuple2 = isBuffer2Prefix ? new BinaryTuplePrefix(numElements, buffer2)
+                : new BinaryTuple(numElements, buffer2, UnsafeByteBufferAccessor::new);
 
         int columnsToCompare = Math.min(tuple1.elementCount(), tuple2.elementCount());
 

--- a/modules/schema/src/main/java/org/apache/ignite/internal/schema/UnsafeByteBufferAccessor.java
+++ b/modules/schema/src/main/java/org/apache/ignite/internal/schema/UnsafeByteBufferAccessor.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.schema;
+
+import java.nio.ByteBuffer;
+import org.apache.ignite.internal.binarytuple.BinaryTupleParser;
+import org.apache.ignite.internal.binarytuple.ByteBufferAccessor;
+import org.apache.ignite.internal.util.GridUnsafe;
+
+/**
+ * The `UnsafeByteBufferAccessor` class provides low-level access to the contents of a `ByteBuffer`.
+ * It implements the `ByteBufferAccessor` interface and uses unsafe operations to read data
+ * directly from the buffer, either from a direct memory address or from a backing array.
+ * This class supports reading various primitive types (e.g., `byte`, `int`, `long`, etc.)
+ * and handles byte order differences between the buffer and the native system.
+ */
+class UnsafeByteBufferAccessor implements ByteBufferAccessor {
+    /** Whether the byte order of the underlying buffer is reversed compared to the native byte order. */
+    private static final boolean REVERSE_BYTE_ORDER = GridUnsafe.NATIVE_BYTE_ORDER != BinaryTupleParser.ORDER;
+
+    private final byte[] bytes;
+    private final long addr;
+    private final int capacity;
+
+    public UnsafeByteBufferAccessor(ByteBuffer buff) {
+        if (buff.isDirect()) {
+            bytes = null;
+            addr = GridUnsafe.bufferAddress(buff);
+        } else {
+            bytes = buff.array();
+            addr = GridUnsafe.BYTE_ARR_OFF + buff.arrayOffset();
+        }
+
+        capacity = buff.capacity();
+    }
+
+    @Override
+    public byte get(int p) {
+        return GridUnsafe.getByte(bytes, addr + p);
+    }
+
+    @Override
+    public int getInt(int p) {
+        int value = GridUnsafe.getInt(bytes, addr + p);
+
+        return REVERSE_BYTE_ORDER ? Integer.reverseBytes(value) : value;
+    }
+
+    @Override
+    public long getLong(int p) {
+        long value = GridUnsafe.getLong(bytes, addr + p);
+
+        return REVERSE_BYTE_ORDER ? Long.reverseBytes(value) : value;
+    }
+
+    @Override
+    public short getShort(int p) {
+        short value = GridUnsafe.getShort(bytes, addr + p);
+
+        return REVERSE_BYTE_ORDER ? Short.reverseBytes(value) : value;
+    }
+
+    @Override
+    public float getFloat(int p) {
+        float value = GridUnsafe.getFloat(bytes, addr + p);
+
+        return REVERSE_BYTE_ORDER ? Float.intBitsToFloat(Integer.reverseBytes(Float.floatToIntBits(value))) : value;
+    }
+
+    @Override
+    public double getDouble(int p) {
+        double value = GridUnsafe.getDouble(bytes, addr + p);
+
+        return REVERSE_BYTE_ORDER ? Double.longBitsToDouble(Long.reverseBytes(Double.doubleToLongBits(value))) : value;
+    }
+
+    @Override
+    public int capacity() {
+        return capacity;
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-25525

```
Benchmark                                         Mode  Cnt  Score    Error  Units
TupleComparatorBenchmark.testBytesFullCompare     avgt   10  0.054 ±  0.001  us/op
TupleComparatorBenchmark.testBytesPartialCompare  avgt   10  0.037 ±  0.001  us/op
TupleComparatorBenchmark.testStrFullCompare       avgt   10  0.782 ±  0.002  us/op
TupleComparatorBenchmark.testStrPartialCompare    avgt   10  0.404 ±  0.001  us/op
TupleComparatorBenchmark.testUuidFullCompare      avgt   10  0.013 ±  0.001  us/op
TupleComparatorBenchmark.testUuidPartialCompare   avgt   10  0.011 ±  0.001  us/op
TupleComparatorBenchmark.timestampFullCompare     avgt   10  0.012 ±  0.001  us/op
TupleComparatorBenchmark.timestampPartialCompare  avgt   10  0.010 ±  0.001  us/op
```