### PR TITLE
IGNITE-26373 Return public API for auto adjust related entities

### DIFF
--- a/modules/api/src/main/java/org/apache/ignite/catalog/annotations/Zone.java
+++ b/modules/api/src/main/java/org/apache/ignite/catalog/annotations/Zone.java
@@ -71,6 +71,15 @@ public @interface Zone {
     String distributionAlgorithm() default "";
 
     /**
+     * Deprecated, should not be used anymore. Timeout in seconds between node added or node left topology event itself and data nodes
+     * switch.
+     *
+     * @return Timeout.
+     */
+    @Deprecated
+    int dataNodesAutoAdjust() default -1;
+
+    /**
      * Timeout in seconds between node added topology event itself and data nodes switch.
      *
      * @return Timeout.

--- a/modules/api/src/main/java/org/apache/ignite/catalog/definitions/ZoneDefinition.java
+++ b/modules/api/src/main/java/org/apache/ignite/catalog/definitions/ZoneDefinition.java
@@ -35,6 +35,8 @@ public class ZoneDefinition {
 
     private final String distributionAlgorithm;
 
+    private final Integer dataNodesAutoAdjust;
+
     private final Integer dataNodesAutoAdjustScaleUp;
 
     private final Integer dataNodesAutoAdjustScaleDown;
@@ -52,6 +54,7 @@ public class ZoneDefinition {
             Integer replicas,
             Integer quorumSize,
             String distributionAlgorithm,
+            Integer dataNodesAutoAdjust,
             Integer dataNodesAutoAdjustScaleUp,
             Integer dataNodesAutoAdjustScaleDown,
             String filter,
@@ -64,6 +67,7 @@ public class ZoneDefinition {
         this.replicas = replicas;
         this.quorumSize = quorumSize;
         this.distributionAlgorithm = distributionAlgorithm;
+        this.dataNodesAutoAdjust = dataNodesAutoAdjust;
         this.dataNodesAutoAdjustScaleUp = dataNodesAutoAdjustScaleUp;
         this.dataNodesAutoAdjustScaleDown = dataNodesAutoAdjustScaleDown;
         this.filter = filter;
@@ -136,6 +140,17 @@ public class ZoneDefinition {
     }
 
     /**
+     * Deprecated, should not be used anymore. Returns timeout in seconds between node added or node left topology event itself and data
+     * nodes switch.
+     *
+     * @return Timeout.
+     */
+    @Deprecated
+    public Integer dataNodesAutoAdjust() {
+        return dataNodesAutoAdjust;
+    }
+
+    /**
      * Returns timeout in seconds between node added topology event itself and data nodes switch.
      *
      * @return Timeout.
@@ -198,6 +213,7 @@ public class ZoneDefinition {
                 + ", replicas=" + replicas
                 + ", quorumSize=" + quorumSize
                 + ", distributionAlgorithm='" + distributionAlgorithm + '\''
+                + ", dataNodesAutoAdjust=" + dataNodesAutoAdjust
                 + ", dataNodesAutoAdjustScaleUp=" + dataNodesAutoAdjustScaleUp
                 + ", dataNodesAutoAdjustScaleDown=" + dataNodesAutoAdjustScaleDown
                 + ", filter='" + filter + '\''
@@ -222,6 +238,8 @@ public class ZoneDefinition {
 
         private String distributionAlgorithm;
 
+        private Integer dataNodesAutoAdjust;
+
         private Integer dataNodesAutoAdjustScaleUp;
 
         private Integer dataNodesAutoAdjustScaleDown;
@@ -241,6 +259,7 @@ public class ZoneDefinition {
             replicas = definition.replicas;
             quorumSize = definition.quorumSize;
             distributionAlgorithm = definition.distributionAlgorithm;
+            dataNodesAutoAdjust = definition.dataNodesAutoAdjust;
             dataNodesAutoAdjustScaleUp = definition.dataNodesAutoAdjustScaleUp;
             dataNodesAutoAdjustScaleDown = definition.dataNodesAutoAdjustScaleDown;
             filter = definition.filter;
@@ -330,6 +349,24 @@ public class ZoneDefinition {
         }
 
         /**
+         * Deprecated, should not be used anymore. Sets timeout in seconds between node added or node left topology event itself and data
+         * nodes switch.
+         *
+         * @param adjust Timeout.
+         * @return This builder instance.
+         */
+        @Deprecated
+        public Builder dataNodesAutoAdjust(Integer adjust) {
+            Objects.requireNonNull(
+                    adjust,
+                    "Timeout between node added or node left topology event itself and data nodes switch must not be null."
+            );
+
+            this.dataNodesAutoAdjust = adjust;
+            return this;
+        }
+
+        /**
          * Sets timeout in seconds between node added topology event itself and data nodes switch.
          *
          * @param adjust Timeout.
@@ -410,6 +447,7 @@ public class ZoneDefinition {
                     replicas,
                     quorumSize,
                     distributionAlgorithm,
+                    dataNodesAutoAdjust,
                     dataNodesAutoAdjustScaleUp,
                     dataNodesAutoAdjustScaleDown,
                     filter,


### PR DESCRIPTION
JIRA Ticket: [IGNITE-26373](https://issues.apache.org/jira/browse/IGNITE-26373)

## The goal

The main goal is to revert public API changes after #6476 especially `Zone` annotation and `ZoneDefinition`.

## The reason

We have to maintain compatibility, especially user's code compilation compatibility.

## The solution

1. `ZoneDefinition#dataNodesAutoAdjust` and it's getters and builder methods are reverted;
2. `Zone#dataNodesAutoAdjust` is reverted
3. All usages above are marked as `@Deprecated`
4. There no more non-test entities from not internal packages