### PR TITLE
IGNITE-25805 Only check actual target ID when sending by ClusterNode

### DIFF
--- a/modules/file-transfer/src/test/java/org/apache/ignite/internal/network/file/TestMessagingService.java
+++ b/modules/file-transfer/src/test/java/org/apache/ignite/internal/network/file/TestMessagingService.java
@@ -25,6 +25,7 @@ import org.apache.ignite.internal.network.ChannelType;
 import org.apache.ignite.internal.network.NetworkMessage;
 import org.apache.ignite.internal.network.NetworkMessageHandler;
 import org.apache.ignite.network.ClusterNode;
+import org.apache.ignite.network.NetworkAddress;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -44,6 +45,11 @@ public class TestMessagingService extends AbstractMessagingService {
 
     @Override
     public CompletableFuture<Void> send(String recipientConsistentId, ChannelType channelType, NetworkMessage msg) {
+        return failedFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Void> send(NetworkAddress recipientNetworkAddress, ChannelType channelType, NetworkMessage msg) {
         return failedFuture(new UnsupportedOperationException());
     }
 

--- a/modules/network-api/src/main/java/org/apache/ignite/internal/network/MessagingService.java
+++ b/modules/network-api/src/main/java/org/apache/ignite/internal/network/MessagingService.java
@@ -23,12 +23,12 @@ import org.apache.ignite.internal.network.annotations.Marshallable;
 import org.apache.ignite.internal.network.annotations.MessageGroup;
 import org.apache.ignite.internal.thread.ExecutorChooser;
 import org.apache.ignite.network.ClusterNode;
+import org.apache.ignite.network.NetworkAddress;
 
 /**
  * Entry point for sending messages between network members in both weak and patient mode.
- *
- * <p>TODO: allow removing event handlers, see https://issues.apache.org/jira/browse/IGNITE-14519
  */
+// TODO: allow removing event handlers, see https://issues.apache.org/jira/browse/IGNITE-14519
 public interface MessagingService {
     /**
      * Send the given message asynchronously to the specific member without any delivery guarantees.
@@ -53,6 +53,10 @@ public interface MessagingService {
      * to B, then the guarantees are maintained. If, on the other hand, A sends m1 to B and m2 to C, then no guarantees
      * exist.
      *
+     * <p>If the recipient is not in the physical topology anymore, the result future will be completed with
+     * a {@link RecipientLeftException}. This also relates to the case when a node with ID different from the one in the {@link ClusterNode}
+     * object is found on the other side of the channel.
+     *
      * @param recipient Recipient of the message.
      * @param msg       Message which should be delivered.
      * @return Future of the send operation.
@@ -75,6 +79,10 @@ public interface MessagingService {
      * <p>Please note that the guarantees only work for same (sender, receiver) pairs. That is, if A sends m1 and m2
      * to B, then the guarantees are maintained. If, on the other hand, A sends m1 to B and m2 to C, then no guarantees
      * exist.
+     *
+     * <p>If the recipient is not in the physical topology anymore, the result future will be completed with
+     * a {@link RecipientLeftException}. This also relates to the case when a node with ID different from the one in the {@link ClusterNode}
+     * object is found on the other side of the channel.
      *
      * @param recipient Recipient of the message.
      * @param msg       Message which should be delivered.
@@ -103,8 +111,32 @@ public interface MessagingService {
     CompletableFuture<Void> send(String recipientConsistentId, ChannelType channelType, NetworkMessage msg);
 
     /**
+     * Tries to send the given message via specified channel asynchronously to the specific cluster member by its network address.
+     *
+     * <p>Guarantees:
+     * <ul>
+     *     <li>Messages send to same receiver will be delivered in the same order as they were sent;</li>
+     *     <li>If a message N has been successfully delivered to a member implies that all messages to same receiver
+     *     preceding N have also been successfully delivered.</li>
+     * </ul>
+     *
+     * <p>Please note that the guarantees only work for same (sender, receiver) pairs. That is, if A sends m1 and m2
+     * to B, then the guarantees are maintained. If, on the other hand, A sends m1 to B and m2 to C, then no guarantees
+     * exist.
+     *
+     * @param recipientNetworkAddress Network address of the recipient of the message.
+     * @param msg       Message which should be delivered.
+     * @return Future of the send operation.
+     */
+    CompletableFuture<Void> send(NetworkAddress recipientNetworkAddress, ChannelType channelType, NetworkMessage msg);
+
+    /**
      * Sends a response to a {@link #invoke} request.
      * Guarantees are the same as for the {@link #send(ClusterNode, NetworkMessage)}.
+     *
+     * <p>If the recipient is not in the physical topology anymore, the result future will be completed with
+     * a {@link RecipientLeftException}. This also relates to the case when a node with ID different from the one in the {@link ClusterNode}
+     * object is found on the other side of the channel.
      *
      * @param recipient     Recipient of the message.
      * @param msg           Message which should be delivered.
@@ -118,6 +150,10 @@ public interface MessagingService {
     /**
      * Sends a response to a {@link #invoke} request.
      * Guarantees are the same as for the {@link #send(ClusterNode, NetworkMessage)}.
+     *
+     * <p>If the recipient is not in the physical topology anymore, the result future will be completed with
+     * a {@link RecipientLeftException}. This also relates to the case when a node with ID different from the one in the {@link ClusterNode}
+     * object is found on the other side of the channel.
      *
      * @param recipient     Recipient of the message.
      * @param msg           Message which should be delivered.
@@ -162,6 +198,10 @@ public interface MessagingService {
      * {@link #send(ClusterNode, NetworkMessage)} and returns a future that will be
      * completed successfully upon receiving a response.
      *
+     * <p>If the recipient is not in the physical topology anymore, the result future will be completed with
+     * a {@link RecipientLeftException}. This also relates to the case when a node with ID different from the one in the {@link ClusterNode}
+     * object is found on the other side of the channel.
+     *
      * @param recipient Recipient of the message.
      * @param msg       The message.
      * @param timeout   Waiting for response timeout in milliseconds.
@@ -175,6 +215,10 @@ public interface MessagingService {
      * Sends a message asynchronously  via specified channel with same guarantees as
      * {@link #send(ClusterNode, NetworkMessage)} and returns a future that will be
      * completed successfully upon receiving a response.
+     *
+     * <p>If the recipient is not in the physical topology anymore, the result future will be completed with
+     * a {@link RecipientLeftException}. This also relates to the case when a node with ID different from the one in the {@link ClusterNode}
+     * object is found on the other side of the channel.
      *
      * @param recipient Recipient of the message.
      * @param channelType Channel which will be used to message transfer.

--- a/modules/network-api/src/main/java/org/apache/ignite/internal/network/wrapper/JumpToExecutorByConsistentIdAfterSend.java
+++ b/modules/network-api/src/main/java/org/apache/ignite/internal/network/wrapper/JumpToExecutorByConsistentIdAfterSend.java
@@ -27,6 +27,7 @@ import org.apache.ignite.internal.network.NetworkMessageHandler;
 import org.apache.ignite.internal.thread.ExecutorChooser;
 import org.apache.ignite.internal.util.CompletableFutures;
 import org.apache.ignite.network.ClusterNode;
+import org.apache.ignite.network.NetworkAddress;
 
 /**
  * Decorator around {@link MessagingService} that switches the response handling to an executor chosen by
@@ -68,6 +69,11 @@ public class JumpToExecutorByConsistentIdAfterSend implements MessagingService {
         CompletableFuture<Void> future = messagingService.send(recipientConsistentId, channelType, msg);
 
         return switchResponseHandlingToAnotherThreadIfNeeded(msg, future, recipientConsistentId);
+    }
+
+    @Override
+    public CompletableFuture<Void> send(NetworkAddress recipientNetworkAddress, ChannelType channelType, NetworkMessage msg) {
+        throw new UnsupportedOperationException("Sending by network address is not supported by this implementation.");
     }
 
     @Override

--- a/modules/network-api/src/test/java/org/apache/ignite/internal/network/wrapper/JumpToExecutorByConsistentIdAfterSendTest.java
+++ b/modules/network-api/src/test/java/org/apache/ignite/internal/network/wrapper/JumpToExecutorByConsistentIdAfterSendTest.java
@@ -23,6 +23,7 @@ import static org.apache.ignite.internal.testframework.matchers.CompletableFutur
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
@@ -103,11 +104,21 @@ class JumpToExecutorByConsistentIdAfterSendTest extends BaseIgniteAbstractTest {
     }
 
     @Test
-    void switchesResponseHandlingToPoolAfterSendToAnotherMemberByConstantId() {
+    void switchesResponseHandlingToPoolAfterSendToAnotherMemberByConsistentId() {
         testSwitchesResponseHandlingToPoolAfterSendToAnotherMember(
                 sendFuture -> when(messagingService.send(RECIPIENT_CONSISTENT_ID, ChannelType.DEFAULT, message)).thenReturn(sendFuture),
                 () -> wrapper.send(RECIPIENT_CONSISTENT_ID, ChannelType.DEFAULT, message)
         );
+    }
+
+    @Test
+    void switchesResponseHandlingToPoolAfterSendToAnotherMemberByAddress() {
+        UnsupportedOperationException ex = assertThrows(
+                UnsupportedOperationException.class,
+                () -> wrapper.send(recipient.address(), ChannelType.DEFAULT, message)
+        );
+
+        assertThat(ex.getMessage(), is("Sending by network address is not supported by this implementation."));
     }
 
     @Test

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/scalecube/ScaleCubeClusterServiceFactory.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/scalecube/ScaleCubeClusterServiceFactory.java
@@ -181,7 +181,6 @@ public class ScaleCubeClusterServiceFactory {
                 var transport = new ScaleCubeDirectMarshallerTransport(
                         scalecubeLocalAddress,
                         messagingService,
-                        topologyService,
                         messageFactory
                 );
 

--- a/modules/network/src/main/java/org/apache/ignite/internal/network/scalecube/ScaleCubeDirectMarshallerTransport.java
+++ b/modules/network/src/main/java/org/apache/ignite/internal/network/scalecube/ScaleCubeDirectMarshallerTransport.java
@@ -26,7 +26,6 @@ import org.apache.ignite.internal.lang.IgniteInternalException;
 import org.apache.ignite.internal.logger.IgniteLogger;
 import org.apache.ignite.internal.logger.Loggers;
 import org.apache.ignite.internal.network.ChannelType;
-import org.apache.ignite.internal.network.ClusterNodeImpl;
 import org.apache.ignite.internal.network.MessagingService;
 import org.apache.ignite.internal.network.NetworkMessage;
 import org.apache.ignite.internal.network.NetworkMessageTypes;
@@ -34,7 +33,6 @@ import org.apache.ignite.internal.network.NetworkMessagesFactory;
 import org.apache.ignite.internal.network.message.ScaleCubeMessage;
 import org.apache.ignite.internal.network.message.ScaleCubeMessageBuilder;
 import org.apache.ignite.internal.network.netty.ConnectionManager;
-import org.apache.ignite.network.ClusterNode;
 import org.apache.ignite.network.NetworkAddress;
 import org.jetbrains.annotations.Nullable;
 import reactor.core.Disposable;
@@ -73,9 +71,6 @@ class ScaleCubeDirectMarshallerTransport implements Transport {
     /** Message factory. */
     private final NetworkMessagesFactory messageFactory;
 
-    /** Topology service. */
-    private final ScaleCubeTopologyService topologyService;
-
     /** Node address. */
     private final Address address;
 
@@ -84,18 +79,15 @@ class ScaleCubeDirectMarshallerTransport implements Transport {
      *
      * @param localAddress Local address.
      * @param messagingService Messaging service.
-     * @param topologyService Topology service.
      * @param messageFactory  Message factory.
      */
     ScaleCubeDirectMarshallerTransport(
             Address localAddress,
             MessagingService messagingService,
-            ScaleCubeTopologyService topologyService,
             NetworkMessagesFactory messageFactory
     ) {
         this.address = localAddress;
         this.messagingService = messagingService;
-        this.topologyService = topologyService;
         this.messageFactory = messageFactory;
 
         this.messagingService.addMessageHandler(NetworkMessageTypes.class, (message, sender, correlationId) -> onMessage(message));
@@ -157,14 +149,7 @@ class ScaleCubeDirectMarshallerTransport implements Transport {
         var addr = new NetworkAddress(address.host(), address.port());
 
         return Mono.fromFuture(() -> {
-            ClusterNode node = topologyService.getByAddress(addr);
-
-            // Create a fake node for nodes that are not in the topology yet
-            if (node == null) {
-                node = new ClusterNodeImpl(null, null, addr);
-            }
-
-            return messagingService.send(node, SCALE_CUBE_CHANNEL_TYPE, fromMessage(message));
+            return messagingService.send(addr, SCALE_CUBE_CHANNEL_TYPE, fromMessage(message));
         });
     }
 

--- a/modules/network/src/test/java/org/apache/ignite/internal/network/scalecube/ScaleCubeDirectMarshallerTransportTest.java
+++ b/modules/network/src/test/java/org/apache/ignite/internal/network/scalecube/ScaleCubeDirectMarshallerTransportTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.network.scalecube;
+
+import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willCompleteSuccessfully;
+import static org.apache.ignite.internal.util.CompletableFutures.nullCompletedFuture;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+import io.scalecube.cluster.transport.api.Message;
+import io.scalecube.net.Address;
+import java.util.concurrent.CompletableFuture;
+import org.apache.ignite.internal.network.MessagingService;
+import org.apache.ignite.internal.network.NetworkMessagesFactory;
+import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
+import org.apache.ignite.network.NetworkAddress;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ScaleCubeDirectMarshallerTransportTest extends BaseIgniteAbstractTest {
+    @Mock
+    private MessagingService messagingService;
+
+    private ScaleCubeDirectMarshallerTransport transport;
+
+    @BeforeEach
+    void createAndStartTransport() {
+        transport = new ScaleCubeDirectMarshallerTransport(
+                Address.create("localhost", 3000),
+                messagingService,
+                new NetworkMessagesFactory()
+        );
+
+        transport.start().block();
+    }
+
+    @AfterEach
+    void stopTransport() {
+        if (transport != null) {
+            transport.stop().block();
+        }
+    }
+
+    @Test
+    void transportSendsByAddress() {
+        when(messagingService.send(any(NetworkAddress.class), any(), any())).thenReturn(nullCompletedFuture());
+
+        CompletableFuture<Void> future = transport.send(Address.create("localhost", 3001), Message.withData("test").build()).toFuture();
+
+        assertThat(future, willCompleteSuccessfully());
+    }
+}

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/ClusterServiceFactory.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/ClusterServiceFactory.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.sql.engine.framework;
 
 import static java.util.UUID.randomUUID;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.apache.ignite.internal.util.CompletableFutures.nullCompletedFuture;
 
 import java.util.Collection;
@@ -251,7 +252,7 @@ public class ClusterServiceFactory {
             LocalMessagingService recipient = messagingServicesByNode.get(recipientConsistentId);
 
             if (recipient == null) {
-                return CompletableFuture.failedFuture(new UnresolvableConsistentIdException(recipientConsistentId));
+                return failedFuture(new UnresolvableConsistentIdException(recipientConsistentId));
             }
 
             for (NetworkMessageHandler handler : recipient.messageHandlers(msg.groupType())) {
@@ -259,6 +260,11 @@ public class ClusterServiceFactory {
             }
 
             return nullCompletedFuture();
+        }
+
+        @Override
+        public CompletableFuture<Void> send(NetworkAddress recipientNetworkAddress, ChannelType channelType, NetworkMessage msg) {
+            return failedFuture(new UnsupportedOperationException());
         }
 
         /** {@inheritDoc} */

--- a/modules/table/src/testFixtures/java/org/apache/ignite/internal/table/impl/DummyInternalTableImpl.java
+++ b/modules/table/src/testFixtures/java/org/apache/ignite/internal/table/impl/DummyInternalTableImpl.java
@@ -753,6 +753,11 @@ public class DummyInternalTableImpl extends InternalTableImpl {
             throw new UnsupportedOperationException("Not implemented yet");
         }
 
+        @Override
+        public CompletableFuture<Void> send(NetworkAddress recipientNetworkAddress, ChannelType channelType, NetworkMessage msg) {
+            throw new UnsupportedOperationException("Not implemented yet");
+        }
+
         /** {@inheritDoc} */
         @Override
         public CompletableFuture<Void> respond(ClusterNode recipient, ChannelType type, NetworkMessage msg, long correlationId) {


### PR DESCRIPTION
When sending by consistent ID or address, the check is redundant and can cause issues.

https://issues.apache.org/jira/browse/IGNITE-25805