### PR TITLE
IGNITE-25586 Sql. Partition awareness. Performance tests

### DIFF
--- a/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientSql.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientSql.java
@@ -291,7 +291,7 @@ public class ClientSql implements IgniteSql {
 
         PartitionMappingProvider mappingProvider = mappingProviderCache.getIfPresent(new PaCacheKey(statement));
 
-        PartitionMapping mapping = mappingProvider != null 
+        PartitionMapping mapping = mappingProvider != null
                 ? mappingProvider.get(arguments)
                 : null;
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/AbstractMultiNodeBenchmark.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/AbstractMultiNodeBenchmark.java
@@ -26,9 +26,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteServer;
 import org.apache.ignite.InitParameters;
+import org.apache.ignite.client.IgniteClient;
 import org.apache.ignite.internal.app.IgniteImpl;
 import org.apache.ignite.internal.catalog.commands.CatalogUtils;
 import org.apache.ignite.internal.failure.handlers.configuration.StopNodeOrHaltFailureHandlerConfigurationSchema;
@@ -251,6 +253,17 @@ public class AbstractMultiNodeBenchmark {
                 igniteImpl = unwrapIgniteImpl(publicIgnite);
             }
         }
+    }
+
+    /**
+     * Gets client connector addresses for the specified nodes.
+     *
+     * @return Array of client addresses.
+     */
+    static String[] getServerEndpoints(IgniteClient client) {
+        return IntStream.range(0, client.cluster().nodes().size())
+                .mapToObj(i -> "127.0.0.1:" + (BASE_CLIENT_PORT + i))
+                .toArray(String[]::new);
     }
 
     private static String nodeName(int port) {

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/BulkLoadBenchmark.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/BulkLoadBenchmark.java
@@ -116,9 +116,13 @@ public class BulkLoadBenchmark extends AbstractMultiNodeBenchmark {
         public void setUp() {
             String queryStr = createInsertStatement();
 
-            client = IgniteClient.builder()
-                    .addresses("127.0.0.1:10800", "127.0.0.1:10801", "127.0.0.1:10802")
-                    .build();
+            client = IgniteClient.builder().addresses("127.0.0.1:10800").build();
+
+            String[] clientAddrs = getServerEndpoints(client);
+
+            client.close();
+
+            client = IgniteClient.builder().addresses(clientAddrs).build();
 
             sql = client.sql();
 
@@ -130,8 +134,7 @@ public class BulkLoadBenchmark extends AbstractMultiNodeBenchmark {
          */
         @TearDown
         public void tearDown() throws Exception {
-            // statement.close() throws `UnsupportedOperationException("Not implemented yet.")`, that's why it's commented.
-            closeAll(/* statement, */ client);
+            closeAll(client);
         }
 
         void upload(int count, int batch) {
@@ -171,9 +174,13 @@ public class BulkLoadBenchmark extends AbstractMultiNodeBenchmark {
                 tuple.set("field" + i, FIELD_VAL);
             }
 
-            client = IgniteClient.builder()
-                    .addresses("127.0.0.1:10800", "127.0.0.1:10801", "127.0.0.1:10802")
-                    .build();
+            client = IgniteClient.builder().addresses("127.0.0.1:10800").build();
+
+            String[] clientAddrs = getServerEndpoints(client);
+
+            client.close();
+
+            client = IgniteClient.builder().addresses(clientAddrs).build();
 
             kvView = client.tables().table(TABLE_NAME).keyValueView();
         }

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/InsertBenchmark.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/InsertBenchmark.java
@@ -244,6 +244,12 @@ public class InsertBenchmark extends AbstractMultiNodeBenchmark {
 
             client = IgniteClient.builder().addresses("127.0.0.1:10800").build();
 
+            String[] clientAddrs = getServerEndpoints(client);
+
+            client.close();
+
+            client = IgniteClient.builder().addresses(clientAddrs).build();
+
             sql = client.sql();
 
             statement = sql.createStatement(queryStr);
@@ -254,8 +260,7 @@ public class InsertBenchmark extends AbstractMultiNodeBenchmark {
          */
         @TearDown
         public void tearDown() throws Exception {
-            // statement.close() throws `UnsupportedOperationException("Not implemented yet.")`, that's why it's commented.
-            closeAll(/* statement, */ client);
+            closeAll(client);
         }
 
         private int id = 0;
@@ -362,6 +367,13 @@ public class InsertBenchmark extends AbstractMultiNodeBenchmark {
             }
 
             client = IgniteClient.builder().addresses("127.0.0.1:10800").build();
+
+            String[] clientAddrs = getServerEndpoints(client);
+
+            client.close();
+
+            client = IgniteClient.builder().addresses(clientAddrs).build();
+
             kvView = client.tables().table(TABLE_NAME).keyValueView();
         }
 

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/SelectBenchmark.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/benchmark/SelectBenchmark.java
@@ -290,6 +290,12 @@ public class SelectBenchmark extends AbstractMultiNodeBenchmark {
         public void setUp() {
             client = IgniteClient.builder().addresses("127.0.0.1:10800").build();
 
+            String[] clientAddrs = getServerEndpoints(client);
+
+            client.close();
+
+            client = IgniteClient.builder().addresses(clientAddrs).build();
+
             sql = client.sql();
         }
 
@@ -354,6 +360,13 @@ public class SelectBenchmark extends AbstractMultiNodeBenchmark {
         @Setup
         public void setUp() {
             client = IgniteClient.builder().addresses("127.0.0.1:10800").build();
+
+            String[] clientAddrs = getServerEndpoints(client);
+
+            client.close();
+
+            client = IgniteClient.builder().addresses(clientAddrs).build();
+
             kvView = client.tables().table(TABLE_NAME).keyValueView();
         }
 


### PR DESCRIPTION
```
Benchmark                   (clusterSize)  (fsync)  Mode  Cnt    Score    Error  Units
SelectBenchmark.kvThinGet               1    false  avgt   10   92.003 ±  6.573  us/op
SelectBenchmark.kvThinGet               2    false  avgt   10  106.230 ±  7.272  us/op
SelectBenchmark.kvThinGet               3    false  avgt   10  108.272 ±  4.888  us/op

with PA
SelectBenchmark.sqlThinGet              1    false  avgt   10  113.470 ±  7.555  us/op
SelectBenchmark.sqlThinGet              2    false  avgt   10  125.362 ±  8.545  us/op
SelectBenchmark.sqlThinGet              3    false  avgt   10  134.698 ± 10.957  us/op

without PA
SelectBenchmark.sqlThinGet              1    false  avgt   10  123.102 ±  4.035  us/op
SelectBenchmark.sqlThinGet              2    false  avgt   10  199.868 ±  6.106  us/op
SelectBenchmark.sqlThinGet              3    false  avgt   10  254.119 ± 13.346  us/op


BulkLoadBenchmark
with PA
Benchmark                        (batchSize)  (clusterSize)  (count)  (fsync)  (partitionCount)  (replicaCount)  Mode  Cnt   Score   Error  Units
BulkLoadBenchmark.kvThinInsert             5              3   100000    false                32               1    ss       57.936           s/op
BulkLoadBenchmark.sqlThinInsert            5              3   100000    false                32               1    ss       66.412           s/op

without PA 
Benchmark                        (batchSize)  (clusterSize)  (count)  (fsync)  (partitionCount)  (replicaCount)  Mode  Cnt   Score   Error  Units
BulkLoadBenchmark.kvThinInsert             5              3   100000    false                32               1    ss       59.397           s/op
BulkLoadBenchmark.sqlThinInsert            5              3   100000    false                32               1    ss       79.723           s/op

with PA
Benchmark                      (clusterSize)  (fsync)  (partitionCount)  (replicaCount)  Mode  Cnt    Score    Error  Units
InsertBenchmark.sqlThinInsert              1    false                 4               1  avgt   10  235.139 ± 12.768  us/op
InsertBenchmark.sqlThinInsert              1    false                 4               2  avgt   10  235.085 ± 17.832  us/op
InsertBenchmark.sqlThinInsert              1    false                 8               1  avgt   10  237.887 ± 12.491  us/op
InsertBenchmark.sqlThinInsert              1    false                 8               2  avgt   10  238.302 ± 15.643  us/op
InsertBenchmark.sqlThinInsert              3    false                 4               1  avgt   10  287.871 ± 18.961  us/op
InsertBenchmark.sqlThinInsert              3    false                 4               2  avgt   10  505.013 ± 37.723  us/op
InsertBenchmark.sqlThinInsert              3    false                 8               1  avgt   10  286.832 ± 18.120  us/op
InsertBenchmark.sqlThinInsert              3    false                 8               2  avgt   10  520.169 ± 34.243  us/op

without PA
InsertBenchmark.sqlThinInsert              1    false                 4               1  avgt   10  231.087 ±  21.104  us/op
InsertBenchmark.sqlThinInsert              1    false                 4               2  avgt   10  232.096 ±  23.294  us/op
InsertBenchmark.sqlThinInsert              1    false                 8               1  avgt   10  237.592 ±  12.888  us/op
InsertBenchmark.sqlThinInsert              1    false                 8               2  avgt   10  235.292 ±  12.224  us/op
InsertBenchmark.sqlThinInsert              3    false                 4               1  avgt   10  392.940 ±  28.232  us/op
InsertBenchmark.sqlThinInsert              3    false                 4               2  avgt   10  600.974 ± 112.884  us/op
InsertBenchmark.sqlThinInsert              3    false                 8               1  avgt   10  359.860 ±  21.925  us/op
InsertBenchmark.sqlThinInsert              3    false                 8               2  avgt   10  562.113 ±  28.394  us/op

pure kv:
InsertBenchmark.kvThinInsert               1    false                 4               1  avgt   10  199.921 ± 23.434  us/op
InsertBenchmark.kvThinInsert               1    false                 4               2  avgt   10  195.279 ±  7.100  us/op
InsertBenchmark.kvThinInsert               1    false                 8               1  avgt   10  199.841 ±  6.142  us/op
InsertBenchmark.kvThinInsert               1    false                 8               2  avgt   10  200.350 ±  6.887  us/op
InsertBenchmark.kvThinInsert               3    false                 4               1  avgt   10  240.908 ± 22.282  us/op
InsertBenchmark.kvThinInsert               3    false                 4               2  avgt   10  435.487 ± 17.063  us/op
InsertBenchmark.kvThinInsert               3    false                 8               1  avgt   10  240.884 ± 15.045  us/op
InsertBenchmark.kvThinInsert               3    false                 8               2  avgt   10  460.191 ± 19.105  us/op
```