### PR TITLE
IGNITE-26136 Disable ItCmgDisasterRecoveryTest#repairWorksWhenCmgMajorityIsOnline

### DIFF
--- a/modules/system-disaster-recovery/src/integrationTest/java/org/apache/ignite/internal/disaster/system/ItCmgDisasterRecoveryTest.java
+++ b/modules/system-disaster-recovery/src/integrationTest/java/org/apache/ignite/internal/disaster/system/ItCmgDisasterRecoveryTest.java
@@ -42,6 +42,7 @@ import org.apache.ignite.internal.cluster.management.ClusterState;
 import org.apache.ignite.internal.cluster.management.topology.api.LogicalTopologySnapshot;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.apache.ignite.table.KeyValueView;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class ItCmgDisasterRecoveryTest extends ItSystemGroupDisasterRecoveryTest {
@@ -342,6 +343,7 @@ class ItCmgDisasterRecoveryTest extends ItSystemGroupDisasterRecoveryTest {
     }
 
     @Test
+    @Disabled("https://issues.apache.org/jira/browse/IGNITE-26136")
     void repairWorksWhenCmgMajorityIsOnline() throws Exception {
         startAndInitCluster(3, new int[]{0, 1, 2}, new int[]{1});
         waitTillClusterStateIsSavedToVaultOnConductor(1);

--- a/modules/system-disaster-recovery/src/integrationTest/java/org/apache/ignite/internal/disaster/system/ItCmgDisasterRecoveryTest.java
+++ b/modules/system-disaster-recovery/src/integrationTest/java/org/apache/ignite/internal/disaster/system/ItCmgDisasterRecoveryTest.java
@@ -343,7 +343,7 @@ class ItCmgDisasterRecoveryTest extends ItSystemGroupDisasterRecoveryTest {
     }
 
     @Test
-    @Disabled("https://issues.apache.org/jira/browse/IGNITE-26136")
+    @Disabled("https://issues.apache.org/jira/browse/IGNITE-26144")
     void repairWorksWhenCmgMajorityIsOnline() throws Exception {
         startAndInitCluster(3, new int[]{0, 1, 2}, new int[]{1});
         waitTillClusterStateIsSavedToVaultOnConductor(1);


### PR DESCRIPTION
JIRA Ticket: [IGNITE-26136](https://issues.apache.org/jira/browse/IGNITE-26136)

Disable flaky test ItCmgDisasterRecoveryTest#repairWorksWhenCmgMajorityIsOnline due to https://issues.apache.org/jira/browse/IGNITE-26144