### PR TITLE
IGNITE-25537 Fix MulticastNodeFinder for same-machine scenarios

### DIFF
--- a/modules/network/src/integrationTest/java/org/apache/ignite/internal/network/scalecube/ItMulticastNodeFinderTest.java
+++ b/modules/network/src/integrationTest/java/org/apache/ignite/internal/network/scalecube/ItMulticastNodeFinderTest.java
@@ -57,7 +57,7 @@ class ItMulticastNodeFinderTest extends IgniteAbstractTest {
     private final ClusterIdSupplier clusterIdSupplier = new ConstantClusterIdSupplier(UUID.randomUUID());
 
     /** Created {@link ClusterService}s. Needed for resource management. */
-    private List<ClusterService> services = new ArrayList<>();
+    private final List<ClusterService> services = new ArrayList<>();
     /** Created {@link NodeFinder}s. Needed for resource management. */
     private final List<NodeFinder> finders = new ArrayList<>();
 

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/DefaultMessagingService.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/DefaultMessagingService.java
@@ -372,7 +372,7 @@ public class DefaultMessagingService extends AbstractMessagingService {
                     );
                 })
                 // TODO: IGNITE-25375 - consider removing logging after the fix as it might be too much
-                // (the caller alse gets the exception).
+                // (the caller also gets the exception).
                 .whenComplete((res, ex) -> {
                     if (ex != null && hasCause(ex, HandshakeException.class)) {
                         LOG.error(

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/MulticastNodeFinder.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/MulticastNodeFinder.java
@@ -30,7 +30,6 @@ import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
-import java.net.StandardSocketOptions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -196,7 +195,13 @@ public class MulticastNodeFinder implements NodeFinder {
     }
 
     private void configureSocket(MulticastSocket socket, @Nullable NetworkInterface networkInterface, int soTimeout) throws IOException {
-        socket.setOption(StandardSocketOptions.IP_MULTICAST_LOOP, true);
+        // Using setLoopbackMode() (which is deprecated in Java versions starting with 14) because it still works in all Java versions,
+        // while the replacement suggested by the deprecation message -
+        // socket.setOption(StandardSocketOptions.IP_MULTICAST_LOOP, true/false) - is not portable across Java versions
+        // (before Java 14, we need to pass 'false', while since Java 14, it's 'true').
+
+        // Use 'false' to enable support for more than one node on the same machine.
+        socket.setLoopbackMode(false);
 
         if (networkInterface != null) {
             socket.setNetworkInterface(networkInterface);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-25537

In Apache Ignite 2, we do socket.setLoopbackMode(false). This works, but the method is deprecated since Java 14. The deprecation comment suggests to switch to 
socket.setOption(StandardSocketOptions.IP_MULTICAST_LOOP, true/false), but here comes the problem: socket.setOption() is not portable across Java versions. 
socket.setOption(StandardSocketOptions.IP_MULTICAST_LOOP, false) works before Java 14 (for example, in Java 11), but starting with Java 14, it must be socket.setOption(StandardSocketOptions.IP_MULTICAST_LOOP, true). So the fix is to still use socket.setLoopbackMode(false) even though it's deprecated in newer Java versions - as it still works in all Java versions.