### PR TITLE
IGNITE-25941 .NET: Fix pooled buffer bugs

### DIFF
--- a/modules/api/src/main/java/org/apache/ignite/Ignite.java
+++ b/modules/api/src/main/java/org/apache/ignite/Ignite.java
@@ -101,5 +101,10 @@ public interface Ignite {
      */
     IgniteCatalog catalog();
 
+    /**
+     * Returns the cluster object, which provides access to the cluster nodes and the local node.
+     *
+     * @return Ignite cluster.
+     */
     IgniteCluster cluster();
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -476,6 +476,24 @@ namespace Apache.Ignite.Tests.Compute
         }
 
         [Test]
+        public async Task TestManyDeploymentUnits()
+        {
+            var units = Enumerable.Range(1, 10_000)
+                .Select(x => new DeploymentUnit($"unit{x}", x + ".0.0"))
+                .ToList();
+
+            using var server = new FakeServer();
+            using var client = await server.ConnectClientAsync();
+
+            var res = await client.Compute.SubmitAsync(
+                await GetNodeAsync(1),
+                new JobDescriptor<object?, string>(FakeServer.GetDetailsJob, units),
+                null);
+
+            StringAssert.StartsWith("{ NodeName = fake-server, Units = unit1|1.0.0", await res.GetResultAsync());
+        }
+
+        [Test]
         public void TestExecuteOnUnknownUnitWithLatestVersionThrows()
         {
             var job = NodeNameJob with

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compute/ComputeTests.cs
@@ -476,11 +476,11 @@ namespace Apache.Ignite.Tests.Compute
         }
 
         [Test]
-        public async Task TestManyDeploymentUnits()
+        public async Task TestManyDeploymentUnits([Values(true, false)] bool lazyCollection)
         {
-            var units = Enumerable.Range(1, 10_000)
-                .Select(x => new DeploymentUnit($"unit{x}", x + ".0.0"))
-                .ToList();
+            var units = lazyCollection
+                ? GetUnits()
+                : GetUnits().ToList();
 
             using var server = new FakeServer();
             using var client = await server.ConnectClientAsync();
@@ -491,6 +491,14 @@ namespace Apache.Ignite.Tests.Compute
                 null);
 
             StringAssert.StartsWith("{ NodeName = fake-server, Units = unit1|1.0.0", await res.GetResultAsync());
