### PR TITLE
IGNITE-26367 Improve error message when deployment unit is not provided

### DIFF
--- a/modules/compute/src/integrationTest/java/org/apache/ignite/internal/compute/ItComputeTestStandalone.java
+++ b/modules/compute/src/integrationTest/java/org/apache/ignite/internal/compute/ItComputeTestStandalone.java
@@ -42,13 +42,13 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.apache.ignite.Ignite;
 import org.apache.ignite.compute.ComputeException;
 import org.apache.ignite.compute.JobDescriptor;
 import org.apache.ignite.compute.JobTarget;
+import org.apache.ignite.compute.TaskDescriptor;
 import org.apache.ignite.deployment.DeploymentUnit;
 import org.apache.ignite.deployment.version.Version;
-import org.apache.ignite.internal.app.IgniteImpl;
+import org.apache.ignite.internal.deployunit.IgniteDeployment;
 import org.apache.ignite.internal.deployunit.NodesToDeploy;
 import org.apache.ignite.internal.testframework.IgniteTestUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -71,20 +71,20 @@ class ItComputeTestStandalone extends ItComputeBaseTest {
 
     @BeforeEach
     void deploy() throws IOException {
-        deployJar(node(0), unit.name(), unit.version(), "ignite-integration-test-jobs-1.0-SNAPSHOT.jar");
+        deployJar(unit.name(), unit.version(), "ignite-integration-test-jobs-1.0-SNAPSHOT.jar");
     }
 
     @AfterEach
     void undeploy() {
-        IgniteImpl entryNode = unwrapIgniteImpl(node(0));
+        IgniteDeployment deployment = deployment(0);
 
         try {
-            entryNode.deployment().undeployAsync(unit.name(), unit.version()).join();
+            deployment.undeployAsync(unit.name(), unit.version()).join();
         } catch (Exception ignored) {
             // ignored
         }
         await().until(
-                () -> entryNode.deployment().clusterStatusAsync(unit.name(), unit.version()),
+                () -> deployment.clusterStatusAsync(unit.name(), unit.version()),
                 willBe(nullValue())
         );
     }
@@ -96,13 +96,12 @@ class ItComputeTestStandalone extends ItComputeBaseTest {
 
     @Test
     void executeMultipleRemoteJobs() {
-        IgniteImpl ignite = unwrapIgniteImpl(node(0));
-        CompletableFuture<Set<String>> majority = ignite.clusterManagementGroupManager().majority();
+        CompletableFuture<Set<String>> majority = unwrapIgniteImpl(node(0)).clusterManagementGroupManager().majority();
         assertThat(majority, will(contains(node(0).name(), node(1).name())));
 
-        assertThat(unwrapIgniteImpl(node(0)).deployment().nodeStatusAsync(unit.name(), unit.version()), willBe(DEPLOYED));
-        assertThat(unwrapIgniteImpl(node(1)).deployment().nodeStatusAsync(unit.name(), unit.version()), willBe(oneOf(UPLOADING, DEPLOYED)));
-        assertThat(unwrapIgniteImpl(node(2)).deployment().nodeStatusAsync(unit.name(), unit.version()), willBe(nullValue()));
+        assertThat(deployment(0).nodeStatusAsync(unit.name(), unit.version()), willBe(DEPLOYED));
+        assertThat(deployment(1).nodeStatusAsync(unit.name(), unit.version()), willBe(oneOf(UPLOADING, DEPLOYED)));
+        assertThat(deployment(2).nodeStatusAsync(unit.name(), unit.version()), willBe(nullValue()));
 
         // Execute concurrently on majority, unit should be in the uploading or deployed state at this point
         List<CompletableFuture<String>> resultsMajority = IntStream.range(0, 3).mapToObj(i -> compute().executeAsync(
@@ -124,11 +123,9 @@ class ItComputeTestStandalone extends ItComputeBaseTest {
 
     @Test
     void executesJobWithNonExistingUnit() {
-        Ignite entryNode = node(0);
-
         List<DeploymentUnit> nonExistingUnits = List.of(new DeploymentUnit("non-existing", "1.0.0"));
-        CompletableFuture<String> result = entryNode.compute().executeAsync(
-                JobTarget.node(clusterNode(entryNode)),
+        CompletableFuture<String> result = compute().executeAsync(
+                JobTarget.node(clusterNode(0)),
                 JobDescriptor.builder(toStringJobClass()).units(nonExistingUnits).build(),
                 null
         );
@@ -140,15 +137,11 @@ class ItComputeTestStandalone extends ItComputeBaseTest {
     }
 
     @Test
-    void executeJobWithoutUnit() throws IOException {
-        IgniteImpl entryNode = unwrapIgniteImpl(node(0));
-
-        deployJar(entryNode, "unit", Version.parseVersion("1.0.0"), "ignite-unit-test-job1-1.0-SNAPSHOT.jar");
-
+    void executeJobWithoutUnit() {
         IgniteTestUtils.assertThrows(
                 ComputeException.class,
-                () -> entryNode.compute().execute(
-                        JobTarget.node(clusterNode(entryNode)),
+                () -> compute().execute(
+                        JobTarget.node(clusterNode(0)),
                         JobDescriptor.builder("org.apache.ignite.internal.compute.UnitJob").build(),
                         null
                 ),
@@ -157,60 +150,69 @@ class ItComputeTestStandalone extends ItComputeBaseTest {
     }
 
     @Test
+    void executeTaskWithoutUnit() {
+        IgniteTestUtils.assertThrows(
+                ComputeException.class,
+                () -> compute().executeMapReduce(
+                        TaskDescriptor.builder("org.apache.ignite.internal.compute.UnitJob").build(),
+                        null
+                ),
+                "Cannot load task class by name 'org.apache.ignite.internal.compute.UnitJob'."
+                        + " Deployment units list is empty.");
+    }
+
+    @Test
     void executesJobWithLatestUnitVersion() throws IOException {
         List<DeploymentUnit> jobUnits = List.of(new DeploymentUnit("latest-unit", Version.LATEST));
 
-        Ignite entryNode = node(0);
-
         DeploymentUnit firstVersion = new DeploymentUnit("latest-unit", Version.parseVersion("1.0.0"));
-        deployJar(entryNode, firstVersion.name(), firstVersion.version(), "ignite-unit-test-job1-1.0-SNAPSHOT.jar");
+        deployJar(firstVersion.name(), firstVersion.version(), "ignite-unit-test-job1-1.0-SNAPSHOT.jar");
 
         JobDescriptor job = JobDescriptor.builder("org.apache.ignite.internal.compute.UnitJob").units(jobUnits).build();
-        CompletableFuture<Integer> result1 = entryNode.compute().executeAsync(JobTarget.node(clusterNode(entryNode)), job, null);
+        CompletableFuture<Integer> result1 = compute().executeAsync(JobTarget.node(clusterNode(0)), job, null);
         assertThat(result1, willBe(1));
 
         DeploymentUnit secondVersion = new DeploymentUnit("latest-unit", Version.parseVersion("1.0.1"));
-        deployJar(entryNode, secondVersion.name(), secondVersion.version(), "ignite-unit-test-job2-1.0-SNAPSHOT.jar");
+        deployJar(secondVersion.name(), secondVersion.version(), "ignite-unit-test-job2-1.0-SNAPSHOT.jar");
 
-        CompletableFuture<String> result2 = entryNode.compute().executeAsync(JobTarget.node(clusterNode(entryNode)), job, null);
+        CompletableFuture<String> result2 = compute().executeAsync(JobTarget.node(clusterNode(0)), job, null);
         assertThat(result2, willBe("Hello World!"));
     }
 
     @Test
     void undeployAcquiredUnit() {
-        IgniteImpl entryNode = unwrapIgniteImpl(node(0));
-
-        CompletableFuture<Void> job = entryNode.compute().executeAsync(
-                JobTarget.node(clusterNode(entryNode)),
+        CompletableFuture<Void> job = compute().executeAsync(
+                JobTarget.node(clusterNode(0)),
                 JobDescriptor.builder(SleepJob.class).units(units).build(),
                 3L);
 
-        assertThat(entryNode.deployment().undeployAsync(unit.name(), unit.version()), willCompleteSuccessfully());
+        IgniteDeployment deployment = deployment(0);
 
-        assertThat(entryNode.deployment().clusterStatusAsync(unit.name(), unit.version()), willBe(OBSOLETE));
-        assertThat(entryNode.deployment().nodeStatusAsync(unit.name(), unit.version()), willBe(OBSOLETE));
+        assertThat(deployment.undeployAsync(unit.name(), unit.version()), willCompleteSuccessfully());
+
+        assertThat(deployment.clusterStatusAsync(unit.name(), unit.version()), willBe(OBSOLETE));
+        assertThat(deployment.nodeStatusAsync(unit.name(), unit.version()), willBe(OBSOLETE));
 
         await().failFast("The unit must not be removed until the job is completed", () -> {
-            assertThat(entryNode.deployment().clusterStatusAsync(unit.name(), unit.version()), willBe(OBSOLETE));
-            assertThat(entryNode.deployment().nodeStatusAsync(unit.name(), unit.version()), willBe(OBSOLETE));
+            assertThat(deployment.clusterStatusAsync(unit.name(), unit.version()), willBe(OBSOLETE));
+            assertThat(deployment.nodeStatusAsync(unit.name(), unit.version()), willBe(OBSOLETE));
         }).until(() -> job, willCompleteSuccessfully());
 
         await().until(
-                () -> entryNode.deployment().clusterStatusAsync(unit.name(), unit.version()),
+                () -> deployment.clusterStatusAsync(unit.name(), unit.version()),
                 willBe(nullValue())
         );
     }
 
     @Test
     void executeJobWithObsoleteUnit() {
-        IgniteImpl entryNode = unwrapIgniteImpl(node(0));
         JobDescriptor<Long, Void> job = JobDescriptor.builder(SleepJob.class).units(units).build();
 
-        CompletableFuture<Void> successJob = entryNode.compute().executeAsync(JobTarget.node(clusterNode(entryNode)), job, 2L);
+        CompletableFuture<Void> successJob = compute().executeAsync(JobTarget.node(clusterNode(0)), job, 2L);
 
-        assertThat(entryNode.deployment().undeployAsync(unit.name(), unit.version()), willCompleteSuccessfully());
+        assertThat(deployment(0).undeployAsync(unit.name(), unit.version()), willCompleteSuccessfully());
 
-        CompletableFuture<Void> failedJob = entryNode.compute().executeAsync(JobTarget.node(clusterNode(entryNode)), job, 2L);
+        CompletableFuture<Void> failedJob = compute().executeAsync(JobTarget.node(clusterNode(0)), job, 2L);
 
         assertThat(failedJob, willThrow(computeJobFailedException(
                 ClassNotFoundException.class.getName(),
@@ -220,11 +222,11 @@ class ItComputeTestStandalone extends ItComputeBaseTest {
         assertThat(successJob, willCompleteSuccessfully());
     }
 
-    private static void deployJar(Ignite node, String unitId, Version unitVersion, String jarName) throws IOException {
-        IgniteImpl igniteImpl = unwrapIgniteImpl(node);
+    private static void deployJar(String unitId, Version unitVersion, String jarName) throws IOException {
+        IgniteDeployment deployment = deployment(0);
 
         try (InputStream jarStream = ItComputeTestStandalone.class.getClassLoader().getResourceAsStream("units/" + jarName)) {
-            CompletableFuture<Boolean> deployed = igniteImpl.deployment().deployAsync(
+            CompletableFuture<Boolean> deployed = deployment.deployAsync(
                     unitId,
                     unitVersion,
                     new org.apache.ignite.internal.deployunit.DeploymentUnit(Map.of(jarName, jarStream)),
@@ -232,7 +234,11 @@ class ItComputeTestStandalone extends ItComputeBaseTest {
             );
 
             assertThat(deployed, willBe(true));
-            await().until(() -> igniteImpl.deployment().clusterStatusAsync(unitId, unitVersion), willBe(DEPLOYED));
+            await().until(() -> deployment.clusterStatusAsync(unitId, unitVersion), willBe(DEPLOYED));
         }
+    }
+
+    private static IgniteDeployment deployment(int nodeIndex) {
+        return unwrapIgniteImpl(node(nodeIndex)).deployment();
     }
 }

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/ComputeComponentImpl.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/ComputeComponentImpl.java
@@ -20,7 +20,6 @@ package org.apache.ignite.internal.compute;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.apache.ignite.internal.compute.ClassLoaderExceptionsMapper.mapClassLoaderExceptions;
-import static org.apache.ignite.internal.compute.ComputeUtils.taskClass;
 import static org.apache.ignite.internal.util.CompletableFutures.nullCompletedFuture;
 import static org.apache.ignite.lang.ErrorGroups.Common.NODE_STOPPING_ERR;
 
@@ -357,7 +356,7 @@ public class ComputeComponentImpl implements ComputeComponent, SystemViewProvide
             @Nullable I arg
     ) {
         try {
-            return executor.executeTask(jobSubmitter, taskClass(context.classLoader().classLoader(), taskClassName), metadataBuilder, arg);
+            return executor.executeTask(jobSubmitter, taskClassName, context.classLoader(), metadataBuilder, arg);
         } catch (Throwable e) {
             context.close();
             throw e;

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/ComputeUtils.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/ComputeUtils.java
@@ -142,16 +142,20 @@ public class ComputeUtils {
     /**
      * Resolve map reduce task class name to map reduce task class reference.
      *
+     * @param <R> Map reduce task return type.
      * @param taskClassLoader Class loader.
      * @param taskClassName Map reduce task class name.
-     * @param <R> Map reduce task return type.
      * @return Map reduce task class.
      */
-    public static <I, M, T, R> Class<MapReduceTask<I, M, T, R>> taskClass(ClassLoader taskClassLoader, String taskClassName) {
+    public static <I, M, T, R> Class<MapReduceTask<I, M, T, R>> taskClass(JobClassLoader taskClassLoader, String taskClassName) {
         try {
-            return (Class<MapReduceTask<I, M, T, R>>) Class.forName(taskClassName, true, taskClassLoader);
+            return (Class<MapReduceTask<I, M, T, R>>) Class.forName(taskClassName, true, taskClassLoader.classLoader());
         } catch (ClassNotFoundException e) {
-            throw new ComputeException(CLASS_INITIALIZATION_ERR, "Cannot load task class by name '" + taskClassName + "'", e);
+            String message = "Cannot load task class by name '" + taskClassName + "'.";
+            if (taskClassLoader.units().isEmpty()) {
+                throw new ComputeException(CLASS_INITIALIZATION_ERR, message + " Deployment units list is empty.", e);
+            }
+            throw new ComputeException(CLASS_INITIALIZATION_ERR, message, e);
         }
     }
 

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/executor/ComputeExecutor.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/executor/ComputeExecutor.java
@@ -17,7 +17,6 @@
 
 package org.apache.ignite.internal.compute.executor;
 
-import org.apache.ignite.compute.task.MapReduceTask;
 import org.apache.ignite.internal.compute.ComputeJobDataHolder;
 import org.apache.ignite.internal.compute.ExecutionOptions;
 import org.apache.ignite.internal.compute.events.ComputeEventMetadataBuilder;
@@ -40,7 +39,8 @@ public interface ComputeExecutor {
 
     <I, M, T, R> TaskExecutionInternal<I, M, T, R> executeTask(
             JobSubmitter<M, T> jobSubmitter,
-            Class<? extends MapReduceTask<I, M, T, R>> taskClass,
+            String taskClassName,
+            JobClassLoader classLoader,
             ComputeEventMetadataBuilder metadataBuilder,
             @Nullable I arg
     );

--- a/modules/compute/src/main/java/org/apache/ignite/internal/compute/executor/ComputeExecutorImpl.java
+++ b/modules/compute/src/main/java/org/apache/ignite/internal/compute/executor/ComputeExecutorImpl.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.compute.executor;
 
 import static org.apache.ignite.internal.compute.ComputeUtils.getJobExecuteArgumentType;
 import static org.apache.ignite.internal.compute.ComputeUtils.jobClass;
+import static org.apache.ignite.internal.compute.ComputeUtils.taskClass;
 import static org.apache.ignite.internal.compute.ComputeUtils.unmarshalOrNotIfNull;
 import static org.apache.ignite.internal.thread.ThreadOperation.STORAGE_READ;
 import static org.apache.ignite.internal.thread.ThreadOperation.STORAGE_WRITE;
@@ -242,7 +243,8 @@ public class ComputeExecutorImpl implements ComputeExecutor {
     @Override
     public <I, M, T, R> TaskExecutionInternal<I, M, T, R> executeTask(
             JobSubmitter<M, T> jobSubmitter,
-            Class<? extends MapReduceTask<I, M, T, R>> taskClass,
+            String taskClassName,
+            JobClassLoader classLoader,
             ComputeEventMetadataBuilder metadataBuilder,
             @Nullable I arg
     ) {
@@ -252,9 +254,10 @@ public class ComputeExecutorImpl implements ComputeExecutor {
         TaskExecutionContext context = new TaskExecutionContextImpl(ignite, isCancelled);
 
         metadataBuilder
-                .jobClassName(taskClass.getName())
+                .jobClassName(taskClassName)
                 .targetNode(ignite.name());
 
+        Class<MapReduceTask<I, M, T, R>> taskClass = taskClass(classLoader, taskClassName);
         return new TaskExecutionInternal<>(executorService, eventLog, jobSubmitter, taskClass, context, isCancelled, metadataBuilder, arg);
     }
 

--- a/modules/compute/src/test/java/org/apache/ignite/internal/compute/loader/JobClassLoaderTest.java
+++ b/modules/compute/src/test/java/org/apache/ignite/internal/compute/loader/JobClassLoaderTest.java
@@ -90,7 +90,7 @@ class JobClassLoaderTest extends BaseIgniteAbstractTest {
         DisposableDeploymentUnit unit1 = mock(DisposableDeploymentUnit.class);
         DisposableDeploymentUnit unit2 = mock(DisposableDeploymentUnit.class);
 
-        try (TestJobClassLoader jobClassLoader = new TestJobClassLoader(List.of(unit1, unit2), parentClassLoader)) {
+        try (JobClassLoader jobClassLoader = new JobClassLoader(List.of(unit1, unit2), parentClassLoader)) {
             jobClassLoader.close();
             verify(unit1, times(1)).release();
             verify(unit2, times(1)).release();
@@ -104,7 +104,7 @@ class JobClassLoaderTest extends BaseIgniteAbstractTest {
         RuntimeException toBeThrown = new RuntimeException("Expected exception");
         doThrow(toBeThrown).when(unit1).release();
 
-        TestJobClassLoader jobClassLoader = new TestJobClassLoader(List.of(unit1, unit2), parentClassLoader);
+        JobClassLoader jobClassLoader = new JobClassLoader(List.of(unit1, unit2), parentClassLoader);
         IgniteException igniteException = assertThrows(IgniteException.class, jobClassLoader::close);
         assertThat(igniteException.getSuppressed(), arrayContaining(toBeThrown));
     }
@@ -117,12 +117,6 @@ class JobClassLoaderTest extends BaseIgniteAbstractTest {
         @Override
         public Class<?> findClass(String name) throws ClassNotFoundException {
             return super.findClass(name);
-        }
-    }
-
-    private static class TestJobClassLoader extends JobClassLoader {
-        TestJobClassLoader(List<DisposableDeploymentUnit> units, ClassLoader parent) {
-            super(units, parent);
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-26367

`taskClass` instantiation was moved to the executor solely for the sake of similarity with `jobClass` instantiation.