### PR TITLE
IGNITE-26160 Introduce bootstrap configuration 

### DIFF
--- a/modules/configuration-storage/src/main/java/org/apache/ignite/internal/configuration/storage/LocalFileConfigurationStorage.java
+++ b/modules/configuration-storage/src/main/java/org/apache/ignite/internal/configuration/storage/LocalFileConfigurationStorage.java
@@ -79,7 +79,7 @@ import org.jetbrains.annotations.TestOnly;
 /**
  * Implementation of {@link ConfigurationStorage} based on local file configuration storage.
  */
-public class LocalFileConfigurationStorage implements ConfigurationStorage {
+public class LocalFileConfigurationStorage implements LocalConfigurationStorage {
     private static final IgniteLogger LOG = Loggers.forClass(LocalFileConfigurationStorage.class);
 
     /** Path to config file. */
@@ -132,7 +132,11 @@ public class LocalFileConfigurationStorage implements ConfigurationStorage {
      * @param module Configuration module, which provides configuration patches.
      */
     public LocalFileConfigurationStorage(
-            String nodeName, Path configPath, ConfigurationTreeGenerator generator, @Nullable ConfigurationModule module) {
+            String nodeName,
+            Path configPath,
+            ConfigurationTreeGenerator generator,
+            @Nullable ConfigurationModule module
+    ) {
         this.configPath = configPath;
         this.generator = generator;
         this.tempConfigPath = configPath.resolveSibling(configPath.getFileName() + ".tmp");
@@ -299,16 +303,6 @@ public class LocalFileConfigurationStorage implements ConfigurationStorage {
     }
 
     private void saveConfigFile() {
-        if (!Files.isWritable(configPath)) {
-            NodeConfigWriteException e = new NodeConfigWriteException(
-                    "The configuration file is read-only, so changes cannot be applied. "
-                            + "Check your system configuration. "
-                            + "If you are using containerization, such as Kubernetes, "
-                            + "the file can only be modified through native Kubernetes methods."
-            );
-            LOG.warn("The config file " + configPath + " is not writable", e);
-            throw e;
-        }
         try {
             Files.write(
                     tempConfigPath,
@@ -391,5 +385,10 @@ public class LocalFileConfigurationStorage implements ConfigurationStorage {
         );
 
         futureTracker.registerFuture(future);
+    }
+
+    @Override
+    public boolean userModificationsAllowed() {
+        return true;
     }
 }

--- a/modules/configuration-storage/src/main/java/org/apache/ignite/internal/configuration/storage/VaultConfigurationStorage.java
+++ b/modules/configuration-storage/src/main/java/org/apache/ignite/internal/configuration/storage/VaultConfigurationStorage.java
@@ -46,7 +46,7 @@ import org.apache.ignite.internal.vault.VaultManager;
 /**
  * Local configuration storage.
  */
-public class LocalConfigurationStorage implements ConfigurationStorage {
+public class VaultConfigurationStorage implements LocalConfigurationStorage {
     /** Prefix that we add to configuration keys to distinguish them in the Vault. */
     private static final String LOC_PREFIX = "loc-cfg.";
 
@@ -54,7 +54,7 @@ public class LocalConfigurationStorage implements ConfigurationStorage {
     private static final ByteArray VERSION_KEY = new ByteArray(LOC_PREFIX + "$version");
 
     /** Logger. */
-    private static final IgniteLogger LOG = Loggers.forClass(LocalConfigurationStorage.class);
+    private static final IgniteLogger LOG = Loggers.forClass(VaultConfigurationStorage.class);
 
     /** Vault manager. */
     private final VaultManager vaultMgr;
@@ -89,9 +89,14 @@ public class LocalConfigurationStorage implements ConfigurationStorage {
      *
      * @param vaultMgr Vault manager.
      */
-    public LocalConfigurationStorage(String nodeName, VaultManager vaultMgr) {
+    public VaultConfigurationStorage(String nodeName, VaultManager vaultMgr) {
         this.vaultMgr = vaultMgr;
         this.threadPool = Executors.newFixedThreadPool(4, IgniteThreadFactory.create(nodeName, "loc-cfg", LOG));
+    }
+
+    @Override
+    public boolean userModificationsAllowed() {
+        return false;
     }
 
     @Override

--- a/modules/configuration-storage/src/test/java/org/apache/ignite/internal/configuration/storage/LocalConfigurationStorageTest.java
+++ b/modules/configuration-storage/src/test/java/org/apache/ignite/internal/configuration/storage/LocalConfigurationStorageTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 /**
- * Tests for the {@link LocalConfigurationStorage}.
+ * Tests for the {@link VaultConfigurationStorage}.
  */
 public class LocalConfigurationStorageTest extends ConfigurationStorageTest {
     private final VaultManager vaultManager = new VaultManager(new InMemoryVaultService());
@@ -51,6 +51,6 @@ public class LocalConfigurationStorageTest extends ConfigurationStorageTest {
     /** {@inheritDoc} */
     @Override
     public ConfigurationStorage getStorage() {
-        return new LocalConfigurationStorage("test-node-name", vaultManager);
+        return new VaultConfigurationStorage("test-node-name", vaultManager);
     }
 }

--- a/modules/configuration/src/main/java/org/apache/ignite/internal/configuration/storage/LocalConfigurationStorage.java
+++ b/modules/configuration/src/main/java/org/apache/ignite/internal/configuration/storage/LocalConfigurationStorage.java
@@ -1,0 +1,14 @@
+/*
+ *  Copyright (C) GridGain Systems. All Rights Reserved.
+ *  _________        _____ __________________        _____
+ *  __  ____/___________(_)______  /__  ____/______ ____(_)_______
+ *  _  / __  __  ___/__  / _  __  / _  / __  _  __ `/__  / __  __ \
+ *  / /_/ /  _  /    _  /  / /_/ /  / /_/ /  / /_/ / _  /  _  / / /
+ *  \____/   /_/     /_/   \_,__/   \____/   \__,_/  /_/   /_/ /_/
+ */
+
+package org.apache.ignite.internal.configuration.storage;
+
+public interface LocalConfigurationStorage extends ConfigurationStorage {
+    boolean userModificationsAllowed();
+}

--- a/modules/runner/src/main/java/org/apache/ignite/IgniteServer.java
+++ b/modules/runner/src/main/java/org/apache/ignite/IgniteServer.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
 import org.apache.ignite.internal.app.IgniteServerImpl;
+import org.apache.ignite.internal.app.config.NodeConfigFactory;
 import org.apache.ignite.lang.IgniteException;
 import org.jetbrains.annotations.Nullable;
 
@@ -78,6 +79,12 @@ public interface IgniteServer {
         return server;
     }
 
+    static IgniteServer start(String nodeName, NodeConfig nodeConfig, Path workDir) {
+        IgniteServer server = builder(nodeName, nodeConfig, workDir).build();
+        server.start();
+        return server;
+    }
+
     /**
      * Starts the node.
      *
@@ -97,7 +104,11 @@ public interface IgniteServer {
      * @return Node instance.
      */
     static Builder builder(String nodeName, Path configPath, Path workDir) {
-        return new Builder(nodeName, configPath, workDir);
+        return new Builder(nodeName, NodeConfigFactory.fromFile(configPath), workDir);
+    }
+
+    static Builder builder(String nodeName, NodeConfig nodeConfig, Path workDir) {
+        return new Builder(nodeName, nodeConfig, workDir);
     }
 
     /**
@@ -187,15 +198,15 @@ public interface IgniteServer {
      */
     final class Builder {
         private final String nodeName;
-        private final Path configPath;
+        private final NodeConfig nodeConfig;
         private final Path workDir;
 
         private @Nullable ClassLoader serviceLoaderClassLoader;
         private Executor asyncContinuationExecutor = ForkJoinPool.commonPool();
 
-        private Builder(String nodeName, Path configPath, Path workDir) {
+        private Builder(String nodeName, NodeConfig nodeConfig, Path workDir) {
             this.nodeName = nodeName;
-            this.configPath = configPath;
+            this.nodeConfig = nodeConfig;
             this.workDir = workDir;
         }
 
@@ -230,7 +241,7 @@ public interface IgniteServer {
         public IgniteServer build() {
             return new IgniteServerImpl(
                     nodeName,
-                    configPath,
+                    nodeConfig,
                     workDir,
                     serviceLoaderClassLoader,
                     asyncContinuationExecutor

--- a/modules/runner/src/main/java/org/apache/ignite/NodeConfig.java
+++ b/modules/runner/src/main/java/org/apache/ignite/NodeConfig.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (C) GridGain Systems. All Rights Reserved.
+ *  _________        _____ __________________        _____
+ *  __  ____/___________(_)______  /__  ____/______ ____(_)_______
+ *  _  / __  __  ___/__  / _  __  / _  / __  _  __ `/__  / __  __ \
+ *  / /_/ /  _  /    _  /  / /_/ /  / /_/ /  / /_/ / _  /  _  / / /
+ *  \____/   /_/     /_/   \_,__/   \____/   \__,_/  /_/   /_/ /_/
+ */
+
+package org.apache.ignite;
+
+import org.apache.ignite.internal.app.config.NodeConfigVisitor;
+
+public interface NodeConfig {
+    String initialContent();
+
+    <T> T visit(NodeConfigVisitor<T> visitor);
+}

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteImpl.java
@@ -57,6 +57,7 @@ import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteServer;
+import org.apache.ignite.NodeConfig;
 import org.apache.ignite.catalog.IgniteCatalog;
 import org.apache.ignite.client.handler.ClientHandlerMetricSource;
 import org.apache.ignite.client.handler.ClientHandlerModule;
@@ -68,6 +69,7 @@ import org.apache.ignite.compute.IgniteCompute;
 import org.apache.ignite.configuration.ConfigurationDynamicDefaultsPatcher;
 import org.apache.ignite.configuration.ConfigurationModule;
 import org.apache.ignite.configuration.KeyIgnorer;
+import org.apache.ignite.internal.app.config.ConfigurationStorageFactory;
 import org.apache.ignite.internal.catalog.CatalogManager;
 import org.apache.ignite.internal.catalog.CatalogManagerImpl;
 import org.apache.ignite.internal.catalog.compaction.CatalogCompactionRunner;
@@ -117,9 +119,10 @@ import org.apache.ignite.internal.configuration.SystemDistributedExtensionConfig
 import org.apache.ignite.internal.configuration.SystemLocalConfiguration;
 import org.apache.ignite.internal.configuration.SystemLocalExtensionConfiguration;
 import org.apache.ignite.internal.configuration.hocon.HoconConverter;
+import org.apache.ignite.internal.configuration.presentation.HoconPresentation;
 import org.apache.ignite.internal.configuration.storage.ConfigurationStorage;
 import org.apache.ignite.internal.configuration.storage.DistributedConfigurationStorage;
-import org.apache.ignite.internal.configuration.storage.LocalFileConfigurationStorage;
+import org.apache.ignite.internal.configuration.storage.LocalConfigurationStorage;
 import org.apache.ignite.internal.configuration.tree.ConfigurationSource;
 import org.apache.ignite.internal.configuration.validation.ConfigurationValidator;
 import org.apache.ignite.internal.configuration.validation.ConfigurationValidatorImpl;
@@ -513,7 +516,7 @@ public class IgniteImpl implements Ignite {
      * The Constructor.
      *
      * @param node Embedded node.
-     * @param configPath Path to node configuration in the HOCON format.
+     * @param nodeConfig Path to node configuration in the HOCON format.
      * @param workDir Work directory for the started node. Must not be {@code null}.
      * @param serviceProviderClassLoader The class loader to be used to load provider-configuration files and provider classes, or
      *         {@code null} if the system class loader (or, failing that the bootstrap class loader) is to be used.
@@ -522,7 +525,7 @@ public class IgniteImpl implements Ignite {
     IgniteImpl(
             IgniteServer node,
             ServerRestarter restarter,
-            Path configPath,
+            NodeConfig nodeConfig,
             Path workDir,
             @Nullable ClassLoader serviceProviderClassLoader,
             Executor asyncContinuationExecutor
@@ -550,19 +553,16 @@ public class IgniteImpl implements Ignite {
                 modules.local().polymorphicSchemaExtensions()
         );
 
-        LocalFileConfigurationStorage localFileConfigurationStorage = new LocalFileConfigurationStorage(
-                name,
-                configPath,
-                localConfigurationGenerator,
-                modules.local()
-        );
+        ConfigurationStorageFactory storageFactory = new ConfigurationStorageFactory(name, localConfigurationGenerator, vaultMgr, modules);
+
+        LocalConfigurationStorage localConfigurationStorage = nodeConfig.visit(storageFactory);
 
         ConfigurationValidator localConfigurationValidator =
                 ConfigurationValidatorImpl.withDefaultValidators(localConfigurationGenerator, modules.local().validators());
 
         nodeCfgMgr = new ConfigurationManager(
                 modules.local().rootKeys(),
-                localFileConfigurationStorage,
+                localConfigurationStorage,
                 localConfigurationGenerator,
                 localConfigurationValidator,
                 modules.local()::migrateDeprecatedConfigurations,
@@ -573,12 +573,14 @@ public class IgniteImpl implements Ignite {
         try {
             lifecycleManager.startComponentsAsync(new ComponentContext(), nodeCfgMgr);
         } catch (NodeStoppingException e) {
-            throw new AssertionError(String.format("Unexpected exception: [nodeName=%s, configPath=%s]", name, configPath), e);
+            throw new AssertionError(String.format("Unexpected exception: [nodeName=%s, configPath=%s]", name, nodeConfig), e);
         }
 
-        LOG.info("Starting node: [name={}, workDir={}, configPath={}]", name, workDir, configPath);
+        LOG.info("Starting node: [name={}, workDir={}, configPath={}]", name, workDir, nodeConfig);
 
         ConfigurationRegistry nodeConfigRegistry = nodeCfgMgr.configurationRegistry();
+
+        new HoconPresentation(nodeConfigRegistry).update(nodeConfig.initialContent());
 
         LOG.info("Local node configuration: {}", convertToHoconString(nodeConfigRegistry));
 

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteServerImpl.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/IgniteServerImpl.java
@@ -30,7 +30,6 @@ import static org.apache.ignite.lang.ErrorGroups.Common.INTERNAL_ERR;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -39,6 +38,7 @@ import java.util.function.Supplier;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteServer;
 import org.apache.ignite.InitParameters;
+import org.apache.ignite.NodeConfig;
 import org.apache.ignite.internal.eventlog.api.IgniteEventType;
 import org.apache.ignite.internal.lang.IgniteStringFormatter;
 import org.apache.ignite.internal.lang.NodeStoppingException;
@@ -87,7 +87,7 @@ public class IgniteServerImpl implements IgniteServer {
 
     private final String nodeName;
 
-    private final Path configPath;
+    private final NodeConfig nodeConfig;
 
     private final Path workDir;
 
@@ -145,7 +145,7 @@ public class IgniteServerImpl implements IgniteServer {
      */
     public IgniteServerImpl(
             String nodeName,
-            Path configPath,
+            NodeConfig nodeConfig,
             Path workDir,
             @Nullable ClassLoader classLoader,
             Executor asyncContinuationExecutor
@@ -156,11 +156,8 @@ public class IgniteServerImpl implements IgniteServer {
         if (nodeName.isEmpty()) {
             throw new NodeStartException("Node name must not be empty.");
         }
-        if (configPath == null) {
-            throw new NodeStartException("Config path must not be null");
-        }
-        if (Files.notExists(configPath)) {
-            throw new NodeStartException("Config file doesn't exist");
+        if (nodeConfig == null) {
+            throw new NodeStartException("Node config must not be null");
         }
         if (workDir == null) {
             throw new NodeStartException("Working directory must not be null");
@@ -170,7 +167,7 @@ public class IgniteServerImpl implements IgniteServer {
         }
 
         this.nodeName = nodeName;
-        this.configPath = configPath;
+        this.nodeConfig = nodeConfig;
         this.workDir = workDir;
         this.classLoader = classLoader;
         this.asyncContinuationExecutor = asyncContinuationExecutor;
@@ -389,7 +386,7 @@ public class IgniteServerImpl implements IgniteServer {
             return failedFuture(new NodeNotStartedException());
         }
 
-        IgniteImpl instance = new IgniteImpl(this, this::restartAsync, configPath, workDir, classLoader, asyncContinuationExecutor);
+        IgniteImpl instance = new IgniteImpl(this, this::restartAsync, nodeConfig, workDir, classLoader, asyncContinuationExecutor);
 
         ackBanner();
 

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/config/BootstrapNodeConfig.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/config/BootstrapNodeConfig.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (C) GridGain Systems. All Rights Reserved.
+ *  _________        _____ __________________        _____
+ *  __  ____/___________(_)______  /__  ____/______ ____(_)_______
+ *  _  / __  __  ___/__  / _  __  / _  / __  _  __ `/__  / __  __ \
+ *  / /_/ /  _  /    _  /  / /_/ /  / /_/ /  / /_/ / _  /  _  / / /
+ *  \____/   /_/     /_/   \_,__/   \____/   \__,_/  /_/   /_/ /_/
+ */
+
+package org.apache.ignite.internal.app.config;
+
+import org.apache.ignite.NodeConfig;
+
+public class BootstrapNodeConfig implements NodeConfig {
+    private final String nodeConfig;
+
+    public BootstrapNodeConfig(String nodeConfig) {
+        this.nodeConfig = nodeConfig;
+    }
+
+    public String nodeConfig() {
+        return nodeConfig;
+    }
+
+    @Override
+    public String initialContent() {
+        return nodeConfig;
+    }
+
+    @Override
+    public <T> T visit(NodeConfigVisitor<T> visitor) {
+        return visitor.visitBootstrapConfig(this);
+    }
+}

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/config/ConfigurationStorageFactory.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/config/ConfigurationStorageFactory.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (C) GridGain Systems. All Rights Reserved.
+ *  _________        _____ __________________        _____
+ *  __  ____/___________(_)______  /__  ____/______ ____(_)_______
+ *  _  / __  __  ___/__  / _  __  / _  / __  _  __ `/__  / __  __ \
+ *  / /_/ /  _  /    _  /  / /_/ /  / /_/ /  / /_/ / _  /  _  / / /
+ *  \____/   /_/     /_/   \_,__/   \____/   \__,_/  /_/   /_/ /_/
+ */
+
+package org.apache.ignite.internal.app.config;
+
+import org.apache.ignite.NodeConfig;
+import org.apache.ignite.internal.configuration.ConfigurationModules;
+import org.apache.ignite.internal.configuration.ConfigurationTreeGenerator;
+import org.apache.ignite.internal.configuration.storage.LocalConfigurationStorage;
+import org.apache.ignite.internal.configuration.storage.VaultConfigurationStorage;
+import org.apache.ignite.internal.configuration.storage.LocalFileConfigurationStorage;
+import org.apache.ignite.internal.vault.VaultManager;
+
+public class ConfigurationStorageFactory implements NodeConfigVisitor<LocalConfigurationStorage> {
+    private final String nodeName;
+
+    private final ConfigurationTreeGenerator localConfigurationGenerator;
+
+    private final VaultManager vaultManager;
+
+    private final ConfigurationModules modules;
+
+    public ConfigurationStorageFactory(
+            String nodeName,
+            ConfigurationTreeGenerator localConfigurationGenerator,
+            VaultManager vaultManager,
+            ConfigurationModules modules
+    ) {
+        this.nodeName = nodeName;
+        this.localConfigurationGenerator = localConfigurationGenerator;
+        this.vaultManager = vaultManager;
+        this.modules = modules;
+    }
+
+    @Override
+    public LocalConfigurationStorage visitFileConfig(FileNodeConfig fileNodeConfig) {
+        return new LocalFileConfigurationStorage(
+                nodeName,
+                fileNodeConfig.configPath(),
+                localConfigurationGenerator,
+                modules.local()
+        );
+    }
+
+    @Override
+    public LocalConfigurationStorage visitBootstrapConfig(BootstrapNodeConfig bootstrapNodeConfig) {
+        return new VaultConfigurationStorage(
+                nodeName,
+                vaultManager
+        );
+    }
+}

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/config/FileNodeConfig.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/config/FileNodeConfig.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) GridGain Systems. All Rights Reserved.
+ *  _________        _____ __________________        _____
+ *  __  ____/___________(_)______  /__  ____/______ ____(_)_______
+ *  _  / __  __  ___/__  / _  __  / _  / __  _  __ `/__  / __  __ \
+ *  / /_/ /  _  /    _  /  / /_/ /  / /_/ /  / /_/ / _  /  _  / / /
+ *  \____/   /_/     /_/   \_,__/   \____/   \__,_/  /_/   /_/ /_/
+ */
+
+package org.apache.ignite.internal.app.config;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.ignite.NodeConfig;
+import org.apache.ignite.internal.configuration.NodeConfigParseException;
+
+public class FileNodeConfig implements NodeConfig {
+    private final Path configPath;
+
+    public FileNodeConfig(Path configPath) {
+        this.configPath = configPath;
+    }
+
+    public Path configPath() {
+        return configPath;
+    }
+
+    @Override
+    public String initialContent() {
+        try {
+            return Files.readString(configPath);
+        } catch (IOException e) {
+            throw new NodeConfigParseException("Failed to read configuration file: " + configPath, e);
+        }
+    }
+
+    @Override
+    public <T> T visit(NodeConfigVisitor<T> visitor) {
+        return visitor.visitFileConfig(this);
+    }
+}

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/config/NodeConfigFactory.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/config/NodeConfigFactory.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (C) GridGain Systems. All Rights Reserved.
+ *  _________        _____ __________________        _____
+ *  __  ____/___________(_)______  /__  ____/______ ____(_)_______
+ *  _  / __  __  ___/__  / _  __  / _  / __  _  __ `/__  / __  __ \
+ *  / /_/ /  _  /    _  /  / /_/ /  / /_/ /  / /_/ / _  /  _  / / /
+ *  \____/   /_/     /_/   \_,__/   \____/   \__,_/  /_/   /_/ /_/
+ */
+
+package org.apache.ignite.internal.app.config;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.ignite.NodeConfig;
+import org.apache.ignite.internal.configuration.NodeConfigWriteException;
+
+public class NodeConfigFactory {
+    public static NodeConfig fromFile(Path configPath) {
+        if (!Files.isWritable(configPath)) {
+            throw new NodeConfigWriteException(
+                    "The configuration file is read-only, so changes cannot be applied. "
+                            + "Check your system configuration. "
+                            + "If you are using containerization, such as Kubernetes, "
+                            + "the file can only be modified through native Kubernetes methods."
+            );
+        }
+        return new FileNodeConfig(configPath);
+    }
+
+    public static NodeConfig fromBootstrap(String nodeConfig) {
+
+        return new BootstrapNodeConfig(nodeConfig);
+    }
+}

--- a/modules/runner/src/main/java/org/apache/ignite/internal/app/config/NodeConfigVisitor.java
+++ b/modules/runner/src/main/java/org/apache/ignite/internal/app/config/NodeConfigVisitor.java
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (C) GridGain Systems. All Rights Reserved.
+ *  _________        _____ __________________        _____
+ *  __  ____/___________(_)______  /__  ____/______ ____(_)_______
+ *  _  / __  __  ___/__  / _  __  / _  / __  _  __ `/__  / __  __ \
+ *  / /_/ /  _  /    _  /  / /_/ /  / /_/ /  / /_/ / _  /  _  / / /
+ *  \____/   /_/     /_/   \_,__/   \____/   \__,_/  /_/   /_/ /_/
+ */
+
+package org.apache.ignite.internal.app.config;
+
+public interface NodeConfigVisitor<T> {
+    T visitFileConfig(FileNodeConfig fileNodeConfig);
+
+    T visitBootstrapConfig(BootstrapNodeConfig bootstrapNodeConfig);
+}


### PR DESCRIPTION
# Bootstrap Configuration Feature Design Document

## Overview

This document describes the introduction of the `--bootstrap-config` command-line option to Ignite 3, which enables users to provide read-only configuration directly as a string parameter instead of relying on configuration files.

## Background

Previously, Ignite nodes could only be configured using configuration files specified via the `--config-path` option. This approach presented challenges in containerized environments, particularly with Kubernetes, where:

- Configuration files might be mounted as read-only volumes
- Dynamic configuration injection is limited by file system constraints
- Container orchestration platforms prefer configuration-as-code approaches
- Immutable infrastructure patterns require configuration to be baked into deployment descriptors

## Feature Description

### New Command Line Option

The `--bootstrap-config` option allows users to provide node configuration directly as a string parameter containing HOCON (Human-Optimized Config Object Notation) formatted configuration.

**Usage:**
```bash
# Traditional file-based configuration
java -jar ignite3-runner.jar --node-name myNode --work-dir /opt/ignite3/work --config-path /path/to/config.hocon

# New bootstrap configuration approach
java -jar ignite3-server.jar --node-name myNode --work-dir /opt/ignite3/work --bootstrap-config "{ node: { network: { port: 3322 } } }"
```

### Key Benefits

1. **Container-Native Configuration**: Enables seamless integration with container orchestration platforms
2. **Immutable Infrastructure**: Supports configuration-as-code practices where configuration is embedded in deployment manifests
3. **Simplified Deployment**: Eliminates the need for separate configuration file management in containerized environments
4. **Read-Only Compliance**: Works with read-only file systems and security-hardened environments

## Technical Implementation

### Configuration Architecture

The implementation introduces a new abstraction layer through the `NodeConfig` interface that supports multiple configuration sources:

- **File-based Configuration**: Traditional approach using `FileNodeConfig`
- **Bootstrap Configuration**: New approach using `BootstrapNodeConfig`

### Command Line Interface

The command line interface now uses mutually exclusive configuration options:
- Either `--config-path` for file-based configuration
- Or `--bootstrap-config` for inline configuration

This ensures users cannot accidentally specify both options simultaneously.

### Configuration Processing

The system uses a visitor pattern to handle different configuration types uniformly, allowing the same downstream processing logic to work with both file-based and bootstrap configurations.

### Configuration Storage and Persistence

Bootstrap configuration works differently from file-based configuration in terms of storage and mutability:

- **Vault Storage**: Bootstrap configuration is stored in the Ignite vault (persistent key-value storage) rather than in files
- **Initial Population**: The bootstrap configuration string is used to populate the vault storage during node startup
- **Read-Only Nature**: Bootstrap configuration cannot be modified through REST API or CLI commands once the node is started
- **No File Updates**: Unlike file-based configuration, changes are not written back to any configuration files
- **Restart Required**: Any configuration changes require restarting the node with a new bootstrap configuration string
- **Immutable Operations**: Administrative operations that attempt to modify configuration will be rejected with appropriate error messages

This design ensures consistency with containerized deployment patterns where configuration is expected to be immutable and managed through infrastructure-as-code practices.

## Use Cases

### Container Orchestration

**Kubernetes Deployment:**
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: ignite-cluster
spec:
  template:
    spec:
      containers:
      - name: ignite
        image: ignite3/ignite3:3.x
        args:
        - --node-name=$(POD_NAME)
        - --work-dir=/opt/ignite3/work
        - --bootstrap-config={ "cluster": { "name": "my-cluster" }, "network": { "port": 3322 } }
```

### Cloud-Native Deployments

**Docker Compose:**
```yaml
services:
  ignite-node:
    image: ignite3/ignite3:3.x
    command: >
      --node-name=node1
      --work-dir=/opt/igntie/work
      --bootstrap-config={"cluster":{"name":"docker-cluster"},"network":{"port":3322}}
```

### Development and Testing

Developers can quickly spin up nodes with specific configurations without creating temporary configuration files, making testing and development more efficient.

## Migration Strategy

### Backward Compatibility

The existing `--config-path` option remains fully supported. All existing deployments and scripts will continue to work without modification.
