### PR TITLE
IGNITE-25754 DB API Driver 3: Make sure package name is compliant with PEP 625

### DIFF
--- a/modules/platforms/python/README.md
+++ b/modules/platforms/python/README.md
@@ -1,4 +1,4 @@
-# pyignite-dbapi
+# pyignite_dbapi
 Apache Ignite 3 DB API Driver.
 
 ## Prerequisites
@@ -9,9 +9,9 @@ Apache Ignite 3 DB API Driver.
 ## Installation
 
 ### From repository
-This is a recommended way for users. If you only want to use the `pyignite-dbapi` module in your project, do:
+This is a recommended way for users. If you only want to use the `pyignite_dbapi` module in your project, do:
 ```
-$ pip install pyignite-dbapi
+$ pip install pyignite_dbapi
 ```
 
 ### From sources
@@ -25,7 +25,7 @@ $ cd <pyignite_dbapi_path>
 $ pip install -e .
 ```
 
-This will install the repository version of `pyignite-dbapi` into your environment in so-called “develop” or “editable”
+This will install the repository version of `pyignite_dbapi` into your environment in so-called “develop” or “editable”
 mode. You may read more about [editable installs](https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs)
 in the `pip` manual.
 
@@ -70,13 +70,13 @@ Ready wheels will be located in `distr` directory.
 
 To upgrade an existing package, use the following command:
 ```
-pip install --upgrade pyignite-dbapi
+pip install --upgrade pyignite_dbapi
 ```
 
 To install the latest version of a package:
 
 ```
-pip install pyignite-dbapi
+pip install pyignite_dbapi
 ```
 
 To install a specific version:

--- a/modules/platforms/python/docs/conf.py
+++ b/modules/platforms/python/docs/conf.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath('../'))
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'pyignite-dbapi'
+project = 'pyignite_dbapi'
 copyright = '2024, The Apache Software Foundation'
 author = 'The Apache Software Foundation'
 release = pyignite_dbapi.__version__

--- a/modules/platforms/python/setup.py
+++ b/modules/platforms/python/setup.py
@@ -129,7 +129,7 @@ class CMakeBuild(build_ext):
 
 def run_setup():
     setuptools.setup(
-        name=PACKAGE_NAME.replace('_', '-'),
+        name=PACKAGE_NAME,
         version=version,
         python_requires='>=3.8',
         author='The Apache Software Foundation',

--- a/modules/platforms/python/setup.py
+++ b/modules/platforms/python/setup.py
@@ -158,7 +158,6 @@ def run_setup():
             'Intended Audience :: Developers',
             'Topic :: Database :: Front-Ends',
             'Topic :: Software Development :: Libraries :: Python Modules',
-            'License :: Free for non-commercial use',
             'Operating System :: MacOS',
             'Operating System :: Microsoft :: Windows',
             'Operating System :: POSIX :: Linux',

--- a/modules/platforms/python/tests/conftest.py
+++ b/modules/platforms/python/tests/conftest.py
@@ -19,7 +19,7 @@ import pytest
 
 from tests.util import check_cluster_started, start_cluster_gen, server_addresses_basic
 
-logger = logging.getLogger('pyignite-dbapi')
+logger = logging.getLogger('pyignite_dbapi')
 logger.setLevel(logging.DEBUG)
 
 TEST_PAGE_SIZE = 32

--- a/modules/platforms/python/tox.ini
+++ b/modules/platforms/python/tox.ini
@@ -19,7 +19,7 @@ envlist = codestyle,py{39,310,311,312,313}
 
 [testenv]
 passenv = TEAMCITY_VERSION IGNITE_HOME
-envdir = {homedir}/.virtualenvs/pyignite-dbapi-{envname}
+envdir = {homedir}/.virtualenvs/pyignite_dbapi_{envname}
 deps =
     -r ./requirements/install.txt
     -r ./requirements/tests.txt


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-25754

Basically just replaced all mentions of `pyignite-dbapi` with `pyignite_dbapi` to satisfy [PEP 625](https://peps.python.org/pep-0625/).