### PR TITLE
IGNITE-25556: Sql. Date/Time. Datetime format scanner

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/DateTimeFormatElement.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/DateTimeFormatElement.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.util.format;
+
+import java.util.Objects;
+
+/**
+ * Format element - a delimiter or a template field.
+ */
+final class DateTimeFormatElement {
+    enum ElementKind {
+        DELIMITER,
+        FIELD
+    }
+
+    final ElementKind kind;
+    final char delimiter;
+    final DateTimeTemplateField template;
+
+    DateTimeFormatElement(char c) {
+        this.kind = ElementKind.DELIMITER;
+        this.delimiter = c;
+        this.template = null;
+    }
+
+    DateTimeFormatElement(DateTimeTemplateField template) {
+        this.kind = ElementKind.FIELD;
+        this.delimiter = '\0';
+        this.template = template;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof DateTimeFormatElement)) {
+            return false;
+        }
+        DateTimeFormatElement element = (DateTimeFormatElement) o;
+        return delimiter == element.delimiter && kind == element.kind && template == element.template;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kind, delimiter, template);
+    }
+
+    @Override
+    public String toString() {
+        switch (kind) {
+            case DELIMITER:
+                return String.format("<%s>", delimiter);
+            case FIELD:
+                return template.name();
+            default:
+                throw new IllegalStateException();
+        }
+    }
+}

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/DateTimeFormatException.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/DateTimeFormatException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.util.format;
+
+/**
+ * Exception indicating an error with a date/time formatting.
+ */
+final class DateTimeFormatException extends RuntimeException {
+    private static final long serialVersionUID = 7351496651746646434L;
+
+    DateTimeFormatException(String message) {
+        super(message);
+    }
+
+    DateTimeFormatException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/DateTimeTemplateField.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/DateTimeTemplateField.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.util.format;
+
+/**
+ * Supported datetime template fields.
+ */
+enum DateTimeTemplateField {
+    YYYY,
+    YYY,
+    YY,
+    Y,
+    RRRR,
+    RR,
+    MM,
+    DD,
+    DDD,
+    HH,
+    HH12,
+    HH24,
+    MI,
+    SS,
+    SSSSS,
+    FF1,
+    FF2,
+    FF3,
+    FF4,
+    FF5,
+    FF6,
+    FF7,
+    FF8,
+    FF9,
+    PM,
+    AM,
+    TZH,
+    TZM;
+
+    String asPattern() {
+        if (this == AM) {
+            return "A.M.";
+        } else if (this == PM) {
+            return "P.M.";
+        } else {
+            return this.name();
+        }
+    }
+
+    FieldKind kind() {
+        switch (this) {
+            case YYYY:
+            case YYY:
+            case YY:
+            case Y:
+                return FieldKind.YEAR;
+            case RRRR:
+            case RR:
+                return FieldKind.ROUNDED_YEAR;
+            case MM:
+                return FieldKind.MONTH;
+            case DD:
+                return FieldKind.DAY_OF_MONTH;
+            case DDD:
+                return FieldKind.DAY_OF_YEAR;
+            case HH:
+            case HH12:
+                return FieldKind.HOUR_12;
+            case HH24:
+                return FieldKind.HOUR_24;
+            case MI:
+                return FieldKind.MINUTE;
+            case SS:
+                return FieldKind.SECOND_OF_MINUTE;
+            case SSSSS:
+                return FieldKind.SECOND_OF_DAY;
+            case FF1:
+            case FF2:
+            case FF3:
+            case FF4:
+            case FF5:
+            case FF6:
+            case FF7:
+            case FF8:
+            case FF9:
+                return FieldKind.FRACTION;
+            case PM:
+            case AM:
+                return FieldKind.AM_PM;
+            case TZH:
+            case TZM:
+                return FieldKind.TIMEZONE;
+            default:
+                throw new IllegalStateException("Unexpected template field: " + this);
+        }
+    }
+
+    enum FieldKind {
+        YEAR,
+        ROUNDED_YEAR,
+        MONTH,
+        DAY_OF_MONTH,
+        DAY_OF_YEAR,
+        HOUR_12,
+        HOUR_24,
+        MINUTE,
+        SECOND_OF_MINUTE,
+        SECOND_OF_DAY,
+        FRACTION,
+        AM_PM,
+        TIMEZONE;
+    }
+}

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/DateTimeTemplateField.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/DateTimeTemplateField.java
@@ -21,91 +21,56 @@ package org.apache.ignite.internal.sql.engine.util.format;
  * Supported datetime template fields.
  */
 enum DateTimeTemplateField {
-    YYYY,
-    YYY,
-    YY,
-    Y,
-    RRRR,
-    RR,
-    MM,
-    DD,
-    DDD,
-    HH,
-    HH12,
-    HH24,
-    MI,
-    SS,
-    SSSSS,
-    FF1,
-    FF2,
-    FF3,
-    FF4,
-    FF5,
-    FF6,
-    FF7,
-    FF8,
-    FF9,
-    PM,
-    AM,
-    TZH,
-    TZM;
+    YYYY(FieldKind.YEAR),
+    YYY(FieldKind.YEAR),
+    YY(FieldKind.YEAR),
+    Y(FieldKind.YEAR),
+    RRRR(FieldKind.ROUNDED_YEAR),
+    RR(FieldKind.ROUNDED_YEAR),
+    MM(FieldKind.MONTH),
+    DD(FieldKind.DAY_OF_MONTH),
+    DDD(FieldKind.DAY_OF_YEAR),
+    HH(FieldKind.HOUR_12),
+    HH12(FieldKind.HOUR_12),
+    HH24(FieldKind.HOUR_24),
+    MI(FieldKind.MINUTE),
+    SS(FieldKind.SECOND_OF_MINUTE),
+    SSSSS(FieldKind.SECOND_OF_DAY),
+    FF1(FieldKind.FRACTION),
+    FF2(FieldKind.FRACTION),
+    FF3(FieldKind.FRACTION),
+    FF4(FieldKind.FRACTION),
+    FF5(FieldKind.FRACTION),
+    FF6(FieldKind.FRACTION),
+    FF7(FieldKind.FRACTION),
+    FF8(FieldKind.FRACTION),
+    FF9(FieldKind.FRACTION),
+    PM(FieldKind.AM_PM, "P.M."),
+    AM(FieldKind.AM_PM, "A.M."),
+    TZH(FieldKind.TIMEZONE),
+    TZM(FieldKind.TIMEZONE)
+    ;
 
-    String asPattern() {
-        if (this == AM) {
-            return "A.M.";
-        } else if (this == PM) {
-            return "P.M.";
-        } else {
-            return this.name();
-        }
+    private final FieldKind kind;
+
+    private final String pattern;
+
+    DateTimeTemplateField(FieldKind kind) {
+        this.kind = kind;
+        this.pattern = this.name();
+    }
+
+    DateTimeTemplateField(FieldKind kind, String pattern) {
+        this.kind = kind;
+        this.pattern = pattern;
+    }
+
+    String pattern() {
+        return pattern;
     }
 
     FieldKind kind() {
-        switch (this) {
-            case YYYY:
-            case YYY:
-            case YY:
-            case Y:
-                return FieldKind.YEAR;
-            case RRRR:
-            case RR:
-                return FieldKind.ROUNDED_YEAR;
-            case MM:
-                return FieldKind.MONTH;
-            case DD:
-                return FieldKind.DAY_OF_MONTH;
-            case DDD:
-                return FieldKind.DAY_OF_YEAR;
-            case HH:
-            case HH12:
-                return FieldKind.HOUR_12;
-            case HH24:
-                return FieldKind.HOUR_24;
-            case MI:
-                return FieldKind.MINUTE;
-            case SS:
-                return FieldKind.SECOND_OF_MINUTE;
-            case SSSSS:
-                return FieldKind.SECOND_OF_DAY;
-            case FF1:
-            case FF2:
-            case FF3:
-            case FF4:
-            case FF5:
-            case FF6:
-            case FF7:
-            case FF8:
-            case FF9:
-                return FieldKind.FRACTION;
-            case PM:
-            case AM:
-                return FieldKind.AM_PM;
-            case TZH:
-            case TZM:
-                return FieldKind.TIMEZONE;
-            default:
-                throw new IllegalStateException("Unexpected template field: " + this);
-        }
+        return kind;
     }
 
     enum FieldKind {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/Scanner.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/format/Scanner.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.util.format;
+
+import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.ignite.internal.sql.engine.util.format.DateTimeFormatElement.ElementKind;
+import org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FieldKind;
+
+/**
+ * Converts a format string into a sequence of elements (delimiters or fields).
+ */
+final class Scanner {
+    private static final Map<String, DateTimeTemplateField> FIELDS_BY_PATTERN;
+
+    static {
+        FIELDS_BY_PATTERN = new HashMap<>();
+        for (var field : DateTimeTemplateField.values()) {
+            FIELDS_BY_PATTERN.put(field.asPattern(), field);
+        }
+    }
+
+    private final String pattern;
+
+    /** Encountered elements. */
+    private final List<DateTimeFormatElement> elements = new ArrayList<>();
+
+    /** A set of encountered fields. Each field can be present at most once. */
+    private final EnumSet<DateTimeTemplateField> fields = EnumSet.noneOf(DateTimeTemplateField.class);
+
+    /** A set of encountered fields kind. */
+    private final EnumSet<FieldKind> groups = EnumSet.noneOf(FieldKind.class);
+
+    private int start;
+
+    private int current;
+
+    Scanner(String pattern) {
+        Objects.requireNonNull(pattern, "pattern");
+        // the SQL date time format is case-insensitive.
+        this.pattern = pattern.toUpperCase(Locale.US);
+    }
+
+    List<DateTimeFormatElement> parse() {
+        while (!atEnd()) {
+            start = current;
+            scanToken();
+        }
+
+        validateFields();
+
+        return elements;
+    }
+
+    private boolean atEnd() {
+        return current >= pattern.length();
+    }
+
+    private void scanToken() {
+        char c = advance();
+        switch (c) {
+            case '-':
+            case '.':
+            case '/':
+            case ',':
+            case '\'':
+            case ';':
+            case ':':
+            case ' ':
+                addToken(ElementKind.DELIMITER);
+                break;
+            default:
+                if (isAlpha(c)) {
+                    field();
+                } else {
+                    throw formatError("Unexpected character <{}> in pattern <{}>", c, pattern);
+                }
+        }
+    }
+
+    private void field() {
+        if (match("YYYY") || match("YYY") || match("YY") || match("Y")) {
+            addToken(ElementKind.FIELD);
+        } else if (match("RRRR") || match("RR")) {
+            addToken(ElementKind.FIELD);
+        } else if (match("MM")) {
+            addToken(ElementKind.FIELD);
+        } else if (match("DDD") || match("DD")) {
+            addToken(ElementKind.FIELD);
+        } else if (match("HH24") || match("HH12") || match("HH")) {
+            addToken(ElementKind.FIELD);
+        } else if (match("MI")) {
+            addToken(ElementKind.FIELD);
+        } else if (match("SSSSS") || match("SS")) {
+            addToken(ElementKind.FIELD);
+        } else if (match("FF1") || match("FF2") || match("FF3")
+                || match("FF4") || match("FF5") || match("FF6")
+                || match("FF7") || match("FF8") || match("FF9")) {
+            addToken(ElementKind.FIELD);
+        } else if (match("A.M.") || match("P.M.")) {
+            addToken(ElementKind.FIELD);
+        } else if (match("TZH") || match("TZM")) {
+            addToken(ElementKind.FIELD);
+        } else {
+            // Consume unexpected field
+            while (isAlphaNumeric(peek())) {
+                advance();
+            }
+            throw formatError("Unexpected element <{}> in pattern <{}>", pattern.substring(start, current), pattern);
+        }
+    }
+
+    private boolean match(String text) {
+        // Match the first char
+        if (pattern.charAt(start) != text.charAt(0)) {
+            return false;
+        }
+
+        int pos = current;
+        boolean matches = true;
+
+        // Match the rest, if do not match then current position.
+        for (int i = 1; i < text.length(); i++) {
+            if (atEnd()) {
+                matches = false;
+                break;
+            }
+            char c = advance();
+            if (c != text.charAt(i)) {
+                matches = false;
+                break;
+            }
+        }
+
+        if (!matches) {
+            current = pos;
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private char advance() {
+        current += 1;
+        return pattern.charAt(current - 1);
+    }
+
+    private char peek() {
+        if (atEnd()) {
+            return '\0';
+        } else {
+            return pattern.charAt(current);
+        }
+    }
+
+    private void addToken(ElementKind elementKind) {
+        String token = pattern.substring(start, current);
+
+        switch (elementKind) {
+            case DELIMITER:
+                addDelimiter(token);
+                break;
+            case FIELD:
+                addField(token);
+                break;
+            default:
+                throw new IllegalStateException("Unexpected element: " + elementKind);
+        }
+    }
+
+    private void addDelimiter(String token) {
+        assert token.length() == 1 : "Delimiter is always a single character";
+
+        // Syntax rules 3) Ensure there are no consecutive delimiters.
+        if (!elements.isEmpty()) {
+            DateTimeFormatElement e = elements.get(elements.size() - 1);
+            if (e.kind == ElementKind.DELIMITER) {
+                throw formatError("Consecutive delimiters are not allowed");
+            }
+        }
+
+        elements.add(new DateTimeFormatElement(token.charAt(0)));
+    }
+
+    private void addField(String token) {
+        DateTimeTemplateField field = FIELDS_BY_PATTERN.get(token);
+        if (field == null) {
+            throw formatError("Unexpected field <{}>", token);
+        }
+
+        // Syntax rules 4) each field can be present at most once
+        FieldKind dtField = field.kind();
+        boolean alreadyPresent = !groups.add(dtField);
+
+        if (dtField == FieldKind.TIMEZONE) {
+            alreadyPresent = !fields.add(field);
+        }
+
+        if (alreadyPresent) {
+            throw formatError("Element is already present: {}", dtField);
+        }
+
+        elements.add(new DateTimeFormatElement(field));
+    }
+
+    private static boolean isAlpha(char c) {
+        return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z';
+    }
+
+    private static boolean isAlphaNumeric(char c) {
+        return isAlpha(c) || Character.isDigit(c);
+    }
+
+    private void ensureOnlyOnePresent(FieldKind f1, FieldKind f2, String message) {
+        if (groups.contains(f1) && groups.contains(f2)) {
+            throw formatError("Invalid format. Only one field must be present: {}", message);
+        }
+    }
+
+    private void ensureBothPresent(FieldKind f1, FieldKind f2, String message) {
+        if (groups.contains(f1) != groups.contains(f2)) {
+            throw formatError("Invalid format. Expected both fields: {}", message);
+        }
+    }
+
+    private void validateFields() {
+        // Syntax rules 5) It shall not contain both <datetime template year> and <datetime template rounded year>,
+        ensureOnlyOnePresent(FieldKind.YEAR, FieldKind.ROUNDED_YEAR, "year / rounded year");
+
+        // Syntax rules 6) if contains <datetime template day of year>,
+        // then it shall not contain <datetime template month> or <datetime template day of month>.
+        ensureOnlyOnePresent(FieldKind.DAY_OF_YEAR, FieldKind.MONTH, "day of year / month");
+        ensureOnlyOnePresent(FieldKind.DAY_OF_YEAR, FieldKind.DAY_OF_MONTH, "day of year / day of month");
+
+        // Syntax rules 7)
+        ensureOnlyOnePresent(FieldKind.HOUR_24, FieldKind.HOUR_12, "24-hour / 12-hour");
+
+        // Syntax rules 8) if any of 12-hour and am pm must present, then both of them must present
+        ensureBothPresent(FieldKind.HOUR_12, FieldKind.AM_PM, "12-hour / am pm");
+
+        // Syntax rules 9) 24-hour and am pm
+        ensureOnlyOnePresent(FieldKind.HOUR_24, FieldKind.AM_PM, "24-hour / am pm");
+
+        // Syntax rules 10) second of day
+        ensureOnlyOnePresent(FieldKind.SECOND_OF_DAY, FieldKind.HOUR_12, "second of day / 12-hour");
+        ensureOnlyOnePresent(FieldKind.SECOND_OF_DAY, FieldKind.HOUR_24, "second of day / 24-hour");
+        ensureOnlyOnePresent(FieldKind.SECOND_OF_DAY, FieldKind.MINUTE, "second of day / minute");
+        ensureOnlyOnePresent(FieldKind.SECOND_OF_DAY, FieldKind.SECOND_OF_MINUTE, "second of day / second of minute");
+
+        // Syntax rules 11) time zone hour and minute
+        if (fields.contains(DateTimeTemplateField.TZH) != fields.contains(DateTimeTemplateField.TZM)) {
+            throw formatError("Invalid format. Expected both fields: time zone hour / time zone minute");
+        }
+    }
+
+    private static DateTimeFormatException formatError(String message, Object... elements) {
+        return new DateTimeFormatException(format(message, elements));
+    }
+}

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/format/ScannerSelfTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/format/ScannerSelfTest.java
@@ -139,7 +139,7 @@ class ScannerSelfTest extends BaseIgniteAbstractTest {
                 pattern.append(delimiter);
                 expected.add(new DateTimeFormatElement(delimiter));
             }
-            pattern.append(f.asPattern());
+            pattern.append(f.pattern());
             expected.add(new DateTimeFormatElement(f));
         }
 
@@ -161,7 +161,7 @@ class ScannerSelfTest extends BaseIgniteAbstractTest {
     @MethodSource("invalidPatterns")
     public void testRejectInvalidPattern(String pattern, String error) {
         Scanner scanner = new Scanner(pattern);
-        DateTimeFormatException err = assertThrows(DateTimeFormatException.class, scanner::parse);
+        DateTimeFormatException err = assertThrows(DateTimeFormatException.class, scanner::scan);
         assertThat(err.getMessage(), containsString(error));
     }
 
@@ -187,18 +187,18 @@ class ScannerSelfTest extends BaseIgniteAbstractTest {
         boolean checkConsecutive = field != Y && field != YY && field != RR && field != DD;
 
         if (checkConsecutive) {
-            String pattern = field.asPattern() + field.asPattern();
+            String pattern = field.pattern() + field.pattern();
 
             DateTimeFormatException err = assertThrows(DateTimeFormatException.class,
-                    () -> new Scanner(pattern).parse());
+                    () -> new Scanner(pattern).scan());
             assertThat(err.getMessage(), containsString("Element is already present: " + field.kind()));
         }
 
         {
-            String pattern = field.asPattern() + " " + field.asPattern();
+            String pattern = field.pattern() + " " + field.pattern();
 
             DateTimeFormatException err = assertThrows(DateTimeFormatException.class,
-                    () -> new Scanner(pattern).parse());
+                    () -> new Scanner(pattern).scan());
             assertThat(err.getMessage(), containsString("Element is already present: " + field.kind()));
         }
     }
@@ -213,7 +213,7 @@ class ScannerSelfTest extends BaseIgniteAbstractTest {
         Collections.shuffle(shuffledFields, random);
 
         for (DateTimeTemplateField f : shuffledFields) {
-            pattern.append(f.asPattern());
+            pattern.append(f.pattern());
             expected.add(new DateTimeFormatElement(f));
         }
 
@@ -240,7 +240,7 @@ class ScannerSelfTest extends BaseIgniteAbstractTest {
                     expected.add(new DateTimeFormatElement(delimiter));
                 }
             }
-            pattern.append(f.asPattern());
+            pattern.append(f.pattern());
             expected.add(new DateTimeFormatElement(f));
         }
 
@@ -310,7 +310,7 @@ class ScannerSelfTest extends BaseIgniteAbstractTest {
 
     private static void expectParsed(String pattern, List<DateTimeFormatElement> expected) {
         Scanner scanner = new Scanner(pattern);
-        List<DateTimeFormatElement> actual = scanner.parse();
+        List<DateTimeFormatElement> actual = scanner.scan();
         assertEquals(expected, actual);
     }
 
@@ -333,7 +333,7 @@ class ScannerSelfTest extends BaseIgniteAbstractTest {
         log.info("Updated pattern: {}", updated);
 
         DateTimeFormatException err = assertThrows(DateTimeFormatException.class,
-                () -> new Scanner(updated).parse());
+                () -> new Scanner(updated).scan());
         assertThat(err.getMessage(), containsString("Unexpected character "));
     }
 
@@ -466,7 +466,7 @@ class ScannerSelfTest extends BaseIgniteAbstractTest {
         log.info("Pattern: {}", shuffled);
 
         Scanner scanner = new Scanner(pattern);
-        DateTimeFormatException err = assertThrows(DateTimeFormatException.class, scanner::parse);
+        DateTimeFormatException err = assertThrows(DateTimeFormatException.class, scanner::scan);
         assertThat(err.getMessage(), containsString(error));
     }
 }

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/format/ScannerSelfTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/util/format/ScannerSelfTest.java
@@ -1,0 +1,472 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.util.format;
+
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.AM;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.DD;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.DDD;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.FF3;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.HH;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.HH12;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.HH24;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.MI;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.MM;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.PM;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.RR;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.RRRR;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.SS;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.SSSSS;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.TZH;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.TZM;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.Y;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.YY;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.YYY;
+import static org.apache.ignite.internal.sql.engine.util.format.DateTimeTemplateField.YYYY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for {@link Scanner}.
+ */
+class ScannerSelfTest extends BaseIgniteAbstractTest {
+    private static final List<Character> DELIMITERS = List.of('-', '.', '/', ',', '\'', ';', ':', ' ');
+
+    private final Random random = new Random();
+
+    @BeforeEach
+    public void before() {
+        long seed = System.nanoTime();
+        random.setSeed(seed);
+        log.info("Seed: {}", seed);
+    }
+
+    @ParameterizedTest
+    @MethodSource("singleElements")
+    public void testSingleElement(String pattern, List<DateTimeTemplateField> expected) {
+        List<DateTimeFormatElement> elements = expected.stream()
+                .map(DateTimeFormatElement::new)
+                .collect(Collectors.toList());
+        expectParsed(pattern, elements);
+    }
+
+    @ParameterizedTest
+    @MethodSource("singleElements")
+    public void testPreserveWhitespace(String pattern, List<DateTimeTemplateField> expected) {
+        {
+            // Leading
+            List<DateTimeFormatElement> elements = new ArrayList<>();
+            elements.add(new DateTimeFormatElement(' '));
+            expected.forEach(f -> elements.add(new DateTimeFormatElement(f)));
+
+            expectParsed(" " + pattern, elements);
+        }
+
+        {
+            // Trailing
+            List<DateTimeFormatElement> elements = new ArrayList<>();
+            expected.forEach(f -> elements.add(new DateTimeFormatElement(f)));
+            elements.add(new DateTimeFormatElement(' '));
+
+            expectParsed(pattern + " ", elements);
+        }
+    }
+
+    private static Stream<Arguments> singleElements() {
+        return Stream.of(
+                Arguments.of("Y", List.of(Y)),
+                Arguments.of("YY", List.of(YY)),
+                Arguments.of("YYY", List.of(YYY)),
+                Arguments.of("YYYY", List.of(YYYY)),
+                Arguments.of("RR", List.of(RR)),
+                Arguments.of("RRRR", List.of(RRRR)),
+                Arguments.of("MM", List.of(MM)),
+                Arguments.of("DDD", List.of(DDD)),
+                Arguments.of("HHA.M.", List.of(HH, AM)),
+                Arguments.of("HHP.M.", List.of(HH, PM)),
+                Arguments.of("HH12A.M.", List.of(HH12, AM)),
+                Arguments.of("HH12P.M.", List.of(HH12, PM)),
+                Arguments.of("HH24", List.of(HH24)),
+                Arguments.of("MI", List.of(MI)),
+                Arguments.of("SS", List.of(SS)),
+                Arguments.of("SSSSS", List.of(SSSSS))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("singleElements")
+    public void testSingleElementWithDelimiters(String ignore, List<DateTimeTemplateField> fields) {
+        StringBuilder pattern = new StringBuilder();
+        List<DateTimeFormatElement> expected = new ArrayList<>();
+
+        List<DateTimeTemplateField> shuffledFields = new ArrayList<>(fields);
+        Collections.shuffle(shuffledFields, random);
+
+        for (DateTimeTemplateField f : shuffledFields) {
+            // Conditionally add a delimiter between fields
+            if (random.nextBoolean()) {
+                char delimiter = DELIMITERS.get(random.nextInt(DELIMITERS.size()));
+                pattern.append(delimiter);
+                expected.add(new DateTimeFormatElement(delimiter));
+            }
+            pattern.append(f.asPattern());
+            expected.add(new DateTimeFormatElement(f));
+        }
+
+        // Conditionally add a delimiter after the last field
+        if (random.nextBoolean()) {
+            char delimiter = DELIMITERS.get(random.nextInt(DELIMITERS.size()));
+            pattern.append(delimiter);
+            expected.add(new DateTimeFormatElement(delimiter));
+        }
+
+        log.info("Fields: {}", fields);
+        log.info("Pattern: {}", pattern);
+        log.info("Expected: {}", expected);
+
+        expectParsed(pattern.toString(), expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidPatterns")
+    public void testRejectInvalidPattern(String pattern, String error) {
+        Scanner scanner = new Scanner(pattern);
+        DateTimeFormatException err = assertThrows(DateTimeFormatException.class, scanner::parse);
+        assertThat(err.getMessage(), containsString(error));
+    }
+
+    private static Stream<Arguments> invalidPatterns() {
+        return Stream.of(
+                Arguments.of("gY", "Unexpected element <GY> in pattern"),
+                Arguments.of("Yx", "Unexpected element <X> in pattern"),
+                Arguments.of("Yxyz", "Unexpected element <XYZ> in pattern"),
+                Arguments.of("Y gogogo", "Unexpected element <GOGOGO> in pattern"),
+                Arguments.of("Y gogo!abc", "Unexpected element <GOGO> in pattern"),
+                Arguments.of("Y=", "Unexpected character <=> in pattern"),
+                Arguments.of("MM[Y", "Unexpected character <[> in pattern"),
+                Arguments.of("MM[Y", "Unexpected character <[> in pattern"),
+                Arguments.of("YYYY<DD>", "Unexpected character <<> in pattern")
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(DateTimeTemplateField.class)
+    public void testElementAppearsAtMostOnce(DateTimeTemplateField field) {
+        // Ignore Y as Y + Y = YY which is a valid pattern, same applies to YY and RR.
+        // Ignore DD, since DDDD is parsed as <DDD>D and we get D unexpected is patter here.
+        boolean checkConsecutive = field != Y && field != YY && field != RR && field != DD;
+
+        if (checkConsecutive) {
+            String pattern = field.asPattern() + field.asPattern();
+
+            DateTimeFormatException err = assertThrows(DateTimeFormatException.class,
+                    () -> new Scanner(pattern).parse());
+            assertThat(err.getMessage(), containsString("Element is already present: " + field.kind()));
+        }
+
+        {
+            String pattern = field.asPattern() + " " + field.asPattern();
+
+            DateTimeFormatException err = assertThrows(DateTimeFormatException.class,
+                    () -> new Scanner(pattern).parse());
+            assertThat(err.getMessage(), containsString("Element is already present: " + field.kind()));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("validFields")
+    public void testValidFieldsShuffledNoDelimiters(List<DateTimeTemplateField> fields) {
+        StringBuilder pattern = new StringBuilder();
+        List<DateTimeFormatElement> expected = new ArrayList<>();
+
+        List<DateTimeTemplateField> shuffledFields = new ArrayList<>(fields);
+        Collections.shuffle(shuffledFields, random);
+
+        for (DateTimeTemplateField f : shuffledFields) {
+            pattern.append(f.asPattern());
+            expected.add(new DateTimeFormatElement(f));
+        }
+
+        log.info("Fields: {}", shuffledFields);
+        log.info("Pattern: {}", pattern);
+
+        expectParsed(pattern.toString(), expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("validFields")
+    public void testValidFieldsShuffled(List<DateTimeTemplateField> fields) {
+        StringBuilder pattern = new StringBuilder();
+        List<DateTimeFormatElement> expected = new ArrayList<>();
+
+        List<DateTimeTemplateField> shuffledFields = new ArrayList<>(fields);
+        Collections.shuffle(shuffledFields, random);
+
+        for (DateTimeTemplateField f : shuffledFields) {
+            if (random.nextBoolean()) {
+                char delimiter = DELIMITERS.get(random.nextInt(DELIMITERS.size()));
+                if (pattern.length() > 0) {
+                    pattern.append(delimiter);
+                    expected.add(new DateTimeFormatElement(delimiter));
+                }
+            }
+            pattern.append(f.asPattern());
+            expected.add(new DateTimeFormatElement(f));
+        }
+
+        log.info("Fields: {}", shuffledFields);
+        log.info("Pattern: {}", pattern);
+
+        expectParsed(pattern.toString(), expected);
+    }
+
+    private static Stream<List<DateTimeTemplateField>> validFields() {
+        return Stream.of(
+                List.of(YY, DD, MM),
+                List.of(YYY, DD, MM),
+                List.of(YYYY, DD, MM),
+
+                List.of(RR, DD, MM),
+                List.of(RRRR, DD, MM),
+
+                List.of(HH, MI, SS, AM),
+                List.of(HH, MI, SS, FF3, AM),
+
+                List.of(HH, MI, SS, PM),
+                List.of(HH, MI, SS, FF3, PM),
+
+                List.of(HH12, MI, SS, AM),
+                List.of(HH12, MI, SS, FF3, AM),
+
+                List.of(HH12, MI, SS, AM),
+                List.of(HH12, MI, SS, FF3, AM),
+                List.of(HH12, MI, SS, FF3, AM, TZH, TZM),
+
+                List.of(HH24, MI, SS),
+                List.of(HH24, MI, SS, FF3),
+                List.of(HH24, MI, SS, FF3, TZH, TZM),
+
+                List.of(YY, DDD, HH, MI, SS, FF3, AM),
+                List.of(YY, DDD, HH, MI, SS, FF3, AM, TZH, TZM),
+                List.of(YY, DDD, HH, MI, SS, FF3, PM, TZH, TZM),
+                List.of(YY, DDD, HH24, MI, SS, FF3, TZH, TZM),
+                List.of(YY, DDD, HH24, MI, SS, FF3, TZH, TZM),
+
+                List.of(YYY, DDD, HH, MI, SS, FF3, AM),
+                List.of(YYY, DDD, HH, MI, SS, FF3, AM, TZH, TZM),
+                List.of(YYY, DDD, HH, MI, SS, FF3, PM, TZH, TZM),
+                List.of(YYY, DDD, HH24, MI, SS, FF3, TZH, TZM),
+                List.of(YYY, DDD, HH24, MI, SS, FF3, TZH, TZM),
+
+                List.of(YYYY, DD, MM, HH, MI, SS, FF3, AM),
+                List.of(YYYY, DD, MM, HH, MI, SS, FF3, AM, TZH, TZM),
+                List.of(YYYY, DD, MM, HH, MI, SS, FF3, PM, TZH, TZM),
+                List.of(YYYY, DD, MM, HH24, MI, SS, FF3),
+                List.of(YYYY, DD, MM, HH24, MI, SS, FF3, TZH, TZM),
+
+                List.of(DDD),
+                List.of(Y, DDD),
+                List.of(YY, DDD),
+                List.of(YYY, DDD),
+                List.of(YYYY, DDD),
+
+                List.of(DDD),
+                List.of(RR, DDD),
+                List.of(RRRR, DDD),
+
+                List.of(SSSSS)
+        );
+    }
+
+    private static void expectParsed(String pattern, List<DateTimeFormatElement> expected) {
+        Scanner scanner = new Scanner(pattern);
+        List<DateTimeFormatElement> actual = scanner.parse();
+        assertEquals(expected, actual);
+    }
+
+    @ParameterizedTest
+    @MethodSource("singleElements")
+    public void testWrongDelimiters(String pattern) {
+        boolean before = random.nextBoolean();
+
+        char[] wrongDelimiters = {'[', ']', '!', '?', '<', '>', '\\'};
+
+        char c = wrongDelimiters[random.nextInt(wrongDelimiters.length)];
+
+        String updated;
+        if (before) {
+            updated = c + pattern;
+        } else {
+            updated = pattern + c;
+        }
+
+        log.info("Updated pattern: {}", updated);
+
+        DateTimeFormatException err = assertThrows(DateTimeFormatException.class,
+                () -> new Scanner(updated).parse());
+        assertThat(err.getMessage(), containsString("Unexpected character "));
+    }
+
+    @ParameterizedTest
+    @MethodSource("consecutiveDelimitersPatterns")
+    public void testConsecutiveDelimiters(String pattern) {
+        String updated = pattern;
+
+        for (int i = 0; i < 9; i++) {
+            char d = DELIMITERS.get(random.nextInt(DELIMITERS.size()));
+            updated = updated.replace(Integer.toString(i), Character.toString(d));
+        }
+
+        log.info("Updated pattern: {}", updated);
+
+        checkSyntaxRule(updated, "Consecutive delimiters are not allowed");
+    }
+
+    private static Stream<Arguments> consecutiveDelimitersPatterns() {
+        String f1 = "MM";
+        String f2 = "DD";
+
+        List<String> patterns = new ArrayList<>();
+
+        patterns.add(f1 + "12" + f2);
+        patterns.add("12" + f1 + f2);
+        patterns.add(f1 + f2 + "12");
+        patterns.add("1" + f1 + f2 + "33");
+        patterns.add("1" + f1 + "23" + f2 + "4");
+
+        return patterns.stream().map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("yearPatterns")
+    public void testYearRule(String pattern, String error) {
+        checkSyntaxRule(pattern, error);
+    }
+
+    private static Stream<Arguments> yearPatterns() {
+        String error = "Only one field must be present: year / rounded year";
+        return Stream.of(
+                Arguments.of("Y RR", error),
+                Arguments.of("YY RR", error),
+                Arguments.of("YYY RR", error),
+                Arguments.of("YYYY RR", error),
+
+                Arguments.of("Y RRRR", error),
+                Arguments.of("YY RRRR", error),
+                Arguments.of("YYY RRRR", error),
+                Arguments.of("YYYY RRRR", error)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("dayPatterns")
+    public void testDayRule(String pattern, String error) {
+        checkSyntaxRule(pattern, error);
+    }
+
+    private static Stream<Arguments> dayPatterns() {
+        return Stream.of(
+                Arguments.of("MM DDD", "day of year / month"),
+                Arguments.of("DD DDD", "day of year / day of month")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("hourPatterns")
+    public void testHourRule(String pattern, String error) {
+        checkSyntaxRule(pattern, error);
+    }
+
+    private static Stream<Arguments> hourPatterns() {
+        return Stream.of(
+                Arguments.of("HH24 HH12", "24-hour / 12-hour"),
+                Arguments.of("HH24 HH", "24-hour / 12-hour")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("amPmPatterns")
+    public void testAmPmRule(String pattern, String error) {
+        checkSyntaxRule(pattern, error);
+    }
+
+    private static Stream<Arguments> amPmPatterns() {
+        return Stream.of(
+                Arguments.of("HH12", "12-hour / am pm"),
+                // Handled by the previous rule
+                Arguments.of("HH24 A.M.", "/ am pm"),
+                Arguments.of("HH24 P.M.", "/ am pm")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("secondPatterns")
+    public void testSecondRule(String pattern, String error) {
+        checkSyntaxRule(pattern, error);
+    }
+
+    private static Stream<Arguments> secondPatterns() {
+        return Stream.of(
+                Arguments.of("SSSSS HH A.M.", "second of day / 12-hour"),
+                Arguments.of("SSSSS HH24", "second of day / 24-hour"),
+                Arguments.of("SSSSS MI", "second of day / minute"),
+                Arguments.of("SSSSS SS", "second of day / second of minute")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("timeZonePatterns")
+    public void testTimeZoneRule(String pattern, String error) {
+        checkSyntaxRule(pattern, error);
+    }
+
+    private static Stream<Arguments> timeZonePatterns() {
+        return Stream.of(
+                Arguments.of("TZH", "Expected both fields: time zone hour / time zone minute"),
+                Arguments.of("TZM", "Expected both fields: time zone hour / time zone minute")
+        );
+    }
+
+    private void checkSyntaxRule(String pattern, String error) {
+        String[] split = pattern.split(" ");
+
+        List<String> shuffled = Arrays.asList(split);
+        Collections.shuffle(shuffled, random);
+
+        log.info("Pattern: {}", shuffled);
+
+        Scanner scanner = new Scanner(pattern);
+        DateTimeFormatException err = assertThrows(DateTimeFormatException.class, scanner::parse);
+        assertThat(err.getMessage(), containsString(error));
+    }
+}


### PR DESCRIPTION
Implements a scanner that converts a string into a list of datetime format elements. An element can either be a field or a delimiter.

Tests:

- One field pattern for each field.
- One field pattern with delimiters before and after the field.
- Some Invalid patterns.
- Multiple fields with delimiters between them (fields are shuffled)
- Syntax rules: each field can appear only once, consecutive delimiters.
- Syntax rules: whether some field can be used with others, etc.

The code is based on this a scanner described in https://craftinginterpreters.com/scanning.html

https://issues.apache.org/jira/browse/IGNITE-25556:

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)