### PR TITLE
dotnet pack bug reproducer

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.csproj
@@ -28,6 +28,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <EmitCompilerGeneratedFiles>false</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+
+    <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
```bash
git clone https://github.com/ptupitsyn/ignite-3.git -b nuget-validation-bug
cd ignite-3/modules/platforms/dotnet/Apache.Ignite
dotnet pack
```

```
/home/pavel/w/ignite-3/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.csproj : error NU1505: Warning As Error: Duplicate 'PackageDownload' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageDownload' items are: Apache.Ignite [3.0.0], Apache.Ignite [3.0.0].

Restore failed with 1 error(s) in 0.2s
```