### PR TITLE
IGNITE-26312 .NET: Fix port issues in compat tests

### DIFF
--- a/modules/compatibility-tests/src/testFixtures/java/org/apache/ignite/internal/PlatformCompatibilityTestNodeRunner.java
+++ b/modules/compatibility-tests/src/testFixtures/java/org/apache/ignite/internal/PlatformCompatibilityTestNodeRunner.java
@@ -57,20 +57,23 @@ public class PlatformCompatibilityTestNodeRunner {
     public static void main(String[] args) throws Exception {
         String version = System.getenv("IGNITE_OLD_SERVER_VERSION");
         String workDir = System.getenv("IGNITE_OLD_SERVER_WORK_DIR");
-        int portOffset = Integer.parseInt(System.getenv().getOrDefault("IGNITE_OLD_SERVER_PORT_OFFSET", "20000"));
 
         if (version == null || workDir == null) {
             throw new Exception("IGNITE_OLD_SERVER_VERSION and IGNITE_OLD_SERVER_WORK_DIR environment variables are not set.");
         }
 
+        int port = Integer.parseInt(System.getenv("IGNITE_OLD_SERVER_PORT"));
+        int httpPort = Integer.parseInt(System.getenv("IGNITE_OLD_SERVER_HTTP_PORT"));
+        int clientPort = Integer.parseInt(System.getenv("IGNITE_OLD_SERVER_CLIENT_PORT"));
+
         System.out.println(">>> Starting test node with version: " + version + " in work directory: " + workDir);
+        System.out.println(">>> Ports: node=" + port + ", http=" + httpPort + ", client=" + clientPort);
 
         ClusterConfiguration clusterConfiguration = ClusterConfiguration.builder(new PlatformTestInfo(), Path.of(workDir))
                 .defaultNodeBootstrapConfigTemplate(NODE_BOOTSTRAP_CFG_TEMPLATE)
-                .basePort(portOffset)
-                .baseHttpPort(portOffset + 1)
-                .baseHttpsPort(portOffset + 2)
-                .baseClientPort(portOffset + 3)
+                .basePort(port)
+                .baseHttpPort(httpPort)
+                .baseClientPort(clientPort)
                 .build();
 
         var cluster = new IgniteCluster(clusterConfiguration);

--- a/modules/compatibility-tests/src/testFixtures/java/org/apache/ignite/internal/PlatformCompatibilityTestNodeRunner.java
+++ b/modules/compatibility-tests/src/testFixtures/java/org/apache/ignite/internal/PlatformCompatibilityTestNodeRunner.java
@@ -55,16 +55,12 @@ public class PlatformCompatibilityTestNodeRunner {
      * @param args Args.
      */
     public static void main(String[] args) throws Exception {
-        String version = System.getenv("IGNITE_OLD_SERVER_VERSION");
-        String workDir = System.getenv("IGNITE_OLD_SERVER_WORK_DIR");
+        String version = getEnvOrThrow("IGNITE_OLD_SERVER_VERSION");
+        String workDir = getEnvOrThrow("IGNITE_OLD_SERVER_WORK_DIR");
 
-        if (version == null || workDir == null) {
-            throw new Exception("IGNITE_OLD_SERVER_VERSION and IGNITE_OLD_SERVER_WORK_DIR environment variables are not set.");
-        }
-
-        int port = Integer.parseInt(System.getenv("IGNITE_OLD_SERVER_PORT"));
-        int httpPort = Integer.parseInt(System.getenv("IGNITE_OLD_SERVER_HTTP_PORT"));
-        int clientPort = Integer.parseInt(System.getenv("IGNITE_OLD_SERVER_CLIENT_PORT"));
+        int port = Integer.parseInt(getEnvOrThrow("IGNITE_OLD_SERVER_PORT"));
+        int httpPort = Integer.parseInt(getEnvOrThrow("IGNITE_OLD_SERVER_HTTP_PORT"));
+        int clientPort = Integer.parseInt(getEnvOrThrow("IGNITE_OLD_SERVER_CLIENT_PORT"));
 
         System.out.println(">>> Starting test node with version: " + version + " in work directory: " + workDir);
         System.out.println(">>> Ports: node=" + port + ", http=" + httpPort + ", client=" + clientPort);
@@ -89,6 +85,16 @@ public class PlatformCompatibilityTestNodeRunner {
         Thread.sleep(60_000);
 
         cluster.stop();
+    }
+
+    private static String getEnvOrThrow(String name) throws Exception {
+        String val = System.getenv(name);
+
+        if (val == null || val.isEmpty()) {
+            throw new Exception(name + " environment variable is not set or empty.");
+        }
+
+        return val;
     }
 
     private static class PlatformTestInfo implements TestInfo {

--- a/modules/compatibility-tests/src/testFixtures/java/org/apache/ignite/internal/PlatformCompatibilityTestNodeRunner.java
+++ b/modules/compatibility-tests/src/testFixtures/java/org/apache/ignite/internal/PlatformCompatibilityTestNodeRunner.java
@@ -17,10 +17,6 @@
 
 package org.apache.ignite.internal;
 
-import static org.apache.ignite.internal.ClusterConfiguration.DEFAULT_BASE_CLIENT_PORT;
-import static org.apache.ignite.internal.ClusterConfiguration.DEFAULT_BASE_HTTPS_PORT;
-import static org.apache.ignite.internal.ClusterConfiguration.DEFAULT_BASE_HTTP_PORT;
-import static org.apache.ignite.internal.ClusterConfiguration.DEFAULT_BASE_PORT;
 import static org.apache.ignite.internal.TestDefaultProfilesNames.DEFAULT_AIMEM_PROFILE_NAME;
 import static org.apache.ignite.internal.TestDefaultProfilesNames.DEFAULT_AIPERSIST_PROFILE_NAME;
 import static org.apache.ignite.internal.TestDefaultProfilesNames.DEFAULT_ROCKSDB_PROFILE_NAME;
@@ -71,10 +67,10 @@ public class PlatformCompatibilityTestNodeRunner {
 
         ClusterConfiguration clusterConfiguration = ClusterConfiguration.builder(new PlatformTestInfo(), Path.of(workDir))
                 .defaultNodeBootstrapConfigTemplate(NODE_BOOTSTRAP_CFG_TEMPLATE)
-                .basePort(DEFAULT_BASE_PORT + portOffset)
-                .baseHttpPort(DEFAULT_BASE_HTTP_PORT + portOffset)
-                .baseHttpsPort(DEFAULT_BASE_HTTPS_PORT + portOffset)
-                .baseClientPort(DEFAULT_BASE_CLIENT_PORT + portOffset)
+                .basePort(portOffset)
+                .baseHttpPort(portOffset + 1)
+                .baseHttpsPort(portOffset + 2)
+                .baseClientPort(portOffset + 3)
                 .build();
 
         var cluster = new IgniteCluster(clusterConfiguration);

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Compatibility/CurrentClientWithOldServerCompatibilityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Compatibility/CurrentClientWithOldServerCompatibilityTest.cs
@@ -75,8 +75,11 @@ public class CurrentClientWithOldServerCompatibilityTest
     [OneTimeTearDown]
     public void OneTimeTearDown()
     {
-        _client.Dispose();
-        _javaServer.Dispose();
+        // ReSharper disable ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
+        _client?.Dispose();
+        _javaServer?.Dispose();
+
+        // ReSharper restore ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
         _workDir.Dispose();
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -70,6 +70,7 @@ namespace Apache.Ignite.Tests
 
         public static async Task<JavaServer> StartOldAsync(string version, string workDir)
         {
+            // TODO: Find 4 ports that are free instead of using fixed offsets.
             // Calculate port offset based on the server version (minor + patch) to avoid conflicts with other tests.
             // This way we can have multiple active nodes with different versions (separate clusters).
             var portOffset = 20_000 + int.Parse(version[2..].Replace(".", string.Empty));

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/JavaServer.cs
@@ -156,6 +156,7 @@ namespace Apache.Ignite.Tests
 
             process.OutputDataReceived += handler;
             process.ErrorDataReceived += handler;
+            process.Exited += (_, _) => evt.Set();
 
             process.Start();
 
@@ -167,6 +168,11 @@ namespace Apache.Ignite.Tests
                 process.Kill(entireProcessTree: true);
 
                 throw new InvalidOperationException("Failed to wait for THIN_CLIENT_PORTS. Check logs for details.");
+            }
+
+            if (process.HasExited)
+            {
+                throw new InvalidOperationException("Java server process has exited. Check logs for details.");
             }
 
             if (ports == null)


### PR DESCRIPTION
Use random free ports to start Java server for compatibility tests.