+
+            static IEnumerable<DeploymentUnit> GetUnits()
+            {
+                for (var i = 1; i <= 10_000; i++)
+                {
+                    yield return new DeploymentUnit($"unit{i}", $"{i}.0.0");
+                }
+            }
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
@@ -32,22 +32,7 @@ namespace Apache.Ignite.Tests.Table
     public class RecordViewBinaryTests : IgniteTestsBase
     {
         [TearDown]
-        public async Task CleanTable()
-        {
-            await Client.Sql.ExecuteScriptAsync($"DELETE FROM {Table.Name}");
-        }
-
-        [Test]
-        public async Task TestUpsertAllMany()
-        {
-            int count = 3709;
-
-            var tuples = Enumerable.Range(0, count)
-                .Select(id => new IgniteTuple { [KeyCol] = (long)id, [ValCol] = $"test{id}" })
-                .ToList();
-
-            await TupleView.UpsertAllAsync(null, tuples);
-        }
+        public async Task CleanTable() => await Client.Sql.ExecuteScriptAsync($"DELETE FROM {Table.Name}");
 
         [Test]
         public async Task TestUpsertGet()
@@ -613,6 +598,18 @@ namespace Apache.Ignite.Tests.Table
         public void TestToString()
         {
             StringAssert.StartsWith("RecordView`1[IIgniteTuple] { Table = Table { Name = PUBLIC.TBL1, Id =", TupleView.ToString());
+        }
+
+        [Test]
+        public async Task TestUpsertAllMany()
+        {
+            int count = 50_000;
+
+            var tuples = Enumerable.Range(0, count)
+                .Select(id => new IgniteTuple { [KeyCol] = (long)id, [ValCol] = $"test{id}" })
+                .ToList();
+
+            await TupleView.UpsertAllAsync(null, tuples);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
@@ -34,7 +34,19 @@ namespace Apache.Ignite.Tests.Table
         [TearDown]
         public async Task CleanTable()
         {
-            await TupleView.DeleteAllAsync(null, Enumerable.Range(-1, 50).Select(x => GetTuple(x)));
+            await Client.Sql.ExecuteScriptAsync($"DELETE FROM {Table.Name}");
+        }
+
+        [Test]
+        public async Task TestUpsertAllMany()
+        {
+            int count = 12345;
+
+            var tuples = Enumerable.Range(0, count)
+                .Select(id => new IgniteTuple { [KeyCol] = (long)id, [ValCol] = $"test{id}" })
+                .ToList();
+
+            await TupleView.UpsertAllAsync(null, tuples);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
@@ -40,7 +40,7 @@ namespace Apache.Ignite.Tests.Table
         [Test]
         public async Task TestUpsertAllMany()
         {
-            int count = 12345;
+            int count = 3709;
 
             var tuples = Enumerable.Range(0, count)
                 .Select(id => new IgniteTuple { [KeyCol] = (long)id, [ValCol] = $"test{id}" })

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Tests.Table
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
     using Ignite.Table;
@@ -613,16 +614,16 @@ namespace Apache.Ignite.Tests.Table
         }
 
         [Test]
-        public async Task TestUpsertAllBufferOverflow()
+        public void TestUpsertAllBufferOverflow()
         {
-            int count = 5_000_000;
-            string val = new string('x', 10_000);
+            int count = 50_000;
+            string val = new string('x', 100_000);
 
             var tuples = Enumerable.Range(0, count)
                 .Select(id => new IgniteTuple(2) { [KeyCol] = (long)id, [ValCol] = val })
                 .ToList();
 
-            await TupleView.UpsertAllAsync(null, tuples);
+            Assert.ThrowsAsync<InternalBufferOverflowException>(async () => await TupleView.UpsertAllAsync(null, tuples));
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
@@ -611,5 +611,18 @@ namespace Apache.Ignite.Tests.Table
 
             await TupleView.UpsertAllAsync(null, tuples);
         }
+
+        [Test]
+        public async Task TestUpsertAllBufferOverflow()
+        {
+            int count = 5_000_000;
+            string val = new string('x', 10_000);
+
+            var tuples = Enumerable.Range(0, count)
+                .Select(id => new IgniteTuple(2) { [KeyCol] = (long)id, [ValCol] = val })
+                .ToList();
+
+            await TupleView.UpsertAllAsync(null, tuples);
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
@@ -128,7 +128,7 @@ namespace Apache.Ignite.Internal.Buffers
         public Span<byte> GetSpan(int sizeHint)
         {
             CheckAndResizeBuffer(sizeHint);
-            return _buffer.AsSpan(_index);
+            return _buffer.AsSpan(_index, sizeHint);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
@@ -105,13 +105,7 @@ namespace Apache.Ignite.Internal.Buffers
             Debug.Assert(count >= 0, "count >= 0");
             Debug.Assert(_index + count <= _buffer.Length, $"_index + count <= _buffer.Length [{_index} + {count} <= {_buffer.Length}]");
 
-#if DEBUG
-            // Get span and fill.
-            GetSpan(count);
-#else
-            // Release mode - just advance the index.
             _index += count;
-#endif
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
@@ -145,7 +145,7 @@ namespace Apache.Ignite.Internal.Buffers
 
 #if DEBUG
             // Fill the span to catch certain bugs, such as "got the span but forgot to write to it".
-            span.Fill(255);
+            span.Fill(254);
 #endif
 
             return span;
@@ -165,7 +165,7 @@ namespace Apache.Ignite.Internal.Buffers
 
 #if DEBUG
             // Fill the span to catch certain bugs, such as "got the span but forgot to write to it".
-            span.Fill(255);
+            span.Fill(253);
 #endif
 
             return span;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
@@ -132,7 +132,7 @@ namespace Apache.Ignite.Internal.Buffers
 
 #if DEBUG
             // Fill the span to catch certain bugs, such as "got the span but forgot to write to it".
-            span.Fill(255);
+            span.Fill(254);
 #endif
 
             return span;

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
@@ -128,7 +128,14 @@ namespace Apache.Ignite.Internal.Buffers
         public Span<byte> GetSpan(int sizeHint)
         {
             CheckAndResizeBuffer(sizeHint);
-            return _buffer.AsSpan(_index, sizeHint);
+            var span = _buffer.AsSpan(_index, sizeHint);
+
+#if DEBUG
+            // Fill the span to catch certain bugs, such as "got the span but forgot to write to it".
+            span.Fill(255);
+#endif
+
+            return span;
         }
 
         /// <summary>
@@ -142,6 +149,11 @@ namespace Apache.Ignite.Internal.Buffers
 
             var span = _buffer.AsSpan(_index, size);
             Advance(size);
+
+#if DEBUG
+            // Fill the span to catch certain bugs, such as "got the span but forgot to write to it".
+            span.Fill(255);
+#endif
 
             return span;
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
@@ -93,7 +93,7 @@ namespace Apache.Ignite.Internal.Buffers
         {
             Debug.Assert(!_disposed, "!_disposed");
 
-            return new(_buffer, start: Offset, length: _index);
+            return new(_buffer, start: Offset, length: _index - Offset);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
@@ -103,7 +103,7 @@ namespace Apache.Ignite.Internal.Buffers
         public void Advance(int count)
         {
             Debug.Assert(count >= 0, "count >= 0");
-            Debug.Assert(_index + count < _buffer.Length, "_index + count < _buffer.Length");
+            Debug.Assert(_index + count <= _buffer.Length, $"_index + count <= _buffer.Length [{_index} + {count} <= {_buffer.Length}]");
 
             _index += count;
         }
@@ -290,6 +290,7 @@ namespace Apache.Ignite.Internal.Buffers
             // Arrays from ArrayPool are sized to powers of 2, so we don't need to implement the same logic here.
             // Even if requested size is 1 byte more than current, we'll get at lest 2x bigger array.
             var newBuf = ByteArrayPool.Rent(newSize);
+            Debug.Assert(newBuf.Length >= newSize, "newBuf.Length >= newSize");
 
             Array.Copy(_buffer, newBuf, _index);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
@@ -93,7 +93,7 @@ namespace Apache.Ignite.Internal.Buffers
         {
             Debug.Assert(!_disposed, "!_disposed");
 
-            return new(_buffer, start: Offset, length: _index);
+            return new(_buffer, start: Offset, length: _index - Offset);
         }
 
         /// <summary>
@@ -128,14 +128,8 @@ namespace Apache.Ignite.Internal.Buffers
         public Span<byte> GetSpan(int sizeHint)
         {
             CheckAndResizeBuffer(sizeHint);
-            var span = _buffer.AsSpan(_index, sizeHint);
 
-#if DEBUG
-            // Fill the span to catch certain bugs, such as "got the span but forgot to write to it".
-            span.Fill(254);
-#endif
-
-            return span;
+            return _buffer.AsSpan(_index, sizeHint);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Buffers/PooledArrayBuffer.cs
@@ -93,7 +93,7 @@ namespace Apache.Ignite.Internal.Buffers
         {
             Debug.Assert(!_disposed, "!_disposed");
 
-            return new(_buffer, start: Offset, length: _index - Offset);
+            return new(_buffer, start: Offset, length: _index);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -239,14 +239,6 @@ namespace Apache.Ignite.Internal.Compute
         private static ICollection<IClusterNode> GetNodesCollection(IEnumerable<IClusterNode> nodes) =>
             nodes as ICollection<IClusterNode> ?? nodes.ToList();
 
-        private static ICollection<DeploymentUnit> GetUnitsCollection(IEnumerable<DeploymentUnit>? units) =>
-            units switch
-            {
-                null => Array.Empty<DeploymentUnit>(),
-                ICollection<DeploymentUnit> c => c,
-                var u => u.ToList()
-            };
-
         private static void WriteEnumerable<T>(IEnumerable<T> items, PooledArrayBuffer buf, Action<T, PooledArrayBuffer> writerFunc)
         {
             var w = buf.MessageWriter;
@@ -287,7 +279,7 @@ namespace Apache.Ignite.Internal.Compute
             JobDescriptor<TArg, TResult> jobDescriptor,
             bool canWriteJobExecType)
         {
-            WriteUnits(GetUnitsCollection(jobDescriptor.DeploymentUnits), writer);
+            WriteUnits(jobDescriptor.DeploymentUnits, writer);
 
             var w = writer.MessageWriter;
             w.Write(jobDescriptor.JobClassName);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Compute/Compute.cs
@@ -264,6 +264,8 @@ namespace Apache.Ignite.Internal.Compute
 
             // Enumerable without known count - enumerate first, write count later.
             count = 0;
+
+            // TODO: Bug
             var countSpan = buf.GetSpan(5);
             buf.Advance(5);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Proto/BinaryTuple/BinaryTupleBuilder.cs
@@ -1581,11 +1581,16 @@ namespace Apache.Ignite.Internal.Proto.BinaryTuple
             _elementIndex++;
         }
 
-        private Span<byte> GetSpan(int size)
+        private readonly Span<byte> GetSpan(int size)
         {
             var span = _buffer.GetSpan(size)[..size];
 
             _buffer.Advance(size);
+
+#if DEBUG
+            // Fill the span to catch certain bugs, such as "got the span but forgot to write to it".
+            span.Fill(255);
+#endif
 
             return span;
         }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
@@ -213,14 +213,10 @@ internal static class DataStreamer
         Batch<T> Add0(DataStreamerItem<T> item, ref BinaryTupleBuilder tupleBuilder, Schema schema0)
         {
             var columnCount = schema0.Columns.Length;
-
-            // Use MemoryMarshal to work around [CS8352]: "Cannot use variable 'noValueSet' in this context
-            // because it may expose referenced variables outside of their declaration scope".
             Span<byte> noValueSet = stackalloc byte[columnCount / 8 + 1];
-            Span<byte> noValueSetRef = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(noValueSet), noValueSet.Length);
 
             var keyOnly = item.OperationType == DataStreamerOperationType.Remove;
-            writer.Write(ref tupleBuilder, item.Data, schema0, keyOnly: keyOnly, noValueSetRef);
+            writer.Write(ref tupleBuilder, item.Data, schema0, keyOnly: keyOnly, noValueSet);
 
             var partitionId = Math.Abs(tupleBuilder.GetHash() % partitionCount);
             var batch = GetOrCreateBatch(partitionId);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/DataStreamer.cs
@@ -217,7 +217,7 @@ internal static class DataStreamer
             // Use MemoryMarshal to work around [CS8352]: "Cannot use variable 'noValueSet' in this context
             // because it may expose referenced variables outside of their declaration scope".
             Span<byte> noValueSet = stackalloc byte[columnCount / 8 + 1];
-            Span<byte> noValueSetRef = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(noValueSet), columnCount);
+            Span<byte> noValueSetRef = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(noValueSet), noValueSet.Length);
 
             var keyOnly = item.OperationType == DataStreamerOperationType.Remove;
             writer.Write(ref tupleBuilder, item.Data, schema0, keyOnly: keyOnly, noValueSetRef);

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/BinaryTupleBuilderExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/BinaryTupleBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         /// </summary>
         /// <param name="builder">Builder.</param>
         /// <param name="noValueSet">No-value bit set.</param>
-        public static void AppendNoValue(this ref BinaryTupleBuilder builder, Span<byte> noValueSet)
+        public static void AppendNoValue(this ref BinaryTupleBuilder builder, scoped Span<byte> noValueSet)
         {
             noValueSet.SetBit(builder.ElementIndex);
             builder.AppendNull();

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/IRecordSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/IRecordSerializerHandler.cs
@@ -108,6 +108,6 @@ namespace Apache.Ignite.Internal.Table.Serialization
             T record,
             Schema schema,
             bool keyOnly,
-            Span<byte> noValueSet);
+            scoped Span<byte> noValueSet);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/ObjectSerializerHandler.cs
@@ -42,7 +42,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         private readonly ConcurrentDictionary<(int, bool), ReadDelegate<T>> _readers = new();
 
         [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Reviewed.")]
-        private delegate void WriteDelegate<in TV>(ref BinaryTupleBuilder writer, Span<byte> noValueSet, TV value);
+        private delegate void WriteDelegate<in TV>(ref BinaryTupleBuilder writer, scoped Span<byte> noValueSet, TV value);
 
         [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "Reviewed.")]
         private delegate TV ReadDelegate<out TV>(ref BinaryTupleReader reader);
@@ -64,7 +64,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
         }
 
         /// <inheritdoc/>
-        public void Write(ref BinaryTupleBuilder tupleBuilder, T record, Schema schema, bool keyOnly, Span<byte> noValueSet)
+        public void Write(ref BinaryTupleBuilder tupleBuilder, T record, Schema schema, bool keyOnly, scoped Span<byte> noValueSet)
         {
             var cacheKey = (schema.Version, keyOnly);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/RecordSerializer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/RecordSerializer.cs
@@ -220,9 +220,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
             var count = 0;
             var firstHash = 0;
 
-            // TODO: This span is invalid if we resize the buffer.
-            // Review all GetSpan usages that "reserve" space for a fixed number of bytes.
-            var countSpan = buf.GetSpan(5);
+            var countPos = buf.Position;
             buf.Advance(5);
 
             do
@@ -245,6 +243,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
             }
             while (recs.MoveNext()); // First MoveNext is called outside to check for empty IEnumerable.
 
+            var countSpan = buf.GetSpanAt(countPos, 5);
             countSpan[0] = MsgPackCode.Int32;
             BinaryPrimitives.WriteInt32BigEndian(countSpan[1..], count);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/RecordSerializer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/RecordSerializer.cs
@@ -219,6 +219,9 @@ namespace Apache.Ignite.Internal.Table.Serialization
 
             var count = 0;
             var firstHash = 0;
+
+            // TODO: This span is invalid if we resize the buffer.
+            // Review all GetSpan usages that "reserve" space for a fixed number of bytes.
             var countSpan = buf.GetSpan(5);
             buf.Advance(5);
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TuplePairSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TuplePairSerializerHandler.cs
@@ -81,7 +81,7 @@ internal sealed class TuplePairSerializerHandler : IRecordSerializerHandler<KvPa
         KvPair<IIgniteTuple, IIgniteTuple> record,
         Schema schema,
         bool keyOnly,
-        Span<byte> noValueSet)
+        scoped Span<byte> noValueSet)
     {
         var key = record.Key;
         var val = record.Val;
@@ -139,12 +139,10 @@ internal sealed class TuplePairSerializerHandler : IRecordSerializerHandler<KvPa
             {
                 var name = record.Key.GetName(i);
 
-                if (extraColumns.Contains(name))
+                if (!extraColumns.Add(name))
                 {
                     throw new ArgumentException("Duplicate column in Key portion of KeyValue pair: " + name, nameof(record));
                 }
-
-                extraColumns.Add(name);
             }
 
             if (record.Val != null)
@@ -153,12 +151,10 @@ internal sealed class TuplePairSerializerHandler : IRecordSerializerHandler<KvPa
                 {
                     var name = record.Val.GetName(i);
 
-                    if (extraColumns.Contains(name))
+                    if (!extraColumns.Add(name))
                     {
                         throw new ArgumentException("Duplicate column in Value portion of KeyValue pair: " + name, nameof(record));
                     }
-
-                    extraColumns.Add(name);
                 }
             }
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TupleSerializerHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Table/Serialization/TupleSerializerHandler.cs
@@ -89,7 +89,7 @@ namespace Apache.Ignite.Internal.Table.Serialization
                 keyOnly);
 
         /// <inheritdoc/>
-        public void Write(ref BinaryTupleBuilder tupleBuilder, IIgniteTuple record, Schema schema, bool keyOnly, Span<byte> noValueSet)
+        public void Write(ref BinaryTupleBuilder tupleBuilder, IIgniteTuple record, Schema schema, bool keyOnly, scoped Span<byte> noValueSet)
         {
             int written = 0;
             var columns = keyOnly ? schema.KeyColumns : schema.Columns;


### PR DESCRIPTION
* Fix use-after-free with `PooledArrayBuffer.GetSpan` when underlying pooled array is reallocated - use the span immediately, or save position and use `GetSpanAt` later (for "reserved count" scenarios)
* Fix integer overflow in `CheckAndResizeBuffer`
* Fix `Compute.WriteEnumerable` - wrong type code and span handling in fallback branch
* Get rid of unsafe `MemoryMarshal.CreateSpan` in data streamer - use `scoped` lifetime for `noValueSet` instead