### PR TITLE
IGNITE-26218 Sql. Fixed flaky test ItSqlMultiStatementTest.statementRestrictedByQueryType.

### DIFF
--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/BaseSqlMultiStatementTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/BaseSqlMultiStatementTest.java
@@ -19,9 +19,9 @@ package org.apache.ignite.internal.sql.engine;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.await;
-import static org.apache.ignite.internal.testframework.IgniteTestUtils.waitForCondition;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -30,13 +30,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.ignite.internal.sql.BaseSqlIntegrationTest;
 import org.apache.ignite.internal.sql.engine.util.CursorUtils;
 import org.apache.ignite.internal.tx.InternalTransaction;
 import org.apache.ignite.internal.util.AsyncCursor.BatchedResult;
+import org.apache.ignite.internal.util.CompletableFutures;
 import org.apache.ignite.lang.CancellationToken;
+import org.awaitility.Awaitility;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,22 +53,16 @@ public abstract class BaseSqlMultiStatementTest extends BaseSqlIntegrationTest {
     @BeforeEach
     void cleanupResources() {
         cursorsToClose.forEach(cursor -> await(cursor.closeAsync()));
+        cursorsToClose.clear();
     }
 
     @AfterEach
     protected void checkNoPendingTransactionsAndOpenedCursors() {
-        assertEquals(0, txManager().pending());
+        waitUntilActiveTransactionsCount(is(0));
 
-        try {
-            boolean success = waitForCondition(() -> queryProcessor().openedCursors() == 0, 5_000);
-
-            if (!success) {
-                assertEquals(0, queryProcessor().openedCursors());
-            }
-
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        Awaitility.await().timeout(5, TimeUnit.SECONDS).untilAsserted(
+                () -> assertThat(queryProcessor().openedCursors(), is(0))
+        );
     }
 
     /** Fully executes multi-statements query without reading cursor data. */
@@ -110,9 +107,7 @@ public abstract class BaseSqlMultiStatementTest extends BaseSqlIntegrationTest {
 
         cursors.add(cursor);
 
-        if (close) {
-            cursor.closeAsync();
-        } else {
+        if (!close) {
             cursorsToClose.add(cursor);
         }
 
@@ -123,11 +118,15 @@ public abstract class BaseSqlMultiStatementTest extends BaseSqlIntegrationTest {
 
             cursors.add(cursor);
 
-            if (close) {
-                cursor.closeAsync();
-            } else {
+            if (!close) {
                 cursorsToClose.add(cursor);
             }
+        }
+
+        if (close) {
+            List<CompletableFuture<?>> closeCursorFutures = new ArrayList<>(cursors.size());
+            cursors.forEach(c -> closeCursorFutures.add(c.closeAsync()));
+            await(CompletableFutures.allOf(closeCursorFutures));
         }
 
         return cursors;

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlMultiStatementTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlMultiStatementTest.java
@@ -323,6 +323,10 @@ public class ItSqlMultiStatementTest extends BaseSqlMultiStatementTest {
                 () -> runner.apply(properties, "START TRANSACTION; SELECT 1; COMMIT;")
         );
 
+        assertThat(txManager().pending(), is(0));
+
         fetchCursors(runner.apply(properties, "SELECT 1; SELECT 2;"), -1, true);
+
+        assertThat(txManager().pending(), is(0));
     }
 }

--- a/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlMultiStatementTest.java
+++ b/modules/sql-engine/src/integrationTest/java/org/apache/ignite/internal/sql/engine/ItSqlMultiStatementTest.java
@@ -323,10 +323,6 @@ public class ItSqlMultiStatementTest extends BaseSqlMultiStatementTest {
                 () -> runner.apply(properties, "START TRANSACTION; SELECT 1; COMMIT;")
         );
 
-        assertThat(txManager().pending(), is(0));
-
         fetchCursors(runner.apply(properties, "SELECT 1; SELECT 2;"), -1, true);
-
-        assertThat(txManager().pending(), is(0));
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-26218

Test fails because `fetchCursors` does not wait for all cursors to close.

General check has been relaxed (replaced with conditional wait) to prevent flaky failures like IGNITE-25930