### PR TITLE
IGNITE-25688 Fix names of C++ parametrized tests

### DIFF
--- a/modules/platforms/cpp/ignite/client/detail/table/name_utils_test.cpp
+++ b/modules/platforms/cpp/ignite/client/detail/table/name_utils_test.cpp
@@ -24,9 +24,13 @@
 using namespace ignite;
 using namespace detail;
 
+namespace {
+
 template<typename T>
 std::string PrintTestIndex(const testing::TestParamInfo<typename T::ParamType>& info) {
     return "_" + std::to_string(info.index);
+}
+
 }
 
 class quote_if_needed_fixture : public ::testing::TestWithParam<std::tuple<std::string, std::string>> {};

--- a/modules/platforms/cpp/ignite/client/table/qualified_name_test.cpp
+++ b/modules/platforms/cpp/ignite/client/table/qualified_name_test.cpp
@@ -24,9 +24,13 @@
 using namespace ignite;
 using namespace detail;
 
+namespace {
+
 template<typename T>
 std::string PrintTestIndex(const testing::TestParamInfo<typename T::ParamType>& info) {
-        return "_" + std::to_string(info.index);
+    return "_" + std::to_string(info.index);
+}
+
 }
 
 TEST(client_qualified_name, create_empty_schema_empty_name_throws) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-25688

Some of our tests parameters have malformed unicode in them, and these parameters used by default as the part of the test name, which may result in malformed test name, which can not be parsed by the TC. This PR fix this by using simple indexing instead in such parametrized tests.