### PR TITLE
IGNITE-26273 Make DDL converter API asynchronous

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PrepareServiceImpl.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/PrepareServiceImpl.java
@@ -327,7 +327,7 @@ public class PrepareServiceImpl implements PrepareService {
 
         assert sqlNode instanceof SqlDdl : sqlNode == null ? "null" : sqlNode.getClass().getName();
 
-        return CompletableFuture.completedFuture(new DdlPlan(nextPlanId(), ddlConverter.convert((SqlDdl) sqlNode, ctx)));
+        return ddlConverter.convert((SqlDdl) sqlNode, ctx).thenApply(command -> new DdlPlan(nextPlanId(), command));
     }
 
     private CompletableFuture<QueryPlan> prepareKill(ParsedResult parsedResult) {

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/ddl/ClusterWideStorageProfileValidator.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/ddl/ClusterWideStorageProfileValidator.java
@@ -17,12 +17,14 @@
 
 package org.apache.ignite.internal.sql.engine.prepare.ddl;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
 import static org.apache.ignite.lang.ErrorGroups.Sql.STMT_VALIDATION_ERR;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import org.apache.ignite.internal.cluster.management.topology.api.LogicalNode;
 import org.apache.ignite.internal.cluster.management.topology.api.LogicalTopologyService;
 import org.apache.ignite.internal.cluster.management.topology.api.LogicalTopologySnapshot;
@@ -39,7 +41,7 @@ public class ClusterWideStorageProfileValidator implements StorageProfileValidat
     }
 
     @Override
-    public void validate(Collection<String> storageProfiles) {
+    public CompletableFuture<Void> validate(Collection<String> storageProfiles) {
         LogicalTopologySnapshot localLogicalTopologySnapshot = logicalTopologyService.localLogicalTopology();
 
         Set<String> missedStorageProfileNames = findStorageProfileNotPresentedInLogicalTopologySnapshot(
@@ -53,6 +55,8 @@ public class ClusterWideStorageProfileValidator implements StorageProfileValidat
                     missedStorageProfileNames
             ));
         }
