### PR TITLE
IGNITE-25654 ZonePartitionReplicaListenerTest#writeIntentSwitchForCompactedCatalogTimestampWorks is flaky

### DIFF
--- a/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/replication/ZonePartitionReplicaListenerTest.java
+++ b/modules/table/src/test/java/org/apache/ignite/internal/table/distributed/replication/ZonePartitionReplicaListenerTest.java
@@ -1467,7 +1467,7 @@ public class ZonePartitionReplicaListenerTest extends IgniteAbstractTest {
         // We have to force push clock forward because we will invoke listener directly bypassing ReplicaManager or MessageService, so clock
         // won't be updated if the test computes too fast for physical clock ticking and then we may have equal clock#current and the
         // given above commit timestamp.
-        clock.update(clock.now().addPhysicalTime(10));
+        clock.update(commitTs);
 
         HybridTimestamp reliableCatalogVersionTs = commit ? commitTs : beginTs;
         when(catalogService.activeCatalog(reliableCatalogVersionTs.longValue())).thenThrow(new CatalogNotFoundException("Oops"));


### PR DESCRIPTION
JIRA Ticket: [IGNITE-25654](https://issues.apache.org/jira/browse/IGNITE-25654)

## The goal

The goal is to fix and enable the test.

## The reason

Test should be enabled and green.

## The solution

Physical clock may not tick yet before `activeCatalog` will be called and commit timestamp may be equal to `clock#current`. Also we call `#invoke` ReplicaManager or MessageService so logical clock isn't ticking too.