### PR TITLE
IGNITE-26087 Ability to obtain results of a multi-statement query execution using the internal thin client SQL API.

### DIFF
--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientOp.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/proto/ClientOp.java
@@ -200,6 +200,9 @@ public class ClientOp {
     /** Response to a server->client operation. */
     public static final int SERVER_OP_RESPONSE = 73;
 
+    /** Get next result set. */
+    public static final int SQL_CURSOR_NEXT_RESULT_SET = 74;
+
     /** Reserved for extensions: min. */
     @SuppressWarnings("unused")
     public static final int RESERVED_EXTENSION_RANGE_START = 1000;

--- a/modules/client-common/src/main/java/org/apache/ignite/internal/client/sql/QueryModifier.java
+++ b/modules/client-common/src/main/java/org/apache/ignite/internal/client/sql/QueryModifier.java
@@ -34,13 +34,16 @@ public enum QueryModifier {
     ALLOW_APPLIED_RESULT(2),
 
     /** Queries with transaction control statements. */
-    ALLOW_TX_CONTROL(3);
+    ALLOW_TX_CONTROL(3),
+
+    /** Queries with multiple statements. */
+    ALLOW_MULTISTATEMENT(4);
 
     /** A set containing all modifiers. **/
     public static final Set<QueryModifier> ALL = EnumSet.allOf(QueryModifier.class);
 
     /** A set of modifiers that can apply to single statements. **/
-    public static final Set<QueryModifier> SINGLE_STMT_MODIFIERS = EnumSet.complementOf(EnumSet.of(ALLOW_TX_CONTROL));
+    public static final Set<QueryModifier> SINGLE_STMT_MODIFIERS = EnumSet.complementOf(EnumSet.of(ALLOW_TX_CONTROL, ALLOW_MULTISTATEMENT));
 
     private static final QueryModifier[] VALS = new QueryModifier[values().length];
 

--- a/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/sql/QueryModifierTest.java
+++ b/modules/client-common/src/test/java/org/apache/ignite/internal/client/proto/sql/QueryModifierTest.java
@@ -58,7 +58,10 @@ public class QueryModifierTest {
                 Arguments.of(Set.of(QueryModifier.ALLOW_ROW_SET_RESULT, QueryModifier.ALLOW_AFFECTED_ROWS_RESULT)),
                 Arguments.of(Set.of(QueryModifier.ALLOW_AFFECTED_ROWS_RESULT, QueryModifier.ALLOW_APPLIED_RESULT)),
                 Arguments.of(Set.of(QueryModifier.ALLOW_APPLIED_RESULT, QueryModifier.ALLOW_TX_CONTROL)),
-                Arguments.of(Set.of(QueryModifier.ALLOW_TX_CONTROL, QueryModifier.ALLOW_ROW_SET_RESULT)),
+                Arguments.of(Set.of(QueryModifier.ALLOW_TX_CONTROL, QueryModifier.ALLOW_MULTISTATEMENT)),
+                Arguments.of(Set.of(QueryModifier.ALLOW_MULTISTATEMENT, QueryModifier.ALLOW_ROW_SET_RESULT)),
+                Arguments.of(Set.of(QueryModifier.ALLOW_ROW_SET_RESULT, QueryModifier.ALLOW_MULTISTATEMENT,
+                        QueryModifier.ALLOW_APPLIED_RESULT)),
                 Arguments.of(QueryModifier.ALL));
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientInboundMessageHandler.java
@@ -80,6 +80,7 @@ import org.apache.ignite.client.handler.requests.jdbc.ClientJdbcTableMetadataReq
 import org.apache.ignite.client.handler.requests.jdbc.JdbcMetadataCatalog;
 import org.apache.ignite.client.handler.requests.sql.ClientSqlCursorCloseRequest;
 import org.apache.ignite.client.handler.requests.sql.ClientSqlCursorNextPageRequest;
+import org.apache.ignite.client.handler.requests.sql.ClientSqlCursorNextResultRequest;
 import org.apache.ignite.client.handler.requests.sql.ClientSqlExecuteBatchRequest;
 import org.apache.ignite.client.handler.requests.sql.ClientSqlExecuteRequest;
 import org.apache.ignite.client.handler.requests.sql.ClientSqlExecuteScriptRequest;
@@ -947,6 +948,9 @@ public class ClientInboundMessageHandler
                         clockService, notificationSender(requestId), resolveCurrentUsername(),
                         clientContext.hasFeature(SQL_MULTISTATEMENT_SUPPORT)
                 );
+
+            case ClientOp.SQL_CURSOR_NEXT_RESULT_SET:
+                return ClientSqlCursorNextResultRequest.process(in, resources, partitionOperationsExecutor, metrics);
 
             case ClientOp.OPERATION_CANCEL:
                 return ClientOperationCancelRequest.process(in, cancelHandles);

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientResourceRegistry.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/ClientResourceRegistry.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.ignite.internal.lang.IgniteInternalCheckedException;
 import org.apache.ignite.internal.lang.IgniteInternalException;
 import org.apache.ignite.internal.util.IgniteSpinBusyLock;
+import org.jetbrains.annotations.TestOnly;
 
 /**
  * Per-connection resource registry.
@@ -138,6 +139,11 @@ public class ClientResourceRegistry {
         if (ex != null) {
             throw ex;
         }
+    }
+
+    @TestOnly
+    public int size() {
+        return res.size();
     }
 
     /**

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlCommon.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlCommon.java
@@ -23,15 +23,28 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.apache.ignite.client.handler.ClientHandlerMetricSource;
+import org.apache.ignite.client.handler.ClientResource;
+import org.apache.ignite.client.handler.ClientResourceRegistry;
+import org.apache.ignite.client.handler.ResponseWriter;
 import org.apache.ignite.internal.binarytuple.BinaryTupleBuilder;
 import org.apache.ignite.internal.client.proto.ClientMessagePacker;
 import org.apache.ignite.internal.client.sql.QueryModifier;
+import org.apache.ignite.internal.lang.IgniteInternalCheckedException;
+import org.apache.ignite.internal.lang.IgniteInternalException;
+import org.apache.ignite.internal.sql.api.AsyncResultSetImpl;
+import org.apache.ignite.internal.sql.engine.AsyncSqlCursor;
+import org.apache.ignite.internal.sql.engine.InternalSqlRow;
 import org.apache.ignite.internal.sql.engine.SqlQueryType;
+import org.apache.ignite.internal.sql.engine.prepare.partitionawareness.PartitionAwarenessMetadata;
+import org.apache.ignite.internal.util.AsyncCursor;
 import org.apache.ignite.sql.ColumnMetadata;
 import org.apache.ignite.sql.ColumnMetadata.ColumnOrigin;
 import org.apache.ignite.sql.ResultSetMetadata;
 import org.apache.ignite.sql.SqlRow;
 import org.apache.ignite.sql.async.AsyncResultSet;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Common SQL request handling logic.
@@ -223,11 +236,148 @@ class ClientSqlCommon {
                     queryTypes.add(SqlQueryType.TX_CONTROL);
                     break;
 
+                case ALLOW_MULTISTATEMENT:
+                    break;
+
                 default:
                     throw new IllegalArgumentException("Unexpected modifier " + queryModifier);
             }
         }
 
         return queryTypes;
+    }
+
+    static CompletableFuture<ResponseWriter> writeResultSetAsync(
+            ClientResourceRegistry resources,
+            AsyncResultSetImpl asyncResultSet,
+            ClientHandlerMetricSource metrics,
+            int pageSize,
+            boolean includePartitionAwarenessMeta,
+            boolean sqlDirectTxMappingSupported,
+            boolean sqlMultiStatementSupported
+    ) {
+        try {
+            Long nextResultResourceId = sqlMultiStatementSupported && asyncResultSet.cursor().hasNextResult()
+                    ? saveNextResult(asyncResultSet.cursor().nextResult(), pageSize, resources)
+                    : null;
+
+            if ((asyncResultSet.hasRowSet() && asyncResultSet.hasMorePages())) {
+                metrics.cursorsActiveIncrement();
+
+                var clientResultSet = new ClientSqlResultSet(asyncResultSet, metrics);
+
+                ClientResource resource = new ClientResource(
+                        clientResultSet,
+                        clientResultSet::closeAsync);
+
+                var resourceId = resources.put(resource);
+
+                return CompletableFuture.completedFuture(out ->
+                        writeResultSet(out, asyncResultSet, resourceId, includePartitionAwarenessMeta, sqlDirectTxMappingSupported,
+                                sqlMultiStatementSupported, nextResultResourceId));
+            }
+            return asyncResultSet.closeAsync()
+                    .thenApply(v -> (ResponseWriter) out ->
+                            writeResultSet(out, asyncResultSet, null, includePartitionAwarenessMeta, sqlDirectTxMappingSupported,
+                                    sqlMultiStatementSupported, nextResultResourceId));
+
+        } catch (IgniteInternalCheckedException e) {
+            return asyncResultSet
+                    .closeAsync()
+                    .thenRun(() -> {
+                        throw new IgniteInternalException(e.getMessage(), e);
+                    });
+        }
+    }
+
+    private static Long saveNextResult(
+            CompletableFuture<AsyncSqlCursor<InternalSqlRow>> nextResultFuture,
+            int pageSize,
+            ClientResourceRegistry resources
+    ) throws IgniteInternalCheckedException {
+        ClientResource resource = new ClientResource(
+                new CursorWithPageSize(nextResultFuture, pageSize),
+                () -> nextResultFuture.thenApply(AsyncCursor::closeAsync));
+
+        return resources.put(resource);
+    }
+
+    private static void writeResultSet(
+            ClientMessagePacker out,
+            AsyncResultSetImpl res,
+            @Nullable Long resourceId,
+            boolean includePartitionAwarenessMeta,
+            boolean sqlDirectTxMappingSupported,
+            boolean sqlMultiStatementsSupported,
+            @Nullable Long nextResultResourceId
+    ) {
+        out.packLongNullable(resourceId);
+
+        out.packBoolean(res.hasRowSet());
+        out.packBoolean(res.hasMorePages());
+        out.packBoolean(res.wasApplied());
+        out.packLong(res.affectedRows());
+
+        packMeta(out, res.metadata());
+
+        if (includePartitionAwarenessMeta) {
+            packPartitionAwarenessMeta(out, res.partitionAwarenessMetadata(), sqlDirectTxMappingSupported);
+        }
+
+        if (sqlMultiStatementsSupported) {
+            out.packLongNullable(nextResultResourceId);
+        }
+
+        if (res.hasRowSet()) {
+            packCurrentPage(out, res);
+        }
+    }
+
+    private static void packMeta(ClientMessagePacker out, @Nullable ResultSetMetadata meta) {
+        // TODO IGNITE-17179 metadata caching - avoid sending same meta over and over.
+        if (meta == null || meta.columns() == null) {
+            out.packInt(0);
+            return;
+        }
+
+        packColumns(out, meta.columns());
+    }
+
+    private static void packPartitionAwarenessMeta(
+            ClientMessagePacker out,
+            @Nullable PartitionAwarenessMetadata meta,
+            boolean sqlDirectTxMappingSupported
+    ) {
+        if (meta == null) {
+            out.packNil();
+            return;
+        }
+
+        out.packInt(meta.tableId());
+        out.packIntArray(meta.indexes());
+        out.packIntArray(meta.hash());
+
+        if (sqlDirectTxMappingSupported) {
+            out.packByte(meta.directTxMode().id);
+        }
+    }
+
+    /** Holder of the cursor future and page size. */
+    static class CursorWithPageSize {
+        private final CompletableFuture<AsyncSqlCursor<InternalSqlRow>> cursorFuture;
+        private final int pageSize;
+
+        CursorWithPageSize(CompletableFuture<AsyncSqlCursor<InternalSqlRow>> cursorFuture, int pageSize) {
+            this.cursorFuture = cursorFuture;
+            this.pageSize = pageSize;
+        }
+
+        CompletableFuture<AsyncSqlCursor<InternalSqlRow>> cursorFuture() {
+            return cursorFuture;
+        }
+
+        int pageSize() {
+            return pageSize;
+        }
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlCommon.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlCommon.java
@@ -258,7 +258,7 @@ class ClientSqlCommon {
     ) {
         try {
             Long nextResultResourceId = sqlMultiStatementSupported && asyncResultSet.cursor().hasNextResult()
-                    ? saveNextResult(asyncResultSet.cursor().nextResult(), pageSize, resources)
+                    ? saveNextResultResource(asyncResultSet.cursor().nextResult(), pageSize, resources)
                     : null;
 
             if ((asyncResultSet.hasRowSet() && asyncResultSet.hasMorePages())) {
@@ -273,15 +273,17 @@ class ClientSqlCommon {
                 var resourceId = resources.put(resource);
 
                 return CompletableFuture.completedFuture(out ->
-                        writeResultSet(out, asyncResultSet, resourceId, includePartitionAwarenessMeta, sqlDirectTxMappingSupported,
-                                sqlMultiStatementSupported, nextResultResourceId));
+                        writeResultSet(out, asyncResultSet, resourceId, includePartitionAwarenessMeta,
+                                sqlDirectTxMappingSupported, sqlMultiStatementSupported, nextResultResourceId));
             }
+
             return asyncResultSet.closeAsync()
                     .thenApply(v -> (ResponseWriter) out ->
-                            writeResultSet(out, asyncResultSet, null, includePartitionAwarenessMeta, sqlDirectTxMappingSupported,
-                                    sqlMultiStatementSupported, nextResultResourceId));
+                            writeResultSet(out, asyncResultSet, null, includePartitionAwarenessMeta,
+                                    sqlDirectTxMappingSupported, sqlMultiStatementSupported, nextResultResourceId));
 
         } catch (IgniteInternalCheckedException e) {
+            // Resource registry was closed.
             return asyncResultSet
                     .closeAsync()
                     .thenRun(() -> {
@@ -290,7 +292,7 @@ class ClientSqlCommon {
         }
     }
 
-    private static Long saveNextResult(
+    private static Long saveNextResultResource(
             CompletableFuture<AsyncSqlCursor<InternalSqlRow>> nextResultFuture,
             int pageSize,
             ClientResourceRegistry resources

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlCursorNextResultRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlCursorNextResultRequest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client.handler.requests.sql;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.apache.ignite.client.handler.ClientHandlerMetricSource;
+import org.apache.ignite.client.handler.ClientResource;
+import org.apache.ignite.client.handler.ClientResourceRegistry;
+import org.apache.ignite.client.handler.ResponseWriter;
+import org.apache.ignite.client.handler.requests.sql.ClientSqlCommon.CursorWithPageSize;
+import org.apache.ignite.internal.client.proto.ClientMessageUnpacker;
+import org.apache.ignite.internal.lang.IgniteInternalCheckedException;
+import org.apache.ignite.internal.sql.api.AsyncResultSetImpl;
+import org.apache.ignite.sql.SqlRow;
+
+/**
+ * Client SQL cursor next result.
+ */
+public class ClientSqlCursorNextResultRequest {
+    /**
+     * Processes the request.
+     *
+     * @param in Unpacker.
+     * @return Future representing result of operation.
+     */
+    public static CompletableFuture<ResponseWriter> process(
+            ClientMessageUnpacker in,
+            ClientResourceRegistry resources,
+            Executor operationExecutor,
+            ClientHandlerMetricSource metrics
+    ) throws IgniteInternalCheckedException {
+        long resourceId = in.unpackLong();
+        ClientResource resource = resources.remove(resourceId);
+        CursorWithPageSize cursorWithPageSize = resource.get(CursorWithPageSize.class);
+        int pageSize = cursorWithPageSize.pageSize();
+
+        return cursorWithPageSize.cursorFuture()
+                .thenComposeAsync(cur -> cur.requestNextAsync(pageSize)
+                        .thenApply(batchRes -> new AsyncResultSetImpl<SqlRow>(
+                                        cur,
+                                        batchRes,
+                                        pageSize
+                                )
+                        ).thenCompose(asyncResultSet ->
+                                ClientSqlCommon.writeResultSetAsync(resources, asyncResultSet, metrics, pageSize, false, false, true)
+                        ).thenApply(rsWriter -> rsWriter), operationExecutor);
+    }
+}

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlExecuteRequest.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlExecuteRequest.java
@@ -17,39 +17,38 @@
 
 package org.apache.ignite.client.handler.requests.sql;
 
-import static org.apache.ignite.client.handler.requests.sql.ClientSqlCommon.packCurrentPage;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.readTx;
 import static org.apache.ignite.client.handler.requests.table.ClientTableCommon.writeTxMeta;
 import static org.apache.ignite.internal.lang.SqlExceptionMapperUtil.mapToPublicSqlException;
+import static org.apache.ignite.internal.util.CompletableFutures.allOf;
 import static org.apache.ignite.internal.util.CompletableFutures.nullCompletedFuture;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
+import java.util.function.Function;
 import org.apache.ignite.client.handler.ClientHandlerMetricSource;
-import org.apache.ignite.client.handler.ClientResource;
 import org.apache.ignite.client.handler.ClientResourceRegistry;
 import org.apache.ignite.client.handler.NotificationSender;
 import org.apache.ignite.client.handler.ResponseWriter;
-import org.apache.ignite.internal.client.proto.ClientMessagePacker;
 import org.apache.ignite.internal.client.proto.ClientMessageUnpacker;
 import org.apache.ignite.internal.hlc.ClockService;
 import org.apache.ignite.internal.hlc.HybridTimestamp;
 import org.apache.ignite.internal.hlc.HybridTimestampTracker;
-import org.apache.ignite.internal.lang.IgniteInternalCheckedException;
-import org.apache.ignite.internal.lang.IgniteInternalException;
 import org.apache.ignite.internal.sql.api.AsyncResultSetImpl;
+import org.apache.ignite.internal.sql.engine.AsyncSqlCursor;
+import org.apache.ignite.internal.sql.engine.InternalSqlRow;
 import org.apache.ignite.internal.sql.engine.QueryProcessor;
 import org.apache.ignite.internal.sql.engine.SqlProperties;
-import org.apache.ignite.internal.sql.engine.prepare.partitionawareness.PartitionAwarenessMetadata;
 import org.apache.ignite.internal.tx.InternalTransaction;
 import org.apache.ignite.internal.tx.TxManager;
 import org.apache.ignite.internal.util.ArrayUtils;
 import org.apache.ignite.internal.util.ExceptionUtils;
 import org.apache.ignite.lang.CancelHandle;
 import org.apache.ignite.lang.CancellationToken;
-import org.apache.ignite.sql.ResultSetMetadata;
 import org.apache.ignite.sql.SqlRow;
 import org.apache.ignite.tx.Transaction;
 import org.jetbrains.annotations.Nullable;
@@ -57,7 +56,6 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Client SQL execute request.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class ClientSqlExecuteRequest {
     /**
      * Processes the request.
@@ -128,7 +126,8 @@ public class ClientSqlExecuteRequest {
                 () -> cancelHandles.remove(requestId),
                 arguments
         ).thenCompose(asyncResultSet ->
-                        writeResultSetAsync(resources, asyncResultSet, metrics, includePartitionAwarenessMeta, sqlDirectTxMappingSupported))
+                        ClientSqlCommon.writeResultSetAsync(resources, asyncResultSet, metrics, props.pageSize(),
+                                includePartitionAwarenessMeta, sqlDirectTxMappingSupported, sqlMultistatementsSupported))
                 .thenApply(rsWriter -> out -> {
                     if (tx != null) {
                         writeTxMeta(out, timestampTracker, clockService, tx, resIdHolder[0]);
@@ -144,95 +143,6 @@ public class ClientSqlExecuteRequest {
 
         // SQL engine requires non-null arguments, but we don't want to complicate the protocol with this requirement.
         return arguments == null ? ArrayUtils.OBJECT_EMPTY_ARRAY : arguments;
-    }
-
-    private static CompletableFuture<ResponseWriter> writeResultSetAsync(
-            ClientResourceRegistry resources,
-            AsyncResultSetImpl asyncResultSet,
-            ClientHandlerMetricSource metrics,
-            boolean includePartitionAwarenessMeta,
-            boolean sqlDirectTxMappingSupported
-    ) {
-        if (asyncResultSet.hasRowSet() && asyncResultSet.hasMorePages()) {
-            try {
-                metrics.cursorsActiveIncrement();
-
-                var clientResultSet = new ClientSqlResultSet(asyncResultSet, metrics);
-
-                ClientResource resource = new ClientResource(
-                        clientResultSet,
-                        clientResultSet::closeAsync);
-
-                var resourceId = resources.put(resource);
-
-                return CompletableFuture.completedFuture(out ->
-                        writeResultSet(out, asyncResultSet, resourceId, includePartitionAwarenessMeta, sqlDirectTxMappingSupported));
-            } catch (IgniteInternalCheckedException e) {
-                return asyncResultSet
-                        .closeAsync()
-                        .thenRun(() -> {
-                            throw new IgniteInternalException(e.getMessage(), e);
-                        });
-            }
-        }
-
-        return asyncResultSet.closeAsync()
-                .thenApply(v -> (ResponseWriter) out ->
-                        writeResultSet(out, asyncResultSet, null, includePartitionAwarenessMeta, sqlDirectTxMappingSupported));
-    }
-
-    private static void writeResultSet(
-            ClientMessagePacker out,
-            AsyncResultSetImpl res,
-            @Nullable Long resourceId,
-            boolean includePartitionAwarenessMeta,
-            boolean sqlDirectTxMappingSupported
-    ) {
-        out.packLongNullable(resourceId);
-
-        out.packBoolean(res.hasRowSet());
-        out.packBoolean(res.hasMorePages());
-        out.packBoolean(res.wasApplied());
-        out.packLong(res.affectedRows());
-
-        packMeta(out, res.metadata());
-
-        if (includePartitionAwarenessMeta) {
-            packPartitionAwarenessMeta(out, res.partitionAwarenessMetadata(), sqlDirectTxMappingSupported);
-        }
-
-        if (res.hasRowSet()) {
-            packCurrentPage(out, res);
-        }
-    }
-
-    private static void packMeta(ClientMessagePacker out, @Nullable ResultSetMetadata meta) {
-        // TODO IGNITE-17179 metadata caching - avoid sending same meta over and over.
-        if (meta == null || meta.columns() == null) {
-            out.packInt(0);
-            return;
-        }
-
-        ClientSqlCommon.packColumns(out, meta.columns());
-    }
-
-    private static void packPartitionAwarenessMeta(
-            ClientMessagePacker out,
-            @Nullable PartitionAwarenessMetadata meta,
-            boolean sqlDirectTxMappingSupported
-    ) {
-        if (meta == null) {
-            out.packNil();
-            return;
-        }
-
-        out.packInt(meta.tableId());
-        out.packIntArray(meta.indexes());
-        out.packIntArray(meta.hash());
-
-        if (sqlDirectTxMappingSupported) {
-            out.packByte(meta.directTxMode().id);
-        }
     }
 
     private static CompletableFuture<AsyncResultSetImpl<SqlRow>> executeAsync(
@@ -256,7 +166,7 @@ public class ClientSqlExecuteRequest {
                         arguments
                     )
                     .thenCompose(cur -> {
-                                cur.onClose().whenComplete((none, ignore) -> onComplete.run());
+                                doWhenAllCursorsComplete(cur, onComplete);
 
                                 return cur.requestNextAsync(pageSize)
                                         .thenApply(
@@ -279,5 +189,31 @@ public class ClientSqlExecuteRequest {
         } catch (Exception e) {
             return CompletableFuture.failedFuture(mapToPublicSqlException(e));
         }
+    }
+
+    private static void doWhenAllCursorsComplete(AsyncSqlCursor<InternalSqlRow> cursor, Runnable action) {
+        List<CompletableFuture<?>> dependency = new ArrayList<>();
+        var cursorChainTraverser = new Function<AsyncSqlCursor<?>, CompletableFuture<AsyncSqlCursor<?>>>() {
+            @Override
+            public CompletableFuture<AsyncSqlCursor<?>> apply(AsyncSqlCursor<?> cursor) {
+                dependency.add(cursor.onClose());
+
+                if (cursor.hasNextResult()) {
+                    return cursor.nextResult().thenCompose(this);
+                }
+
+                return allOf(dependency)
+                        .thenRun(action)
+                        .thenApply(ignored -> cursor);
+            }
+        };
+
+        cursorChainTraverser
+                .apply(cursor)
+                .exceptionally(ex -> {
+                    action.run();
+
+                    return null;
+                });
     }
 }

--- a/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlProperties.java
+++ b/modules/client-handler/src/main/java/org/apache/ignite/client/handler/requests/sql/ClientSqlProperties.java
@@ -75,7 +75,7 @@ class ClientSqlProperties {
         SqlProperties sqlProperties = new SqlProperties()
                 .queryTimeout(queryTimeout)
                 .allowedQueryTypes(ClientSqlCommon.convertQueryModifierToQueryType(queryModifiers))
-                .allowMultiStatement(false);
+                .allowMultiStatement(queryModifiers.contains(QueryModifier.ALLOW_MULTISTATEMENT));
 
         if (schema != null) {
             sqlProperties.defaultSchema(schema);

--- a/modules/client-handler/src/test/java/org/apache/ignite/client/handler/requests/sql/ClientSqlCommonTest.java
+++ b/modules/client-handler/src/test/java/org/apache/ignite/client/handler/requests/sql/ClientSqlCommonTest.java
@@ -43,7 +43,7 @@ public class ClientSqlCommonTest {
     void testConvertQueryModifierToQueryType(QueryModifier type) {
         Set<SqlQueryType> sqlQueryTypes = ClientSqlCommon.convertQueryModifierToQueryType(Set.of(type));
 
-        assertFalse(sqlQueryTypes.isEmpty());
+        assertThat(sqlQueryTypes.isEmpty(), is(type == QueryModifier.ALLOW_MULTISTATEMENT));
 
         sqlQueryTypes.forEach(sqlQueryType -> {
             switch (type) {

--- a/modules/client/src/main/java/org/apache/ignite/client/ClientOperationType.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/ClientOperationType.java
@@ -176,6 +176,11 @@ public enum ClientOperationType {
     SQL_CURSOR_NEXT_PAGE,
 
     /**
+     * SQL Cursor Next ResultSet.
+     */
+    SQL_CURSOR_NEXT_RESULT_SET,
+
+    /**
      * Send streamer batch ({@link DataStreamerTarget#streamData}).
      */
     STREAMER_BATCH_SEND,

--- a/modules/client/src/main/java/org/apache/ignite/client/RetryReadPolicy.java
+++ b/modules/client/src/main/java/org/apache/ignite/client/RetryReadPolicy.java
@@ -59,6 +59,7 @@ public class RetryReadPolicy extends RetryLimitPolicy {
             case SQL_EXECUTE:
             case SQL_EXECUTE_BATCH:
             case SQL_CURSOR_NEXT_PAGE:
+            case SQL_CURSOR_NEXT_RESULT_SET:
             case SQL_EXECUTE_SCRIPT:
             case STREAMER_BATCH_SEND:
             case PRIMARY_REPLICAS_GET:

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/ClientUtils.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/ClientUtils.java
@@ -175,6 +175,9 @@ public class ClientUtils {
             case ClientOp.SQL_CURSOR_NEXT_PAGE:
                 return ClientOperationType.SQL_CURSOR_NEXT_PAGE;
 
+            case ClientOp.SQL_CURSOR_NEXT_RESULT_SET:
+                return ClientOperationType.SQL_CURSOR_NEXT_RESULT_SET;
+
             case ClientOp.SQL_CURSOR_CLOSE:
                 return null;
 

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientAsyncResultSet.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientAsyncResultSet.java
@@ -187,8 +187,6 @@ public class ClientAsyncResultSet<T> implements AsyncResultSet<T> {
             return nextResultFuture;
         }
 
-        assert marshaller == null : "Multi-statement execution doesn't support custom mapper";
-
         ch.<ClientAsyncResultSet<T>>serviceAsync(ClientOp.SQL_CURSOR_NEXT_RESULT_SET,
                         w -> w.out().packLong(nextResultResourceId),
                         r -> new ClientAsyncResultSet<>(

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientAsyncResultSet.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientAsyncResultSet.java
@@ -22,7 +22,9 @@ import static org.apache.ignite.internal.util.CompletableFutures.nullCompletedFu
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.ignite.internal.binarytuple.BinaryTupleReader;
 import org.apache.ignite.internal.client.ClientChannel;
 import org.apache.ignite.internal.client.proto.ClientMessageUnpacker;
@@ -46,7 +48,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Client async result set.
  */
-class ClientAsyncResultSet<T> implements AsyncResultSet<T> {
+public class ClientAsyncResultSet<T> implements AsyncResultSet<T> {
     /** Channel. */
     private final ClientChannel ch;
 
@@ -84,6 +86,17 @@ class ClientAsyncResultSet<T> implements AsyncResultSet<T> {
     /** Closed flag. */
     private volatile boolean closed;
 
+    /** ID of the resource that holds the next cursor, can be {@code null} if current result set is the last one. */
+    @Nullable
+    private final Long nextResultResourceId;
+
+    /** Future that holds the next result set, can be {@code null} if the current result set is the last one. */
+    @Nullable
+    private final CompletableFuture<ClientAsyncResultSet<T>> nextResultFuture;
+
+    /** A flag indicating whether the next result set already was requested or not. */
+    private final AtomicBoolean nextResultSetRetrieved = new AtomicBoolean();
+
     /**
      * Constructor.
      *
@@ -93,6 +106,7 @@ class ClientAsyncResultSet<T> implements AsyncResultSet<T> {
      * @param mapper Mapper.
      * @param partitionAwarenessEnabled Whether partitions awareness is enabled, hence response may contain related metadata.
      * @param sqlDirectMappingSupported Whether direct mapping is supported, hence response may contain additional metadata.
+     * @param sqlMultiStatementsSupported Whether iteration over the results of script execution is supported.
      */
     ClientAsyncResultSet(
             ClientChannel ch,
@@ -100,7 +114,8 @@ class ClientAsyncResultSet<T> implements AsyncResultSet<T> {
             ClientMessageUnpacker in,
             @Nullable Mapper<T> mapper,
             boolean partitionAwarenessEnabled,
-            boolean sqlDirectMappingSupported
+            boolean sqlDirectMappingSupported,
+            boolean sqlMultiStatementsSupported
     ) {
         this.ch = ch;
 
@@ -115,6 +130,14 @@ class ClientAsyncResultSet<T> implements AsyncResultSet<T> {
             partitionAwarenessMetadata = ClientPartitionAwarenessMetadata.read(in, sqlDirectMappingSupported);
         } else {
             partitionAwarenessMetadata = null;
+        }
+
+        if (sqlMultiStatementsSupported && !in.tryUnpackNil()) {
+            nextResultResourceId = in.unpackLong();
+            nextResultFuture = new CompletableFuture<>();
+        } else {
+            nextResultResourceId = null;
+            nextResultFuture = null;
         }
 
         this.mapper = mapper;
@@ -137,6 +160,44 @@ class ClientAsyncResultSet<T> implements AsyncResultSet<T> {
     @Override
     public boolean hasRowSet() {
         return hasRowSet;
+    }
+
+    /**
+     * Returns flag indicating whether the current result set is the result of
+     * a multi-statement query and this statement is not the last one.
+     */
+    public boolean hasNextResultSet() {
+        return nextResultResourceId != null;
+    }
+
+    /**
+     * Retrieves the next result set of a multi-statement query.
+     *
+     * @return Next result set.
+     * @throws NoSuchElementException if the query has no more statements to execute.
+     */
+    public CompletableFuture<ClientAsyncResultSet<T>> nextResultSet() {
+        if (nextResultResourceId == null) {
+            return CompletableFuture.failedFuture(new NoSuchElementException("Query has no more results"));
+        }
+
+        assert nextResultFuture != null;
+
+        if (!nextResultSetRetrieved.compareAndSet(false, true)) {
+            return nextResultFuture;
+        }
+
+        assert marshaller == null : "Multi-statement execution doesn't support custom mapper";
+
+        ch.<ClientAsyncResultSet<T>>serviceAsync(ClientOp.SQL_CURSOR_NEXT_RESULT_SET,
+                        w -> w.out().packLong(nextResultResourceId),
+                        r -> new ClientAsyncResultSet<>(
+                                r.clientChannel(), null, r.in(), null, false, false, true
+                        ))
+                .thenApply(nextResultFuture::complete)
+                .exceptionally(nextResultFuture::completeExceptionally);
+
+        return nextResultFuture;
     }
 
     /** {@inheritDoc} */

--- a/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientAsyncResultSet.java
+++ b/modules/client/src/main/java/org/apache/ignite/internal/client/sql/ClientAsyncResultSet.java
@@ -194,8 +194,13 @@ public class ClientAsyncResultSet<T> implements AsyncResultSet<T> {
                         r -> new ClientAsyncResultSet<>(
                                 r.clientChannel(), null, r.in(), null, false, false, true
                         ))
-                .thenApply(nextResultFuture::complete)
-                .exceptionally(nextResultFuture::completeExceptionally);
+                .whenComplete((r, e) -> {
+                    if (e != null) {
+                        nextResultFuture.completeExceptionally(e);
+                    } else {
+                        nextResultFuture.complete(r);
+                    }
+                });
 
         return nextResultFuture;
     }

--- a/modules/client/src/test/java/org/apache/ignite/client/ClientSqlTest.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/ClientSqlTest.java
@@ -307,6 +307,10 @@ public class ClientSqlTest extends AbstractClientTableTest {
                     expected = "TX_CONTROL";
                     break;
 
+                case ALLOW_MULTISTATEMENT:
+                    expected = "MULTISTATEMENT";
+                    break;
+
                 default:
                     throw new IllegalArgumentException("Unexpected type: " + modifier);
             }

--- a/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeCursor.java
+++ b/modules/client/src/test/java/org/apache/ignite/client/fakes/FakeCursor.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.ignite.internal.sql.engine.AsyncSqlCursor;
 import org.apache.ignite.internal.sql.engine.InternalSqlRow;
 import org.apache.ignite.internal.sql.engine.SqlProperties;
@@ -121,8 +122,8 @@ public class FakeCursor implements AsyncSqlCursor<InternalSqlRow> {
             columns.add(new FakeColumnMetadata("col1", ColumnType.INT32));
         } else if ("SELECT ALLOWED QUERY TYPES".equals(qry)) {
             paMeta = null;
-            String row = properties.allowedQueryTypes().stream().map(SqlQueryType::name).sorted()
-                    .collect(Collectors.joining(", "));
+            String row = Stream.concat(properties.allowedQueryTypes().stream().map(SqlQueryType::name).sorted(),
+                    properties.allowMultiStatement() ? Stream.of("MULTISTATEMENT") : Stream.empty()).collect(Collectors.joining(", "));
             rows.add(getRow(row));
             columns.add(new FakeColumnMetadata("col1", ColumnType.STRING));
         } else {

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMultistatementSqlTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientMultistatementSqlTest.java
@@ -1,0 +1,490 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.runner.app.client;
+
+import static org.apache.ignite.internal.TestWrappers.unwrapIgniteImpl;
+import static org.apache.ignite.internal.sql.engine.util.SqlTestUtils.assertThrowsSqlException;
+import static org.apache.ignite.internal.sql.engine.util.SqlTestUtils.expectQueryCancelled;
+import static org.apache.ignite.internal.testframework.IgniteTestUtils.assertThrows;
+import static org.apache.ignite.internal.testframework.IgniteTestUtils.await;
+import static org.apache.ignite.lang.ErrorGroups.Sql.RUNTIME_ERR;
+import static org.apache.ignite.lang.ErrorGroups.Sql.STMT_VALIDATION_ERR;
+import static org.apache.ignite.lang.ErrorGroups.Transactions.TX_ALREADY_FINISHED_ERR;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.ignite.client.handler.ClientResourceRegistry;
+import org.apache.ignite.internal.client.sql.ClientAsyncResultSet;
+import org.apache.ignite.internal.client.sql.ClientSql;
+import org.apache.ignite.internal.client.sql.QueryModifier;
+import org.apache.ignite.internal.sql.SyncResultSetAdapter;
+import org.apache.ignite.internal.sql.engine.SqlQueryProcessor;
+import org.apache.ignite.internal.tx.TxManager;
+import org.apache.ignite.lang.CancelHandle;
+import org.apache.ignite.lang.CancellationToken;
+import org.apache.ignite.sql.ResultSet;
+import org.apache.ignite.sql.SqlRow;
+import org.apache.ignite.sql.Statement;
+import org.apache.ignite.sql.async.AsyncResultSet;
+import org.apache.ignite.table.Table;
+import org.apache.ignite.table.mapper.Mapper;
+import org.apache.ignite.tx.Transaction;
+import org.awaitility.Awaitility;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Thin client SQL multi-statement integration test.
+ *
+ * <p>Tests to check internal API for reading script execution results.
+ */
+@SuppressWarnings("resource")
+public class ItThinClientMultistatementSqlTest extends ItAbstractThinClientTest {
+    private final List<ClientAsyncResultSet<SqlRow>> resultsToClose = new ArrayList<>();
+
+    private int resourcesBefore;
+
+    @BeforeEach
+    void cleanupResources() {
+        resultsToClose.forEach(resultSet -> await(resultSet.closeAsync()));
+
+        resourcesBefore = countResources();
+    }
+
+    private int countResources() {
+        int count = 0;
+
+        for (int i = 0; i < nodes(); i++) {
+            ClientResourceRegistry resources = unwrapIgniteImpl(server(i)).clientInboundMessageHandler().resources();
+
+            count += resources.size();
+        }
+
+        return count;
+    }
+
+    @AfterEach
+    protected void checkNoPendingTransactionsAndOpenedCursors() {
+        Awaitility.await().timeout(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            for (int i = 0; i < nodes(); i++) {
+                assertEquals(0, queryProcessor(i).openedCursors());
+            }
+
+            for (int i = 0; i < nodes(); i++) {
+                assertEquals(0, txManager(i).pending());
+            }
+
+            assertThat(countResources() - resourcesBefore, is(0));
+        });
+
+        String dropTablesScript = client().tables().tables().stream()
+                .map(Table::name)
+                .map(name -> "DROP TABLE " + name)
+                .collect(Collectors.joining(";\n"));
+
+        if (!dropTablesScript.isEmpty()) {
+            client().sql().executeScript(dropTablesScript);
+        }
+    }
+
+    @Test
+    void iterateOverResults() {
+        ClientAsyncResultSet<SqlRow> asyncRs = runSql("SELECT 1; SELECT 2; SELECT 3;");
+
+        // First result set.
+        {
+            SyncResultSetAdapter<SqlRow> rs = new SyncResultSetAdapter<>(asyncRs);
+            assertThat(rs.hasRowSet(), is(true));
+            assertThat(rs.next().intValue(0), is(1));
+
+            rs.close();
+        }
+
+        assertThat(asyncRs.hasNextResultSet(), is(true));
+        assertThat(asyncRs.nextResultSet(), is(asyncRs.nextResultSet()));
+        asyncRs = await(asyncRs.nextResultSet());
+
+        // Second result set.
+        {
+            SyncResultSetAdapter<SqlRow> rs = new SyncResultSetAdapter<>(asyncRs);
+            assertThat(rs.hasRowSet(), is(true));
+            assertThat(rs.next().intValue(0), is(2));
+
+            rs.close();
+        }
+
+        assertThat(asyncRs.hasNextResultSet(), is(true));
+        assertThat(asyncRs.nextResultSet(), is(asyncRs.nextResultSet()));
+        asyncRs = await(asyncRs.nextResultSet());
+
+        // Second result set.
+        {
+            SyncResultSetAdapter<SqlRow> rs = new SyncResultSetAdapter<>(asyncRs);
+            assertThat(rs.hasRowSet(), is(true));
+            assertThat(rs.next().intValue(0), is(3));
+
+            rs.close();
+        }
+
+        assertThat(asyncRs.hasNextResultSet(), is(false));
+    }
+
+    @Test
+    void basicMultiStatementQuery() {
+        String sql = "CREATE TABLE test (id INT PRIMARY KEY, val INT);"
+                + "INSERT INTO test VALUES (3, 3);"
+                + "UPDATE test SET val=7 WHERE id=3;"
+                + "EXPLAIN PLAN FOR SELECT * FROM test;"
+                + "SELECT * FROM test;"
+                + "DELETE FROM test;"
+                + "DROP TABLE IF EXISTS non_existing_table;";
+
+        List<ClientAsyncResultSet<SqlRow>> resultSets = fetchAllResults(runSql(sql));
+        Iterator<ClientAsyncResultSet<SqlRow>> curItr = resultSets.iterator();
+
+        ResultValidator.ddl(curItr.next(), true);
+        ResultValidator.dml(curItr.next(), 1);
+        ResultValidator.dml(curItr.next(), 1);
+        assertNotNull(curItr.next()); // skip EXPLAIN.
+        ResultValidator.singleRow(curItr.next(), 3, 7);
+        ResultValidator.dml(curItr.next(), 1);
+        ResultValidator.ddl(curItr.next(), false);
+
+        assertFalse(curItr.hasNext());
+
+        resultSets.forEach(AsyncResultSet::closeAsync);
+
+        // Ensures that the script is executed completely, even if the cursor data has not been read.
+        executeSql("INSERT INTO test VALUES (1, 1);"
+                + "INSERT INTO test VALUES (2, 2);"
+                + "SELECT * FROM test;"
+                + "INSERT INTO test VALUES (3, 3);");
+
+        ResultSet<SqlRow> rs = client().sql().execute(null, "SELECT COUNT(*) FROM test");
+        assertEquals(3, rs.next().longValue(0));
+    }
+
+    @Test
+    public void txControlStatement() {
+        String query = "START TRANSACTION; COMMIT";
+
+        // Execution of the TX_CONTROL statement is allowed.
+        {
+            EnumSet<QueryModifier> modifiers = EnumSet.of(
+                    QueryModifier.ALLOW_TX_CONTROL,
+                    QueryModifier.ALLOW_MULTISTATEMENT
+            );
+
+            ClientAsyncResultSet<SqlRow> startFuture = runSql((Transaction) null, null, modifiers, query);
+            List<ClientAsyncResultSet<SqlRow>> resultSets = fetchAllResults(startFuture);
+
+            assertThat(resultSets, hasSize(2));
+
+            ClientAsyncResultSet<SqlRow> rs = resultSets.get(0);
+            assertThat(rs.hasNextResultSet(), is(true));
+            assertThat(rs.hasRowSet(), is(false));
+            assertThat(rs.wasApplied(), is(false));
+            assertThat(rs.affectedRows(), is(-1L));
+
+            rs = resultSets.get(1);
+            assertThat(rs.hasNextResultSet(), is(false));
+            assertThat(rs.hasRowSet(), is(false));
+            assertThat(rs.wasApplied(), is(false));
+            assertThat(rs.affectedRows(), is(-1L));
+        }
+
+        // Execution of the TX_CONTROL statement is not allowed.
+        {
+            EnumSet<QueryModifier> modifiers = EnumSet.of(
+                    QueryModifier.ALLOW_ROW_SET_RESULT,
+                    QueryModifier.ALLOW_MULTISTATEMENT
+            );
+
+            assertThrowsSqlException(
+                    STMT_VALIDATION_ERR,
+                    "Invalid SQL statement type.",
+                    () -> runSql((Transaction) null, null, modifiers, query)
+            );
+        }
+    }
+
+    @Test
+    void throwsNoSuchElementExceptionIfNoMoreResults() {
+        ClientAsyncResultSet<SqlRow> resulSet = runSql("SELECT 1");
+
+        assertThat(resulSet.hasNextResultSet(), is(false));
+
+        //noinspection ThrowableNotThrown
+        assertThrows(NoSuchElementException.class, () -> await(resulSet.nextResultSet()), "Query has no more results");
+    }
+
+    @Test
+    void queryWithDynamicParameters() {
+        String sql = "CREATE TABLE test (id INT PRIMARY KEY, val VARCHAR DEFAULT '3');"
+                + "INSERT INTO test VALUES(?, ?);"
+                + "INSERT INTO test VALUES(?, DEFAULT);"
+                + "INSERT INTO test VALUES(?, ?);";
+
+        executeSql(sql, 0, "1", 2, 4, "5");
+
+        ResultSet<SqlRow> rs = client().sql().execute(null, "SELECT COUNT(*) FROM test");
+        assertEquals(3, rs.next().longValue(0));
+    }
+
+    @Test
+    void explicitTransaction() {
+        executeSql("CREATE TABLE test (id INT PRIMARY KEY);");
+
+        Transaction tx = client().transactions().begin();
+        executeSql(tx, "INSERT INTO test VALUES (0); INSERT INTO test VALUES (1); INSERT INTO test VALUES (2)");
+
+        expectRowsCount(tx, "test", 3);
+        expectRowsCount(null, "test", 0);
+
+        tx.commit();
+
+        expectRowsCount(null, "test", 3);
+    }
+
+    @Test
+    void queryWithIncorrectNumberOfDynamicParametersFailsWithValidationError() {
+        String sql = "CREATE TABLE test (id INT PRIMARY KEY, val INT);"
+                + "INSERT INTO test VALUES(?, ?);"
+                + "INSERT INTO test VALUES(?, ?);";
+
+        String expectedMessage = "Unexpected number of query parameters";
+
+        assertThrowsSqlException(STMT_VALIDATION_ERR, expectedMessage, () -> runSql(sql, 0));
+        assertThrowsSqlException(STMT_VALIDATION_ERR, expectedMessage, () -> runSql(sql, 0, 1, 2, 3, 4, 5));
+    }
+
+    @Test
+    void scriptStopsExecutionOnError() {
+        // Runtime error.
+        {
+            assertThrowsSqlException(
+                    RUNTIME_ERR,
+                    "Division by zero",
+                    () -> executeSql(
+                            "CREATE TABLE test (id INT PRIMARY KEY);"
+                                    + "INSERT INTO test VALUES (2/0);" // Runtime error.
+                                    + "INSERT INTO test VALUES (0)"
+                    )
+            );
+
+            ResultSet<SqlRow> rs = client().sql().execute(null, "SELECT COUNT(*) FROM test");
+            assertEquals(0, rs.next().longValue(0));
+        }
+
+        // Validation error.
+        {
+            assertThrowsSqlException(
+                    STMT_VALIDATION_ERR,
+                    "Values passed to VALUES operator must have compatible types",
+                    () -> executeSql(
+                            "INSERT INTO test VALUES (?), (?)",
+                            "1", 2
+                    )
+            );
+
+            try (ResultSet<SqlRow> rs = client().sql().execute(null, "SELECT COUNT(*) FROM test")) {
+                assertEquals(0, rs.next().longValue(0));
+            }
+        }
+
+        // Internal error.
+        {
+            assertThrowsSqlException(
+                    RUNTIME_ERR,
+                    "Subquery returned more than 1 value",
+                    () -> executeSql(
+                            "INSERT INTO test VALUES(0);"
+                                    + "INSERT INTO test VALUES(1);"
+                                    + "DELETE FROM test WHERE id = (SELECT id FROM test);" // Internal error.
+                                    + "INSERT INTO test VALUES(2);"
+                    )
+            );
+
+            try (ResultSet<SqlRow> rs = client().sql().execute(null, "SELECT COUNT(*) FROM test")) {
+                assertEquals(2, rs.next().longValue(0));
+            }
+        }
+
+        // Internal error due to transaction exception.
+        {
+            Transaction tx = client().transactions().begin();
+            client().sql().execute(tx, "INSERT INTO test VALUES(2);").close();
+            tx.commit();
+
+            assertThrowsSqlException(
+                    TX_ALREADY_FINISHED_ERR,
+                    "Transaction is already finished",
+                    () -> executeSql(
+                            tx,
+                            "INSERT INTO test VALUES(3); INSERT INTO test VALUES(4);"
+                    )
+            );
+
+            try (ResultSet<SqlRow> rs = client().sql().execute(null, "SELECT COUNT(*) FROM test")) {
+                assertEquals(3, rs.next().longValue(0));
+            }
+        }
+    }
+
+    @Test
+    public void cancelScript() {
+        StringBuilder query = new StringBuilder();
+
+        int statementsCount = 100;
+
+        for (int j = 0; j < statementsCount; j++) {
+            query.append("SELECT x FROM TABLE(SYSTEM_RANGE(0, 100))").append(";");
+        }
+
+        CancelHandle cancelHandle = CancelHandle.create();
+        CancellationToken token = cancelHandle.token();
+
+        List<ClientAsyncResultSet<SqlRow>> allResults = fetchAllResults(runSql((Transaction) null, token, null, query.toString()));
+
+        assertThat(allResults, hasSize(statementsCount));
+
+        cancelHandle.cancel();
+
+        allResults.forEach(rs -> {
+            expectQueryCancelled(() -> {
+                AsyncResultSet<SqlRow> res;
+                do {
+                    res = await(rs.fetchNextPage());
+                } while (res.hasMorePages());
+            });
+
+            rs.closeAsync();
+        });
+    }
+
+    private void expectRowsCount(@Nullable Transaction tx, String table, int expectedCount) {
+        ResultSet<SqlRow> rs = client().sql().execute(tx, "SELECT COUNT(*) FROM " + table);
+        assertEquals(expectedCount, rs.next().longValue(0));
+    }
+
+    private SqlQueryProcessor queryProcessor(int idx) {
+        return ((SqlQueryProcessor) unwrapIgniteImpl(server(idx)).queryEngine());
+    }
+
+    private TxManager txManager(int idx) {
+        return unwrapIgniteImpl(server(idx)).txManager();
+    }
+
+    private ClientAsyncResultSet<SqlRow> runSql(String query, Object ... args) {
+        return runSql(null, null, null, query, args);
+    }
+
+    private ClientAsyncResultSet<SqlRow> runSql(
+            @Nullable Transaction tx,
+            @Nullable CancellationToken cancelToken,
+            @Nullable Set<QueryModifier> queryModifiers,
+            String query,
+            Object... args
+    ) {
+        ClientSql clientSql = (ClientSql) client().sql();
+        Statement stmt = clientSql.statementBuilder().query(query).pageSize(1).build();
+
+        return (ClientAsyncResultSet<SqlRow>) await(
+                clientSql.executeAsyncInternal(
+                        tx,
+                        (Mapper<SqlRow>) null,
+                        cancelToken,
+                        queryModifiers == null ? QueryModifier.ALL : queryModifiers,
+                        stmt,
+                        args
+                )
+        );
+    }
+
+    private void executeSql(String sql, Object... args) {
+        executeSql(null, sql, args);
+    }
+
+    private void executeSql(@Nullable Transaction tx, String sql, Object ... args) {
+        fetchAllResults(runSql(tx, null, null, sql, args))
+                .forEach(rs -> await(rs.closeAsync()));
+    }
+
+    private List<ClientAsyncResultSet<SqlRow>> fetchAllResults(ClientAsyncResultSet<SqlRow> resultSet) {
+        List<ClientAsyncResultSet<SqlRow>> resultSets = new ArrayList<>();
+
+        resultSets.add(resultSet);
+        resultsToClose.add(resultSet);
+
+        ClientAsyncResultSet<SqlRow> resultSet0 = resultSet;
+
+        while (resultSet0.hasNextResultSet()) {
+            resultSet0 = await(resultSet0.nextResultSet());
+
+            assertNotNull(resultSet0);
+
+            resultSets.add(resultSet0);
+
+            resultsToClose.add(resultSet0);
+        }
+
+        return resultSets;
+    }
+
+    private static class ResultValidator {
+        static void dml(ClientAsyncResultSet<SqlRow> resultSet, long affectedRows) {
+            assertThat(resultSet.hasRowSet(), is(false));
+            assertThat(resultSet.affectedRows(), is(affectedRows));
+        }
+
+        private static void ddl(ClientAsyncResultSet<SqlRow> resultSet, boolean wasApplied) {
+            assertThat(resultSet.hasRowSet(), is(false));
+            assertThat(resultSet.wasApplied(), is(wasApplied));
+        }
+
+        private static void singleRow(ClientAsyncResultSet<SqlRow> resultSet, Object... expected) {
+            assertThat(resultSet.hasRowSet(), is(true));
+            Iterator<SqlRow> pageIter = resultSet.currentPage().iterator();
+            SqlRow row = pageIter.next();
+            int rowSize = row.metadata().columns().size();
+            List<Object> actual = new ArrayList<>(rowSize);
+
+            for (int i = 0; i < rowSize; i++) {
+                actual.add(row.value(i));
+            }
+
+            assertThat(List.of(expected), equalTo(actual));
+            assertThat(pageIter.hasNext(), is(false));
+        }
+    }
+}

--- a/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSqlTest.java
+++ b/modules/runner/src/integrationTest/java/org/apache/ignite/internal/runner/app/client/ItThinClientSqlTest.java
@@ -760,11 +760,12 @@ public class ItThinClientSqlTest extends ItAbstractThinClientTest {
         Statement ddlStatement = client().sql().createStatement("CREATE TABLE x(id INT PRIMARY KEY)");
         Statement dmlStatement = client().sql().createStatement("INSERT INTO x VALUES (1), (2), (3)");
         Statement selectStatement = client().sql().createStatement("SELECT * FROM x");
+        Statement multiStatement = client().sql().createStatement("SELECT 1; SELECT 2;");
 
         BiConsumer<Statement, Set<QueryModifier>> check = (stmt, types) -> {
             await(sql.executeAsyncInternal(
                     null,
-                    () -> SqlRow.class,
+                    null,
                     null,
                     types,
                     stmt
@@ -816,10 +817,20 @@ public class ItThinClientSqlTest extends ItAbstractThinClientTest {
             );
         }
 
-        // No exception expected with correct modifiers.
-        check.accept(ddlStatement, QueryModifier.ALL);
-        check.accept(dmlStatement, QueryModifier.ALL);
-        check.accept(selectStatement, QueryModifier.ALL);
+        // Incorrect modifier for multi-statement.
+        {
+            IgniteTestUtils.assertThrows(
+                    SqlException.class,
+                    () -> check.accept(multiStatement, QueryModifier.SINGLE_STMT_MODIFIERS),
+                    "Multiple statements are not allowed."
+            );
+        }
+
+        // No exception expected with correct query modifier.
+        check.accept(ddlStatement, QueryModifier.SINGLE_STMT_MODIFIERS);
+        check.accept(dmlStatement, QueryModifier.SINGLE_STMT_MODIFIERS);
+        check.accept(selectStatement, QueryModifier.SINGLE_STMT_MODIFIERS);
+        check.accept(multiStatement, QueryModifier.ALL);
     }
 
     private static class Pojo {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/api/AsyncResultSetImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/api/AsyncResultSetImpl.java
@@ -77,6 +77,11 @@ public class AsyncResultSetImpl<T> implements AsyncResultSet<T> {
         return cursor.partitionAwarenessMetadata();
     }
 
+    /** Returns query cursor. */
+    public AsyncSqlCursor<InternalSqlRow> cursor() {
+        return cursor;
+    }
+
     /** {@inheritDoc} */
     @Override
     public boolean hasRowSet() {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/SqlExceptionMapperProvider.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/SqlExceptionMapperProvider.java
@@ -31,6 +31,7 @@ import org.apache.ignite.internal.catalog.CatalogValidationException;
 import org.apache.ignite.internal.lang.IgniteExceptionMapper;
 import org.apache.ignite.internal.lang.IgniteExceptionMappersProvider;
 import org.apache.ignite.internal.sql.engine.QueryCancelledException;
+import org.apache.ignite.internal.sql.engine.TxControlInsideExternalTxNotSupportedException;
 import org.apache.ignite.internal.sql.engine.exec.RemoteFragmentExecutionException;
 import org.apache.ignite.lang.ErrorGroups.Common;
 import org.apache.ignite.lang.IgniteException;
@@ -75,6 +76,9 @@ public class SqlExceptionMapperProvider implements IgniteExceptionMappersProvide
 
         mappers.add(unchecked(InternalCompilerException.class,
                 err -> new SqlException(Common.INTERNAL_ERR, "Expression compiler error. " + err.getMessage(), err)));
+
+        mappers.add(unchecked(TxControlInsideExternalTxNotSupportedException.class,
+                err -> new SqlException(err.code(), err.getMessage(), err)));
 
         return mappers;
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-26087

* `SQL_EXEC` operation extended, server response now contains the flag indicating whether the sql cursor has next result.
* Added new `SQL_CURSOR_NEXT_RESULT_SET` operation to able obtain next cursor result of the multi-statement query.
* Added new `ALLOW_MULTISTATEMENT` query modifier and the corresponding SQL property flag `allowMultiStatement`.
* Execution of a multi-statement query is now based on the `allowMultiStatement` flag (from `SqlProperties`) rather than the presence of the `TX_CONTROL` query type.