### PR TITLE
IGNITE-25448 Reenable tests

### DIFF
--- a/modules/rest/src/integrationTest/java/org/apache/ignite/internal/rest/recovery/ItDisasterRecoveryControllerTest.java
+++ b/modules/rest/src/integrationTest/java/org/apache/ignite/internal/rest/recovery/ItDisasterRecoveryControllerTest.java
@@ -219,8 +219,6 @@ public class ItDisasterRecoveryControllerTest extends ClusterPerClassIntegration
         assertEmptyStates(response.body(), true);
     }
 
-    // TODO: https://issues.apache.org/jira/browse/IGNITE-25448 Does not work with colocation enabled.
-    @DisabledIf("org.apache.ignite.internal.lang.IgniteSystemProperties#colocationEnabled")
     @Test
     void testLocalPartitionStatesByZones() {
         String path = localStatePath();
@@ -509,8 +507,6 @@ public class ItDisasterRecoveryControllerTest extends ClusterPerClassIntegration
         ));
     }
 
-    // TODO: https://issues.apache.org/jira/browse/IGNITE-25448 Does not work with colocation enabled.
-    @DisabledIf("org.apache.ignite.internal.lang.IgniteSystemProperties#colocationEnabled")
     @Test
     void testLocalPartitionStatesWithUpdatedEstimatedRows() {
         insertRowToAllTables(1, 1);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-25448

The timeouts that caused the tests to fail comes from the slow log4j loggers. If disabled, the tests start to pass 