### PR TITLE
IGNITE-25579 Fix index meta storage recovery for dropped indices

### DIFF
--- a/modules/catalog-compaction/src/main/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunner.java
+++ b/modules/catalog-compaction/src/main/java/org/apache/ignite/internal/catalog/compaction/CatalogCompactionRunner.java
@@ -21,6 +21,7 @@ import static java.util.function.Predicate.not;
 import static org.apache.ignite.internal.lang.IgniteSystemProperties.enabledColocation;
 import static org.apache.ignite.internal.replicator.message.ReplicaMessageUtils.toTablePartitionIdMessage;
 import static org.apache.ignite.internal.replicator.message.ReplicaMessageUtils.toZonePartitionIdMessage;
+import static org.apache.ignite.internal.util.ExceptionUtils.hasCause;
 import static org.apache.ignite.internal.util.IgniteUtils.inBusyLock;
 
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
@@ -738,7 +739,9 @@ public class CatalogCompactionRunner implements IgniteComponent {
 
             propagateTimeToLocalReplicas(txBeginTime)
                     .exceptionally(ex -> {
-                        LOG.warn("Failed to propagate minimum required time to replicas.", ex);
+                        if (!hasCause(ex, NodeStoppingException.class)) {
+                            LOG.warn("Failed to propagate minimum required time to replicas.", ex);
+                        }
 
                         return null;
                     });

--- a/modules/index/build.gradle
+++ b/modules/index/build.gradle
@@ -78,6 +78,8 @@ dependencies {
     integrationTestImplementation project(':ignite-partition-replicator')
     integrationTestImplementation project(':ignite-placement-driver-api')
     integrationTestImplementation project(':ignite-schema')
+    integrationTestImplementation project(':ignite-vault')
+    integrationTestImplementation project(':ignite-low-watermark')
     integrationTestImplementation testFixtures(project(':ignite-core'))
     integrationTestImplementation testFixtures(project(':ignite-runner'))
     integrationTestImplementation testFixtures(project(':ignite-sql-engine'))

--- a/modules/index/src/integrationTest/java/org/apache/ignite/internal/index/ItIndexRecoveryTest.java
+++ b/modules/index/src/integrationTest/java/org/apache/ignite/internal/index/ItIndexRecoveryTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.index;
+
+import static org.apache.ignite.internal.TestDefaultProfilesNames.DEFAULT_AIPERSIST_PROFILE_NAME;
+import static org.apache.ignite.internal.TestWrappers.unwrapIgniteImpl;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.nio.file.Path;
+import org.apache.ignite.InitParametersBuilder;
+import org.apache.ignite.internal.ClusterPerTestIntegrationTest;
+import org.apache.ignite.internal.app.IgniteImpl;
+import org.apache.ignite.internal.app.IgniteServerImpl;
+import org.apache.ignite.internal.catalog.Catalog;
+import org.apache.ignite.internal.configuration.IgnitePaths;
+import org.apache.ignite.internal.hlc.HybridTimestamp;
+import org.apache.ignite.internal.lowwatermark.LowWatermarkImpl;
+import org.apache.ignite.internal.sql.engine.util.SqlTestUtils;
+import org.apache.ignite.internal.vault.VaultService;
+import org.apache.ignite.internal.vault.persistence.PersistentVaultService;
+import org.apache.ignite.tx.TransactionOptions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ItIndexRecoveryTest extends ClusterPerTestIntegrationTest {
+    private static final String ZONE_NAME = "TEST_ZONE";
+    private static final String TABLE_NAME = "TEST_TABLE";
+    private static final String INDEX_NAME = "INDEX_TABLE";
+
+    @Override
+    protected int initialNodes() {
+        return 0;
+    }
+
+    private static void aggressiveLowWatermarkIncrease(InitParametersBuilder builder) {
+        builder.clusterConfiguration("{\n"
+                + "  ignite.gc.lowWatermark {\n"
+                + "    dataAvailabilityTimeMillis: 1000,\n"
+                + "    updateIntervalMillis: 100\n"
+                + "  }\n"
+                + "}");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void nodeHandlesDroppedTablePrimaryIndexBelowLwmOnRecovery(boolean dropVersionIsNotLast) {
+        testNodeRecoveryWithDroppedIndexBelowLwm(() -> {}, this::dropTable, dropVersionIsNotLast);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void nodeHandlesDroppedTableSecondaryIndexesBelowLwmOnRecovery(boolean dropVersionIsNotLast) {
+        testNodeRecoveryWithDroppedIndexBelowLwm(this::createSecondaryIndex, this::dropTable, dropVersionIsNotLast);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void nodeHandlesDroppedSecondaryIndexBelowLwmOnRecovery(boolean dropVersionIsNotLast) {
+        testNodeRecoveryWithDroppedIndexBelowLwm(this::createSecondaryIndex, this::dropSecondaryIndex, dropVersionIsNotLast);
+    }
+
+    private void testNodeRecoveryWithDroppedIndexBelowLwm(Runnable creator, Runnable dropper, boolean createCatalogVersionAfterDrop) {
+        cluster.startAndInit(1, ItIndexRecoveryTest::aggressiveLowWatermarkIncrease);
+        IgniteImpl ignite0 = unwrapIgniteImpl(cluster.node(0));
+        Path workDir0 = ((IgniteServerImpl) cluster.server(0)).workDir();
+
+        createZoneAndTable(1);
+
+        creator.run();
+
+        // We don't want the dropped table to be destroyed before restart.
+        disallowLwmRaiseUntilRestart(ignite0);
+
+        dropper.run();
+
+        if (createCatalogVersionAfterDrop) {
+            executeUpdate("CREATE TABLE ANOTHER_TABLE (ID INT PRIMARY KEY, VAL VARCHAR)");
+        }
+
+        HybridTimestamp tsAfterDrop = latestCatalogVersionTs(ignite0);
+
+        cluster.stopNode(0);
+
+        // Simulate a situation when an LWM was raised (and persisted) and the node was stopped immediately, so we were not
+        // able to destroy the dropped table and index yet, even though the drop moment is already under LWM.
+        raisePersistedLwm(workDir0, tsAfterDrop.tick());
+
+        assertDoesNotThrow(() -> cluster.startNode(0));
+    }
+
+    private void createZoneAndTable(int replicas) {
+        executeUpdate(
+                "CREATE ZONE " + ZONE_NAME + " (REPLICAS " + replicas + ", PARTITIONS 1) STORAGE PROFILES ['"
+                        + DEFAULT_AIPERSIST_PROFILE_NAME + "']"
+        );
+        executeUpdate("CREATE TABLE " + TABLE_NAME + " (id INT PRIMARY KEY, val VARCHAR) ZONE test_zone");
+    }
+
+    private void createSecondaryIndex() {
+        executeUpdate("CREATE INDEX " + INDEX_NAME + " ON " + TABLE_NAME + "(val)");
+    }
+
+    private void executeUpdate(String query) {
+        SqlTestUtils.executeUpdate(query, cluster.aliveNode().sql());
+    }
+
+    private static void disallowLwmRaiseUntilRestart(IgniteImpl ignite) {
+        ignite.transactions().begin(new TransactionOptions().readOnly(true));
+    }
+
+    private void dropTable() {
+        executeUpdate("DROP TABLE " + TABLE_NAME);
+    }
+
+    private void dropSecondaryIndex() {
+        executeUpdate("DROP INDEX " + INDEX_NAME);
+    }
+
+    private static HybridTimestamp latestCatalogVersionTs(IgniteImpl ignite) {
+        Catalog latestCatalog = ignite.catalogManager().catalog(ignite.catalogManager().latestCatalogVersion());
+        return HybridTimestamp.hybridTimestamp(latestCatalog.time());
+    }
+
+    private static void raisePersistedLwm(Path workDir, HybridTimestamp newLwm) {
+        VaultService vaultService = new PersistentVaultService(IgnitePaths.vaultPath(workDir));
+
+        try {
+            vaultService.start();
+            vaultService.put(LowWatermarkImpl.LOW_WATERMARK_VAULT_KEY, newLwm.toBytes());
+        } finally {
+            vaultService.close();
+        }
+    }
+}

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/DefaultMessagingService.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/DefaultMessagingService.java
@@ -373,8 +373,6 @@ public class DefaultMessagingService extends AbstractMessagingService {
                             () -> triggerChannelCreation(nodeId, type, addr)
                     );
                 })
-                // TODO: IGNITE-25375 - consider removing logging after the fix as it might be too much
-                // (the caller also gets the exception).
                 .whenComplete((res, ex) -> {
                     if (ex != null && hasCause(ex, CriticalHandshakeException.class)) {
                         LOG.error(

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/index/IndexMeta.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/index/IndexMeta.java
@@ -222,6 +222,22 @@ public class IndexMeta {
         }
     }
 
+    /** Returns {@code true} if the index was already removed from the Catalog (it can still exist and function though). */
+    public boolean isRemovedFromCatalog() {
+        switch (currentStatus) {
+            case REMOVED:
+            case READ_ONLY:
+                return true;
+            case REGISTERED:
+            case BUILDING:
+            case AVAILABLE:
+            case STOPPING:
+                return false;
+            default:
+                throw new AssertionError(String.format("Unknown status: [indexId=%s, currentStatus=%s]", indexId, currentStatus));
+        }
+    }
+
     @Override
     public String toString() {
         return S.toString(this);

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/replicator/PartitionReplicaBuildIndexProcessor.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/replicator/PartitionReplicaBuildIndexProcessor.java
@@ -122,10 +122,7 @@ public class PartitionReplicaBuildIndexProcessor {
     }
 
     private void prepareIndexBuilderTxRwOperationTracker() {
-        // TODO: https://issues.apache.org/jira/browse/IGNITE-25603 the following comment says the method must be executed
-        // on Metastore thread, but this is not currently true.
-
-        // Expected to be executed on the metastore thread.
+        // Expected to be executed on the metastore notification chain or on node start (when Catalog does not change).
         IndexMeta indexMeta = latestIndexMetaInBuildingStatus(catalogService, indexMetaStorage, tableId);
 
         if (indexMeta != null) {

--- a/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/replicator/ReplicatorUtils.java
+++ b/modules/table/src/main/java/org/apache/ignite/internal/table/distributed/replicator/ReplicatorUtils.java
@@ -43,10 +43,7 @@ class ReplicatorUtils {
      */
     static @Nullable IndexMeta latestIndexMetaInBuildingStatus(CatalogService catalogService,
             IndexMetaStorage indexMetaStorage, int tableId) {
-        // TODO: https://issues.apache.org/jira/browse/IGNITE-25603 the following comment says the method must be executed
-        // on Metastore thread, but this is not currently true.
-
-        // Since we expect to be executed on the metastore thread, it is safe to use these versions.
+        // Expected to be executed on the metastore notification chain or on node start (when Catalog does not change).
         int latestCatalogVersion = catalogService.latestCatalogVersion();
         int earliestCatalogVersion = catalogService.earliestCatalogVersion();
 

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/index/IndexMetaStorageRecoveryTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/index/IndexMetaStorageRecoveryTest.java
@@ -22,6 +22,7 @@ import static org.apache.ignite.internal.table.TableTestUtils.INDEX_NAME;
 import static org.apache.ignite.internal.table.TableTestUtils.PK_INDEX_NAME;
 import static org.apache.ignite.internal.table.TableTestUtils.TABLE_NAME;
 import static org.apache.ignite.internal.table.TableTestUtils.createSimpleHashIndex;
+import static org.apache.ignite.internal.table.TableTestUtils.createSimpleTable;
 import static org.apache.ignite.internal.table.TableTestUtils.dropSimpleIndex;
 import static org.apache.ignite.internal.table.TableTestUtils.dropSimpleTable;
 import static org.apache.ignite.internal.table.TableTestUtils.makeIndexAvailable;
@@ -63,11 +64,15 @@ import org.apache.ignite.internal.testframework.WorkDirectoryExtension;
 import org.apache.ignite.internal.util.IgniteUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /** For testing recovery of {@link IndexMetaStorage}. */
 @ExtendWith(WorkDirectoryExtension.class)
 @ExtendWith(ExecutorServiceExtension.class)
 public class IndexMetaStorageRecoveryTest extends BaseIndexMetaStorageTest {
+    private static final String ANOTHER_TABLE_NAME = "ANOTHER_TABLE";
+
     @WorkDirectory
     private Path workDir;
 
@@ -492,6 +497,96 @@ public class IndexMetaStorageRecoveryTest extends BaseIndexMetaStorageTest {
         checkFields(fromMetastore, indexId, tableId, tableVersion, INDEX_NAME, READ_ONLY, expectedStatuses, removingIndexCatalogVersion);
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testRemoveStoppingIndexMissingPreRestartLwmUpdate(boolean dropVersionIsNotLast) throws Exception {
+        executeCatalogUpdate(() -> createSimpleHashIndex(catalogManager, TABLE_NAME, INDEX_NAME));
+
+        int indexId = indexId(INDEX_NAME);
+
+        executeCatalogUpdate(() -> startBuildingIndex(catalogManager, indexId));
+        executeCatalogUpdate(() -> makeIndexAvailable(catalogManager, indexId));
+        executeCatalogUpdate(() -> dropSimpleIndex(catalogManager, INDEX_NAME));
+
+        updateTableVersion(TABLE_NAME);
+
+        removeIndex(catalogManager, indexId);
+        if (dropVersionIsNotLast) {
+            createAnotherCatalogVersion();
+        }
+
+        restartComponentsSimulatingMissedLwmUpdate();
+
+        assertNull(indexMetaStorage.indexMeta(indexId));
+        assertNull(fromMetastore(indexId));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testDropTableMissingPreRestartLwmUpdate(boolean dropVersionIsNotLast) throws Exception {
+        int indexId = indexId(PK_INDEX_NAME);
+
+        dropSimpleTable(catalogManager, TABLE_NAME);
+        if (dropVersionIsNotLast) {
+            createAnotherCatalogVersion();
+        }
+
+        restartComponentsSimulatingMissedLwmUpdate();
+
+        assertNull(indexMetaStorage.indexMeta(indexId));
+        assertNull(fromMetastore(indexId));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testDropRegisteredIndexMissingPreRestartLwmUpdate(boolean dropVersionIsNotLast) throws Exception {
+        executeCatalogUpdate(() -> createSimpleHashIndex(catalogManager, TABLE_NAME, INDEX_NAME));
+
+        int indexId = indexId(INDEX_NAME);
+
+        updateTableVersion(TABLE_NAME);
+
+        dropSimpleIndex(catalogManager, INDEX_NAME);
+        if (dropVersionIsNotLast) {
+            createAnotherCatalogVersion();
+        }
+
+        restartComponentsSimulatingMissedLwmUpdate();
+
+        assertNull(indexMetaStorage.indexMeta(indexId));
+        assertNull(fromMetastore(indexId));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testDropBuildingIndexMissingPreRestartLwmUpdate(boolean dropVersionIsNotLast) throws Exception {
+        executeCatalogUpdate(() -> createSimpleHashIndex(catalogManager, TABLE_NAME, INDEX_NAME));
+
+        int indexId = indexId(INDEX_NAME);
+
+        executeCatalogUpdate(() -> startBuildingIndex(catalogManager, indexId));
+
+        updateTableVersion(TABLE_NAME);
+
+        dropSimpleIndex(catalogManager, INDEX_NAME);
+        if (dropVersionIsNotLast) {
+            createAnotherCatalogVersion();
+        }
+
+        restartComponentsSimulatingMissedLwmUpdate();
+
+        assertNull(indexMetaStorage.indexMeta(indexId));
+        assertNull(fromMetastore(indexId));
+    }
+
+    private void createAnotherCatalogVersion() {
+        createSimpleTable(catalogManager, ANOTHER_TABLE_NAME);
+    }
+
+    private void restartComponentsSimulatingMissedLwmUpdate() throws Exception {
+        restartComponents(true);
+    }
+
     private void executeCatalogUpdateWithDropEvents(RunnableX task) {
         CompletableFuture<Void> startDropEventsFuture = interceptor.startDropEvents();
 
@@ -501,6 +596,10 @@ public class IndexMetaStorageRecoveryTest extends BaseIndexMetaStorageTest {
     }
 
     private void restartComponents() throws Exception {
+        restartComponents(false);
+    }
+
+    private void restartComponents(boolean updateLwmToTriggerDestruction) throws Exception {
         var componentContext = new ComponentContext();
 
         IgniteUtils.closeAll(
@@ -522,6 +621,10 @@ public class IndexMetaStorageRecoveryTest extends BaseIndexMetaStorageTest {
         assertThat(metastore.deployWatches(), willCompleteSuccessfully());
 
         assertThat(catalogManager.catalogInitializationFuture(), willCompleteSuccessfully());
+
+        if (updateLwmToTriggerDestruction) {
+            updateLwm(clock.now().addPhysicalTime(DELTA_TO_TRIGGER_DESTROY));
+        }
 
         assertThat(startAsync(componentContext, indexMetaStorage), willCompleteSuccessfully());
     }

--- a/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/replicator/ReplicatorUtilsTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/replicator/ReplicatorUtilsTest.java
@@ -17,16 +17,19 @@
 
 package org.apache.ignite.internal.table.distributed.replicator;
 
+import static org.apache.ignite.internal.sql.SqlCommon.DEFAULT_SCHEMA_NAME;
 import static org.apache.ignite.internal.table.TableTestUtils.INDEX_NAME;
 import static org.apache.ignite.internal.table.TableTestUtils.TABLE_NAME;
 import static org.apache.ignite.internal.table.TableTestUtils.createSimpleHashIndex;
 import static org.apache.ignite.internal.table.TableTestUtils.createSimpleTable;
+import static org.apache.ignite.internal.table.TableTestUtils.dropIndex;
 import static org.apache.ignite.internal.table.TableTestUtils.getIndexIdStrict;
 import static org.apache.ignite.internal.table.TableTestUtils.getTableIdStrict;
 import static org.apache.ignite.internal.table.TableTestUtils.makeIndexAvailable;
+import static org.apache.ignite.internal.table.TableTestUtils.removeIndex;
 import static org.apache.ignite.internal.table.TableTestUtils.startBuildingIndex;
 import static org.apache.ignite.internal.table.distributed.replicator.ReplicatorUtils.beginRwTxTs;
-import static org.apache.ignite.internal.table.distributed.replicator.ReplicatorUtils.latestIndexDescriptorInBuildingStatus;
+import static org.apache.ignite.internal.table.distributed.replicator.ReplicatorUtils.latestIndexMetaInBuildingStatus;
 import static org.apache.ignite.internal.table.distributed.replicator.ReplicatorUtils.rwTxActiveCatalogVersion;
 import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willCompleteSuccessfully;
 import static org.apache.ignite.internal.tx.TransactionIds.transactionId;
@@ -34,14 +37,17 @@ import static org.apache.ignite.internal.util.IgniteUtils.closeAll;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import org.apache.ignite.internal.catalog.CatalogManager;
 import org.apache.ignite.internal.catalog.CatalogService;
 import org.apache.ignite.internal.catalog.CatalogTestUtils;
@@ -50,6 +56,8 @@ import org.apache.ignite.internal.hlc.HybridClockImpl;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.apache.ignite.internal.manager.ComponentContext;
 import org.apache.ignite.internal.partition.replicator.network.replication.ReadWriteReplicaRequest;
+import org.apache.ignite.internal.table.distributed.index.IndexMeta;
+import org.apache.ignite.internal.table.distributed.index.IndexMetaStorage;
 import org.apache.ignite.internal.testframework.IgniteAbstractTest;
 import org.junit.jupiter.api.Test;
 
@@ -83,39 +91,62 @@ public class ReplicatorUtilsTest extends IgniteAbstractTest {
 
     @Test
     void testLatestIndexDescriptorInBuildingStatus() throws Exception {
-        withCatalogManager(catalogManager -> {
+        withServices((catalogManager, indexMetaStorage) -> {
             createSimpleTable(catalogManager, TABLE_NAME);
 
             int tableId = tableId(catalogManager, TABLE_NAME);
 
-            assertNull(latestIndexDescriptorInBuildingStatus(catalogManager, tableId));
+            assertNull(latestIndexMetaInBuildingStatus(catalogManager, indexMetaStorage, tableId));
 
             createSimpleHashIndex(catalogManager, TABLE_NAME, INDEX_NAME);
-            assertNull(latestIndexDescriptorInBuildingStatus(catalogManager, tableId));
 
             int indexId = indexId(catalogManager, INDEX_NAME);
 
+            configureNonNullIndexMeta(indexMetaStorage, indexId);
+
+            assertNull(latestIndexMetaInBuildingStatus(catalogManager, indexMetaStorage, tableId));
+
             startBuildingIndex(catalogManager, indexId);
-            assertEquals(indexId, latestIndexDescriptorInBuildingStatus(catalogManager, tableId).id());
+            assertEquals(indexId, latestIndexMetaInBuildingStatus(catalogManager, indexMetaStorage, tableId).indexId());
 
             makeIndexAvailable(catalogManager, indexId);
-            assertEquals(indexId, latestIndexDescriptorInBuildingStatus(catalogManager, tableId).id());
+            assertEquals(indexId, latestIndexMetaInBuildingStatus(catalogManager, indexMetaStorage, tableId).indexId());
 
             String otherIndexName = INDEX_NAME + 1;
 
             createSimpleHashIndex(catalogManager, TABLE_NAME, otherIndexName);
-            assertEquals(indexId, latestIndexDescriptorInBuildingStatus(catalogManager, tableId).id());
+            assertEquals(indexId, latestIndexMetaInBuildingStatus(catalogManager, indexMetaStorage, tableId).indexId());
 
             int otherIndexId = indexId(catalogManager, otherIndexName);
 
+            configureNonNullIndexMeta(indexMetaStorage, otherIndexId);
+
             startBuildingIndex(catalogManager, otherIndexId);
-            assertEquals(otherIndexId, latestIndexDescriptorInBuildingStatus(catalogManager, tableId).id());
+            assertEquals(otherIndexId, latestIndexMetaInBuildingStatus(catalogManager, indexMetaStorage, tableId).indexId());
+
+            makeIndexAvailable(catalogManager, otherIndexId);
+            dropIndex(catalogManager, DEFAULT_SCHEMA_NAME, otherIndexName);
+            removeIndex(catalogManager, otherIndexId);
+            configureNullIndexMeta(indexMetaStorage, otherIndexId);
+
+            // Expecting that second index will not be returned (as it's already removed), even though it became BUILDING later.
+            assertEquals(indexId, latestIndexMetaInBuildingStatus(catalogManager, indexMetaStorage, tableId).indexId());
         });
+    }
+
+    private static void configureNonNullIndexMeta(IndexMetaStorage indexMetaStorage, int indexId) {
+        IndexMeta indexMeta = mock(IndexMeta.class);
+        doReturn(indexMeta).when(indexMetaStorage).indexMeta(indexId);
+        doReturn(indexId).when(indexMeta).indexId();
+    }
+
+    private static void configureNullIndexMeta(IndexMetaStorage indexMetaStorage, int indexId) {
+        doReturn(null).when(indexMetaStorage).indexMeta(indexId);
     }
 
     @Test
     void testLatestIndexDescriptorInBuildingStatusForOtherTable() throws Exception {
-        withCatalogManager(catalogManager -> {
+        withServices((catalogManager, indexMetaStorage) -> {
             String otherTableName = TABLE_NAME + 1;
 
             createSimpleTable(catalogManager, TABLE_NAME);
@@ -124,7 +155,7 @@ public class ReplicatorUtilsTest extends IgniteAbstractTest {
             createSimpleHashIndex(catalogManager, TABLE_NAME, INDEX_NAME);
             startBuildingIndex(catalogManager, indexId(catalogManager, INDEX_NAME));
 
-            assertNull(latestIndexDescriptorInBuildingStatus(catalogManager, tableId(catalogManager, otherTableName)));
+            assertNull(latestIndexMetaInBuildingStatus(catalogManager, indexMetaStorage, tableId(catalogManager, otherTableName)));
         });
     }
 
@@ -136,13 +167,18 @@ public class ReplicatorUtilsTest extends IgniteAbstractTest {
         return request;
     }
 
-    private void withCatalogManager(Consumer<CatalogManager> consumer) throws Exception {
+    private void withServices(BiConsumer<CatalogManager, IndexMetaStorage> consumer) throws Exception {
         CatalogManager catalogManager = CatalogTestUtils.createCatalogManagerWithTestUpdateLog("test-node", clock);
 
         assertThat(catalogManager.startAsync(new ComponentContext()), willCompleteSuccessfully());
 
+        IndexMetaStorage indexMetaStorage = mock(IndexMetaStorage.class);
+
+        // Making any unexpected calls to index meta storage visible.
+        doThrow(AssertionError.class).when(indexMetaStorage).indexMeta(anyInt());
+
         try {
-            consumer.accept(catalogManager);
+            consumer.accept(catalogManager, indexMetaStorage);
         } finally {
             closeAll(
                     catalogManager::beforeNodeStop,


### PR DESCRIPTION
Also, another bug is fixed in ReplicatorUtils, where we could fail if Catalog still contains information about an index that is already removed from the index meta storage

https://issues.apache.org/jira/browse/IGNITE-25579