### PR TITLE
IGNITE-26032 .NET: Fix TestUpsertAllMany flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Table/RecordViewBinaryTests.cs
@@ -604,7 +604,7 @@ namespace Apache.Ignite.Tests.Table
         [Test]
         public async Task TestUpsertAllMany()
         {
-            int count = 50_000;
+            int count = 25_000;
 
             var tuples = Enumerable.Range(0, count)
                 .Select(id => new IgniteTuple { [KeyCol] = (long)id, [ValCol] = $"test{id}" })


### PR DESCRIPTION
Reduce payload to avoid test timeout.