### PR TITLE
IGNITE-25783 TIME cast truncates fractional seconds

### DIFF
--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcResultSet.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcResultSet.java
@@ -387,13 +387,21 @@ public class JdbcResultSet implements ResultSet {
     /** {@inheritDoc} */
     @Override
     public String getString(int colIdx) throws SQLException {
-        Object val = getJdbcValue(colIdx);
-        if (val == null) {
+        Object value = getValue(colIdx);
+
+        if (value == null) {
             return null;
-        } else if (val instanceof byte[]) {
-            return StringUtils.toHexString((byte[]) val);
+        } else if (value instanceof Instant) {
+            LocalDateTime localDateTime = instantWithLocalTimeZone((Instant) value);
+            return Timestamp.valueOf(localDateTime).toString();
+        } else if (value instanceof LocalTime) {
+            return value.toString();
+        } else if (value instanceof LocalDateTime) {
+            return Timestamp.valueOf((LocalDateTime) value).toString();
+        } else if (value instanceof byte[]) {
+            return StringUtils.toHexString((byte[]) value);
         } else {
-            return String.valueOf(val);
+            return String.valueOf(value);
         }
     }
 
@@ -2160,21 +2168,6 @@ public class JdbcResultSet implements ResultSet {
             return val;
         } catch (IndexOutOfBoundsException e) {
             throw new SQLException("Invalid column index: " + colIdx, SqlStateCode.PARSING_EXCEPTION, e);
-        }
-    }
-
-    private Object getJdbcValue(int colIdx) throws SQLException {
-        Object value = getValue(colIdx);
-
-        if (value instanceof Instant) {
-            LocalDateTime localDateTime = instantWithLocalTimeZone((Instant) value);
-            return Timestamp.valueOf(localDateTime);
-        } else if (value instanceof LocalTime) {
-            return Time.valueOf((LocalTime) value);
-        } else if (value instanceof LocalDateTime) {
-            return Timestamp.valueOf((LocalDateTime) value);
-        } else {
-            return value;
         }
     }
 

--- a/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc/JdbcResultSetTest.java
+++ b/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc/JdbcResultSetTest.java
@@ -339,7 +339,7 @@ public class JdbcResultSetTest extends BaseIgniteAbstractTest {
                     + " | " + resultSet.getString(3)
                     + " | " + resultSet.getString(4);
 
-            String expected = time.format(DateTimeFormatter.ofPattern("HH:mm:ss"))
+            String expected = time.format(DateTimeFormatter.ofPattern("HH:mm:ss.SSS"))
                     + " | " + date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
                     + " | " + dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"))
                     + " | " + localDateTime;


### PR DESCRIPTION
Fixes ResultSet getString to return milliseconds when converting TIME values to string.

```
sql-cli> select '13:44:56.123'::time(3);
╔═══════════════════════════╗
║ '13:44:56.123' :: TIME(3) ║
╠═══════════════════════════╣
║ 13:44:56.123              ║
╚═══════════════════════════╝
```

https://issues.apache.org/jira/browse/IGNITE-25783

---
Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)