### PR TITLE
IGNITE-26163 Improve migration error logging of RecordAndTableSchemaMismatchException to also show the table name

### DIFF
--- a/migration-tools/modules/migration-tools-cli/src/main/java/org/apache/ignite/migrationtools/cli/exceptions/RecordAndTableSchemaMismatchExceptionHandler.java
+++ b/migration-tools/modules/migration-tools-cli/src/main/java/org/apache/ignite/migrationtools/cli/exceptions/RecordAndTableSchemaMismatchExceptionHandler.java
@@ -28,6 +28,23 @@ public class RecordAndTableSchemaMismatchExceptionHandler implements ExceptionHa
 
     @Override
     public int handle(ExceptionWriter writer, RecordAndTableSchemaMismatchException e) {
+        writer.write(
+                ErrorUiComponent.builder()
+                        .header(DefaultMigrateCacheExceptionHandler.HEADER)
+                        .details(details(e))
+                .build()
+                .render());
+
+        return 1;
+    }
+
+    /**
+     * Builds the details output.
+     *
+     * @param e Exception.
+     * @return The output as String.
+     */
+    public static String details(RecordAndTableSchemaMismatchException e) {
         StringBuilder msgBuilder = new StringBuilder();
         msgBuilder.append("Mismatch between cache records and the target table definition."
                 + "\nAt least one record in the cache was not compatible with the target table definition.");
@@ -53,15 +70,7 @@ public class RecordAndTableSchemaMismatchExceptionHandler implements ExceptionHa
                             + " While Ignite 3 does not natively support unmarshalling the original record from this column, it can be"
                             + " accessed by another application to retrieve the information contained in these additional fields.");
         }
-
-        writer.write(
-                ErrorUiComponent.builder()
-                        .header(DefaultMigrateCacheExceptionHandler.HEADER)
-                        .details(msgBuilder.toString())
-                .build()
-                .render());
-
-        return 1;
+        return msgBuilder.toString();
     }
 
     @Override

--- a/migration-tools/modules/migration-tools-persistence/src/main/java/org/apache/ignite/migrationtools/persistence/Ignite2PersistentCacheTools.java
+++ b/migration-tools/modules/migration-tools-persistence/src/main/java/org/apache/ignite/migrationtools/persistence/Ignite2PersistentCacheTools.java
@@ -20,6 +20,7 @@ package org.apache.ignite.migrationtools.persistence;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -34,7 +35,9 @@ import org.apache.ignite.internal.processors.cache.DynamicCacheDescriptor;
 import org.apache.ignite.internal.processors.cache.IgniteCacheOffheapManager;
 import org.apache.ignite.internal.processors.cache.persistence.CacheDataRow;
 import org.apache.ignite.internal.util.lang.GridCursor;
+import org.apache.ignite.migrationtools.persistence.exceptions.MigrateCacheException;
 import org.apache.ignite.migrationtools.persistence.mappers.CacheDataRowProcessor;
+import org.apache.ignite.migrationtools.persistence.utils.pubsub.BasicProcessor;
 import org.apache.ignite.migrationtools.persistence.utils.pubsub.StreamerPublisher;
 import org.apache.ignite.migrationtools.sql.SqlDdlGenerator;
 import org.apache.ignite.migrationtools.tablemanagement.SchemaUtils;
@@ -196,6 +199,7 @@ public class Ignite2PersistentCacheTools {
 
         var view = table.keyValueView();
         ClientSchema schema = SchemaUtils.getLatestSchemaForTable(table).join();
+        String tableName = table.name();
 
         // TODO: GG-40802 Allow more control on the converters side.
         // Call dump table
@@ -206,6 +210,24 @@ public class Ignite2PersistentCacheTools {
                                 schema,
                                 columnToFieldMappings,
                                 StaticTypeConverterFactory.DEFAULT_INSTANCE))
+                        .map(itemPublisher -> {
+                                var p = new BasicProcessor<DataStreamerItem<Map.Entry<Tuple, Tuple>>,
+                                        DataStreamerItem<Map.Entry<Tuple, Tuple>>>() {
+                                    @Override
+                                    public void onNext(DataStreamerItem<Entry<Tuple, Tuple>> item) {
+                                        subscriber.onNext(item);
+                                    }
+
+                                    @Override
+                                    public void onError(Throwable throwable) {
+                                        super.onError(new MigrateCacheException(cacheName, tableName, throwable));
+                                    }
+                                };
+
+                                itemPublisher.subscribe(p);
+                                return p;
+                            }
+                        )
                         .map((itemPublisher) -> view.streamData(itemPublisher, null)));
     }
 

--- a/migration-tools/modules/migration-tools-persistence/src/main/java/org/apache/ignite/migrationtools/persistence/exceptions/MigrateCacheException.java
+++ b/migration-tools/modules/migration-tools-persistence/src/main/java/org/apache/ignite/migrationtools/persistence/exceptions/MigrateCacheException.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.migrationtools.persistence.exceptions;
+
+/** MigrateCacheException. */
+public class MigrateCacheException extends Exception {
+    private final String cacheName;
+
+    private final String tableName;
+
+    /**
+     * Default constructor.
+     *
+     * @param cacheName Cache Name.
+     * @param tableName Table Name.
+     * @param cause Underlying cause of the error.
+     */
+    public MigrateCacheException(String cacheName, String tableName, Throwable cause) {
+        super("Error while migrating cache:(" + cacheName + ") to table:(" + tableName + ")", cause);
+        this.cacheName = cacheName;
+        this.tableName = tableName;
+    }
+
+    public String cacheName() {
+        return cacheName;
+    }
+
+    public String tableName() {
+        return tableName;
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-26163

- Improve migrate error reporting by adding a wrapper exception with cache and table names
- Improve migrate cache cli error reporting by adding cache and table names to the message