### PR TITLE
IGNITE-25560  Sql.  Partition awareness cover extension

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/RelWithSources.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/RelWithSources.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.sql.engine.prepare;
+
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import org.apache.ignite.internal.sql.engine.rel.IgniteRel;
+
+/**
+ * Relation with sources.
+ */
+public final class RelWithSources {
+
+    private final IgniteRel rel;
+
+    private final Long2ObjectMap<IgniteRel> sourceRels;
+
+    private final IntSet modifiedTables;
+
+    /**
+     * Constructor.
+     *
+     * @param rel Relation.
+     * @param sourceRels Source relations.
+     * @param modifiedTables Modified tables.
+     */
+    public RelWithSources(IgniteRel rel, Long2ObjectMap<IgniteRel> sourceRels, IntSet modifiedTables) {
+        this.rel = rel;
+        this.sourceRels = sourceRels;
+        this.modifiedTables = modifiedTables;
+    }
+
+    /** Plan. */
+    public IgniteRel root() {
+        return rel;
+    }
+
+    /** Returns tables modified by the plan. */
+    public IntSet modifiedTables() {
+        return modifiedTables;
+    }
+
+    /** Returns a source relation by the given id. */
+    public IgniteRel get(long sourceId) {
+        return sourceRels.get(sourceId);
+    }
+
+    /** Returns a map of source relations. */
+    public Long2ObjectMap<IgniteRel> sources() {
+        return sourceRels;
+    }
+}

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/partitionawareness/PartitionAwarenessMetadata.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/partitionawareness/PartitionAwarenessMetadata.java
@@ -110,7 +110,8 @@ public final class PartitionAwarenessMetadata {
     public String toString() {
         return S.toString(PartitionAwarenessMetadata.class, this,
                 "indexes", Arrays.toString(indexes),
-                "hash", Arrays.toString(hash)
+                "hash", Arrays.toString(hash),
+                "directTxMode", directTxMode
         );
     }
 }

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/partitionawareness/PartitionAwarenessMetadataExtractor.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/partitionawareness/PartitionAwarenessMetadataExtractor.java
@@ -75,23 +75,6 @@ public class PartitionAwarenessMetadataExtractor {
     /**
      * Extracts partition awareness metadata from the given plan.
      *
-     * @param rel Plan.
-     * @return Metadata.
-     */
-    @Nullable
-    public static PartitionAwarenessMetadata getMetadata(IgniteRel rel) {
-        if (rel instanceof IgniteKeyValueGet) {
-            return getMetadata((IgniteKeyValueGet) rel);
-        } else if (rel instanceof IgniteKeyValueModify) {
-            return getMetadata((IgniteKeyValueModify) rel);
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Extracts partition awareness metadata from the given plan.
-     *
      * @param relationWithSources Relation with sources.
      * @param partitionPruningMetadata Partition-pruning metadata.
      * @return Metadata.

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/Cloner.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/Cloner.java
@@ -17,18 +17,24 @@
 
 package org.apache.ignite.internal.sql.engine.util;
 
-import it.unimi.dsi.fastutil.ints.IntObjectImmutablePair;
-import it.unimi.dsi.fastutil.ints.IntObjectPair;
+import it.unimi.dsi.fastutil.ints.IntArraySet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
 import org.apache.ignite.internal.sql.engine.prepare.IgniteRelShuttle;
+import org.apache.ignite.internal.sql.engine.prepare.RelWithSources;
 import org.apache.ignite.internal.sql.engine.rel.IgniteRel;
+import org.apache.ignite.internal.sql.engine.rel.IgniteTableModify;
 import org.apache.ignite.internal.sql.engine.rel.SourceAwareIgniteRel;
+import org.apache.ignite.internal.sql.engine.schema.IgniteTable;
 
 /**
- * Utility class to clone relational tree and optionally replace assigned {@link RelOptCluster cluster}
- * to another one.
+ * Utility class to clone relational tree and optionally replace assigned {@link RelOptCluster cluster} to another one.
  */
 public class Cloner {
     private final RelOptCluster cluster;
@@ -61,12 +67,11 @@ public class Cloner {
      * @param cluster Cluster.
      * @return The number of source relations in the given plan and the plan itself.
      */
-    public static IntObjectPair<IgniteRel> cloneAndAssignSourceId(IgniteRel root, RelOptCluster cluster) {
+    public static RelWithSources cloneAndAssignSourceId(IgniteRel root, RelOptCluster cluster) {
         CloneAndAssignIds assigner = new CloneAndAssignIds(cluster);
         IgniteRel result = assigner.visit(root);
-        int numSources = assigner.sourceIndex;
 
-        return new IntObjectImmutablePair<>(numSources, result);
+        return new RelWithSources(result, assigner.sources, assigner.modifiedTables);
     }
 
     private static class CloneAndAssignIds extends IgniteRelShuttle {
@@ -74,6 +79,10 @@ public class Cloner {
         private final RelOptCluster cluster;
 
         private int sourceIndex;
+
+        private final Long2ObjectMap<IgniteRel> sources = new Long2ObjectOpenHashMap<>();
+
+        private IntSet modifiedTables = IntSets.emptySet();
 
         private CloneAndAssignIds(RelOptCluster cluster) {
             this.cluster = cluster;
@@ -85,13 +94,28 @@ public class Cloner {
                 // Take into account only actual source relations.
                 SourceAwareIgniteRel src = (SourceAwareIgniteRel) rel;
 
-                int sourceId = sourceIndex++;
+                long sourceId = sourceIndex++;
                 IgniteRel relWithSourceId = src.clone(sourceId);
+
+                if (rel instanceof IgniteTableModify) {
+                    RelOptTable relOptTable = rel.getTable();
+                    assert relOptTable != null;
+
+                    IgniteTable table = relOptTable.unwrap(IgniteTable.class);
+                    assert table != null;
+
+                    if (modifiedTables.isEmpty()) {
+                        modifiedTables = new IntArraySet(1);
+                    }
+                    modifiedTables.add(table.id());
+                }
 
                 for (int i = 0; i < rel.getInputs().size(); i++) {
                     IgniteRel childNode = visit((IgniteRel) rel.getInput(i));
                     relWithSourceId.replaceInput(i, childNode);
                 }
+
+                sources.put(sourceId, rel);
 
                 return relWithSourceId;
             } else {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/Cloner.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/util/Cloner.java
@@ -78,7 +78,7 @@ public class Cloner {
 
         private final RelOptCluster cluster;
 
-        private int sourceIndex;
+        private long sourceIndex;
 
         private final Long2ObjectMap<IgniteRel> sources = new Long2ObjectOpenHashMap<>();
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/PartitionPruningMetadataTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/PartitionPruningMetadataTest.java
@@ -19,7 +19,6 @@ package org.apache.ignite.internal.sql.engine.planner;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import it.unimi.dsi.fastutil.ints.IntObjectPair;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,6 +31,7 @@ import org.apache.calcite.sql.SqlExplainFormat;
 import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.ignite.internal.sql.engine.framework.TestBuilders;
+import org.apache.ignite.internal.sql.engine.prepare.RelWithSources;
 import org.apache.ignite.internal.sql.engine.prepare.pruning.PartitionPruningColumns;
 import org.apache.ignite.internal.sql.engine.prepare.pruning.PartitionPruningMetadata;
 import org.apache.ignite.internal.sql.engine.prepare.pruning.PartitionPruningMetadataExtractor;
@@ -616,8 +616,8 @@ public class PartitionPruningMetadataTest extends AbstractPlannerTest {
 
     private void extractMetadataAndCheck(IgniteRel rel, List<String> columnNames, List<String> expectedMetadata) {
         PartitionPruningMetadataExtractor extractor = new PartitionPruningMetadataExtractor();
-        IntObjectPair<IgniteRel> pair = Cloner.cloneAndAssignSourceId(rel, rel.getCluster());
-        PartitionPruningMetadata actual = extractor.go(pair.second());
+        RelWithSources relWithSoucres = Cloner.cloneAndAssignSourceId(rel, rel.getCluster());
+        PartitionPruningMetadata actual = extractor.go(relWithSoucres.root());
 
         List<String> actualMetadata;
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/PartitionPruningTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/planner/PartitionPruningTest.java
@@ -35,6 +35,7 @@ import org.apache.ignite.internal.sql.engine.schema.IgniteIndex.Collation;
 import org.apache.ignite.internal.sql.engine.schema.IgniteSchema;
 import org.apache.ignite.internal.sql.engine.schema.IgniteTable;
 import org.apache.ignite.internal.type.NativeTypes;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -207,6 +208,27 @@ public class PartitionPruningTest extends AbstractPlannerTest {
         PartitionPruningColumns cols = actual.get(1);
         assertNotNull(cols, "No metadata for source=1");
         assertEquals("[[0=2, 1=1], [0=4, 1=3]]", PartitionPruningColumns.canonicalForm(cols).toString());
+    }
+
+    @Test
+    @Disabled("https://issues.apache.org/jira/browse/IGNITE-26203")
+    public void testInsertFromSelect() throws Exception {
+        IgniteTable table = TestBuilders.table()
+                .name("T")
+                .addKeyColumn("C1", NativeTypes.INT32)
+                .addKeyColumn("C2", NativeTypes.INT32)
+                .addColumn("C3", NativeTypes.INT32, true)
+                .distribution(TestBuilders.affinity(List.of(1, 0), 1, 2))
+                .build();
+
+        PartitionPruningMetadata actual = extractMetadata(
+                "INSERT INTO t SELECT * FROM t WHERE c2=1 and c1=2",
+                table
+        );
+
+        PartitionPruningColumns cols = actual.get(1);
+        assertNotNull(cols, "No metadata for source=1");
+        assertEquals("[[0=2, 1=1]]", PartitionPruningColumns.canonicalForm(cols).toString());
     }
 
     @Test

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/prepare/partitionawareness/PartitionAwarenessMetadataTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/prepare/partitionawareness/PartitionAwarenessMetadataTest.java
@@ -35,6 +35,7 @@ import org.apache.ignite.internal.sql.SqlCommon;
 import org.apache.ignite.internal.sql.engine.framework.TestBuilders;
 import org.apache.ignite.internal.sql.engine.framework.TestCluster;
 import org.apache.ignite.internal.sql.engine.framework.TestNode;
+import org.apache.ignite.internal.sql.engine.prepare.ExplainablePlan;
 import org.apache.ignite.internal.sql.engine.prepare.QueryPlan;
 import org.apache.ignite.internal.sql.engine.util.Commons;
 import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
@@ -98,11 +99,12 @@ public class PartitionAwarenessMetadataTest extends BaseIgniteAbstractTest {
             "KILL TRANSACTION '1'",
             "CREATE TABLE x (a INT, b INT, PRIMARY KEY (a))",
             "SELECT * FROM table(system_range(1, 10)) WHERE x = 1",
-            "SELECT count(*) FROM t WHERE c1=?",
-            "UPDATE t SET c2=1 WHERE c1=?",
+            "SELECT (SELECT MIN(c1) FROM t WHERE c1=k1) FROM t2 WHERE k1=?",
+            "SELECT (SELECT COUNT(*) FROM t2 WHERE k2=c2) FROM t WHERE t.c1=1",
     })
     public void noMetadata(String query) {
         node.initSchema("CREATE TABLE t (c1 INT PRIMARY KEY, c2 INT)");
+        node.initSchema("CREATE TABLE t2 (k1 INT PRIMARY KEY, k2 INT)");
 
         QueryPlan plan = node.prepare(query);
         PartitionAwarenessMetadata metadata = plan.partitionAwarenessMetadata();
@@ -112,12 +114,10 @@ public class PartitionAwarenessMetadataTest extends BaseIgniteAbstractTest {
     @ParameterizedTest
     @MethodSource("simpleKeyMetadata")
     public void simpleKey(String query, PartitionAwarenessMetadata expected) {
-        node.initSchema("CREATE TABLE t (c1 INT PRIMARY KEY, c2 INT)");
+        node.initSchema("CREATE TABLE t (c1 INT PRIMARY KEY, c2 INT, c3 INT)");
 
         QueryPlan plan = node.prepare(query);
-        PartitionAwarenessMetadata metadata = plan.partitionAwarenessMetadata();
-
-        expectMetadata(expected, metadata);
+        expectMetadata(plan, expected);
     }
 
     private static Stream<Arguments> simpleKeyMetadata() {
@@ -133,9 +133,9 @@ public class PartitionAwarenessMetadataTest extends BaseIgniteAbstractTest {
                 Arguments.of("SELECT * FROM t WHERE c2=? and c1=? and c1=?", meta(1)),
 
                 // KV PUT
-                Arguments.of("INSERT INTO t VALUES(?, ?)", metaTrackingRequired(0)),
-                Arguments.of("INSERT INTO t VALUES(1, ?)", metaTrackingRequired(new int[]{-1}, new int[]{1})),
-                Arguments.of("INSERT INTO t VALUES(1+1, ?)", null),
+                Arguments.of("INSERT INTO t VALUES(?, ?, 0)", metaTrackingRequired(0)),
+                Arguments.of("INSERT INTO t VALUES(1, ?, 0)", metaTrackingRequired(new int[]{-1}, new int[]{1})),
+                Arguments.of("INSERT INTO t VALUES(1+1, ?, 0)", null),
                 Arguments.of("INSERT INTO t(c2, c1) VALUES(?, ?)", metaTrackingRequired(1)),
                 Arguments.of("INSERT INTO t(c2, c1) VALUES(1, ?)", metaTrackingRequired(0)),
                 Arguments.of("INSERT INTO t(c2, c1) VALUES(?, 1)", metaTrackingRequired(new int[]{-1}, new int[]{1})),
@@ -143,7 +143,41 @@ public class PartitionAwarenessMetadataTest extends BaseIgniteAbstractTest {
                 // KV DELETE
                 Arguments.of("DELETE FROM t WHERE c1=?", metaTrackingRequired(0)),
                 Arguments.of("DELETE FROM t WHERE c1=1", metaTrackingRequired(new int[]{-1}, new int[]{1})),
-                Arguments.of("DELETE FROM t WHERE c1=1+1", metaTrackingRequired(new int[]{-1}, new int[]{2}))
+                Arguments.of("DELETE FROM t WHERE c1=1+1", metaTrackingRequired(new int[]{-1}, new int[]{2})),
+
+                // SELECT 
+                Arguments.of("SELECT * FROM t WHERE c1=?", meta(0)),
+                Arguments.of("SELECT * FROM t WHERE c1=? AND c2=?", meta(0)),
+                Arguments.of("SELECT c1, c2 FROM t WHERE c1=? UNION SELECT 1, x FROM SYSTEM_RANGE(1, 100)", meta(0)),
+                Arguments.of("SELECT c1, c2 FROM t JOIN (SELECT x FROM SYSTEM_RANGE(1, 100)) r ON r.x=c2 WHERE c1 = ? ", meta(0)),
+                Arguments.of("SELECT c1, c2 FROM t JOIN (SELECT x FROM SYSTEM_RANGE(1, 100)) r ON r.x=c2 WHERE c1 = 1 ", 
+                        meta(new int[]{-1}, new int[]{1})),
+
+                // Can refer multiple partitions - skip
+                Arguments.of("SELECT * FROM t WHERE c1=1 or c1=2", null),
+                Arguments.of("SELECT * FROM t WHERE c1 IN (?, 2)", null),
+                Arguments.of("SELECT * FROM t WHERE c1=? AND c2 IN (SELECT * FROM SYSTEM_RANGE(1, 100))", meta(0)),
+
+                // UPDATE
+                Arguments.of("UPDATE t SET c2=1 WHERE c1=?", meta(new int[]{0}, new int[0], DirectTxMode.NOT_SUPPORTED)),
+                Arguments.of("UPDATE t SET c2=? WHERE c1=1", meta(new int[]{-1}, new int[]{1}, DirectTxMode.NOT_SUPPORTED)),
+                Arguments.of("UPDATE t SET c2=? WHERE c1=1 AND c3 IN (SELECT * FROM SYSTEM_RANGE(1, 100))",
+                        meta(new int[]{-1}, new int[]{1}, DirectTxMode.NOT_SUPPORTED)),
+
+                // Can refer multiple partitions - skip
+                Arguments.of("UPDATE t SET c2=1 WHERE c1=1 or c1=2", null),
+                Arguments.of("UPDATE t SET c2=? WHERE c1 IN (?, 2)", null),
+
+                // INSERT  
+                // TODO https://issues.apache.org/jira/browse/IGNITE-26203 No partition pruning metadata for INSERT INTO ... SELECT
+                // Arguments.of("INSERT INTO t SELECT 1 as c1, 2 as c2, x as c3 FROM SYSTEM_RANGE(1, 100)",
+                //        meta(new int[]{-1}, new int[]{1}), DirectTxMode.NOT_SUPPORTED),
+
+                // DELETE
+                Arguments.of("DELETE FROM t WHERE c1=1 AND c2 IN (SELECT * FROM SYSTEM_RANGE(1, 100)) ",
+                        meta(new int[]{-1}, new int[]{1}, DirectTxMode.NOT_SUPPORTED)),
+                // Can refer multiple partitions - skip
+                Arguments.of("DELETE FROM t WHERE c1=1 or c1=2", null)
         );
     }
 
@@ -153,9 +187,7 @@ public class PartitionAwarenessMetadataTest extends BaseIgniteAbstractTest {
         node.initSchema("CREATE TABLE t (c1 INT, c2 INT, c3 TIMESTAMP WITH LOCAL TIME ZONE, PRIMARY KEY (c3, c2))");
 
         QueryPlan plan = node.prepare(query);
-        PartitionAwarenessMetadata metadata = plan.partitionAwarenessMetadata();
-
-        expectMetadata(expected, metadata);
+        expectMetadata(plan, expected);
     }
 
     private static Stream<Arguments> tsKeyMetadata() {
@@ -165,7 +197,7 @@ public class PartitionAwarenessMetadataTest extends BaseIgniteAbstractTest {
                 Arguments.of("SELECT * FROM t WHERE c2=? and c3 = TIMESTAMP WITH LOCAL TIME ZONE '1970-01-01 00:00:00'", null),
 
                 // KV PUT
-                Arguments.of("INSERT INTO t VALUES (?, ?, ?)",  metaTrackingRequired(2, 1)),
+                Arguments.of("INSERT INTO t VALUES (?, ?, ?)", metaTrackingRequired(2, 1)),
                 Arguments.of("INSERT INTO t (c1, c2, c3) VALUES (?, ?, TIMESTAMP WITH LOCAL TIME ZONE '1970-01-01 00:00:00')", null)
         );
     }
@@ -176,9 +208,7 @@ public class PartitionAwarenessMetadataTest extends BaseIgniteAbstractTest {
         node.initSchema("CREATE TABLE t (c1 INT, c2 INT, c3 INT, PRIMARY KEY (c3, c2)) COLOCATE BY (c3)");
 
         QueryPlan plan = node.prepare(query);
-        PartitionAwarenessMetadata metadata = plan.partitionAwarenessMetadata();
-
-        expectMetadata(expected, metadata);
+        expectMetadata(plan, expected);
     }
 
     private static Stream<Arguments> shortKeyMetadata() {
@@ -191,12 +221,12 @@ public class PartitionAwarenessMetadataTest extends BaseIgniteAbstractTest {
                 Arguments.of("SELECT * FROM t WHERE c3=? and c2=1", meta(0)),
                 Arguments.of("SELECT * FROM t WHERE c1=1 and c2=? and c3=?", meta(1)),
 
-                Arguments.of("SELECT * FROM t WHERE c3=3", null),
+                Arguments.of("SELECT * FROM t WHERE c3=3", meta(new int[]{-1}, new int[]{3})),
                 Arguments.of("SELECT * FROM t WHERE c2=? and c3=3", meta(new int[]{-1}, new int[]{3})),
                 Arguments.of("SELECT * FROM t WHERE c1=? and c2=? and c3=3", meta(new int[]{-1}, new int[]{3})),
 
                 // KV PUT
-                Arguments.of("INSERT INTO t VALUES (?, ?, ?)",  metaTrackingRequired(2)),
+                Arguments.of("INSERT INTO t VALUES (?, ?, ?)", metaTrackingRequired(2)),
                 Arguments.of("INSERT INTO t (c1, c2, c3) VALUES (?, ?, ?)", metaTrackingRequired(2)),
                 Arguments.of("INSERT INTO t (c3, c1, c2) VALUES (?, ?, ?)", metaTrackingRequired(0)),
 
@@ -208,9 +238,35 @@ public class PartitionAwarenessMetadataTest extends BaseIgniteAbstractTest {
                 Arguments.of("DELETE FROM t WHERE c3=? and c2=?", metaTrackingRequired(0)),
                 Arguments.of("DELETE FROM t WHERE c2=? and c3=?", metaTrackingRequired(1)),
                 Arguments.of("DELETE FROM t WHERE c3=? and c2=1", metaTrackingRequired(0)),
+                Arguments.of("DELETE FROM t WHERE c2=? and c3=3",
+                        meta(new int[]{-1}, new int[]{3}, DirectTxMode.SUPPORTED_TRACKING_REQUIRED)),
 
-                Arguments.of("DELETE FROM t WHERE c3=3", null),
-                Arguments.of("DELETE FROM t WHERE c2=? and c3=3", metaTrackingRequired(new int[]{-1}, new int[]{3}))
+                // SELECT
+                Arguments.of("SELECT * FROM t WHERE c3=3 AND c1 IN (SELECT * FROM SYSTEM_RANGE(1, 100))",
+                        meta(new int[]{-1}, new int[]{3})
+                ),
+
+                // UPDATE
+                Arguments.of("UPDATE t SET c1=? WHERE c3=? and c2=?",
+                        meta(new int[]{1}, new int[0], DirectTxMode.NOT_SUPPORTED)
+                ),
+                Arguments.of("UPDATE t SET c1=? WHERE c3=1 and c2=?",
+                        meta(new int[]{-1}, new int[]{1}, DirectTxMode.NOT_SUPPORTED)
+                ),
+                Arguments.of("UPDATE t SET c1=? WHERE c3=1 and c2 IN (SELECT * FROM SYSTEM_RANGE(1, 100))",
+                        meta(new int[]{-1}, new int[]{1}, DirectTxMode.NOT_SUPPORTED)
+                ),
+
+                // INSERT
+                // TODO https://issues.apache.org/jira/browse/IGNITE-26203 No partition pruning metadata for INSERT INTO ... SELECT
+                // Arguments.of("INSERT INTO t SELECT 1 as c1, 2 as c2, 3 as c3 FROM SYSTEM_RANGE(1, 100)",
+                //        meta(new int[]{-1}, new int[]{3}, DirectTxMode.NOT_SUPPORTED)
+                // ),
+
+                // DELETE
+                Arguments.of("DELETE FROM t WHERE c3=3", meta(new int[]{-1}, new int[]{3}, DirectTxMode.NOT_SUPPORTED)),
+                Arguments.of("DELETE FROM t WHERE c3=3 and c2 IN (SELECT * FROM SYSTEM_RANGE(1, 100))",
+                        meta(new int[]{-1}, new int[]{3}, DirectTxMode.NOT_SUPPORTED))
         );
     }
 
@@ -220,9 +276,7 @@ public class PartitionAwarenessMetadataTest extends BaseIgniteAbstractTest {
         node.initSchema("CREATE TABLE t (c1 INT, c2 INT, c3 INT, c4 INT, PRIMARY KEY(c1, c2, c3)) COLOCATE BY (c3, c1, c2)");
 
         QueryPlan plan = node.prepare(query);
-        PartitionAwarenessMetadata metadata = plan.partitionAwarenessMetadata();
-
-        expectMetadata(expected, metadata);
+        expectMetadata(plan, expected);
     }
 
     private static Stream<Arguments> compoundKeyMetadata() {
@@ -252,7 +306,7 @@ public class PartitionAwarenessMetadataTest extends BaseIgniteAbstractTest {
                 Arguments.of("INSERT INTO t VALUES (1, ?, ?, ?)", metaTrackingRequired(new int[]{1, -1, 0}, new int[]{1})),
                 Arguments.of("INSERT INTO t (c3, c2, c4, c1) VALUES (?, ?, ?, ?)", metaTrackingRequired(0, 3, 1)),
                 Arguments.of("INSERT INTO t (c3, c2, c4, c1) VALUES (?, ?, 1, ?)", metaTrackingRequired(0, 2, 1)),
-                Arguments.of("INSERT INTO t VALUES (1, 2, 3, 4)", null),
+                Arguments.of("INSERT INTO t VALUES (1, 2, 3, 4)", metaTrackingRequired(new int[]{-1, -2, -3}, new int[]{3, 1, 2})),
 
                 // KV DELETE
                 Arguments.of("DELETE FROM t WHERE c1=? and c2=? and c3=?", metaTrackingRequired(2, 0, 1)),
@@ -262,7 +316,34 @@ public class PartitionAwarenessMetadataTest extends BaseIgniteAbstractTest {
                 Arguments.of("DELETE FROM t WHERE c1=1 and c2=? and c3=?", metaTrackingRequired(new int[]{1, -1, 0}, new int[]{1})),
                 Arguments.of("DELETE FROM t WHERE c1=? and c2=2 and c3=?", metaTrackingRequired(new int[]{1, 0, -1}, new int[]{2})),
                 Arguments.of("DELETE FROM t WHERE c1=? and c2=? and c3=3", metaTrackingRequired(new int[]{-1, 0, 1}, new int[]{3})),
-                Arguments.of("DELETE FROM t WHERE c1=1 and c2=2 and c3=3", metaTrackingRequired(new int[]{-1, -2, -3}, new int[]{3, 1, 2}))
+
+                // SELECT 
+                Arguments.of("SELECT * FROM t WHERE c1=? and c2=? and c3=?",
+                        meta(new int[]{2, 0, 1}, new int[]{}, DirectTxMode.SUPPORTED)
+                ),
+                Arguments.of("SELECT * FROM t WHERE c1=1 and c2=? and c3=?",
+                        meta(new int[]{1, -1, 0}, new int[]{1}, DirectTxMode.SUPPORTED)
+                ),
+                Arguments.of("SELECT * FROM t WHERE c1=1 and c2=2 and c3=?",
+                        meta(new int[]{0, -1, -2}, new int[]{1, 2}, DirectTxMode.SUPPORTED)
+                ),
+                Arguments.of("SELECT * FROM t WHERE c1=1 and c2=2 and c3=3",
+                        meta(new int[]{-1, -2, -3}, new int[]{3, 1, 2}, DirectTxMode.SUPPORTED)
+                ),
+                // Multiple partitions - skip
+                Arguments.of("SELECT * FROM t WHERE (c1=? and c2=? and c3=?) OR (c1=1 and c2=2 and c3=3)", null),
+                // Not keys specified - no partition pruning metadata
+                Arguments.of("SELECT * FROM t WHERE c2=? and c3=?", null),
+
+                // INSERT
+                // TODO https://issues.apache.org/jira/browse/IGNITE-26203 No partition pruning metadata for INSERT INTO ... SELECT
+                // Arguments.of("INSERT INTO t SELECT * FROM t WHERE c1=1 and c2=2 and c3=3", null)
+
+                // UPDATE
+                Arguments.of("UPDATE t SET c4=? WHERE c1=? and c2=? and c3=?",
+                        meta(new int[]{3, 1, 2}, new int[]{}, DirectTxMode.NOT_SUPPORTED)
+                ),
+                Arguments.of("UPDATE t SET c4=? WHERE c2=? and c3=3", null)
         );
     }
 
@@ -288,6 +369,19 @@ public class PartitionAwarenessMetadataTest extends BaseIgniteAbstractTest {
 
     private static PartitionAwarenessMetadata metaTrackingRequired(int... dynamicParams) {
         return meta(dynamicParams, new int[0], DirectTxMode.SUPPORTED_TRACKING_REQUIRED);
+    }
+
+    private void expectMetadata(QueryPlan plan, PartitionAwarenessMetadata expected) {
+        PartitionAwarenessMetadata metadata = plan.partitionAwarenessMetadata();
+
+        if (plan instanceof ExplainablePlan) {
+            ExplainablePlan explainablePlan = (ExplainablePlan) plan;
+            log.info("Plan:\n{}", explainablePlan.explain());
+        } else {
+            log.info("Plan:{}", plan.getClass().getName());
+        }
+
+        expectMetadata(expected, metadata);
     }
 
     private static void expectMetadata(PartitionAwarenessMetadata expected, @Nullable PartitionAwarenessMetadata actual) {


### PR DESCRIPTION
Converts partition pruning metadata into partition awareness (PA) metadata to increase the number of queries that can benefit from PA optimisation.

https://issues.apache.org/jira/browse/IGNITE-25560

---

Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)