### PR TITLE
IGNITE-25514 Fix table get by name compatibility with old servers

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTables.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/table/ClientTables.java
@@ -96,7 +96,7 @@ public class ClientTables implements IgniteTables {
                     if (useQualifiedNames(w.clientChannel())) {
                         w.out().packQualifiedName(name);
                     } else {
-                        w.out().packString(name.toCanonicalForm());
+                        w.out().packString(name.objectName());
                     }
                 }, r -> {
                     if (r.in().tryUnpackNil()) {

--- a/modules/compatibility-tests/src/integrationTest/java/org/apache/ignite/internal/client/ClientCompatibilityTests.java
+++ b/modules/compatibility-tests/src/integrationTest/java/org/apache/ignite/internal/client/ClientCompatibilityTests.java
@@ -91,7 +91,6 @@ public interface ClientCompatibilityTests {
     }
 
     @Test
-    @Disabled("IGNITE-25514")
     default void testTableByName() {
         Table testTable = client().tables().table(TABLE_NAME_TEST);
         assertNotNull(testTable);
@@ -100,7 +99,6 @@ public interface ClientCompatibilityTests {
     }
 
     @Test
-    @Disabled("IGNITE-25514")
     default void testTableByQualifiedName() {
         Table testTable = client().tables().table(QualifiedName.fromSimple(TABLE_NAME_TEST));
         assertNotNull(testTable);
@@ -611,10 +609,6 @@ public interface ClientCompatibilityTests {
     }
 
     private Table table(String tableName) {
-        // TODO IGNITE-25514 Use client().tables().table().
-        return client().tables().tables().stream()
-                .filter(t -> t.qualifiedName().objectName().equals(tableName))
-                .findFirst()
-                .orElseThrow();
+        return client().tables().table(tableName);
     }
 }

--- a/modules/platforms/cpp/ignite/client/detail/table/tables_impl.cpp
+++ b/modules/platforms/cpp/ignite/client/detail/table/tables_impl.cpp
@@ -50,7 +50,7 @@ void tables_impl::get_table_async(const qualified_name &name, ignite_callback<st
             writer.write(name.get_schema_name());
             writer.write(name.get_object_name());
         } else {
-            writer.write(name.get_canonical_name());
+            writer.write(name.get_object_name());
         }
     };
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Tables.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Tables.cs
@@ -138,7 +138,7 @@ namespace Apache.Ignite.Internal.Table
                 }
                 else
                 {
-                    w.Write(arg.Name.CanonicalName);
+                    w.Write(arg.Name.ObjectName);
                 }
             }
 


### PR DESCRIPTION
Pass object name instead of canonical name if qualified names are not supported. Fix Java, .NET, C++ clients.