### PR TITLE
IGNITE-25730 Fix testExecuteColocatedThrowsTableNotFoundExceptionWhenTableDoesNotExist

### DIFF
--- a/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/TestClientHandlerModule.java
@@ -228,6 +228,7 @@ public class TestClientHandlerModule implements IgniteComponent {
             features.set(ProtocolBitmaskFeature.TX_DELAYED_ACKS.featureId());
             features.set(ProtocolBitmaskFeature.TX_PIGGYBACK.featureId());
             features.set(ProtocolBitmaskFeature.TX_ALLOW_NOOP_ENLIST.featureId());
+            features.set(ProtocolBitmaskFeature.TABLE_GET_REQS_USE_QUALIFIED_NAME.featureId());
         } else {
             features = new BitSet(ProtocolBitmaskFeature.values().length);
             for (int i = this.features.nextSetBit(0); i != -1; i = this.features.nextSetBit(i + 1)) {


### PR DESCRIPTION
Set `TABLE_GET_REQS_USE_QUALIFIED_NAME` in `TestClientHandlerModule` to fix inconsistent behavior.