### PR TITLE
IGNITE-25552 Sql. Date/Time. Parser for SQL datetime format

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/DateTimeFormatElement.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/DateTimeFormatElement.java
@@ -62,9 +62,9 @@ final class DateTimeFormatElement {
     public String toString() {
         switch (kind) {
             case DELIMITER:
-                return String.format("<%s>", delimiter);
+                return "delimiter <" + delimiter + ">";
             case FIELD:
-                return template.name();
+                return "field " + template.name();
             default:
                 throw new IllegalStateException();
         }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/DateTimeTemplateField.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/DateTimeTemplateField.java
@@ -21,48 +21,52 @@ package org.apache.ignite.internal.sql.engine.util.format;
  * Supported datetime template fields.
  */
 enum DateTimeTemplateField {
-    YYYY(FieldKind.YEAR),
-    YYY(FieldKind.YEAR),
-    YY(FieldKind.YEAR),
-    Y(FieldKind.YEAR),
-    RRRR(FieldKind.ROUNDED_YEAR),
-    RR(FieldKind.ROUNDED_YEAR),
-    MM(FieldKind.MONTH),
-    DD(FieldKind.DAY_OF_MONTH),
-    DDD(FieldKind.DAY_OF_YEAR),
-    HH(FieldKind.HOUR_12),
-    HH12(FieldKind.HOUR_12),
-    HH24(FieldKind.HOUR_24),
-    MI(FieldKind.MINUTE),
-    SS(FieldKind.SECOND_OF_MINUTE),
-    SSSSS(FieldKind.SECOND_OF_DAY),
-    FF1(FieldKind.FRACTION),
-    FF2(FieldKind.FRACTION),
-    FF3(FieldKind.FRACTION),
-    FF4(FieldKind.FRACTION),
-    FF5(FieldKind.FRACTION),
-    FF6(FieldKind.FRACTION),
-    FF7(FieldKind.FRACTION),
-    FF8(FieldKind.FRACTION),
-    FF9(FieldKind.FRACTION),
+    YYYY(FieldKind.YEAR, 4),
+    YYY(FieldKind.YEAR, 3),
+    YY(FieldKind.YEAR, 2),
+    Y(FieldKind.YEAR, 1),
+    RRRR(FieldKind.ROUNDED_YEAR, 4),
+    RR(FieldKind.ROUNDED_YEAR, 2),
+    MM(FieldKind.MONTH, 2),
+    DD(FieldKind.DAY_OF_MONTH, 2),
+    DDD(FieldKind.DAY_OF_YEAR, 3),
+    HH(FieldKind.HOUR_12, 2),
+    HH12(FieldKind.HOUR_12, 2),
+    HH24(FieldKind.HOUR_24, 2),
+    MI(FieldKind.MINUTE, 2),
+    SS(FieldKind.SECOND_OF_MINUTE, 2),
+    SSSSS(FieldKind.SECOND_OF_DAY, 5),
+    FF1(FieldKind.FRACTION, 1),
+    FF2(FieldKind.FRACTION, 2),
+    FF3(FieldKind.FRACTION, 3),
+    FF4(FieldKind.FRACTION, 4),
+    FF5(FieldKind.FRACTION, 5),
+    FF6(FieldKind.FRACTION, 6),
+    FF7(FieldKind.FRACTION, 7),
+    FF8(FieldKind.FRACTION, 8),
+    FF9(FieldKind.FRACTION, 9),
     PM(FieldKind.AM_PM, "P.M."),
     AM(FieldKind.AM_PM, "A.M."),
-    TZH(FieldKind.TIMEZONE),
-    TZM(FieldKind.TIMEZONE)
+    TZH(FieldKind.TIMEZONE, 2),
+    TZM(FieldKind.TIMEZONE, 2)
     ;
 
     private final FieldKind kind;
 
     private final String pattern;
 
-    DateTimeTemplateField(FieldKind kind) {
+    private int maxDigits;
+
+    DateTimeTemplateField(FieldKind kind, int maxDigits) {
         this.kind = kind;
         this.pattern = this.name();
+        this.maxDigits = maxDigits;
     }
 
     DateTimeTemplateField(FieldKind kind, String pattern) {
         this.kind = kind;
         this.pattern = pattern;
+        this.maxDigits = -1;
     }
 
     String pattern() {
@@ -87,5 +91,12 @@ enum DateTimeTemplateField {
         FRACTION,
         AM_PM,
         TIMEZONE;
+    }
+
+    int maxDigits() {
+        if (maxDigits == -1) {
+            throw new IllegalStateException(this + " has no digits");
+        }
+        return maxDigits;
     }
 }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/ParsedFields.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/ParsedFields.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.util.format;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FieldKind;
+
+/**
+ * Parsed fields.
+ */
+final class ParsedFields {
+
+    private final Map<FieldKind, Object> values = new EnumMap<>(FieldKind.class);
+
+    void add(FieldKind field, Object value) {
+        Objects.requireNonNull(field, "field");
+        Objects.requireNonNull(value, "value");
+
+        Object prev = this.values.put(field, value);
+        if (prev != null) {
+            throw new IllegalStateException("Field appeared more than once " + field);
+        }
+    }
+
+    Map<FieldKind, Object> values() {
+        return values;
+    }
+}

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/Parser.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/Parser.java
@@ -1,0 +1,527 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.util.format;
+
+import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
+
+import java.time.Clock;
+import java.time.Year;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
+import org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FieldKind;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Parses text according to format elements.
+ */
+final class Parser {
+
+    private static final char EOF = '\0';
+
+    private final List<DateTimeFormatElement> elements;
+
+    private final StringBuilder buf = new StringBuilder();
+
+    private final Clock clock;
+
+    private int current;
+
+    private int elementIndex;
+
+    private String text;
+
+    private ParsedFields parsedFields;
+
+    private @Nullable Hours12 hh12;
+
+    private @Nullable TimeZoneFields tz;
+
+    Parser(List<DateTimeFormatElement> elements) {
+        this(elements, Clock.systemDefaultZone());
+    }
+
+    Parser(List<DateTimeFormatElement> elements, Clock clock) {
+        if (elements.isEmpty()) {
+            throw new IllegalArgumentException("Element must not be empty");
+        }
+        Objects.requireNonNull(clock, "clock");
+
+        this.elements = elements;
+        this.clock = clock;
+    }
+
+    ParsedFields parse(String text) {
+        Objects.requireNonNull(text, "text");
+
+        current = 0;
+        buf.setLength(0);
+        elementIndex = 0;
+        this.text = text;
+
+        parsedFields = new ParsedFields();
+
+        parseElements(text);
+
+        if (hh12 != null) {
+            int hours = hh12.toHourOfDay();
+            parsedFields.add(FieldKind.HOUR_24, hours);
+        }
+
+        if (tz != null) {
+            ZoneOffset zoneOffset = tz.toZoneOffset();
+            parsedFields.add(FieldKind.TIMEZONE, zoneOffset);
+        }
+
+        return parsedFields;
+    }
+
+    private void parseElements(String text) {
+        for (DateTimeFormatElement element : elements) {
+            if (atEnd()) {
+                break;
+            }
+
+            switch (element.kind) {
+                case DELIMITER:
+                    delimiter(element);
+                    break;
+                case FIELD:
+                    field(element);
+                    break;
+                default:
+                    throw new IllegalStateException("Unexpected element kind: " + element.kind);
+            }
+        }
+
+        if (elementIndex < elements.size()) {
+            String elems = elements.subList(elementIndex, elements.size()).stream()
+                    .map(DateTimeFormatElement::toString)
+                    .collect(Collectors.joining(", "));
+
+            throw parseError("No values for elements {}", elems);
+        }
+
+        if (current < text.length()) {
+            DateTimeFormatElement e = elements.get(elementIndex - 1);
+            throw parseError("Unexpected trailing characters after {}", e);
+        }
+    }
+
+    private boolean atEnd() {
+        return current >= text.length();
+    }
+
+    private void delimiter(DateTimeFormatElement element) {
+        // Value is always set for a delimiter
+        assert element.delimiter != EOF;
+
+        char c = currentChar();
+        if (element.delimiter != c) {
+            throw parseError("Invalid format. Expected literal <{}> but got <{}>", element.delimiter, c);
+        }
+
+        advancePosition();
+        elementIndex += 1;
+    }
+
+    private void field(DateTimeFormatElement element) {
+        DateTimeTemplateField field = element.template;
+        // Field must be present at this point.
+        assert field != null;
+
+        boolean matches;
+        switch (field) {
+            case AM:
+            case PM:
+                // Both AM and PM accept either A.M or P.M.
+                matches = matchHh12(() -> matchChars("A.M.") || matchChars("P.M."));
+                break;
+            case HH:
+            case HH12:
+                matches = matchHh12(() -> matchAtMostDigits(field.maxDigits()));
+                break;
+            case TZH:
+                matches = matchTzField(this::tzh);
+                break;
+            case TZM:
+                matches = matchTzField(() -> matchAtMostDigits(field.maxDigits()));
+                break;
+            default:
+                matches = matchAtMostDigits(field.maxDigits());
+                break;
+        }
+
+        if (matches) {
+            parseFieldValue(field);
+            elementIndex += 1;
+        } else {
+            throw parseError("Expected field {} but got <{}>", field, currentChar());
+        }
+    }
+
+    private boolean matchTzField(BooleanSupplier matcher) {
+        // Initialize tz field if it is not present.
+        if (tz == null) {
+            tz = new TimeZoneFields();
+        }
+
+        boolean matches = matcher.getAsBoolean();
+        if (!matches) {
+            // Reset on error.
+            tz = null;
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private boolean matchHh12(BooleanSupplier matcher) {
+        if (hh12 == null) {
+            hh12 = new Hours12();
+        }
+
+        boolean matches = matcher.getAsBoolean();
+        if (!matches) {
+            // Reset on error.
+            hh12 = null;
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private boolean tzh() {
+        // Time zone hour: +/- followed by 1-2 Digit(s)
+
+        int start = current;
+
+        // TZM may precede TZH, so tz can be null.
+        if (tz == null) {
+            tz = new TimeZoneFields();
+        }
+
+        if (matchSign()) {
+            tz.sign =  buf.charAt(0) == '+' ? 1 : -1;
+        } else {
+            return false;
+        }
+
+        // Reset the buffer because we parse a sign character and digits separately.
+        buf.setLength(0);
+
+        if (!matchAtMostDigits(DateTimeTemplateField.TZH.maxDigits())) {
+            // Return to the position prior to parsing for error reporting.
+            current = start;
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private boolean matchSign() {
+        char c = currentChar();
+
+        if (c == '+' || c == '-') {
+            addChar();
+            advancePosition();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean matchChars(String chars) {
+        // Expects next chars.length() characters from an input to match exactly.
+        int start = current;
+
+        for (int i = 0; i < chars.length(); i++) {
+            char c = currentChar();
+            char p = chars.charAt(i);
+            if (Character.toUpperCase(c) != Character.toUpperCase(p)) {
+                // Does not match, reset position and clear the buffer.
+                current = start;
+                buf.setLength(0);
+                return false;
+            }
+            addChar();
+            advancePosition();
+        }
+
+        return true;
+    }
+
+    private boolean matchAtMostDigits(int n) {
+        // Expected at most n digits, but not least than 1.
+
+        int numDigits = 0;
+        while (numDigits < n) {
+            char c = currentChar();
+            if (!Character.isDigit(c)) {
+                break;
+            }
+            numDigits += 1;
+            addChar();
+            advancePosition();
+        }
+
+        // Succeeds if we parsed at least one digit
+        return numDigits > 0;
+    }
+
+    private char currentChar() {
+        if (atEnd()) {
+            return EOF;
+        }
+        return text.charAt(current);
+    }
+
+    private void advancePosition() {
+        current++;
+    }
+
+    private void addChar() {
+        char c = currentChar();
+        assert c != EOF : "Should never read EOF";
+
+        buf.append(c);
+    }
+
+    private void parseFieldValue(DateTimeTemplateField field) {
+        // This should never happen - this method must not be called when the buffer has some data
+        assert buf.length() > 0 : "Field value is empty";
+
+        String value = buf.toString();
+        buf.setLength(0);
+
+        switch (field) {
+            case YYYY:
+                parseYear(field, value, 1, 9999, 0);
+                break;
+            case YYY:
+                int baseYyy = Year.now(clock).getValue() / 1000 * 1000;
+                parseYear(field, value, 0, 999, baseYyy);
+                break;
+            case YY:
+                int baseYy = Year.now(clock).getValue() / 100 * 100;
+                parseYear(field, value, 0, 99, baseYy);
+                break;
+            case Y:
+                int baseY = Year.now(clock).getValue() / 10 * 10;
+                parseYear(field, value, 0, 9, baseY);
+                break;
+            case MM:
+                parseNumber(field, value, 1, 12);
+                break;
+            case DD:
+                parseNumber(field, value, 1, 31);
+                break;
+            case DDD:
+                parseNumber(field, value, 1, 365);
+                break;
+            case HH:
+            case HH12:
+                parse12Hour(field, value);
+                break;
+            case HH24:
+                parseNumber(field, value, 0, 23);
+                break;
+            case MI:
+                parseNumber(field, value, 0, 59);
+                break;
+            case SS:
+                parseNumber(field, value, 0, 59);
+                break;
+            case SSSSS:
+                parseNumber(field, value, 0, 24 * 60 * 60);
+                break;
+            case RRRR:
+                parseRoundedYear(field, value, 0, 9999);
+                break;
+            case RR:
+                parseRoundedYear(field, value, 0, 99);
+                break;
+            case FF1:
+            case FF3:
+            case FF2:
+                parseFaction(field, value, 3, 0, 999, 1_000_000);
+                break;
+            case FF4:
+            case FF5:
+            case FF6:
+                parseFaction(field, value, 6, 0, 999_999, 1_000);
+                break;
+            case FF7:
+            case FF8:
+            case FF9:
+                parseFaction(field, value, 9, 0, 999_999_999, 1);
+                break;
+            case PM:
+            case AM:
+                parseAmPm(value);
+                break;
+            case TZH:
+                parseTimeZone(field, TimeZoneFields.HOURS, value, 0, 23);
+                break;
+            case TZM:
+                parseTimeZone(field, TimeZoneFields.MINUTES, value, 0, 59);
+                break;
+            default:
+                throw new IllegalStateException("Unexpected field: " + field);
+        }
+    }
+
+    private void parseYear(DateTimeTemplateField field, String value, int min, int max, int base) {
+        int v = parseInt(field.name(), value, min, max) + base;
+        parsedFields.add(field.kind(), v);
+    }
+
+    private void parseRoundedYear(DateTimeTemplateField field, String value, int min, int max) {
+        int v = parseInt(field.name(), value, min, max);
+
+        int now = Year.now(clock).getValue();
+        int year2digits = now % 100;
+        int base = now - year2digits;
+
+        int year;
+        if (v <= 49) {
+            year = (year2digits <= 49) ? base + v   // same century
+                    : base + 100 + v; // next century
+        } else if (v < 100) { // 50-99
+            year =  (year2digits <= 49) ? base - 100 + v // previous century
+                    : base + v;       // same century
+        } else {
+            year = v;
+        }
+
+        // Store rounded year as year.
+        parsedFields.add(FieldKind.YEAR, year);
+    }
+
+    private void parseFaction(DateTimeTemplateField field, String value, int len, int min, int max, int multiplier) {
+        if (value.length() < len) {
+            value = value + "0".repeat(len - value.length());
+        }
+        int v = parseInt(field.name(), value, min, max) * multiplier;
+        parsedFields.add(field.kind(), v);
+    }
+
+    private void parseNumber(DateTimeTemplateField field, String value, int min, int max) {
+        int v = parseInt(field.name(), value, min, max);
+        parsedFields.add(field.kind(), v);
+    }
+
+    private void parse12Hour(DateTimeTemplateField field, String value) {
+        int v = parseInt(field.name(), value, 1, 12);
+
+        assert hh12 != null : "hh12 should have been initialized";
+        hh12.value = v;
+    }
+
+    private void parseAmPm(String value) {
+        assert hh12 != null : "hh12 should have been initialized";
+
+        // A.M. accepts both A.M. and P.M. and vice versa.
+        hh12.setFlag("P.M.".equalsIgnoreCase(value));
+    }
+
+    private void parseTimeZone(DateTimeTemplateField field, int f, String value, int min, int max) {
+        int num = parseInt(field.name(), value, min, max);
+
+        assert tz != null : "tz should have been initialized";
+        tz.setField(f, num);
+    }
+
+    private static int parseInt(String field, String text, int min, int max) {
+        int num;
+        try {
+            num = Integer.parseInt(text);
+        } catch (NumberFormatException ignore) {
+            throw parseError("Invalid value for field {}", field);
+        }
+
+        if (num < min || num > max) {
+            throw parseError("Value out of range for field {}", field);
+        }
+        return num;
+    }
+
+    private static class Hours12 {
+        private static final int AM = 1;
+        private static final int PM = 2;
+        private int clock;
+        private int value = -1;
+
+        void setFlag(boolean pm) {
+            clock = pm ? PM : AM;
+        }
+
+        int toHourOfDay() {
+            assert clock != 0 : "AM/PM flag has not been set";
+            assert value >= 0 : "12-hour value has not been set";
+
+            if (clock == PM) {
+                if (value == 12) {
+                    return value;
+                } else {
+                    return value % 12 + 12;
+                }
+            } else {
+                return value % 12;
+            }
+        }
+    }
+
+    private static class TimeZoneFields {
+        private static final int HOURS = 1;
+        private static final int MINUTES = 2;
+        private int hours;
+        private int minutes;
+        private int parsed;
+        private int sign;
+
+        void setField(int field, int value) {
+            if (field == HOURS) {
+                assert sign != 0 : "No sign character";
+                hours = value;
+            } else if (field == MINUTES) {
+                minutes = value;
+            } else {
+                throw parseError("Unexpected time zone field");
+            }
+            parsed |= field;
+        }
+
+        ZoneOffset toZoneOffset() {
+            assert parsed != 0 : "Time zones has not been parsed";
+            assert sign != 0 : "No sign character";
+
+            try {
+                return ZoneOffset.ofHoursMinutes(sign * hours, sign * minutes);
+            } catch (Exception e) {
+                throw new DateTimeFormatException("Time zone field value is not valid", e);
+            }
+        }
+    }
+
+    private static DateTimeFormatException parseError(String message, Object... elements) {
+        return new DateTimeFormatException(format(message, elements));
+    }
+}

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/format/ParserSelfTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/format/ParserSelfTest.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.util.format;
+
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.AM;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.DD;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FF4;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FieldKind.DAY_OF_MONTH;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FieldKind.DAY_OF_YEAR;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FieldKind.FRACTION;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FieldKind.HOUR_24;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FieldKind.MINUTE;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FieldKind.MONTH;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FieldKind.SECOND_OF_MINUTE;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FieldKind.TIMEZONE;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FieldKind.YEAR;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.HH;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.MI;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.MM;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.SS;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.TZH;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.TZM;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.YYYY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FieldKind;
+import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Basic tests for {@link Parser}.
+ */
+class ParserSelfTest extends BaseIgniteAbstractTest {
+
+    @ParameterizedTest
+    @MethodSource("basicPatterns")
+    public void testBasicPatterns(String pattern, String value, Map<FieldKind, Object> fields) {
+        Scanner scanner = new Scanner(pattern);
+        Parser parser = new Parser(scanner.scan());
+        ParsedFields parsedFields = parser.parse(value);
+        assertEquals(fields, parsedFields.values());
+    }
+
+    private static Stream<Arguments> basicPatterns() {
+        return Stream.of(
+                Arguments.of("YYYY MM DD", "2024 10 01", Map.of(YEAR, 2024, MONTH, 10, DAY_OF_MONTH, 1)),
+                Arguments.of("YYYY-MM-DD", "2024-10-01", Map.of(YEAR, 2024, MONTH, 10, DAY_OF_MONTH, 1)),
+                Arguments.of("YYYY DDD", "2024 1", Map.of(YEAR, 2024, DAY_OF_YEAR, 1)),
+                Arguments.of("YYYY DDD", "2024 50", Map.of(YEAR, 2024, DAY_OF_YEAR, 50)),
+                Arguments.of("YYYY:DDD", "2024:100", Map.of(YEAR, 2024, DAY_OF_YEAR, 100)),
+                Arguments.of("YYYY/DDD", "2024/365", Map.of(YEAR, 2024, DAY_OF_YEAR, 365)),
+                Arguments.of("YYYYDDD", "20243", Map.of(YEAR, 2024, DAY_OF_YEAR, 3)),
+                Arguments.of("YYYYDDD", "202436", Map.of(YEAR, 2024, DAY_OF_YEAR, 36)),
+
+                // TIME
+                Arguments.of("HH24:MI:SS.FF3", "3:7:9.12",
+                        Map.of(HOUR_24, 3, MINUTE, 7, SECOND_OF_MINUTE, 9, FRACTION, 120_000_000)),
+
+                Arguments.of("HH24:MI:SS.FF3 TZH:TZM", "3:7:9.12 +3:30",
+                        Map.of(HOUR_24, 3, MINUTE, 7, SECOND_OF_MINUTE, 9, FRACTION, 120_000_000,
+                                TIMEZONE, ZoneOffset.ofHoursMinutes(3, 30))),
+
+                Arguments.of("HH24:MI:SS.FF5 TZH:TZM", "3:7:9.9995 -10:50",
+                        Map.of(HOUR_24, 3, MINUTE, 7, SECOND_OF_MINUTE, 9, FRACTION, 999_500_000,
+                                TIMEZONE, ZoneOffset.ofHoursMinutes(-10, -50))),
+
+                // YEAR + TIME
+                Arguments.of("YYYY-MM-DD HH24:MI:SS.FF3", "2024-10-01 3:7:9.12",
+                        Map.of(YEAR, 2024, MONTH, 10, DAY_OF_MONTH, 1,
+                                HOUR_24, 3, MINUTE, 7, SECOND_OF_MINUTE, 9, FRACTION, 120_000_000)),
+
+                Arguments.of("YYYY-MM-DD HH24:MI:SS.FF3 TZH:TZM", "2024-10-01 3:7:9.12 +3:30",
+                        Map.of(YEAR, 2024, MONTH, 10, DAY_OF_MONTH, 1,
+                                HOUR_24, 3, MINUTE, 7, SECOND_OF_MINUTE, 9, FRACTION, 120_000_000,
+                                TIMEZONE, ZoneOffset.ofHoursMinutes(3, 30))),
+
+                Arguments.of("YYYY-MM-DD/HH12:MI:SS.FF3 A.M.", "2024-10-01/3:7:9.12 A.M.",
+                        Map.of(YEAR, 2024, MONTH, 10, DAY_OF_MONTH, 1,
+                                HOUR_24, 3, MINUTE, 7, SECOND_OF_MINUTE, 9, FRACTION, 120_000_000))
+
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("basicPatterns")
+    public void testBasicPatternsCaseInsensitivity(String pattern, String value, Map<FieldKind, Object> fields) {
+        Scanner scanner = new Scanner(pattern);
+        Parser parser = new Parser(scanner.scan());
+        ParsedFields parsedFields = parser.parse(value.toLowerCase(Locale.US));
+        assertEquals(fields, parsedFields.values());
+    }
+
+    @ParameterizedTest
+    @MethodSource("hour12Patterns")
+    public void testHour12Patterns(String pattern, String value, Map<FieldKind, Object> fields) {
+        Scanner scanner = new Scanner(pattern);
+        Parser parser = new Parser(scanner.scan());
+        if (fields != null) {
+            ParsedFields parsedFields = parser.parse(value);
+            assertEquals(fields, parsedFields.values());
+        } else {
+            try {
+                ParsedFields parsedFields = parser.parse(value);
+                fail("Unexpected fields: " + parsedFields.values());
+            } catch (DateTimeFormatException e) {
+                assertThat(e.getMessage(), containsString("Value out of range for field"));
+            }
+        }
+    }
+
+    private static Stream<Arguments> hour12Patterns() {
+        return Stream.of(
+                // Out of range
+                Arguments.of("HH12:MI:SS.FF3 A.M.", "0:7:9.12 A.M.", null),
+
+                // A.M.
+                Arguments.of("HH12:MI:SS.FF3 A.M.", "3:7:9.12 A.M.",
+                        Map.of(HOUR_24, 3, MINUTE, 7, SECOND_OF_MINUTE, 9, FRACTION, 120_000_000)),
+
+                Arguments.of("HH12:MI:SS.FF3 A.M.", "11:59:9.12 A.M.",
+                        Map.of(HOUR_24, 11, MINUTE, 59, SECOND_OF_MINUTE, 9, FRACTION, 120_000_000)),
+
+                // P.M.
+
+                // Out of range
+                Arguments.of("HH12:MI:SS.FF3 P.M.", "0:7:9.12 A.M.", null),
+
+                Arguments.of("HH12:MI:SS.FF3 P.M.", "12:59:9.12 P.M.",
+                        Map.of(HOUR_24, 12, MINUTE, 59, SECOND_OF_MINUTE, 9, FRACTION, 120_000_000)),
+
+                Arguments.of("HH12:MI:SS.FF3 P.M.", "11:59:9.12 P.M.",
+                        Map.of(HOUR_24, 23, MINUTE, 59, SECOND_OF_MINUTE, 9, FRACTION, 120_000_000))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("basicInvalidPatterns")
+    public void testBasicInvalidPatterns(String pattern, String text, String error) {
+        Scanner scanner = new Scanner(pattern);
+        Parser parser = new Parser(scanner.scan());
+        DateTimeFormatException err = assertThrows(DateTimeFormatException.class, () -> parser.parse(text));
+        assertThat(err.getMessage(), containsString(error));
+    }
+
+    private static Stream<Arguments> basicInvalidPatterns() {
+        return Stream.of(
+                // Leading space
+                Arguments.of(" YYY", "100", "Expected literal < > but got <1>"),
+                // Trailing space
+                Arguments.of("YYY ", "100", "No values for elements delimiter < >"),
+
+                Arguments.of("YYYY", "100g", "Unexpected trailing characters after field YYYY"),
+                Arguments.of("YYYY/MM", "200020", "Invalid format. Expected literal </> but got <2>"),
+                Arguments.of("YYYYMM", "2000XX", "Expected field MM but got <X>"),
+                Arguments.of("YYYY/MM", "g2000/20", "Expected field YYYY but got <g>"),
+                Arguments.of("YYYY/MM", "2000[20", "Invalid format. Expected literal </> but got <[>"),
+
+                Arguments.of("YYYYMM", "200013", "Value out of range for field MM"),
+                Arguments.of("HH24:MI", "25:50", "Value out of range for field HH24"),
+                Arguments.of("HH24:MI", "22:60", "Value out of range for field MI"),
+
+                Arguments.of("HH24:MI TZH:TZM", "22:40 +:0", "Expected field TZH but got <+>"),
+                Arguments.of("HH24:MI TZMTZH", "22:40 0+", "Expected field TZH but got <+>"),
+                Arguments.of("HH24:MI TZMTZH", "22:40 0-", "Expected field TZH but got <->")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("simpleValuesValid")
+    public void testUnexpectedLeadingDelimiters(String pattern, String value) {
+        Scanner scanner = new Scanner(pattern);
+        Parser parser = new Parser(scanner.scan());
+        DateTimeFormatException e = assertThrows(DateTimeFormatException.class, () -> parser.parse("/" + value));
+        assertThat(e.getMessage(), containsString("Expected field " + pattern + " but got </>"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("simpleValuesValid")
+    public void testUnexpectedTrailingDelimiters(String pattern, String value) {
+        Scanner scanner = new Scanner(pattern);
+        Parser parser = new Parser(scanner.scan());
+        DateTimeFormatException e = assertThrows(DateTimeFormatException.class, () -> parser.parse(value + "/"));
+        assertThat(e.getMessage(), containsString("Unexpected trailing characters after"));
+    }
+
+    private static Stream<Arguments> simpleValuesValid() {
+        return Stream.of(
+                Arguments.of("YY", "1"),
+                Arguments.of("YY", "10"),
+                Arguments.of("DD", "1"),
+                Arguments.of("DD", "10"),
+                Arguments.of("MM", "1"),
+                Arguments.of("MM", "12"),
+                Arguments.of("HH24", "1"),
+                Arguments.of("HH24", "10"),
+                Arguments.of("FF2", "1"),
+                Arguments.of("FF2", "12"),
+                Arguments.of("FF6", "123"),
+                Arguments.of("FF6", "123456")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("shuffledPatterns")
+    public void testFixedLengthPatterNoDelimitersShuffled(
+            List<DateTimeFormatElement> elements,
+            String text,
+            Map<Object, Object> fields
+    ) {
+
+        log.info("Elements: {}", elements);
+        log.info("Text: {}", text);
+        log.info("Values: {}", fields);
+
+        Parser parser = new Parser(elements);
+        ParsedFields parsedText = parser.parse(text);
+
+        assertEquals(fields, parsedText.values());
+    }
+
+    private static Stream<Arguments> shuffledPatterns() {
+        return getShuffledPatterns(false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("shuffledPatternsWithDelimiters")
+    public void fixedLengthPatterWithDelimitersShuffled(
+            List<DateTimeFormatElement> elements,
+            String text,
+            Map<Object, Object> fields
+    ) {
+
+        log.info("Elements: {}", elements);
+        log.info("Text: {}", text);
+        log.info("Values: {}", fields);
+
+        Parser parser = new Parser(elements);
+        ParsedFields parsedText = parser.parse(text);
+
+        assertEquals(fields, parsedText.values());
+    }
+
+    private static Stream<Arguments> shuffledPatternsWithDelimiters() {
+        return getShuffledPatterns(true);
+    }
+
+    private static Stream<Arguments> getShuffledPatterns(boolean addDelimiters) {
+        List<DateTimeTemplateField> fields = List.of(
+                YYYY, MM, DD, HH, MI, SS, FF4, AM, TZH, TZM
+        );
+        List<String> textValues = List.of(
+                "2025", "05", "30", "04", "23", "59", "1234", "P.M.", "+03", "30"
+        );
+
+        Map<Object, Object> values = Map.of(
+                YEAR, 2025,
+                MONTH, 5,
+                DAY_OF_MONTH, 30,
+                HOUR_24, 16,
+                MINUTE, 23,
+                SECOND_OF_MINUTE, 59,
+                FRACTION, 123_400_000,
+                TIMEZONE, ZoneOffset.ofHoursMinutes(3, 30)
+        );
+
+        Random random = new Random();
+        long seed = System.nanoTime();
+        random.setSeed(seed);
+
+        System.err.println("Seed " + seed);
+
+        return IntStream.range(0, 100).mapToObj(v -> {
+
+            List<Integer> ints = IntStream.range(0, fields.size())
+                    .boxed().collect(Collectors.toList());
+            Collections.shuffle(ints, random);
+
+            StringBuilder text = new StringBuilder();
+            List<DateTimeFormatElement> elements = new ArrayList<>();
+
+            for (int i : ints) {
+                DateTimeTemplateField f = fields.get(i);
+                if (addDelimiters) {
+                    char c = '/';
+                    elements.add(new DateTimeFormatElement(c));
+                    text.append(c);
+                }
+                elements.add(new DateTimeFormatElement(f));
+                text.append(textValues.get(i));
+            }
+
+            return Arguments.of(elements, text.toString(), values);
+        });
+    }
+}

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/format/ParserSimpleFieldsTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/format/ParserSimpleFieldsTest.java
@@ -1,0 +1,966 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.util.format;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FieldKind;
+import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Single field tests for {@link Parser}.
+ */
+class ParserSimpleFieldsTest extends BaseIgniteAbstractTest {
+
+    // Fix the clock, because the results of parsing year fields are time dependent.
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2025-01-01T00:00:00.000Z"), ZoneId.of("UTC"));
+
+    @ParameterizedTest
+    @MethodSource("yearValues")
+    public void testParseYear(String pattern, String text, Integer val, String error) {
+        Map<FieldKind, Object> fields = val != null ? Map.of(FieldKind.YEAR, val) : null;
+
+        parseSingleField(pattern, text, fields, error);
+    }
+
+    @ParameterizedTest
+    @MethodSource("yearValuesValid")
+    public void testParseYearUnexpectedDelimiter(String pattern, String text) {
+        parseSingleField(pattern, text + "/", null, unexpectedTrailingCharAfter(pattern));
+        parseSingleField(pattern, "/" + text, null, expectedField(pattern));
+    }
+
+    private static Stream<Arguments> yearValuesValid() {
+        return yearValues().filter(a -> {
+            Object[] args = a.get();
+            return args[2] != null;
+        }).map(a -> {
+            Object[] args = a.get();
+            return Arguments.of(args[0], args[1]);
+        });
+    }
+
+    private static Stream<Arguments> yearValues() {
+        return Stream.of(
+                Arguments.of("Y", "", null, noValuesForFields("Y")),
+                Arguments.of("Y", "+1", null, expectedField("Y")),
+
+                Arguments.of("Y", "0", 2020, null),
+                Arguments.of("Y", "1", 2021, null),
+                Arguments.of("Y", "9", 2029, null),
+                Arguments.of("Y", "10", null, unexpectedTrailingCharAfter("Y")),
+
+                Arguments.of("YY", "", null, noValuesForFields("YY")),
+                Arguments.of("YY", "+1", null, expectedField("YY")),
+                Arguments.of("YY", "0", 2000, null),
+                Arguments.of("YY", "1", 2001, null),
+                Arguments.of("YY", "9", 2009, null),
+                Arguments.of("YY", "12", 2012, null),
+                Arguments.of("YY", "99", 2099, null),
+                Arguments.of("YY", "100", null, unexpectedTrailingCharAfter("YY")),
+
+                Arguments.of("YYY", "", null, noValuesForFields("YYY")),
+                Arguments.of("YYY", "+1", null, expectedField("YYY")),
+                Arguments.of("YYY", "0", 2000, null),
+                Arguments.of("YYY", "1", 2001, null),
+                Arguments.of("YYY", "9", 2009, null),
+                Arguments.of("YYY", "12", 2012, null),
+                Arguments.of("YYY", "99", 2099, null),
+                Arguments.of("YYY", "123", 2123, null),
+                Arguments.of("YYY", "999", 2999, null),
+                Arguments.of("YYY", "1000", null, unexpectedTrailingCharAfter("YYY")),
+
+                Arguments.of("YYYY", "", null, noValuesForFields("YYYY")),
+                Arguments.of("YYYY", "+1", null, expectedField("YYYY")),
+                Arguments.of("YYYY", "0", null, valueOutOfRange("YYYY")),
+                Arguments.of("YYYY", "1", 1, null),
+                Arguments.of("YYYY", "9", 9, null),
+                Arguments.of("YYYY", "12", 12, null),
+                Arguments.of("YYYY", "99", 99, null),
+                Arguments.of("YYYY", "123", 123, null),
+                Arguments.of("YYYY", "999", 999, null),
+                Arguments.of("YYYY", "1234", 1234, null),
+                Arguments.of("YYYY", "9999", 9999, null),
+                Arguments.of("YYYY", "10000", null, unexpectedTrailingCharAfter("YYYY"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("yearValuesAnotherDecade")
+    public void testParseYearAnotherDecade(String pattern, String text, Integer val) {
+        Clock clock = Clock.fixed(Instant.parse("2030-01-01T00:00:00.000Z"), ZoneId.of("UTC"));
+
+        parseSingleField(pattern, text, clock, Map.of(FieldKind.YEAR, val), null);
+    }
+
+    private static Stream<Arguments> yearValuesAnotherDecade() {
+        return Stream.of(
+                Arguments.of("Y", "0", 2030, null),
+                Arguments.of("Y", "1", 2031, null),
+
+                Arguments.of("YY", "0", 2000, null),
+                Arguments.of("YY", "1", 2001, null),
+                Arguments.of("YY", "12", 2012, null),
+
+                Arguments.of("YYY", "0", 2000, null),
+                Arguments.of("YYY", "1", 2001, null),
+                Arguments.of("YYY", "12", 2012, null),
+                Arguments.of("YYY", "123", 2123, null),
+
+                Arguments.of("YYYY", "1", 1, null),
+                Arguments.of("YYYY", "2", 2, null),
+                Arguments.of("YYYY", "12", 12, null),
+                Arguments.of("YYYY", "123", 123, null),
+                Arguments.of("YYYY", "2000", 2000, null),
+                Arguments.of("YYYY", "2031", 2031, null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("roundedYearValues")
+    public void testParseRoundedYear(int currentYear, String pattern, String text, Integer val, String error) {
+        Map<FieldKind, Object> fields = val != null ? Map.of(FieldKind.YEAR, val) : null;
+        Clock clock = Clock.fixed(Instant.parse(currentYear + "-01-01T00:00:00.0Z"), ZoneId.systemDefault());
+
+        parseSingleField(pattern, text, clock, fields, error);
+    }
+
+    @ParameterizedTest
+    @MethodSource("roundedYearValidValues")
+    public void testParseRoundedYearUnexpectedDelimiter(int currentYear, String pattern, String text) {
+        Clock clock = Clock.fixed(Instant.parse(currentYear + "-01-01T00:00:00.0Z"), ZoneId.systemDefault());
+
+        parseSingleField(pattern, text + "/", clock, null, unexpectedTrailingCharAfter(pattern));
+        parseSingleField(pattern, "/" + text, clock, null, expectedField(pattern));
+    }
+
+    private static Stream<Arguments> roundedYearValidValues() {
+        return roundedYearValues().filter(a -> {
+            Object[] args = a.get();
+            return args[3] != null;
+        }).map(a -> {
+            Object[] args = a.get();
+            return Arguments.of(args[0], args[1], args[2]);
+        });
+    }
+
+    private static Stream<Arguments> roundedYearValues() {
+        return Stream.of(
+                // RR
+                Arguments.of(2000, "RR", "", null, noValuesForFields("RR")),
+                Arguments.of(2000, "RR", "+1", null, expectedField("RR")),
+
+                Arguments.of(1999, "RR", "0", 2000, null),
+                Arguments.of(1999, "RR", "1", 2001, null),
+                Arguments.of(1999, "RR", "49", 2049, null),
+                Arguments.of(1999, "RR", "50", 1950, null),
+                Arguments.of(1999, "RR", "77", 1977, null),
+                Arguments.of(1999, "RR", "99", 1999, null),
+                Arguments.of(1999, "RR", "123", null, unexpectedTrailingCharAfter("RR")),
+
+                Arguments.of(2025, "RR", "0", 2000, null),
+                Arguments.of(2025, "RR", "1", 2001, null),
+                Arguments.of(2025, "RR", "49", 2049, null),
+                Arguments.of(2025, "RR", "50", 1950, null),
+                Arguments.of(2025, "RR", "77", 1977, null),
+                Arguments.of(2025, "RR", "99", 1999, null),
+                Arguments.of(2025, "RR", "123", null, unexpectedTrailingCharAfter("RR")),
+
+                Arguments.of(2101, "RR", "0", 2100, null),
+                Arguments.of(2101, "RR", "1", 2101, null),
+                Arguments.of(2101, "RR", "50", 2050, null),
+                Arguments.of(2101, "RR", "77", 2077, null),
+                Arguments.of(2101, "RR", "99", 2099, null),
+                Arguments.of(2101, "RR", "123", null, unexpectedTrailingCharAfter("RR")),
+
+                // RRRR
+
+                Arguments.of(2000, "RRRR", "", null, noValuesForFields("RRRR")),
+                Arguments.of(2000, "RRRR", "+1", null, expectedField("RRRR")),
+
+                Arguments.of(1999, "RRRR", "0", 2000, null),
+                Arguments.of(1999, "RRRR", "1", 2001, null),
+                Arguments.of(1999, "RRRR", "49", 2049, null),
+                Arguments.of(1999, "RRRR", "049", 2049, null),
+                Arguments.of(1999, "RRRR", "50", 1950, null),
+                Arguments.of(1999, "RRRR", "050", 1950, null),
+                Arguments.of(1999, "RRRR", "77", 1977, null),
+                Arguments.of(1999, "RRRR", "077", 1977, null),
+                Arguments.of(1999, "RRRR", "99", 1999, null),
+                Arguments.of(1999, "RRRR", "099", 1999, null),
+                Arguments.of(1999, "RRRR", "123", 123, null),
+                Arguments.of(1999, "RRRR", "9999", 9999, null),
+                Arguments.of(1999, "RRRR", "12345", null, unexpectedTrailingCharAfter("RRRR")),
+
+                Arguments.of(2025, "RRRR", "0", 2000, null),
+                Arguments.of(2025, "RRRR", "1", 2001, null),
+                Arguments.of(2025, "RRRR", "49", 2049, null),
+                Arguments.of(2025, "RRRR", "049", 2049, null),
+                Arguments.of(2025, "RRRR", "50", 1950, null),
+                Arguments.of(2025, "RRRR", "050", 1950, null),
+                Arguments.of(2025, "RRRR", "77", 1977, null),
+                Arguments.of(2025, "RRRR", "077", 1977, null),
+                Arguments.of(2025, "RRRR", "99", 1999, null),
+                Arguments.of(2025, "RRRR", "099", 1999, null),
+                Arguments.of(2025, "RRRR", "123", 123, null),
+                Arguments.of(2025, "RRRR", "9999", 9999, null),
+                Arguments.of(2025, "RRRR", "12345", null, unexpectedTrailingCharAfter("RRRR")),
+
+                Arguments.of(2101, "RRRR", "0", 2100, null),
+                Arguments.of(2101, "RRRR", "1", 2101, null),
+                Arguments.of(2101, "RRRR", "49", 2149, null),
+                Arguments.of(2101, "RRRR", "049", 2149, null),
+                Arguments.of(2101, "RRRR", "50", 2050, null),
+                Arguments.of(2101, "RRRR", "050", 2050, null),
+                Arguments.of(2101, "RRRR", "77", 2077, null),
+                Arguments.of(2101, "RRRR", "077", 2077, null),
+                Arguments.of(2101, "RRRR", "99", 2099, null),
+                Arguments.of(2101, "RRRR", "099", 2099, null),
+                Arguments.of(2101, "RRRR", "9999", 9999, null),
+                Arguments.of(2101, "RRRR", "12345", null, unexpectedTrailingCharAfter("RRRR"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("monthValues")
+    public void testParseMonth(String text, Integer val, String error) {
+        Map<FieldKind, Object> fields = val != null ? Map.of(FieldKind.MONTH, val) : null;
+
+        parseSingleField("MM", text, fields, error);
+    }
+
+    @ParameterizedTest
+    @MethodSource("monthValuesValid")
+    public void testParseMonthUnexpectedDelimiter(String text) {
+        parseSingleField("MM", text + "/", null, unexpectedTrailingCharAfter("MM"));
+        parseSingleField("MM", "/" + text, null, expectedField("MM"));
+    }
+
+    private static Stream<Arguments> monthValuesValid() {
+        return monthValues().filter(a -> {
+            Object[] args = a.get();
+            return args[1] != null;
+        }).map(a -> {
+            Object[] args = a.get();
+            return Arguments.of(args[0]);
+        });
+    }
+
+    private static Stream<Arguments> monthValues() {
+        return Stream.of(
+                Arguments.of("", null, noValuesForFields("MM")),
+                Arguments.of("+1", null, expectedField("MM")),
+                Arguments.of("0", null, valueOutOfRange("MM")),
+                Arguments.of("1", 1, null),
+                Arguments.of("2", 2, null),
+                Arguments.of("3", 3, null),
+                Arguments.of("4", 4, null),
+                Arguments.of("5", 5, null),
+                Arguments.of("6", 6, null),
+                Arguments.of("7", 7, null),
+                Arguments.of("8", 8, null),
+                Arguments.of("9", 9, null),
+                Arguments.of("10", 10, null),
+                Arguments.of("11", 11, null),
+                Arguments.of("12", 12, null),
+                Arguments.of("13", null, valueOutOfRange("MM")),
+                Arguments.of("012", null, unexpectedTrailingCharAfter("MM"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("dayValues")
+    public void testParseDay(String text, Integer val, String error) {
+        Map<FieldKind, Object> fields = val != null ? Map.of(FieldKind.DAY_OF_MONTH, val) : null;
+
+        parseSingleField("DD", text, fields, error);
+    }
+
+    @ParameterizedTest
+    @MethodSource("dayValidValues")
+    public void testParseDayUnexpectedDelimiter(String text) {
+        parseSingleField("DD", text + "/", null, unexpectedTrailingCharAfter("DD"));
+        parseSingleField("DD", "/" + text, null, expectedField("DD"));
+    }
+
+    private static Stream<Arguments> dayValidValues() {
+        return dayValues().filter(a -> {
+            Object[] args = a.get();
+            return args[1] != null;
+        }).map(a -> {
+            Object[] args = a.get();
+            return Arguments.of(args[0]);
+        });
+    }
+
+    private static Stream<Arguments> dayValues() {
+        return Stream.of(
+                Arguments.of("", null, noValuesForFields("DD")),
+                Arguments.of("+1", null, expectedField("DD")),
+                Arguments.of("0", null, valueOutOfRange("DD")),
+                Arguments.of("1", 1, null),
+                Arguments.of("13", 13, null),
+                Arguments.of("17", 17, null),
+                Arguments.of("27", 27, null),
+                Arguments.of("28", 28, null),
+                Arguments.of("31", 31, null),
+                Arguments.of("32", null, valueOutOfRange("DD")),
+                Arguments.of("030", null, unexpectedTrailingCharAfter("DD"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("dayOfYearValues")
+    public void testParseDayOfYear(String text, Integer val, String error) {
+        Map<FieldKind, Object> fields = val != null ? Map.of(FieldKind.DAY_OF_YEAR, val) : null;
+
+        parseSingleField("DDD", text, fields, error);
+    }
+
+    @ParameterizedTest
+    @MethodSource("dayOfYearValidValues")
+    public void testParseDayOfYearUnexpectedDelimiter(String text) {
+        parseSingleField("DDD", text + "/", null, unexpectedTrailingCharAfter("DDD"));
+        parseSingleField("DDD", "/" + text, null, expectedField("DDD"));
+    }
+
+    private static Stream<Arguments> dayOfYearValidValues() {
+        return dayOfYearValues().filter(a -> {
+            Object[] args = a.get();
+            return args[1] != null;
+        }).map(a -> {
+            Object[] args = a.get();
+            return Arguments.of(args[0]);
+        });
+    }
+
+    private static Stream<Arguments> dayOfYearValues() {
+        return Stream.of(
+                Arguments.of("", null, noValuesForFields("DDD")),
+                Arguments.of("+1", null, expectedField("DDD")),
+                Arguments.of("0", null, valueOutOfRange("DDD")),
+                Arguments.of("1", 1, null),
+                Arguments.of("13", 13, null),
+                Arguments.of("37", 37, null),
+                Arguments.of("100", 100, null),
+                Arguments.of("200", 200, null),
+                Arguments.of("365", 365, null),
+                Arguments.of("366", null, valueOutOfRange("DDD")),
+                Arguments.of("0123", null, unexpectedTrailingCharAfter("DDD"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("hours12Values")
+    public void testParseHours12(String pattern, String text, Integer val, String error) {
+        Map<FieldKind, Object> fields = val != null ? Map.of(FieldKind.HOUR_24, val) : null;
+
+        parseSingleField(pattern, text, fields, error);
+    }
+
+    @ParameterizedTest
+    @MethodSource("hours12ValidValues")
+    public void testParseHours12UnexpectedDelimiter(String pattern, String text) {
+        // Error depend on position of AM
+        parseSingleField(pattern, text + "/", null, " ");
+        parseSingleField(pattern, "/" + text, null, " ");
+    }
+
+    @ParameterizedTest
+    @MethodSource("hours12Values")
+    public void testParseHours12pmAm(String pattern, String text, Integer val, String error) {
+        // Pattern HH A.M. accepts both 11 A.M. (11 hours) and 11 P.M. (converts it to 23 hours)
+        pattern = pattern.replace("A.M.", "P.M.");
+        error = error != null ? error.replace("AM", "PM") : error;
+
+        Map<FieldKind, Object> fields = val != null ? Map.of(FieldKind.HOUR_24, val) : null;
+
+        parseSingleField(pattern, text, fields, error);
+    }
+
+    @ParameterizedTest
+    @MethodSource("hours12ValidValues")
+    public void testParseHours12pmAmUnexpectedDelimiter(String pattern, String text) {
+        // Pattern HH A.M. accepts both 11 A.M.
+        pattern = pattern.replace("A.M.", "P.M.");
+
+        // Error depend on position of AM
+        parseSingleField(pattern, text + "/", null, " ");
+        parseSingleField(pattern, "/" + text, null, " ");
+    }
+
+    @ParameterizedTest
+    @MethodSource("hours12Values")
+    public void testParseHours12h12(String pattern, String text, Integer val, String error) {
+        Map<FieldKind, Object> fields = val != null ? Map.of(FieldKind.HOUR_24, val) : null;
+
+        pattern = pattern.replace("HH", "HH12");
+        error = error != null ? error.replace("HH", "HH12") : null;
+
+        parseSingleField(pattern, text, fields, error);
+    }
+
+    @ParameterizedTest
+    @MethodSource("hours12ValidValues")
+    public void testParseHours12h12UnexpectedDelimiter(String pattern, String text) {
+        // Error depend on position of AM
+        pattern = pattern.replace("HH", "HH12");
+        parseSingleField(pattern, text + "/", null, " ");
+        parseSingleField(pattern, "/" + text, null, " ");
+    }
+
+    @ParameterizedTest
+    @MethodSource("hours12Values")
+    public void testParseHours12h12pmAm(String pattern, String text, Integer val, String error) {
+        Map<FieldKind, Object> fields = val != null ? Map.of(FieldKind.HOUR_24, val) : null;
+
+        pattern = pattern.replace("HH", "HH12");
+        error = error != null ? error.replace("HH", "HH12") : null;
+
+        // Pattern HH A.M. accepts both 11 A.M.
+        pattern = pattern.replace("A.M.", "P.M.");
+        error = error != null ? error.replace("AM", "PM") : error;
+
+        parseSingleField(pattern, text, fields, error);
+    }
+
+    @ParameterizedTest
+    @MethodSource("hours12ValidValues")
+    public void testParseHours12h12pmAmUnexpectedDelimiter(String pattern, String text) {
+        // Error depend on position of AM
+        pattern = pattern.replace("HH", "HH12");
+        // Pattern HH A.M. accepts both 11 A.M.
+        pattern = pattern.replace("A.M.", "P.M.");
+
+        parseSingleField(pattern, text + "/", null, " ");
+        parseSingleField(pattern, "/" + text, null, " ");
+    }
+
+    private static Stream<Arguments> hours12ValidValues() {
+        return hours12Values().filter(a -> {
+            Object[] args = a.get();
+            return args[1] != null;
+        }).map(a -> {
+            Object[] args = a.get();
+            return Arguments.of(args[0], args[1]);
+        });
+    }
+
+    private static Stream<Arguments> hours12Values() {
+        return Stream.of(
+                Arguments.of("HHA.M.", "", null, noValuesForFields("HH", "AM")),
+
+                // A.M.
+
+                Arguments.of("HHA.M.", "+1A.M.", null, expectedField("HH")),
+
+                Arguments.of("HHA.M.", "0A.M.", null, valueOutOfRange("HH")),
+                Arguments.of("HHA.M.", "1A.M.", 1, null),
+                Arguments.of("HHA.M.", "7A.M.", 7, null),
+                Arguments.of("HHA.M.", "10A.M.", 10, null),
+                Arguments.of("HHA.M.", "11A.M.", 11, null),
+                Arguments.of("HHA.M.", "12A.M.", 0, null),
+                Arguments.of("HHA.M.", "13A.M.", null, valueOutOfRange("HH")),
+
+                Arguments.of("HHA.M.", "10AM", null, expectedField("AM")),
+                Arguments.of("HHA.M.", "A.M.", null, expectedField("HH")),
+                Arguments.of("HHA.M.", "10A.", null, expectedField("AM")),
+                Arguments.of("HHA.M.", "10A.M", null, expectedField("AM")),
+
+                // P.M.
+
+                Arguments.of("HHA.M.", "+1P.M.", null, expectedField("HH")),
+
+                Arguments.of("HHA.M.", "0P.M.", null, valueOutOfRange("HH")),
+                Arguments.of("HHA.M.", "1P.M.", 13, null),
+                Arguments.of("HHA.M.", "7P.M.", 19, null),
+                Arguments.of("HHA.M.", "10P.M.", 22, null),
+                Arguments.of("HHA.M.", "11P.M.", 23, null),
+                Arguments.of("HHA.M.", "12P.M.", 12, null),
+                Arguments.of("HHA.M.", "13P.M.", null, valueOutOfRange("HH")),
+
+                // Incorrect
+                Arguments.of("HH A.M.", "10 M.M.", null, expectedField("AM")),
+                Arguments.of("HH A.M.", "10 A.T.", null, expectedField("AM")),
+                Arguments.of("HH A.M.", "10 A.T.", null, expectedField("AM"))
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "7 A.m., 7",
+            "7 a.M., 7",
+            "7 a.m., 7",
+            "7 P.m., 19",
+            "7 p.M., 19",
+            "7 p.m., 19"
+    })
+    public void testParseHour12AmPmCaseInsensitivity(String text, int hours24) {
+        Scanner scanner = new Scanner("HH12 A.M.");
+        Parser parser = new Parser(scanner.scan());
+        ParsedFields fields = parser.parse(text);
+        assertEquals(Map.of(FieldKind.HOUR_24, hours24), fields.values());
+    }
+
+    @ParameterizedTest
+    @MethodSource("hour24Values")
+    public void testParseHours24(String text, Integer val, String error) {
+        Map<FieldKind, Object> fields = val != null ? Map.of(FieldKind.HOUR_24, val) : null;
+
+        parseSingleField("HH24", text, fields, error);
+    }
+
+    @ParameterizedTest
+    @MethodSource("hours24Valid")
+    public void testParseHours24UnexpectedDelimiter(String text) {
+        parseSingleField("HH24", text + "/", null, unexpectedTrailingCharAfter("HH24"));
+        parseSingleField("HH24", "/" + text, null, expectedField("HH24"));
+    }
+
+    private static Stream<Arguments> hours24Valid() {
+        return hour24Values().filter(a -> {
+            Object[] args = a.get();
+            return args[1] != null;
+        }).map(a -> {
+            Object[] args = a.get();
+            return Arguments.of(args[0], args[1]);
+        });
+    }
+
+    private static Stream<Arguments> hour24Values() {
+        return Stream.of(
+                Arguments.of("", null, noValuesForFields("HH24")),
+                Arguments.of("+1", null, expectedField("HH24")),
+                Arguments.of("0", 0, null),
+                Arguments.of("1", 1, null),
+                Arguments.of("2", 2, null),
+                Arguments.of("3", 3, null),
+                Arguments.of("4", 4, null),
+                Arguments.of("5", 5, null),
+                Arguments.of("6", 6, null),
+                Arguments.of("7", 7, null),
+                Arguments.of("8", 8, null),
+                Arguments.of("9", 9, null),
+                Arguments.of("10", 10, null),
+                Arguments.of("11", 11, null),
+                Arguments.of("12", 12, null),
+                Arguments.of("13", 13, null),
+                Arguments.of("14", 14, null),
+                Arguments.of("15", 15, null),
+                Arguments.of("16", 16, null),
+                Arguments.of("17", 17, null),
+                Arguments.of("18", 18, null),
+                Arguments.of("19", 19, null),
+                Arguments.of("20", 20, null),
+                Arguments.of("21", 21, null),
+                Arguments.of("22", 22, null),
+                Arguments.of("23", 23, null),
+                Arguments.of("24", null, valueOutOfRange("HH24")),
+                Arguments.of("000", null, unexpectedTrailingCharAfter("HH24"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("minutesValues")
+    public void testParseMinutes(String text, Integer val, String error) {
+        Map<FieldKind, Object> fields = val != null ? Map.of(FieldKind.MINUTE, val) : null;
+
+        parseSingleField("MI", text, fields, error);
+    }
+
+    @ParameterizedTest
+    @MethodSource("minutesValidValues")
+    public void testParseMinutesUnexpectedDelimiter(String text) {
+        parseSingleField("MI", text + "/", null, unexpectedTrailingCharAfter("MI"));
+        parseSingleField("MI", "/" + text, null, expectedField("MI"));
+    }
+
+    private static Stream<Arguments> minutesValidValues() {
+        return minutesValues().filter(a -> {
+            Object[] args = a.get();
+            return args[1] != null;
+        }).map(a -> {
+            Object[] args = a.get();
+            return Arguments.of(args[0], args[1]);
+        });
+    }
+
+    private static Stream<Arguments> minutesValues() {
+        return Stream.of(
+                Arguments.of("", null, noValuesForFields("MI")),
+                Arguments.of("+1", null, expectedField("MI")),
+                Arguments.of("-1", null, expectedField("MI")),
+                Arguments.of("0", 0, null),
+                Arguments.of("00", 0, null),
+                Arguments.of("1", 1, null),
+                Arguments.of("01", 1, null),
+                Arguments.of("09", 9, null),
+                Arguments.of("10", 10, null),
+                Arguments.of("37", 37, null),
+                Arguments.of("59", 59, null),
+                Arguments.of("60", null, valueOutOfRange("MI")),
+                Arguments.of("000", null, unexpectedTrailingCharAfter("MI"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("secondsValues")
+    public void testParseSeconds(String text, Integer val, String error) {
+        Map<FieldKind, Object> fields = val != null ? Map.of(FieldKind.SECOND_OF_MINUTE, val) : null;
+
+        parseSingleField("SS", text, fields, error);
+    }
+
+    @ParameterizedTest
+    @MethodSource("secondValuesValid")
+    public void testParseSecondsUnexpectedDelimiter(String text) {
+        parseSingleField("SS", text + "/", null, unexpectedTrailingCharAfter("SS"));
+        parseSingleField("SS", "/" + text, null, expectedField("SS"));
+    }
+
+    private static Stream<Arguments> secondValuesValid() {
+        return secondsValues().filter(a -> {
+            Object[] args = a.get();
+            return args[1] != null;
+        }).map(a -> {
+            Object[] args = a.get();
+            return Arguments.of(args[0], args[1]);
+        });
+    }
+
+    private static Stream<Arguments> secondsValues() {
+        return Stream.of(
+                Arguments.of("", null, noValuesForFields("SS")),
+                Arguments.of("+1", null, expectedField("SS")),
+                Arguments.of("-1", null, expectedField("SS")),
+                Arguments.of("0", 0, null),
+                Arguments.of("00", 0, null),
+                Arguments.of("1", 1, null),
+                Arguments.of("01", 1, null),
+                Arguments.of("09", 9, null),
+                Arguments.of("10", 10, null),
+                Arguments.of("37", 37, null),
+                Arguments.of("59", 59, null),
+                Arguments.of("60", null, valueOutOfRange("SS")),
+                Arguments.of("000", null, unexpectedTrailingCharAfter("SS"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("secondsOfDayValues")
+    public void testParseSecondsOfDay(String text, Integer val, String error) {
+        Map<FieldKind, Object> fields = val != null ? Map.of(FieldKind.SECOND_OF_DAY, val) : null;
+
+        parseSingleField("SSSSS", text, fields, error);
+    }
+
+    @ParameterizedTest
+    @MethodSource("secondsOfDayValuesValid")
+    public void testParseSecondsOfDayUnexpectedDelimiter(String text) {
+        parseSingleField("SSSSS", text + "/", null, unexpectedTrailingCharAfter("SSSSS"));
+        parseSingleField("SSSSS", "/" + text, null, expectedField("SSSSS"));
+    }
+
+    private static Stream<Arguments> secondsOfDayValuesValid() {
+        return secondsValues().filter(a -> {
+            Object[] args = a.get();
+            return args[1] != null;
+        }).map(a -> {
+            Object[] args = a.get();
+            return Arguments.of(args[0], args[1]);
+        });
+    }
+
+    private static Stream<Arguments> secondsOfDayValues() {
+        return Stream.of(
+                Arguments.of("", null, noValuesForFields("SSSSS")),
+                Arguments.of("+1", null, expectedField("SSSSS")),
+                Arguments.of("-1", null, expectedField("SSSSS")),
+                Arguments.of("0", 0, null),
+                Arguments.of("00000", 0, null),
+                Arguments.of("1", 1, null),
+                Arguments.of("01", 1, null),
+                Arguments.of("09", 9, null),
+                Arguments.of("370", 370, null),
+                Arguments.of("059", 59, null),
+                Arguments.of("00008", 8, null),
+                Arguments.of("00086", 86, null),
+                Arguments.of("00864", 864, null),
+                Arguments.of("08640", 8640, null),
+                Arguments.of("86400", 86400, null),
+                Arguments.of("86401", null, valueOutOfRange("SSSSS")),
+                Arguments.of("90000", null, valueOutOfRange("SSSSS")),
+                Arguments.of("010000", null, unexpectedTrailingCharAfter("SSSSS"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("fractionValues")
+    public void testParseFractions(String pattern, String text, Integer val, String error) {
+        Map<FieldKind, Object> fields = val != null ? Map.of(FieldKind.FRACTION, val) : null;
+
+        parseSingleField(pattern, text, fields, error);
+    }
+
+    @ParameterizedTest
+    @MethodSource("fractionValuesValid")
+    public void testParseFractionsUnexpectedDelimiter(String pattern, String text) {
+        parseSingleField(pattern, text + "/", null, unexpectedTrailingCharAfter(pattern));
+        parseSingleField(pattern, "/" + text, null, "Expected field " + pattern);
+    }
+
+    private static Stream<Arguments> fractionValuesValid() {
+        return fractionValues().filter(a -> {
+            Object[] args = a.get();
+            return args[2] != null;
+        }).map(a -> {
+            Object[] args = a.get();
+            return Arguments.of(args[0], args[1]);
+        });
+    }
+
+    private static Stream<Arguments> fractionValues() {
+        return Stream.of(
+                // Millis
+                Arguments.of("FF1", "1", 100_000_000, null),
+                Arguments.of("FF1", "10", null, unexpectedTrailingCharAfter("FF1")),
+
+                Arguments.of("FF2", "1", 100_000_000, null),
+                Arguments.of("FF2", "12", 120_000_000, null),
+                Arguments.of("FF2", "100", null, unexpectedTrailingCharAfter("FF2")),
+
+                Arguments.of("FF3", "1", 100_000_000, null),
+                Arguments.of("FF3", "12", 120_000_000, null),
+                Arguments.of("FF3", "123", 123_000_000, null),
+                Arguments.of("FF3", "1000", null, unexpectedTrailingCharAfter("FF3")),
+
+                // Micros
+                Arguments.of("FF4", "1", 100_000_000, null),
+                Arguments.of("FF4", "12", 120_000_000, null),
+                Arguments.of("FF4", "123", 123_000_000, null),
+                Arguments.of("FF4", "1234", 123_400_000, null),
+                Arguments.of("FF4", "10000", null, unexpectedTrailingCharAfter("FF4")),
+
+                Arguments.of("FF5", "1", 100_000_000, null),
+                Arguments.of("FF5", "12", 120_000_000, null),
+                Arguments.of("FF5", "123", 123_000_000, null),
+                Arguments.of("FF5", "1234", 123_400_000, null),
+                Arguments.of("FF5", "12345", 123_450_000, null),
+                Arguments.of("FF5", "100000", null, unexpectedTrailingCharAfter("FF5")),
+
+                Arguments.of("FF6", "1", 100_000_000, null),
+                Arguments.of("FF6", "12", 120_000_000, null),
+                Arguments.of("FF6", "123", 123_000_000, null),
+                Arguments.of("FF6", "1234", 123_400_000, null),
+                Arguments.of("FF6", "12345", 123_450_000, null),
+                Arguments.of("FF6", "123456", 123_456_000, null),
+                Arguments.of("FF6", "1000000", null, unexpectedTrailingCharAfter("FF6")),
+
+                // Nanos
+                Arguments.of("FF7", "1", 100_000_000, null),
+                Arguments.of("FF7", "12", 120_000_000, null),
+                Arguments.of("FF7", "123", 123_000_000, null),
+                Arguments.of("FF7", "1234", 123_400_000, null),
+                Arguments.of("FF7", "12345", 123_450_000, null),
+                Arguments.of("FF7", "123456", 123_456_000, null),
+                Arguments.of("FF7", "1234567", 123_456_700, null),
+                Arguments.of("FF7", "10000000", null, unexpectedTrailingCharAfter("FF7")),
+
+                Arguments.of("FF8", "1", 100_000_000, null),
+                Arguments.of("FF8", "12", 120_000_000, null),
+                Arguments.of("FF8", "123", 123_000_000, null),
+                Arguments.of("FF8", "1234", 123_400_000, null),
+                Arguments.of("FF8", "12345", 123_450_000, null),
+                Arguments.of("FF8", "123456", 123_456_000, null),
+                Arguments.of("FF8", "1234567", 123_456_700, null),
+                Arguments.of("FF8", "12345678", 123_456_780, null),
+                Arguments.of("FF8", "100000000", null, unexpectedTrailingCharAfter("FF8")),
+
+                Arguments.of("FF9", "1", 100_000_000, null),
+                Arguments.of("FF9", "12", 120_000_000, null),
+                Arguments.of("FF9", "123", 123_000_000, null),
+                Arguments.of("FF9", "1234", 123_400_000, null),
+                Arguments.of("FF9", "12345", 123_450_000, null),
+                Arguments.of("FF9", "123456", 123_456_000, null),
+                Arguments.of("FF9", "1234567", 123_456_700, null),
+                Arguments.of("FF9", "12345678", 123_456_780, null),
+                Arguments.of("FF9", "123456789", 123_456_789, null),
+                Arguments.of("FF9", "1000000000", null, unexpectedTrailingCharAfter("FF9"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("timeZoneValues")
+    public void testParseTimeZone(String format, String text, ZoneOffset offset, String error) {
+        if (offset != null) {
+            parseSingleField(format, text, Map.of(FieldKind.TIMEZONE, offset), error);
+        } else {
+            parseSingleField(format, text, null, error);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("timeZoneValues")
+    public void testParseTimeZoneSwapped(String format, String text, ZoneOffset offset, String error) {
+        String[] elements = format.split(":");
+        String[] values = text.split(":");
+        String swappedFormat = elements[1] + ":" + elements[0];
+        String swappedText = values[1] + ":" + values[0];
+
+        if (offset != null) {
+            parseSingleField(swappedFormat, swappedText, Map.of(FieldKind.TIMEZONE, offset), error);
+        } else {
+            parseSingleField(swappedFormat, swappedText, null, error);
+        }
+    }
+
+    private static Stream<Arguments> timeZoneValues() {
+        return Stream.of(
+                // Positive
+                Arguments.of("TZH:TZM", "+0:0", ZoneOffset.ofHoursMinutes(0, 0), null),
+                Arguments.of("TZH:TZM", "+0:1", ZoneOffset.ofHoursMinutes(0, 1), null),
+                Arguments.of("TZH:TZM", "+0:10", ZoneOffset.ofHoursMinutes(0, 10), null),
+                Arguments.of("TZH:TZM", "+5:0", ZoneOffset.ofHoursMinutes(5, 0), null),
+                Arguments.of("TZH:TZM", "+5:3", ZoneOffset.ofHoursMinutes(5, 3), null),
+                Arguments.of("TZH:TZM", "+5:45", ZoneOffset.ofHoursMinutes(5, 45), null),
+                Arguments.of("TZH:TZM", "+13:60", null, valueOutOfRange("TZM")),
+                Arguments.of("TZH:TZM", "+10:0", ZoneOffset.ofHoursMinutes(10, 0), null),
+                Arguments.of("TZH:TZM", "+10:12", ZoneOffset.ofHoursMinutes(10, 12), null),
+                Arguments.of("TZH:TZM", "+17:43", ZoneOffset.ofHoursMinutes(17, 43), null),
+                Arguments.of("TZH:TZM", "+18:0", ZoneOffset.ofHoursMinutes(18, 0), null),
+                Arguments.of("TZH:TZM", "+18:1", null, invalidTimeZoneValue()),
+                Arguments.of("TZH:TZM", "+19:0", null, invalidTimeZoneValue()),
+                Arguments.of("TZH:TZM", "+19:59", null, invalidTimeZoneValue()),
+                Arguments.of("TZH:TZM", "+19:60", null, valueOutOfRange("TZM")),
+
+                // Positive
+                Arguments.of("TZH:TZM", "-0:0", ZoneOffset.ofHoursMinutes(0, 0), null),
+                Arguments.of("TZH:TZM", "-0:1", ZoneOffset.ofHoursMinutes(0, -1), null),
+                Arguments.of("TZH:TZM", "-0:10", ZoneOffset.ofHoursMinutes(0, -10), null),
+                Arguments.of("TZH:TZM", "-5:0", ZoneOffset.ofHoursMinutes(-5, 0), null),
+                Arguments.of("TZH:TZM", "-5:3", ZoneOffset.ofHoursMinutes(-5, -3), null),
+                Arguments.of("TZH:TZM", "-5:45", ZoneOffset.ofHoursMinutes(-5, -45), null),
+                Arguments.of("TZH:TZM", "-13:60", null, valueOutOfRange("TZM")),
+                Arguments.of("TZH:TZM", "-10:0", ZoneOffset.ofHoursMinutes(-10, 0), null),
+                Arguments.of("TZH:TZM", "-10:12", ZoneOffset.ofHoursMinutes(-10, -12), null),
+                Arguments.of("TZH:TZM", "-17:43", ZoneOffset.ofHoursMinutes(-17, -43), null),
+                Arguments.of("TZH:TZM", "-18:0", ZoneOffset.ofHoursMinutes(-18, 0), null),
+                Arguments.of("TZH:TZM", "-18:1", null, invalidTimeZoneValue()),
+                Arguments.of("TZH:TZM", "-19:0", null, invalidTimeZoneValue()),
+                Arguments.of("TZH:TZM", "-19:59", null, invalidTimeZoneValue()),
+                Arguments.of("TZH:TZM", "-19:60", null, valueOutOfRange("TZM")),
+
+                // Error depends on field ordering:
+                // Invalid format. Expected literal <:> but got <1>
+                //  Unexpected trailing characters after TZH when swapped
+                Arguments.of("TZH:TZM", "+001:20", null, " "),
+                Arguments.of("TZH:TZM", "+000:20", null, " "),
+
+                // Invalid format. Expected literal <:> but got <0>
+                // Unexpected trailing characters after TZH when swapped
+                Arguments.of("TZH:TZM", "+1:000", null, " "),
+                Arguments.of("TZH:TZM", "+1:001", null, " "),
+
+                Arguments.of("TZH:TZM", "1:20", null, expectedField("TZH")),
+                Arguments.of("TZM:TZH", "10:1", null, expectedField("TZH")),
+
+                // Error depends on field ordering
+                // Invalid value for field TZM when swapped
+                // Expected +/- but got: 1
+                Arguments.of("TZH:TZM", "1:-20", null, " "),
+
+                Arguments.of("TZH:TZM", "+1:+20", null, expectedField("TZM")),
+                Arguments.of("TZH:TZM", "+1:-20", null, expectedField("TZM")),
+                Arguments.of("TZM:TZH", "+10:-1", null, expectedField("TZM"))
+        );
+    }
+
+    private static String valueOutOfRange(String f) {
+        return "Value out of range for field " + f;
+    }
+
+    private static String expectedField(String f) {
+        return "Expected field " + f;
+    }
+
+    private static String invalidTimeZoneValue() {
+        return "Time zone field value is not valid";
+    }
+
+    private static String unexpectedTrailingCharAfter(String f) {
+        return "Unexpected trailing characters after field " + f;
+    }
+
+    private static String noValuesForFields(String... f) {
+        return "No values for elements " + Arrays.stream(f).map(f0 -> "field " + f0).collect(Collectors.joining(", "));
+    }
+
+    private void parseSingleField(
+            String pattern,
+            String text,
+            @Nullable Map<FieldKind, Object> fields,
+            @Nullable String error
+    ) {
+        parseSingleField(pattern, text, FIXED_CLOCK, fields, error);
+    }
+
+    private void parseSingleField(
+            String pattern,
+            String text,
+            Clock clock,
+            @Nullable Map<FieldKind, Object> fields,
+            @Nullable String error
+    ) {
+        List<DateTimeFormatElement> elements = new Scanner(pattern).scan();
+        Parser parser = new Parser(elements, clock);
+
+        log.info("Pattern: {}", pattern);
+        log.info("Result: {}", fields);
+        log.info("Error: {}", error);
+
+        if (fields != null) {
+            ParsedFields parsedText = parser.parse(text);
+
+            assertEquals(fields, parsedText.values());
+        } else {
+            try {
+                ParsedFields parsedText = parser.parse(text);
+                fail("Expected an error but got " + parsedText.values());
+            } catch (DateTimeFormatException e) {
+                assertThat("Error message: ", e.getMessage(), containsString(error));
+            }
+        }
+    }
+}

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/format/ScannerSelfTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/format/ScannerSelfTest.java
@@ -125,6 +125,28 @@ class ScannerSelfTest extends BaseIgniteAbstractTest {
 
     @ParameterizedTest
     @MethodSource("singleElements")
+    public void testPatternCaseInsensitivity(String pattern, List<DateTimeTemplateField> expected) {
+
+        StringBuilder modifiedPattern = new StringBuilder();
+        for (int i = 0; i < pattern.length(); i++) {
+            if (random.nextBoolean()) {
+                modifiedPattern.append(Character.toLowerCase(pattern.charAt(i)));
+            } else {
+                modifiedPattern.append(Character.toUpperCase(pattern.charAt(i)));
+            }
+        }
+        String newPattern = modifiedPattern.toString();
+
+        log.info("Random case pattern: {}", newPattern);
+
+        List<DateTimeFormatElement> elements = expected.stream()
+                .map(DateTimeFormatElement::new)
+                .collect(Collectors.toList());
+        expectParsed(newPattern, elements);
+    }
+
+    @ParameterizedTest
+    @MethodSource("singleElements")
     public void testSingleElementWithDelimiters(String ignore, List<DateTimeTemplateField> fields) {
         StringBuilder pattern = new StringBuilder();
         List<DateTimeFormatElement> expected = new ArrayList<>();


### PR DESCRIPTION
Implement a parser for SQL datetime format.

Parser tests:

- Basic valid patterns 
- Basic invalid patterns
- Unexpected leading delimiters
- Unexpected trailing delimiters
- Matching is case-insensitive (add a case of the scanner as well)

- Each field: valid value, invalid value.
- Each field: unexpected delimiters before the field.
- Each field: unexpected delimiters after the field.

- Multiple fields shuffled.

https://issues.apache.org/jira/browse/IGNITE-25552

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)