+
+        return completedFuture(null);
     }
 
     private static Set<String> findStorageProfileNotPresentedInLogicalTopologySnapshot(

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/ddl/DdlSqlToCommandConverter.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/ddl/DdlSqlToCommandConverter.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.sql.engine.prepare.ddl;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.calcite.rel.type.RelDataType.PRECISION_NOT_SPECIFIED;
 import static org.apache.calcite.rel.type.RelDataType.SCALE_NOT_SPECIFIED;
 import static org.apache.ignite.internal.catalog.commands.CatalogUtils.DEFAULT_LENGTH;
@@ -53,6 +54,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.calcite.rel.type.RelDataType;
@@ -104,7 +106,6 @@ import org.apache.ignite.internal.catalog.commands.DeferredDefaultValue;
 import org.apache.ignite.internal.catalog.commands.DropIndexCommand;
 import org.apache.ignite.internal.catalog.commands.DropSchemaCommand;
 import org.apache.ignite.internal.catalog.commands.DropTableCommand;
-import org.apache.ignite.internal.catalog.commands.DropTableCommandBuilder;
 import org.apache.ignite.internal.catalog.commands.DropZoneCommand;
 import org.apache.ignite.internal.catalog.commands.RenameZoneCommand;
 import org.apache.ignite.internal.catalog.commands.StorageProfileParams;
@@ -239,7 +240,7 @@ public class DdlSqlToCommandConverter {
      * @param ctx Planning context.
      * @return Catalog command.
      */
-    public CatalogCommand convert(SqlDdl ddlNode, PlanningContext ctx) {
+    public CompletableFuture<CatalogCommand> convert(SqlDdl ddlNode, PlanningContext ctx) {
         if (ddlNode instanceof IgniteSqlCreateTable) {
             return convertCreateTable((IgniteSqlCreateTable) ddlNode, ctx);
         }
@@ -301,25 +302,25 @@ public class DdlSqlToCommandConverter {
                 + "querySql=\"" + ctx.query() + "\"]");
     }
 
-    private CatalogCommand convertCreateSchema(IgniteSqlCreateSchema ddlNode, PlanningContext ctx) {
-        return CreateSchemaCommand.builder()
+    private CompletableFuture<CatalogCommand> convertCreateSchema(IgniteSqlCreateSchema ddlNode, PlanningContext ctx) {
+        return completedFuture(CreateSchemaCommand.builder()
                 .name(deriveObjectName(ddlNode.name(), ctx, "schemaName"))
                 .ifNotExists(ddlNode.ifNotExists())
-                .build();
+                .build());
     }
 
-    private CatalogCommand convertDropSchema(IgniteSqlDropSchema ddlNode, PlanningContext ctx) {
-        return DropSchemaCommand.builder()
+    private CompletableFuture<CatalogCommand> convertDropSchema(IgniteSqlDropSchema ddlNode, PlanningContext ctx) {
+        return completedFuture(DropSchemaCommand.builder()
                 .name(deriveObjectName(ddlNode.name(), ctx, "schemaName"))
                 .ifExists(ddlNode.ifExists())
                 .cascade(ddlNode.behavior() == IgniteSqlDropSchemaBehavior.CASCADE)
-                .build();
+                .build());
     }
 
     /**
      * Converts the given '{@code CREATE TABLE}' AST to the {@link CreateTableCommand} catalog command.
      */
-    private CatalogCommand convertCreateTable(IgniteSqlCreateTable createTblNode, PlanningContext ctx) {
+    private CompletableFuture<CatalogCommand> convertCreateTable(IgniteSqlCreateTable createTblNode, PlanningContext ctx) {
         CreateTableCommandBuilder tblBuilder = CreateTableCommand.builder();
 
         List<IgniteSqlPrimaryKeyConstraint> pkConstraints = createTblNode.columnList().getList().stream()
@@ -426,7 +427,7 @@ public class DdlSqlToCommandConverter {
 
         String zone = createTblNode.zone() == null ? null : createTblNode.zone().getSimple();
 
-        return tblBuilder.schemaName(deriveSchemaName(createTblNode.name(), ctx))
+        CatalogCommand command = tblBuilder.schemaName(deriveSchemaName(createTblNode.name(), ctx))
                 .tableName(deriveObjectName(createTblNode.name(), ctx, "tableName"))
                 .columns(columns)
                 .primaryKey(primaryKey)
@@ -435,6 +436,8 @@ public class DdlSqlToCommandConverter {
                 .storageProfile(storageProfile)
                 .ifTableExists(createTblNode.ifNotExists())
                 .build();
+
+        return completedFuture(command);
     }
 
     private static ColumnParams convertColumnDeclaration(SqlColumnDeclaration col, IgnitePlanner planner, boolean nullable) {
@@ -492,7 +495,7 @@ public class DdlSqlToCommandConverter {
     /**
      * Converts the given `{@code ALTER TABLE ... ADD COLUMN}` AST into the {@link IgniteSqlAlterTableAddColumn} catalog command.
      */
-    private CatalogCommand convertAlterTableAdd(IgniteSqlAlterTableAddColumn alterTblNode, PlanningContext ctx) {
+    private CompletableFuture<CatalogCommand> convertAlterTableAdd(IgniteSqlAlterTableAddColumn alterTblNode, PlanningContext ctx) {
         AlterTableAddColumnCommandBuilder builder = AlterTableAddColumnCommand.builder();
 
         builder.schemaName(deriveSchemaName(alterTblNode.name(), ctx));
@@ -517,13 +520,13 @@ public class DdlSqlToCommandConverter {
 
         builder.columns(columns);
 
-        return builder.build();
+        return completedFuture(builder.build());
     }
 
     /**
      * Converts the given `{@code ALTER TABLE ... ALTER COLUMN}` AST into the {@link AlterTableAlterColumnCommand} catalog command.
      */
-    private CatalogCommand convertAlterColumn(IgniteSqlAlterColumn alterColumnNode, PlanningContext ctx) {
+    private CompletableFuture<CatalogCommand> convertAlterColumn(IgniteSqlAlterColumn alterColumnNode, PlanningContext ctx) {
         AlterTableAlterColumnCommandBuilder builder = AlterTableAlterColumnCommand.builder();
 
         builder.schemaName(deriveSchemaName(alterColumnNode.name(), ctx));
@@ -569,7 +572,7 @@ public class DdlSqlToCommandConverter {
             builder.deferredDefaultValue(deferredDfltFunc);
         }
 
-        return builder.build();
+        return completedFuture(builder.build());
     }
 
     private static DeferredDefaultValue convertDefaultExpression(
@@ -599,7 +602,7 @@ public class DdlSqlToCommandConverter {
     /**
      * Converts the given '{@code ALTER TABLE ... DROP COLUMN}' AST to the {@link AlterTableDropColumnCommand} catalog command.
      */
-    private CatalogCommand convertAlterTableDrop(IgniteSqlAlterTableDropColumn alterTblNode, PlanningContext ctx) {
+    private CompletableFuture<CatalogCommand> convertAlterTableDrop(IgniteSqlAlterTableDropColumn alterTblNode, PlanningContext ctx) {
         AlterTableDropColumnCommandBuilder builder = AlterTableDropColumnCommand.builder();
 
         builder.schemaName(deriveSchemaName(alterTblNode.name(), ctx));
@@ -611,25 +614,24 @@ public class DdlSqlToCommandConverter {
 
         builder.columns(cols);
 
-        return builder.build();
+        return completedFuture(builder.build());
     }
 
     /**
      * Converts the given '{@code DROP TABLE}' AST to the {@link DropTableCommand} catalog command.
      */
-    private CatalogCommand convertDropTable(IgniteSqlDropTable dropTblNode, PlanningContext ctx) {
-        DropTableCommandBuilder builder = DropTableCommand.builder();
-
-        return builder.schemaName(deriveSchemaName(dropTblNode.name(), ctx))
+    private CompletableFuture<CatalogCommand> convertDropTable(IgniteSqlDropTable dropTblNode, PlanningContext ctx) {
+        return completedFuture(DropTableCommand.builder()
+                .schemaName(deriveSchemaName(dropTblNode.name(), ctx))
                 .tableName(deriveObjectName(dropTblNode.name(), ctx, "tableName"))
                 .ifTableExists(dropTblNode.ifExists)
-                .build();
+                .build());
     }
 
     /**
      * Converts '{@code CREATE INDEX}' AST to the appropriate catalog command.
      */
-    private CatalogCommand convertAddIndex(IgniteSqlCreateIndex sqlCmd, PlanningContext ctx) {
+    private CompletableFuture<CatalogCommand> convertAddIndex(IgniteSqlCreateIndex sqlCmd, PlanningContext ctx) {
         boolean sortedIndex = sqlCmd.type() == IgniteSqlIndexType.SORTED || sqlCmd.type() == IgniteSqlIndexType.IMPLICIT_SORTED;
         SqlNodeList columnList = sqlCmd.columnList();
         List<String> columns = new ArrayList<>(columnList.size());
@@ -637,8 +639,10 @@ public class DdlSqlToCommandConverter {
 
         parseColumnList(columnList, columns, collations, sortedIndex);
 
+        CatalogCommand command;
+
         if (sortedIndex) {
-            return CreateSortedIndexCommand.builder()
+            command = CreateSortedIndexCommand.builder()
                     .schemaName(deriveSchemaName(sqlCmd.tableName(), ctx))
                     .tableName(deriveObjectName(sqlCmd.tableName(), ctx, "table name"))
                     .ifNotExists(sqlCmd.ifNotExists())
@@ -647,7 +651,7 @@ public class DdlSqlToCommandConverter {
                     .collations(collations)
                     .build();
         } else {
-            return CreateHashIndexCommand.builder()
+            command = CreateHashIndexCommand.builder()
                     .schemaName(deriveSchemaName(sqlCmd.tableName(), ctx))
                     .tableName(deriveObjectName(sqlCmd.tableName(), ctx, "table name"))
                     .ifNotExists(sqlCmd.ifNotExists())
@@ -655,6 +659,8 @@ public class DdlSqlToCommandConverter {
                     .columns(columns)
                     .build();
         }
+
+        return completedFuture(command);
     }
 
     private static void parseColumnList(
@@ -698,21 +704,23 @@ public class DdlSqlToCommandConverter {
     /**
      * Converts '{@code DROP INDEX}' AST to the appropriate catalog command.
      */
-    private CatalogCommand convertDropIndex(IgniteSqlDropIndex sqlCmd, PlanningContext ctx) {
+    private CompletableFuture<CatalogCommand> convertDropIndex(IgniteSqlDropIndex sqlCmd, PlanningContext ctx) {
         String schemaName = deriveSchemaName(sqlCmd.indexName(), ctx);
         String indexName = deriveObjectName(sqlCmd.indexName(), ctx, "index name");
 
-        return DropIndexCommand.builder()
+        CatalogCommand command = DropIndexCommand.builder()
                 .schemaName(schemaName)
                 .indexName(indexName)
                 .ifExists(sqlCmd.ifExists())
                 .build();
+
+        return completedFuture(command);
     }
 
     /**
      * Converts the given '{@code CREATE ZONE}' AST to the {@link CreateZoneCommand} catalog command.
      */
-    private CatalogCommand convertCreateZone(IgniteSqlCreateZone createZoneNode, PlanningContext ctx) {
+    private CompletableFuture<CatalogCommand> convertCreateZone(IgniteSqlCreateZone createZoneNode, PlanningContext ctx) {
         if (createZoneNode.storageProfiles().isEmpty()) {
             throw new SqlException(STMT_VALIDATION_ERR, "STORAGE PROFILES can not be empty");
         }
@@ -738,17 +746,18 @@ public class DdlSqlToCommandConverter {
             storageProfileNames.add(profile.storageProfile());
         }
 
-        storageProfileValidator.validate(storageProfileNames);
+        return storageProfileValidator.validate(storageProfileNames)
+                .thenApply(unused -> {
+                    builder.storageProfilesParams(profiles);
 
-        builder.storageProfilesParams(profiles);
-
-        return builder.build();
+                    return builder.build();
+                });
     }
 
     /**
      * Converts the given '{@code ALTER ZONE}' AST to the {@link AlterZoneCommand} catalog command.
      */
-    private CatalogCommand convertAlterZoneSet(IgniteSqlAlterZoneSet alterZoneSet, PlanningContext ctx) {
+    private CompletableFuture<CatalogCommand> convertAlterZoneSet(IgniteSqlAlterZoneSet alterZoneSet, PlanningContext ctx) {
         AlterZoneCommandBuilder builder = AlterZoneCommand.builder();
 
         builder.zoneName(deriveObjectName(alterZoneSet.name(), ctx, "zoneName"));
@@ -762,38 +771,41 @@ public class DdlSqlToCommandConverter {
             updateZoneOption(option, remainingKnownOptions, alterZoneOptionInfos, alterReplicasOptionInfo, ctx, builder);
         }
 
-        return builder.build();
+        return completedFuture(builder.build());
     }
 
     /**
      * Converts the given '{@code ALTER ZONE ... SET DEFAULT}' AST node to the {@link AlterZoneSetDefaultCommand} catalog command.
      */
-    private CatalogCommand convertAlterZoneSetDefault(IgniteSqlAlterZoneSetDefault alterZoneSetDefault, PlanningContext ctx) {
-        return AlterZoneSetDefaultCommand.builder()
+    private CompletableFuture<CatalogCommand> convertAlterZoneSetDefault(
+            IgniteSqlAlterZoneSetDefault alterZoneSetDefault,
+            PlanningContext ctx
+    ) {
+        return completedFuture(AlterZoneSetDefaultCommand.builder()
                 .zoneName(deriveObjectName(alterZoneSetDefault.name(), ctx, "zoneName"))
                 .ifExists(alterZoneSetDefault.ifExists())
-                .build();
+                .build());
     }
 
     /**
      * Converts the given '{@code ALTER ZONE ... RENAME TO}' AST node to the {@link RenameZoneCommand} catalog command.
      */
-    private CatalogCommand convertAlterZoneRename(IgniteSqlAlterZoneRenameTo alterZoneRename, PlanningContext ctx) {
-        return RenameZoneCommand.builder()
+    private CompletableFuture<CatalogCommand> convertAlterZoneRename(IgniteSqlAlterZoneRenameTo alterZoneRename, PlanningContext ctx) {
+        return completedFuture(RenameZoneCommand.builder()
                 .zoneName(deriveObjectName(alterZoneRename.name(), ctx, "zoneName"))
                 .newZoneName(alterZoneRename.newName().getSimple())
                 .ifExists(alterZoneRename.ifExists())
-                .build();
+                .build());
     }
 
     /**
      * Converts the given '{@code DROP ZONE}' AST to the {@link DropZoneCommand} catalog command.
      */
-    private CatalogCommand convertDropZone(IgniteSqlDropZone dropZoneNode, PlanningContext ctx) {
-        return DropZoneCommand.builder()
+    private CompletableFuture<CatalogCommand> convertDropZone(IgniteSqlDropZone dropZoneNode, PlanningContext ctx) {
+        return completedFuture(DropZoneCommand.builder()
                 .zoneName(deriveObjectName(dropZoneNode.name(), ctx, "zoneName"))
                 .ifExists(dropZoneNode.ifExists())
-                .build();
+                .build());
     }
 
     /** Derives a schema name from the compound identifier. */

--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/ddl/StorageProfileValidator.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/prepare/ddl/StorageProfileValidator.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.sql.engine.prepare.ddl;
 
 import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Common validator for storage profile names.
@@ -30,5 +31,5 @@ public interface StorageProfileValidator {
      *
      * @param storageProfiles Storage profile names to check.
      */
-    void validate(Collection<String> storageProfiles);
+    CompletableFuture<Void> validate(Collection<String> storageProfiles);
 }

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImplTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/exec/ExecutionServiceImplTest.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.sql.engine.exec;
 
 import static java.util.UUID.randomUUID;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
 import static org.apache.ignite.internal.sql.engine.util.SqlTestUtils.assertThrowsSqlException;
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.await;
@@ -241,7 +242,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
     }
 
     private void setupCluster(CacheFactory mappingCacheFactory, Function<String, QueryTaskExecutor> executorsFactory) {
-        DdlSqlToCommandConverter converter = new DdlSqlToCommandConverter(storageProfiles -> {});
+        DdlSqlToCommandConverter converter = new DdlSqlToCommandConverter(storageProfiles -> completedFuture(null));
 
         testCluster = new TestCluster();
         executionServices = nodeNames.stream()
@@ -1092,7 +1093,7 @@ public class ExecutionServiceImplTest extends BaseIgniteAbstractTest {
 
         when(result.getCatalogTime()).thenReturn(expectedCatalogActivationTimestamp.longValue());
         when(ddlCommandHandler.handle(any(CatalogCommand.class)))
-                .thenReturn(CompletableFuture.completedFuture(result));
+                .thenReturn(completedFuture(result));
 
         await(execService.executePlan(plan, planCtx));
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/TestBuilders.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/framework/TestBuilders.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.sql.engine.framework;
 
 import static java.util.UUID.randomUUID;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.ignite.internal.lang.IgniteStringFormatter.format;
 import static org.apache.ignite.internal.sql.engine.exec.ExecutionServiceImplTest.PLANNING_THREAD_COUNT;
 import static org.apache.ignite.internal.testframework.IgniteTestUtils.await;
@@ -744,9 +745,16 @@ public class TestBuilders {
 
             ConcurrentMap<String, Long> tablesSize = new ConcurrentHashMap<>();
             var schemaManager = createSqlSchemaManager(catalogManager, tablesSize);
-            var prepareService = new PrepareServiceImpl(clusterName, 0, CaffeineCacheFactory.INSTANCE,
-                    new DdlSqlToCommandConverter(storageProfiles -> {}), planningTimeout, PLANNING_THREAD_COUNT,
-                    new NoOpMetricManager(), schemaManager);
+            var prepareService = new PrepareServiceImpl(
+                    clusterName,
+                    0,
+                    CaffeineCacheFactory.INSTANCE,
+                    new DdlSqlToCommandConverter(storageProfiles -> completedFuture(null)),
+                    planningTimeout,
+                    PLANNING_THREAD_COUNT,
+                    new NoOpMetricManager(),
+                    schemaManager
+            );
 
             Map<String, List<String>> systemViewsByNode = new HashMap<>();
 
@@ -1810,7 +1818,7 @@ public class TestBuilders {
                         .collect(Collectors.toList());
             }
 
-            return CompletableFuture.completedFuture(assignments);
+            return completedFuture(assignments);
         }
 
         @Override
@@ -1959,7 +1967,7 @@ public class TestBuilders {
 
         @Override
         public <RowT> CompletableFuture<Boolean> delete(@Nullable InternalTransaction explicitTx, ExecutionContext<RowT> ectx, RowT key) {
-            return CompletableFuture.completedFuture(false);
+            return completedFuture(false);
         }
 
         @Override

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/prepare/ddl/AbstractDdlSqlToCommandConverterTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/prepare/ddl/AbstractDdlSqlToCommandConverterTest.java
@@ -26,6 +26,10 @@ import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.calcite.sql.SqlDdl;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
@@ -87,5 +91,23 @@ abstract class AbstractDdlSqlToCommandConverterTest extends BaseIgniteAbstractTe
         assertThat(entry, instanceOf(expected));
 
         return (T) entry;
+    }
+
+    CatalogCommand convert(String query) throws SqlParseException {
+        SqlNode node = parse(query);
+
+        assertThat(node, instanceOf(SqlDdl.class));
+
+        return convert((SqlDdl) node, createContext());
+    }
+
+    CatalogCommand convert(SqlDdl ddlNode, PlanningContext ctx) {
+        try {
+            return converter.convert(ddlNode, ctx).get(2, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            throw (RuntimeException) e.getCause();
+        } catch (InterruptedException | TimeoutException e) {
+            throw new AssertionError("Couldn't get catalog command.", e);
+        }
     }
 }

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/prepare/ddl/DdlSqlToCommandConverterTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/prepare/ddl/DdlSqlToCommandConverterTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.sql.engine.prepare.ddl;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.calcite.sql.type.SqlTypeName.DECIMAL;
 import static org.apache.calcite.sql.type.SqlTypeName.EXACT_TYPES;
 import static org.apache.calcite.sql.type.SqlTypeName.FLOAT;
@@ -110,7 +111,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
 
     @BeforeEach
     void setUp() {
-        converter = new DdlSqlToCommandConverter(storageProfiles -> {});
+        converter = new DdlSqlToCommandConverter(storageProfiles -> completedFuture(null));
     }
 
     @Test
@@ -140,7 +141,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
         assertThrowsSqlException(
                 STMT_VALIDATION_ERR,
                 "Table without PRIMARY KEY is not supported",
-                () -> converter.convert((SqlDdl) node, createContext())
+                () -> convert((SqlDdl) node, createContext())
         );
     }
 
@@ -154,7 +155,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
         assertThrowsSqlException(
                 STMT_VALIDATION_ERR,
                 "Table without PRIMARY KEY is not supported",
-                () -> converter.convert((SqlDdl) node, createContext())
+                () -> convert((SqlDdl) node, createContext())
         );
     }
 
@@ -165,7 +166,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
 
         assertThat(node, instanceOf(SqlDdl.class));
 
-        CatalogCommand cmd = converter.convert((SqlDdl) node, createContext());
+        CatalogCommand cmd = convert((SqlDdl) node, createContext());
 
         assertThat(cmd, Matchers.instanceOf(CreateTableCommand.class));
 
@@ -212,7 +213,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
 
         assertThat(node, instanceOf(SqlDdl.class));
 
-        CatalogCommand cmd = converter.convert((SqlDdl) node, createContext());
+        CatalogCommand cmd = convert((SqlDdl) node, createContext());
 
         assertThat(cmd, Matchers.instanceOf(CreateTableCommand.class));
 
@@ -242,7 +243,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
 
         assertThrowsSqlException(STMT_VALIDATION_ERR,
                 "Unexpected number of primary key constraints [expected at most one, but was 2",
-                () -> converter.convert((SqlDdl) node, createContext())
+                () -> convert((SqlDdl) node, createContext())
         );
     }
 
@@ -252,7 +253,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
 
         assertThat(node, instanceOf(SqlDdl.class));
 
-        CatalogCommand cmd = converter.convert((SqlDdl) node, createContext());
+        CatalogCommand cmd = convert((SqlDdl) node, createContext());
 
         assertThat(cmd, Matchers.instanceOf(CreateTableCommand.class));
 
@@ -277,7 +278,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
 
         assertThat(node, instanceOf(SqlDdl.class));
 
-        CatalogCommand cmd = converter.convert((SqlDdl) node, createContext());
+        CatalogCommand cmd = convert((SqlDdl) node, createContext());
 
         assertThat(cmd, Matchers.instanceOf(CreateTableCommand.class));
 
@@ -295,7 +296,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
 
         assertThat(node, instanceOf(SqlDdl.class));
 
-        CatalogCommand cmd = converter.convert((SqlDdl) node, createContext());
+        CatalogCommand cmd = convert((SqlDdl) node, createContext());
 
         assertThat(cmd, Matchers.instanceOf(CreateTableCommand.class));
 
@@ -330,7 +331,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
         assertThrowsSqlException(
                 STMT_VALIDATION_ERR,
                 error + ". [column=VAL]",
-                () -> converter.convert((SqlDdl) node, createContext())
+                () -> convert((SqlDdl) node, createContext())
         );
     }
 
@@ -358,7 +359,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
         assertThrowsSqlException(
                 STMT_VALIDATION_ERR,
                 error + ". [column=VAL]",
-                () -> converter.convert((SqlDdl) node, createContext())
+                () -> convert((SqlDdl) node, createContext())
         );
     }
 
@@ -455,7 +456,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
         String template = "CREATE TABLE t (id INTEGER PRIMARY KEY, d UUID DEFAULT {})";
 
         String sql = format(template, "NULL");
-        CreateTableCommand cmd = (CreateTableCommand) converter.convert((SqlDdl) parse(sql), ctx);
+        CreateTableCommand cmd = (CreateTableCommand) convert((SqlDdl) parse(sql), ctx);
 
         mockCatalogSchemaAndZone("TEST_ZONE");
         CatalogTableDescriptor tblDesc = invokeAndGetFirstEntry(cmd, NewTableEntry.class).descriptor();
@@ -467,7 +468,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
 
         UUID uuid = UUID.randomUUID();
         sql = format(template, "'" + uuid + "'");
-        cmd = (CreateTableCommand) converter.convert((SqlDdl) parse(sql), ctx);
+        cmd = (CreateTableCommand) convert((SqlDdl) parse(sql), ctx);
 
         tblDesc = invokeAndGetFirstEntry(cmd, NewTableEntry.class).descriptor();
         colDesc = tblDesc.columns().get(1);
@@ -479,7 +480,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
         for (String value : values) {
             String sql0 = format(template, value);
             assertThrowsSqlException(STMT_VALIDATION_ERR, "Invalid default value for column", () ->
-                    converter.convert((SqlDdl) parse(sql0), ctx));
+                    convert((SqlDdl) parse(sql0), ctx));
         }
     }
 
@@ -662,7 +663,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
             String sql = format(template, "TIMESTAMP WITH LOCAL TIME ZONE", "'2020-01-02 01:01:01'");
 
             testItems.add(DynamicTest.dynamicTest(String.format("ALLOW: %s", sql), () ->
-                    converter.convert((SqlDdl) parse(sql), ctx)));
+                    convert((SqlDdl) parse(sql), ctx)));
         }
 
         return testItems.stream();
@@ -676,7 +677,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
 
         assertThat(node, instanceOf(SqlDdl.class));
 
-        CatalogCommand cmd = converter.convert((SqlDdl) node, createContext());
+        CatalogCommand cmd = convert((SqlDdl) node, createContext());
 
         assertThat(cmd, Matchers.instanceOf(CreateTableCommand.class));
 
@@ -709,7 +710,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
 
         assertThrowsSqlException(STMT_VALIDATION_ERR,
                 "String cannot be empty",
-                () -> converter.convert((SqlDdl) node, createContext())
+                () -> convert((SqlDdl) node, createContext())
         );
 
         SqlNode newNode = parse("CREATE TABLE t (val int) ZONE ZONE storage profile ''");
@@ -719,7 +720,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
         assertThrowsSqlException(
                 STMT_VALIDATION_ERR,
                 "String cannot be empty",
-                () -> converter.convert((SqlDdl) newNode, createContext())
+                () -> convert((SqlDdl) newNode, createContext())
         );
     }
 
@@ -736,7 +737,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
             assertThat(node, instanceOf(SqlDdl.class));
 
             assertThrowsSqlException(STMT_VALIDATION_ERR, error,
-                    () -> converter.convert((SqlDdl) node, createContext()));
+                    () -> convert((SqlDdl) node, createContext()));
         }
 
         {
@@ -744,7 +745,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
             assertThat(node, instanceOf(SqlDdl.class));
 
             assertThrowsSqlException(STMT_VALIDATION_ERR, error,
-                    () -> converter.convert((SqlDdl) node, createContext()));
+                    () -> convert((SqlDdl) node, createContext()));
         }
     }
 
@@ -761,7 +762,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
             assertThat(node, instanceOf(SqlDdl.class));
 
             assertThrowsSqlException(STMT_VALIDATION_ERR, error,
-                    () -> converter.convert((SqlDdl) node, createContext()));
+                    () -> convert((SqlDdl) node, createContext()));
         }
 
         {
@@ -769,7 +770,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
             assertThat(node, instanceOf(SqlDdl.class));
 
             assertThrowsSqlException(STMT_VALIDATION_ERR, error,
-                    () -> converter.convert((SqlDdl) node, createContext()));
+                    () -> convert((SqlDdl) node, createContext()));
         }
     }
 
@@ -780,7 +781,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
         assertThat(node, instanceOf(SqlDdl.class));
 
         assertThrows(CatalogValidationException.class,
-                () -> converter.convert((SqlDdl) node, createContext()),
+                () -> convert((SqlDdl) node, createContext()),
                 "Functional defaults are not supported for non-primary key columns [col=A]"
         );
     }
@@ -791,7 +792,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
         SqlNode node = parse("ALTER TABLE t ALTER COLUMN a SET DEFAULT " + func);
         assertThat(node, instanceOf(SqlDdl.class));
 
-        CatalogCommand command = converter.convert((SqlDdl) node, createContext());
+        CatalogCommand command = convert((SqlDdl) node, createContext());
         assertInstanceOf(AlterTableAlterColumnCommand.class, command);
     }
 
@@ -808,7 +809,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
         assertThat(node, instanceOf(SqlDdl.class));
 
         assertThrowsSqlException(STMT_VALIDATION_ERR, error,
-                () -> converter.convert((SqlDdl) node, createContext()));
+                () -> convert((SqlDdl) node, createContext()));
     }
 
     @ParameterizedTest
@@ -824,7 +825,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
         assertThat(node, instanceOf(SqlDdl.class));
 
         assertThrowsSqlException(STMT_VALIDATION_ERR, error,
-                () -> converter.convert((SqlDdl) node, createContext()));
+                () -> convert((SqlDdl) node, createContext()));
     }
 
     @ParameterizedTest
@@ -840,7 +841,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
         assertThat(node, instanceOf(SqlDdl.class));
 
         assertThrowsSqlException(STMT_VALIDATION_ERR, error,
-                () -> converter.convert((SqlDdl) node, createContext()));
+                () -> convert((SqlDdl) node, createContext()));
     }
 
     @ParameterizedTest
@@ -856,7 +857,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
         assertThat(node, instanceOf(SqlDdl.class));
 
         assertThrowsSqlException(STMT_VALIDATION_ERR, error,
-                () -> converter.convert((SqlDdl) node, createContext()));
+                () -> convert((SqlDdl) node, createContext()));
     }
 
     private static Set<SqlTypeName> intervalTypeNames() {
@@ -910,7 +911,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
 
         if (acceptable) {
             testItems.add(DynamicTest.dynamicTest(String.format("ALLOW: %s", sql), () -> {
-                CreateTableCommand cmd = (CreateTableCommand) converter.convert((SqlDdl) parse(sql), ctx);
+                CreateTableCommand cmd = (CreateTableCommand) convert((SqlDdl) parse(sql), ctx);
 
                 mockCatalogSchemaAndZone("TEST_ZONE");
                 CatalogTableDescriptor tblDesc = invokeAndGetFirstEntry(cmd, NewTableEntry.class).descriptor();
@@ -929,7 +930,7 @@ public class DdlSqlToCommandConverterTest extends AbstractDdlSqlToCommandConvert
         } else {
             testItems.add(DynamicTest.dynamicTest(String.format("NOT ALLOW: %s", sql), () ->
                     assertThrowsSqlException(STMT_VALIDATION_ERR, "Invalid default value for column", () ->
-                            converter.convert((SqlDdl) parse(sql), ctx))));
+                            convert((SqlDdl) parse(sql), ctx))));
         }
     }
 

--- a/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/prepare/ddl/DistributionZoneSqlToCommandConverterTest.java
+++ b/modules/sql-engine/src/test/java/org/apache/ignite/internal/sql/engine/prepare/ddl/DistributionZoneSqlToCommandConverterTest.java
@@ -37,8 +37,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.apache.calcite.sql.SqlDdl;
-import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.ignite.internal.catalog.CatalogCommand;
 import org.apache.ignite.internal.catalog.CatalogValidationException;
@@ -776,14 +774,6 @@ public class DistributionZoneSqlToCommandConverterTest extends AbstractDdlSqlToC
     @Test
     public void alterZoneWithUnexpectedOption() {
         expectUnexpectedOption("alter zone test_zone set ABC=1", "ABC");
-    }
-
-    private CatalogCommand convert(String query) throws SqlParseException {
-        SqlNode node = parse(query);
-
-        assertThat(node, instanceOf(SqlDdl.class));
-
-        return converter.convert((SqlDdl) node, createContext());
     }
 
     private void assertThrowsWithPos(String query, String encountered, int pos) {


### PR DESCRIPTION
JIRA Ticket: [IGNITE-26273](https://issues.apache.org/jira/browse/IGNITE-26273)

## The goal

The main goal is to modify `DdlSqlToCommandConverter#convert` to return `CompletableFuture<CatalogCommand>` instead of just `CatalogCommand`.

## The reason

Some validations may require distributed and thus asynchronous interactions.

## The solution

The solution is straightforward: to replace return statements with `completeFuture(...)` wrapping.