### PR TITLE
IGNITE-26369 Jdbc. Add accessor methods to thin client-backed ResultSet (numeric types)

### DIFF
--- a/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcResultSetSelfTest.java
+++ b/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcResultSetSelfTest.java
@@ -384,7 +384,6 @@ public class ItJdbcResultSetSelfTest extends AbstractJdbcSelfTest {
                 assertEquals(new BigDecimal(1), rs.getBigDecimal(7));
                 assertEquals(rs.getString(7), "1.0");
 
-                assertTrue(rs.getObject(7, Boolean.class));
                 assertEquals((byte) 1, rs.getObject(7, Byte.class));
                 assertEquals((short) 1, rs.getObject(7, Short.class));
                 assertEquals(1, rs.getObject(7, Integer.class));
@@ -421,7 +420,6 @@ public class ItJdbcResultSetSelfTest extends AbstractJdbcSelfTest {
                 assertEquals(new BigDecimal(1), rs.getBigDecimal(8));
                 assertEquals(rs.getString(8), "1.0");
 
-                assertTrue(rs.getObject(8, Boolean.class));
                 assertEquals((byte) 1, rs.getObject(8, Byte.class));
                 assertEquals((short) 1, rs.getObject(8, Short.class));
                 assertEquals(1, rs.getObject(8, Integer.class));
@@ -458,7 +456,6 @@ public class ItJdbcResultSetSelfTest extends AbstractJdbcSelfTest {
                 assertEquals(new BigDecimal("1.000"), rs.getBigDecimal(9));
                 assertEquals(rs.getString(9), "1.000");
 
-                assertTrue(rs.getObject(9, Boolean.class));
                 assertEquals((byte) 1, rs.getObject(9, Byte.class));
                 assertEquals((short) 1, rs.getObject(9, Short.class));
                 assertEquals(1, rs.getObject(9, Integer.class));

--- a/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcResultSetSelfTest.java
+++ b/modules/jdbc/src/integrationTest/java/org/apache/ignite/jdbc/ItJdbcResultSetSelfTest.java
@@ -375,7 +375,6 @@ public class ItJdbcResultSetSelfTest extends AbstractJdbcSelfTest {
             if (cnt == 0) {
                 assertEquals(1.0, rs.getFloat("floatVal"));
 
-                assertTrue(rs.getBoolean(7));
                 assertEquals(1, rs.getByte(7));
                 assertEquals(1, rs.getShort(7));
                 assertEquals(1, rs.getInt(7));
@@ -413,7 +412,6 @@ public class ItJdbcResultSetSelfTest extends AbstractJdbcSelfTest {
             if (cnt == 0) {
                 assertEquals(1.0, rs.getDouble("doubleVal"));
 
-                assertTrue(rs.getBoolean(8));
                 assertEquals(1, rs.getByte(8));
                 assertEquals(1, rs.getShort(8));
                 assertEquals(1, rs.getInt(8));
@@ -451,7 +449,6 @@ public class ItJdbcResultSetSelfTest extends AbstractJdbcSelfTest {
             if (cnt == 0) {
                 assertEquals(1, rs.getBigDecimal("bigVal").intValue());
 
-                assertTrue(rs.getBoolean(9));
                 assertEquals(1, rs.getByte(9));
                 assertEquals(1, rs.getShort(9));
                 assertEquals(1, rs.getInt(9));

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcResultSet.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcResultSet.java
@@ -41,9 +41,6 @@ import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.text.ParseException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -84,24 +81,6 @@ import org.jetbrains.annotations.TestOnly;
  * Jdbc result set implementation.
  */
 public class JdbcResultSet implements ResultSet {
-    /** Decimal format to convert string to decimal. */
-    private static final ThreadLocal<DecimalFormat> decimalFormat = new ThreadLocal<>() {
-        /** {@inheritDoc} */
-        @Override
-        protected DecimalFormat initialValue() {
-            DecimalFormatSymbols symbols = new DecimalFormatSymbols();
-
-            symbols.setGroupingSeparator(',');
-            symbols.setDecimalSeparator('.');
-
-            DecimalFormat decimalFormat = new DecimalFormat("", symbols);
-
-            decimalFormat.setParseBigDecimal(true);
-
-            return decimalFormat;
-        }
-    };
-
     private final JdbcStatement stmt;
     private final @Nullable Long cursorId;
     private final boolean hasResultSet;
@@ -455,21 +434,23 @@ public class JdbcResultSet implements ResultSet {
             return false;
         }
 
-        Class<?> cls = val.getClass();
-
-        if (cls == Boolean.class) {
+        if ("0".equals(val)) {
+            return false;
+        } else if ("1".equals(val)) {
+            return true;
+        } else if (val instanceof Boolean) {
             return ((Boolean) val);
-        } else if (val instanceof Number) {
-            return ((Number) val).intValue() != 0;
-        } else if (cls == String.class || cls == Character.class) {
-            try {
-                return Integer.parseInt(val.toString()) != 0;
-            } catch (NumberFormatException e) {
-                throw new SQLException("Cannot convert to boolean: " + val, SqlStateCode.CONVERSION_FAILED, e);
+        } else if (val instanceof Byte || val instanceof Short || val instanceof Integer || val instanceof Long) {
+            long num = ((Number) val).longValue();
+
+            if (num == 0) {
+                return false;
+            } else if (num == 1) {
+                return true;
             }
-        } else {
-            throw new SQLException("Cannot convert to boolean: " + val, SqlStateCode.CONVERSION_FAILED);
         }
+
+        throw new SQLException("Cannot convert to boolean: " + val, SqlStateCode.CONVERSION_FAILED);
     }
 
     /** {@inheritDoc} */
@@ -629,8 +610,6 @@ public class JdbcResultSet implements ResultSet {
 
         if (val instanceof Number) {
             return ((Number) val).floatValue();
-        } else if (cls == Boolean.class) {
-            return ((Boolean) val ? 1 : 0);
         } else if (cls == String.class || cls == Character.class) {
             try {
                 return Float.parseFloat(val.toString());
@@ -663,8 +642,6 @@ public class JdbcResultSet implements ResultSet {
 
         if (val instanceof Number) {
             return ((Number) val).doubleValue();
-        } else if (cls == Boolean.class) {
-            return ((Boolean) val ? 1d : 0d);
         } else if (cls == String.class || cls == Character.class) {
             try {
                 return Double.parseDouble(val.toString());
@@ -701,18 +678,18 @@ public class JdbcResultSet implements ResultSet {
             return null;
         }
 
-        Class<?> cls = val.getClass();
-
-        if (cls == BigDecimal.class) {
+        if (val instanceof BigDecimal) {
             return (BigDecimal) val;
-        } else if (val instanceof Number) {
+        } else if (val instanceof Float || val instanceof Double) {
+            // Perform conversion from double for floating point numbers
             return new BigDecimal(((Number) val).doubleValue());
-        } else if (cls == Boolean.class) {
-            return new BigDecimal((Boolean) val ? 1 : 0);
-        } else if (cls == String.class || cls == Character.class) {
+        } else if (val instanceof Number) {
+            // Perform exact conversion from integer types
+            return new BigDecimal(((Number) val).longValue());
+        } else if (val instanceof String) {
             try {
-                return (BigDecimal) decimalFormat.get().parse(val.toString());
-            } catch (ParseException e) {
+                return new BigDecimal(val.toString());
+            } catch (Exception e) {
                 throw new SQLException("Cannot convert to BigDecimal: " + val, SqlStateCode.CONVERSION_FAILED, e);
             }
         } else {

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcResultSet.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc/JdbcResultSet.java
@@ -442,12 +442,8 @@ public class JdbcResultSet implements ResultSet {
             return ((Boolean) val);
         } else if (val instanceof Byte || val instanceof Short || val instanceof Integer || val instanceof Long) {
             long num = ((Number) val).longValue();
-
-            if (num == 0) {
-                return false;
-            } else if (num == 1) {
-                return true;
-            }
+            // 0 - false, anything else is true.
+            return num != 0;
         }
 
         throw new SQLException("Cannot convert to boolean: " + val, SqlStateCode.CONVERSION_FAILED);

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc2/JdbcResultSet.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc2/JdbcResultSet.java
@@ -192,12 +192,7 @@ public class JdbcResultSet implements ResultSet {
             case INT32:
             case INT64:
                 long num = ((Number) val).longValue();
-                if (num == 0) {
-                    return false;
-                } else if (num == 1) {
-                    return true;
-                }
-                break;
+                return num != 0;
             case STRING:
                 String str = (String) val;
                 if ("0".equals(str)) {

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc2/JdbcResultSet.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc2/JdbcResultSet.java
@@ -398,6 +398,7 @@ public class JdbcResultSet implements ResultSet {
 
     /** {@inheritDoc} */
     @Override
+    @Nullable
     public BigDecimal getBigDecimal(int colIdx, int scale) throws SQLException {
         BigDecimal val = getBigDecimal(colIdx);
 
@@ -406,6 +407,7 @@ public class JdbcResultSet implements ResultSet {
 
     /** {@inheritDoc} */
     @Override
+    @Nullable
     public BigDecimal getBigDecimal(int colIdx) throws SQLException {
         Object val = getValue(colIdx);
 
@@ -434,6 +436,7 @@ public class JdbcResultSet implements ResultSet {
 
     /** {@inheritDoc} */
     @Override
+    @Nullable
     public BigDecimal getBigDecimal(String colLb, int scale) throws SQLException {
         int colIdx = findColumn(colLb);
 
@@ -442,6 +445,7 @@ public class JdbcResultSet implements ResultSet {
 
     /** {@inheritDoc} */
     @Override
+    @Nullable
     public BigDecimal getBigDecimal(String colLb) throws SQLException {
         int colIdx = findColumn(colLb);
 

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc2/JdbcResultSet.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc2/JdbcResultSet.java
@@ -20,6 +20,7 @@ package org.apache.ignite.internal.jdbc2;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.net.URL;
 import java.sql.Array;
 import java.sql.Blob;
@@ -37,9 +38,11 @@ import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.temporal.Temporal;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.ignite.internal.jdbc.proto.SqlStateCode;
 import org.apache.ignite.internal.lang.IgniteExceptionMapperUtil;
 import org.apache.ignite.internal.sql.ResultSetMetadataImpl;
@@ -143,178 +146,303 @@ public class JdbcResultSet implements ResultSet {
         ensureNotClosed();
         ensureHasCurrentRow();
 
-        throw new UnsupportedOperationException();
+        Object value = getValue(colIdx);
+        if (value == null) {
+            return null;
+        }
+
+        if (value instanceof Temporal || value instanceof byte[] || value instanceof UUID) {
+            throw new UnsupportedOperationException();
+        } else {
+            return String.valueOf(value);
+        }
     }
 
     /** {@inheritDoc} */
     @Override
     public String getString(String colLb) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        int colIdx = findColumn(colLb);
 
-        throw new UnsupportedOperationException();
+        return getString(colIdx);
     }
 
     /** {@inheritDoc} */
     @Override
     public boolean getBoolean(int colIdx) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        Object val = getValue(colIdx);
 
-        throw new UnsupportedOperationException();
+        if (val == null) {
+            return false;
+        }
+
+        if (val instanceof Boolean) {
+            return ((Boolean) val);
+        } else if (val instanceof BigDecimal) {
+            return BigDecimal.ZERO.compareTo((BigDecimal) val) != 0;
+        } else if (val instanceof Number) {
+            return ((Number) val).longValue() != 0L;
+        } else if (val instanceof String) {
+            try {
+                return Integer.parseInt(val.toString()) != 0;
+            } catch (NumberFormatException e) {
+                throw new SQLException("Cannot convert to boolean: " + val, SqlStateCode.CONVERSION_FAILED, e);
+            }
+        } else {
+            throw new SQLException("Cannot convert to boolean: " + val, SqlStateCode.CONVERSION_FAILED);
+        }
     }
 
     /** {@inheritDoc} */
     @Override
     public boolean getBoolean(String colLb) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        int colIdx = findColumn(colLb);
 
-        throw new UnsupportedOperationException();
+        return getBoolean(colIdx);
     }
 
     /** {@inheritDoc} */
     @Override
     public byte getByte(int colIdx) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        Object val = getValue(colIdx);
 
-        throw new UnsupportedOperationException();
+        if (val == null) {
+            return 0;
+        }
+
+        if (val instanceof Number) {
+            return ((Number) val).byteValue();
+        } else if (val instanceof Boolean) {
+            return (Boolean) val ? (byte) 1 : (byte) 0;
+        } else if (val instanceof String) {
+            try {
+                return Byte.parseByte(val.toString());
+            } catch (NumberFormatException e) {
+                throw new SQLException("Cannot convert to byte: " + val, SqlStateCode.CONVERSION_FAILED, e);
+            }
+        } else {
+            throw new SQLException("Cannot convert to byte: " + val, SqlStateCode.CONVERSION_FAILED);
+        }
     }
 
     /** {@inheritDoc} */
     @Override
     public byte getByte(String colLb) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        int colIdx = findColumn(colLb);
 
-        throw new UnsupportedOperationException();
+        return getByte(colIdx);
     }
 
     /** {@inheritDoc} */
     @Override
     public short getShort(int colIdx) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        Object val = getValue(colIdx);
 
-        throw new UnsupportedOperationException();
+        if (val == null) {
+            return 0;
+        }
+
+        if (val instanceof Number) {
+            return ((Number) val).shortValue();
+        } else if (val instanceof Boolean) {
+            return (Boolean) val ? (short) 1 : (short) 0;
+        } else if (val instanceof String) {
+            try {
+                return Short.parseShort(val.toString());
+            } catch (NumberFormatException e) {
+                throw new SQLException("Cannot convert to short: " + val, SqlStateCode.CONVERSION_FAILED, e);
+            }
+        } else {
+            throw new SQLException("Cannot convert to short: " + val, SqlStateCode.CONVERSION_FAILED);
+        }
     }
 
     /** {@inheritDoc} */
     @Override
     public short getShort(String colLb) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        int colIdx = findColumn(colLb);
 
-        throw new UnsupportedOperationException();
+        return getShort(colIdx);
     }
 
     /** {@inheritDoc} */
     @Override
     public int getInt(int colIdx) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        Object val = getValue(colIdx);
 
-        throw new UnsupportedOperationException();
+        if (val == null) {
+            return 0;
+        }
+
+        if (val instanceof Number) {
+            return ((Number) val).intValue();
+        } else if (val instanceof Boolean) {
+            return (Boolean) val ? 1 : 0;
+        } else if (val instanceof String) {
+            try {
+                return Integer.parseInt(val.toString());
+            } catch (NumberFormatException e) {
+                throw new SQLException("Cannot convert to int: " + val, SqlStateCode.CONVERSION_FAILED, e);
+            }
+        } else {
+            throw new SQLException("Cannot convert to int: " + val, SqlStateCode.CONVERSION_FAILED);
+        }
     }
 
     /** {@inheritDoc} */
     @Override
     public int getInt(String colLb) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        int colIdx = findColumn(colLb);
 
-        throw new UnsupportedOperationException();
+        return getInt(colIdx);
     }
 
     /** {@inheritDoc} */
     @Override
     public long getLong(int colIdx) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        Object val = getValue(colIdx);
 
-        throw new UnsupportedOperationException();
+        if (val == null) {
+            return 0;
+        }
+        if (val instanceof Number) {
+            return ((Number) val).longValue();
+        } else if (val instanceof Boolean) {
+            return ((Boolean) val ? 1 : 0);
+        } else if (val instanceof String) {
+            try {
+                return Long.parseLong(val.toString());
+            } catch (NumberFormatException e) {
+                throw new SQLException("Cannot convert to long: " + val, SqlStateCode.CONVERSION_FAILED, e);
+            }
+        } else {
+            throw new SQLException("Cannot convert to long: " + val, SqlStateCode.CONVERSION_FAILED);
+        }
     }
 
     /** {@inheritDoc} */
     @Override
     public long getLong(String colLb) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        int colIdx = findColumn(colLb);
 
-        throw new UnsupportedOperationException();
+        return getLong(colIdx);
     }
 
     /** {@inheritDoc} */
     @Override
     public float getFloat(int colIdx) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        Object val = getValue(colIdx);
 
-        throw new UnsupportedOperationException();
+        if (val == null) {
+            return 0;
+        }
+
+        if (val instanceof Number) {
+            return ((Number) val).floatValue();
+        } else if (val instanceof Boolean) {
+            return ((Boolean) val ? 1 : 0);
+        } else if (val instanceof String) {
+            try {
+                return Float.parseFloat(val.toString());
+            } catch (NumberFormatException e) {
+                throw new SQLException("Cannot convert to float: " + val, SqlStateCode.CONVERSION_FAILED, e);
+            }
+        } else {
+            throw new SQLException("Cannot convert to float: " + val, SqlStateCode.CONVERSION_FAILED);
+        }
     }
 
     /** {@inheritDoc} */
     @Override
     public float getFloat(String colLb) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        int colIdx = findColumn(colLb);
 
-        throw new UnsupportedOperationException();
+        return getFloat(colIdx);
     }
 
     /** {@inheritDoc} */
     @Override
     public double getDouble(int colIdx) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        Object val = getValue(colIdx);
 
-        throw new UnsupportedOperationException();
+        if (val == null) {
+            return 0.0d;
+        }
+
+        if (val instanceof Number) {
+            return ((Number) val).doubleValue();
+        } else if (val instanceof Boolean) {
+            return ((Boolean) val ? 1.0d : 0.0d);
+        } else if (val instanceof String) {
+            try {
+                return Double.parseDouble(val.toString());
+            } catch (NumberFormatException e) {
+                throw new SQLException("Cannot convert to double: " + val, SqlStateCode.CONVERSION_FAILED, e);
+            }
+        } else {
+            throw new SQLException("Cannot convert to double: " + val, SqlStateCode.CONVERSION_FAILED);
+        }
     }
 
     /** {@inheritDoc} */
     @Override
     public double getDouble(String colLb) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        int colIdx = findColumn(colLb);
 
-        throw new UnsupportedOperationException();
+        return getDouble(colIdx);
     }
 
     /** {@inheritDoc} */
     @Override
     public BigDecimal getBigDecimal(int colIdx, int scale) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        BigDecimal val = getBigDecimal(colIdx);
 
-        throw new UnsupportedOperationException();
+        return val == null ? null : val.setScale(scale, RoundingMode.HALF_UP);
     }
 
     /** {@inheritDoc} */
     @Override
     public BigDecimal getBigDecimal(int colIdx) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        Object val = getValue(colIdx);
 
-        throw new UnsupportedOperationException();
+        if (val == null) {
+            return null;
+        }
+
+        if (val instanceof BigDecimal) {
+            return (BigDecimal) val;
+        } else if (val instanceof Float || val instanceof Double) {
+            // Perform conversion from double for floating point numbers
+            return new BigDecimal(((Number) val).doubleValue());
+        } else if (val instanceof Number) {
+            // Perform exact conversion from integer types
+            return new BigDecimal(((Number) val).longValue());
+        } else if (val instanceof Boolean) {
+            return new BigDecimal((Boolean) val ? 1 : 0);
+        } else if (val instanceof String) {
+            try {
+                return new BigDecimal(val.toString());
+            } catch (Exception e) {
+                throw new SQLException("Cannot convert to BigDecimal: " + val, SqlStateCode.CONVERSION_FAILED, e);
+            }
+        } else {
+            throw new SQLException("Cannot convert to BigDecimal: " + val, SqlStateCode.CONVERSION_FAILED);
+        }
     }
 
     /** {@inheritDoc} */
     @Override
     public BigDecimal getBigDecimal(String colLb, int scale) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        int colIdx = findColumn(colLb);
 
-        throw new UnsupportedOperationException();
+        return getBigDecimal(colIdx, scale);
     }
 
     /** {@inheritDoc} */
     @Override
     public BigDecimal getBigDecimal(String colLb) throws SQLException {
-        ensureNotClosed();
-        ensureHasCurrentRow();
+        int colIdx = findColumn(colLb);
 
-        throw new UnsupportedOperationException();
+        return getBigDecimal(colIdx);
     }
 
     /** {@inheritDoc} */

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc2/JdbcResultSet.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc2/JdbcResultSet.java
@@ -65,6 +65,10 @@ public class JdbcResultSet implements ResultSet {
 
     private static final ResultSetMetadata EMPTY_METADATA = new ResultSetMetadataImpl(List.of());
 
+    private static final BigDecimal MIN_DOUBLE = BigDecimal.valueOf(-Double.MAX_VALUE);
+
+    private static final BigDecimal MAX_DOUBLE = BigDecimal.valueOf(Double.MAX_VALUE);
+
     private final org.apache.ignite.sql.ResultSet<SqlRow> rs;
 
     private final ResultSetMetadata rsMetadata;
@@ -478,11 +482,7 @@ public class JdbcResultSet implements ResultSet {
                 return (double) val;
             case DECIMAL:
                 BigDecimal bd = (BigDecimal) val;
-
-                BigDecimal min = BigDecimal.valueOf(-Double.MAX_VALUE);
-                BigDecimal max = BigDecimal.valueOf(Double.MAX_VALUE);
-
-                if (bd.compareTo(min) < 0 || bd.compareTo(max) > 0) {
+                if (bd.compareTo(MIN_DOUBLE) < 0 || bd.compareTo(MAX_DOUBLE) > 0) {
                     throw new SQLException("Cannot convert to double: " + val, SqlStateCode.CONVERSION_FAILED);
                 }
                 return bd.doubleValue();

--- a/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc2/JdbcResultSet.java
+++ b/modules/jdbc/src/main/java/org/apache/ignite/internal/jdbc2/JdbcResultSet.java
@@ -175,21 +175,23 @@ public class JdbcResultSet implements ResultSet {
             return false;
         }
 
-        if (val instanceof Boolean) {
+        if ("0".equals(val)) {
+            return false;
+        } else if ("1".equals(val)) {
+            return true;
+        } else if (val instanceof Boolean) {
             return ((Boolean) val);
-        } else if (val instanceof BigDecimal) {
-            return BigDecimal.ZERO.compareTo((BigDecimal) val) != 0;
-        } else if (val instanceof Number) {
-            return ((Number) val).longValue() != 0L;
-        } else if (val instanceof String) {
-            try {
-                return Integer.parseInt(val.toString()) != 0;
-            } catch (NumberFormatException e) {
-                throw new SQLException("Cannot convert to boolean: " + val, SqlStateCode.CONVERSION_FAILED, e);
+        } else if (val instanceof Byte || val instanceof Short || val instanceof Integer || val instanceof Long) {
+            long num = ((Number) val).longValue();
+
+            if (num == 0) {
+                return false;
+            } else if (num == 1) {
+                return true;
             }
-        } else {
-            throw new SQLException("Cannot convert to boolean: " + val, SqlStateCode.CONVERSION_FAILED);
         }
+
+        throw new SQLException("Cannot convert to boolean: " + val, SqlStateCode.CONVERSION_FAILED);
     }
 
     /** {@inheritDoc} */
@@ -338,8 +340,6 @@ public class JdbcResultSet implements ResultSet {
 
         if (val instanceof Number) {
             return ((Number) val).floatValue();
-        } else if (val instanceof Boolean) {
-            return ((Boolean) val ? 1 : 0);
         } else if (val instanceof String) {
             try {
                 return Float.parseFloat(val.toString());
@@ -370,8 +370,6 @@ public class JdbcResultSet implements ResultSet {
 
         if (val instanceof Number) {
             return ((Number) val).doubleValue();
-        } else if (val instanceof Boolean) {
-            return ((Boolean) val ? 1.0d : 0.0d);
         } else if (val instanceof String) {
             try {
                 return Double.parseDouble(val.toString());
@@ -416,8 +414,6 @@ public class JdbcResultSet implements ResultSet {
         } else if (val instanceof Number) {
             // Perform exact conversion from integer types
             return new BigDecimal(((Number) val).longValue());
-        } else if (val instanceof Boolean) {
-            return new BigDecimal((Boolean) val ? 1 : 0);
         } else if (val instanceof String) {
             try {
                 return new BigDecimal(val.toString());

--- a/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc/JdbcResultSetBaseSelfTest.java
+++ b/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc/JdbcResultSetBaseSelfTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.math.RoundingMode;
 import java.sql.Blob;
 import java.sql.Clob;
@@ -179,7 +180,7 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
     }
 
     @ParameterizedTest
-    @ValueSource(bytes = {Byte.MIN_VALUE, -42, -1, 0, 1, 42, Byte.MAX_VALUE})
+    @ValueSource(bytes = {-42, -1, 0, 1, 42})
     public void getByte(byte value) throws SQLException {
         try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.INT8, 0, 0, false), value)) {
             assertTrue(rs.next());
@@ -310,7 +311,64 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
     }
 
     @ParameterizedTest
-    @ValueSource(shorts = {Short.MIN_VALUE, -42, -1, 0, 1, 42, Short.MAX_VALUE})
+    @MethodSource("getByteNumbers")
+    public void getByteFromNumber(boolean valid, Number value) throws SQLException {
+        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false), value)) {
+            assertTrue(rs.next());
+
+            if (valid) {
+                assertEquals(value.byteValue(), rs.getByte(1));
+                assertEquals(value.byteValue(), rs.getByte("C"));
+
+                assertEquals(value.byteValue(), rs.getObject(1, Byte.class));
+                assertEquals(value.byteValue(), rs.getObject("C", Byte.class));
+            } else {
+                expectSqlConversionError(() -> rs.getByte(1), "byte");
+                expectSqlConversionError(() -> rs.getByte("C"), "byte");
+
+                expectSqlConversionError(() -> rs.getObject(1, Byte.class), "byte");
+                expectSqlConversionError(() -> rs.getObject("C", Byte.class), "byte");
+            }
+        }
+    }
+
+    private static Stream<Arguments> getByteNumbers() {
+        return Stream.of(
+                Arguments.of(true, Byte.MAX_VALUE),
+                Arguments.of(true, Byte.MIN_VALUE),
+
+                Arguments.of(true, (short) 42),
+                Arguments.of(false, (short) (Byte.MAX_VALUE + 1)),
+                Arguments.of(false, (short) (Byte.MIN_VALUE - 1)),
+
+                Arguments.of(true, 42),
+                Arguments.of(true, 42L),
+
+                Arguments.of(true, 42.0f),
+                Arguments.of(false, (float) (Byte.MAX_VALUE + 1L)),
+                Arguments.of(false, (float) (Byte.MIN_VALUE - 1L)),
+                Arguments.of(false, Float.NaN),
+                Arguments.of(false, Float.NEGATIVE_INFINITY),
+                Arguments.of(false, Float.POSITIVE_INFINITY),
+
+                Arguments.of(true, 42.0d),
+                Arguments.of(false, (double) (Byte.MAX_VALUE + 1L)),
+                Arguments.of(false, (double) (Byte.MIN_VALUE - 1L)),
+                Arguments.of(false, Double.NaN),
+                Arguments.of(false, Double.NEGATIVE_INFINITY),
+                Arguments.of(false, Double.POSITIVE_INFINITY),
+
+                Arguments.of(true, BigDecimal.valueOf(42.1)),
+                Arguments.of(true, BigDecimal.valueOf(42.9)),
+                Arguments.of(true, BigDecimal.valueOf(Byte.MAX_VALUE)),
+                Arguments.of(true, BigDecimal.valueOf(Byte.MIN_VALUE)),
+                Arguments.of(false, BigDecimal.valueOf((short) (Byte.MAX_VALUE + 1))),
+                Arguments.of(false, BigDecimal.valueOf((short) (Byte.MIN_VALUE - 1)))
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(shorts = {-42, -1, 0, 1, 42})
     public void getShort(short value) throws SQLException {
         try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.INT16, 0, 0, false), value)) {
             assertTrue(rs.next());
@@ -445,7 +503,65 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {Integer.MIN_VALUE, -42, -1, 0, 1, 42, Integer.MAX_VALUE})
+    @MethodSource("getShortNumbers")
+    public void getShortFromNumber(boolean valid, Number value) throws SQLException {
+        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false), value)) {
+            assertTrue(rs.next());
+
+            if (valid) {
+                assertEquals(value.shortValue(), rs.getShort(1));
+                assertEquals(value.shortValue(), rs.getShort("C"));
+
+                assertEquals(value.shortValue(), rs.getObject(1, Short.class));
+                assertEquals(value.shortValue(), rs.getObject("C", Short.class));
+            } else {
+                expectSqlConversionError(() -> rs.getShort(1), "short");
+                expectSqlConversionError(() -> rs.getShort("C"), "short");
+
+                expectSqlConversionError(() -> rs.getObject(1, Short.class), "short");
+                expectSqlConversionError(() -> rs.getObject("C", Short.class), "short");
+            }
+        }
+    }
+
+    private static Stream<Arguments> getShortNumbers() {
+        return Stream.of(
+                Arguments.of(true, (byte) 42),
+
+                Arguments.of(true, Short.MAX_VALUE),
+                Arguments.of(true, Short.MIN_VALUE),
+
+                Arguments.of(false, Short.MAX_VALUE + 1),
+                Arguments.of(false, Short.MIN_VALUE - 1),
+
+                Arguments.of(true, 42),
+                Arguments.of(true, 42L),
+
+                Arguments.of(true, 42.0f),
+                Arguments.of(false, (float) (Short.MAX_VALUE + 1L)),
+                Arguments.of(false, (float) (Short.MIN_VALUE - 1L)),
+                Arguments.of(false, Float.NaN),
+                Arguments.of(false, Float.NEGATIVE_INFINITY),
+                Arguments.of(false, Float.POSITIVE_INFINITY),
+
+                Arguments.of(true, 42.0d),
+                Arguments.of(false, (double) (Short.MAX_VALUE + 1L)),
+                Arguments.of(false, (double) (Short.MIN_VALUE - 1L)),
+                Arguments.of(false, Double.NaN),
+                Arguments.of(false, Double.NEGATIVE_INFINITY),
+                Arguments.of(false, Double.POSITIVE_INFINITY),
+
+                Arguments.of(true, BigDecimal.valueOf(42.1)),
+                Arguments.of(true, BigDecimal.valueOf(42.9)),
+                Arguments.of(true, BigDecimal.valueOf(Short.MAX_VALUE)),
+                Arguments.of(true, BigDecimal.valueOf(Short.MIN_VALUE)),
+                Arguments.of(false, BigDecimal.valueOf(Short.MAX_VALUE + 1)),
+                Arguments.of(false, BigDecimal.valueOf(Short.MIN_VALUE - 1))
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-42, -1, 0, 1, 42})
     public void getInt(int value) throws SQLException {
         try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.INT32, 0, 0, false), value)) {
             assertTrue(rs.next());
@@ -584,7 +700,64 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
     }
 
     @ParameterizedTest
-    @ValueSource(longs = {Long.MIN_VALUE, -42, -1, 0, 1, 42, Long.MAX_VALUE})
+    @MethodSource("getIntNumbers")
+    public void getIntFromNumber(boolean valid, Number value) throws SQLException {
+        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false), value)) {
+            assertTrue(rs.next());
+
+            if (valid) {
+                assertEquals(value.intValue(), rs.getInt(1));
+                assertEquals(value.intValue(), rs.getInt("C"));
+
+                assertEquals(value.intValue(), rs.getObject(1, Integer.class));
+                assertEquals(value.intValue(), rs.getObject("C", Integer.class));
+            } else {
+                expectSqlConversionError(() -> rs.getInt(1), "int");
+                expectSqlConversionError(() -> rs.getInt("C"), "int");
+
+                expectSqlConversionError(() -> rs.getObject(1, Integer.class), "int");
+                expectSqlConversionError(() -> rs.getObject("C", Integer.class), "int");
+            }
+        }
+    }
+
+    private static Stream<Arguments> getIntNumbers() {
+        return Stream.of(
+                Arguments.of(true, (byte) 42),
+                Arguments.of(true, (short) 42),
+
+                Arguments.of(true, Integer.MAX_VALUE),
+                Arguments.of(true, Integer.MIN_VALUE),
+
+                Arguments.of(true, 42L),
+                Arguments.of(false, Integer.MAX_VALUE + 1L),
+                Arguments.of(false, Integer.MIN_VALUE - 1L),
+
+                Arguments.of(true, 42.0f),
+                Arguments.of(false, (float) (Integer.MAX_VALUE + 1L)),
+                Arguments.of(false, Float.NaN),
+                Arguments.of(false, Float.NEGATIVE_INFINITY),
+                Arguments.of(false, Float.POSITIVE_INFINITY),
+
+                Arguments.of(true, 42.0d),
+                Arguments.of(false, (double) (Integer.MAX_VALUE + 1L)),
+                Arguments.of(false, (double) (Integer.MIN_VALUE - 1L)),
+                Arguments.of(false, Double.NaN),
+                Arguments.of(false, Double.NEGATIVE_INFINITY),
+                Arguments.of(false, Double.POSITIVE_INFINITY),
+
+                Arguments.of(true, BigDecimal.valueOf(42)),
+                Arguments.of(true, BigDecimal.valueOf(42.1)),
+                Arguments.of(true, BigDecimal.valueOf(42.9)),
+                Arguments.of(true, BigDecimal.valueOf(Integer.MAX_VALUE)),
+                Arguments.of(true, BigDecimal.valueOf(Integer.MIN_VALUE)),
+                Arguments.of(false, BigDecimal.valueOf(Integer.MAX_VALUE + 1L)),
+                Arguments.of(false, BigDecimal.valueOf(Integer.MIN_VALUE - 1L))
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {-42, -1, 0, 1, 42})
     public void getLong(long value) throws SQLException {
         try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.INT64, 0, 0, false), value)) {
             assertTrue(rs.next());
@@ -727,7 +900,62 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
     }
 
     @ParameterizedTest
-    @ValueSource(floats = {Float.MIN_VALUE, -42.3f, 42.9f, Float.MAX_VALUE})
+    @MethodSource("getLongNumbers")
+    public void getLongFromNumber(boolean valid, Number value) throws SQLException {
+        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false), value)) {
+            assertTrue(rs.next());
+
+            if (valid) {
+                assertEquals(value.longValue(), rs.getLong(1));
+                assertEquals(value.longValue(), rs.getLong("C"));
+
+                assertEquals(value.longValue(), rs.getObject(1, Long.class));
+                assertEquals(value.longValue(), rs.getObject("C", Long.class));
+            } else {
+                expectSqlConversionError(() -> rs.getLong(1), "long");
+                expectSqlConversionError(() -> rs.getLong("C"), "long");
+
+                expectSqlConversionError(() -> rs.getObject(1, Long.class), "long");
+                expectSqlConversionError(() -> rs.getObject("C", Long.class), "long");
+            }
+        }
+    }
+
+    private static Stream<Arguments> getLongNumbers() {
+        return Stream.of(
+                Arguments.of(true, (byte) 42),
+                Arguments.of(true, (short) 42),
+
+                Arguments.of(true, 42),
+                Arguments.of(true, Long.MAX_VALUE),
+                Arguments.of(true, Long.MIN_VALUE),
+
+                Arguments.of(true, 42.0f),
+                Arguments.of(true, (float) (Long.MAX_VALUE)),
+                Arguments.of(true, (float) (Long.MIN_VALUE)),
+                Arguments.of(false, Float.NaN),
+                Arguments.of(false, Float.NEGATIVE_INFINITY),
+                Arguments.of(false, Float.POSITIVE_INFINITY),
+
+                Arguments.of(true, 42.0d),
+                Arguments.of(true, (double) (Long.MAX_VALUE)),
+                Arguments.of(true, (double) (Long.MIN_VALUE)),
+                Arguments.of(false, Double.NaN),
+                Arguments.of(false, Double.NEGATIVE_INFINITY),
+                Arguments.of(false, Double.POSITIVE_INFINITY),
+
+                Arguments.of(true, BigDecimal.valueOf(42)),
+                Arguments.of(true, BigDecimal.valueOf(42.1)),
+                Arguments.of(true, BigDecimal.valueOf(42.9)),
+                Arguments.of(true, BigDecimal.valueOf(Long.MAX_VALUE)),
+                Arguments.of(true, BigDecimal.valueOf(Long.MIN_VALUE)),
+                Arguments.of(false, BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE)),
+                Arguments.of(false, BigDecimal.valueOf(Long.MIN_VALUE).add(BigDecimal.ONE.negate()))
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(floats = {-42.3f, 42.9f})
     public void getFloat(float value) throws SQLException {
         try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.FLOAT, 0, 0, false), value)) {
             assertTrue(rs.next());
@@ -846,7 +1074,60 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
     }
 
     @ParameterizedTest
-    @ValueSource(doubles = {Double.MIN_VALUE, -42.3d, 0, 42.9d, Double.MAX_VALUE})
+    @MethodSource("getFloatNumbers")
+    public void getFloatFromNumber(boolean valid, Number value) throws SQLException {
+        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false), value)) {
+            assertTrue(rs.next());
+
+            if (valid) {
+                assertEquals(value.floatValue(), rs.getFloat(1));
+                assertEquals(value.floatValue(), rs.getFloat("C"));
+
+                assertEquals(value.floatValue(), rs.getObject(1, Float.class));
+                assertEquals(value.floatValue(), rs.getObject("C", Float.class));
+            } else {
+                expectSqlConversionError(() -> rs.getFloat(1), "float");
+                expectSqlConversionError(() -> rs.getFloat("C"), "float");
+
+                expectSqlConversionError(() -> rs.getObject(1, Float.class), "float");
+                expectSqlConversionError(() -> rs.getObject("C", Float.class), "float");
+            }
+        }
+    }
+
+    private static Stream<Arguments> getFloatNumbers() {
+        return Stream.of(
+                Arguments.of(true, (byte) 42),
+                Arguments.of(true, (short) 42),
+
+                Arguments.of(true, 42),
+                Arguments.of(true, Long.MAX_VALUE),
+                Arguments.of(true, Long.MIN_VALUE),
+
+                Arguments.of(true, 42.0f),
+                Arguments.of(true, (float) (Long.MAX_VALUE)),
+                Arguments.of(true, (float) (Long.MIN_VALUE)),
+                Arguments.of(true, Float.NaN),
+                Arguments.of(true, Float.NEGATIVE_INFINITY),
+                Arguments.of(true, Float.POSITIVE_INFINITY),
+
+                Arguments.of(true, 42.0d),
+                Arguments.of(true, (double) (Long.MAX_VALUE)),
+                Arguments.of(true, (double) (Long.MIN_VALUE)),
+                Arguments.of(false, Double.NaN),
+                Arguments.of(false, Double.NEGATIVE_INFINITY),
+                Arguments.of(false, Double.POSITIVE_INFINITY),
+
+                Arguments.of(true, BigDecimal.valueOf(42)),
+                Arguments.of(true, BigDecimal.valueOf(Float.MAX_VALUE)),
+                Arguments.of(true, BigDecimal.valueOf(-Float.MAX_VALUE)),
+                Arguments.of(false, BigDecimal.valueOf(Double.MAX_VALUE)),
+                Arguments.of(false, BigDecimal.valueOf(-Double.MAX_VALUE))
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {-42.3d, 0, 42.9d})
     public void getDouble(double value) throws SQLException {
         try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.DOUBLE, 0, 0, false), value)) {
             assertTrue(rs.next());
@@ -969,6 +1250,59 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
     }
 
     @ParameterizedTest
+    @MethodSource("getDoubleNumbers")
+    public void getDoubleFromNumber(boolean valid, Number value) throws SQLException {
+        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false), value)) {
+            assertTrue(rs.next());
+
+            if (valid) {
+                assertEquals(value.doubleValue(), rs.getDouble(1));
+                assertEquals(value.doubleValue(), rs.getDouble("C"));
+
+                assertEquals(value.doubleValue(), rs.getObject(1, Double.class));
+                assertEquals(value.doubleValue(), rs.getObject("C", Double.class));
+            } else {
+                expectSqlConversionError(() -> rs.getDouble(1), "double");
+                expectSqlConversionError(() -> rs.getDouble("C"), "double");
+
+                expectSqlConversionError(() -> rs.getObject(1, Double.class), "double");
+                expectSqlConversionError(() -> rs.getObject("C", Double.class), "double");
+            }
+        }
+    }
+
+    private static Stream<Arguments> getDoubleNumbers() {
+        return Stream.of(
+                Arguments.of(true, (byte) 42),
+                Arguments.of(true, (short) 42),
+
+                Arguments.of(true, 42),
+                Arguments.of(true, Long.MAX_VALUE),
+                Arguments.of(true, Long.MIN_VALUE),
+
+                Arguments.of(true, 42.0f),
+                Arguments.of(true, (float) (Long.MAX_VALUE)),
+                Arguments.of(true, (float) (Long.MIN_VALUE)),
+                Arguments.of(true, Float.NaN),
+                Arguments.of(true, Float.NEGATIVE_INFINITY),
+                Arguments.of(true, Float.POSITIVE_INFINITY),
+
+                Arguments.of(true, 42.0d),
+                Arguments.of(true, (double) (Long.MAX_VALUE)),
+                Arguments.of(true, (double) (Long.MIN_VALUE)),
+                Arguments.of(true, Double.NaN),
+                Arguments.of(true, Double.NEGATIVE_INFINITY),
+                Arguments.of(true, Double.POSITIVE_INFINITY),
+
+                Arguments.of(true, BigDecimal.valueOf(42.0d)),
+                Arguments.of(true, BigDecimal.valueOf(Double.MAX_VALUE)),
+                Arguments.of(true, BigDecimal.valueOf(-Double.MAX_VALUE)),
+                Arguments.of(false, BigDecimal.TEN.pow(512, MathContext.DECIMAL128)),
+                Arguments.of(false, BigDecimal.TEN.pow(512, MathContext.DECIMAL128).negate())
+        );
+    }
+
+    @ParameterizedTest
     @MethodSource("getBigDecimalValues")
     public void getBigDecimal(BigDecimal value) throws SQLException {
         try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.DECIMAL, 0, 0, false), value)) {
@@ -1048,15 +1382,11 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
 
     private static Stream<BigDecimal> getBigDecimalValues() {
         return Stream.of(
-                new BigDecimal("-9223372036854775808"),
-                new BigDecimal("6786576121.098912301287").negate(),
                 new BigDecimal("121.234").negate(),
                 BigDecimal.ONE.negate(),
                 BigDecimal.ZERO,
                 BigDecimal.ONE,
-                new BigDecimal("121.234"),
-                new BigDecimal("6786576121.098912301287"),
-                new BigDecimal("9223372036854775807")
+                new BigDecimal("121.234")
         );
     }
 
@@ -1088,6 +1418,63 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
                 assertEquals(new BigDecimal(result), rs.getBigDecimal("C"));
             }
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("getBigDecimalNumbers")
+    public void getBigDecimalFromNumber(boolean valid, Number value) throws SQLException {
+        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false), value)) {
+            assertTrue(rs.next());
+
+            if (valid) {
+                BigDecimal expected;
+                if (value instanceof BigDecimal) {
+                    expected = (BigDecimal) value;
+                } else if (value instanceof Float || value instanceof Double) {
+                    expected = new BigDecimal(value.doubleValue());
+                } else {
+                    expected = new BigDecimal(value.longValue());
+                }
+
+                assertEquals(expected, rs.getBigDecimal(1));
+                assertEquals(expected, rs.getBigDecimal("C"));
+
+                assertEquals(expected, rs.getObject(1, BigDecimal.class));
+                assertEquals(expected, rs.getObject("C", BigDecimal.class));
+            } else {
+                expectSqlConversionError(() -> rs.getBigDecimal(1), "double");
+                expectSqlConversionError(() -> rs.getBigDecimal("C"), "double");
+
+                expectSqlConversionError(() -> rs.getObject(1, BigDecimal.class), "double");
+                expectSqlConversionError(() -> rs.getObject("C", BigDecimal.class), "double");
+            }
+        }
+    }
+
+    private static Stream<Arguments> getBigDecimalNumbers() {
+        return Stream.of(
+                Arguments.of(true, (byte) 42),
+                Arguments.of(true, (byte) 42),
+                Arguments.of(true, (short) 42),
+
+                Arguments.of(true, 42),
+                Arguments.of(true, Long.MAX_VALUE),
+                Arguments.of(true, Long.MIN_VALUE),
+
+                Arguments.of(true, 42.0f),
+                Arguments.of(true, (float) (Long.MAX_VALUE)),
+                Arguments.of(true, (float) (Long.MIN_VALUE)),
+
+                Arguments.of(true, 42.0d),
+                Arguments.of(true, (double) (Long.MAX_VALUE)),
+                Arguments.of(true, (double) (Long.MIN_VALUE)),
+
+                Arguments.of(true, BigDecimal.valueOf(42.0d)),
+                Arguments.of(true, BigDecimal.valueOf(42.123d)),
+                Arguments.of(true, BigDecimal.valueOf(45.9d)),
+                Arguments.of(true, BigDecimal.valueOf(Double.MAX_VALUE)),
+                Arguments.of(true, BigDecimal.valueOf(-Double.MAX_VALUE))
+        );
     }
 
     @ParameterizedTest
@@ -1170,13 +1557,11 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
 
     private static Stream<Arguments> getBigDecimalScaledValues() {
         return Stream.of(
-                Arguments.of(new BigDecimal("-9223372036854775808"), 0),
-                Arguments.of(new BigDecimal("6786576121.098912301287").negate(), 13),
+                Arguments.of(new BigDecimal("67.098912301287").negate(), 13),
                 Arguments.of(new BigDecimal("121.234").negate(), 3),
                 Arguments.of(BigDecimal.ZERO, 0),
                 Arguments.of(new BigDecimal("121.234"), 3),
-                Arguments.of(new BigDecimal("6786576121.098912301287"), 13),
-                Arguments.of(new BigDecimal("9223372036854775807"), 0)
+                Arguments.of(new BigDecimal("67.098912301287"), 13)
         );
     }
 

--- a/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc/JdbcResultSetBaseSelfTest.java
+++ b/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc/JdbcResultSetBaseSelfTest.java
@@ -210,14 +210,17 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
             assertTrue(rs.next());
 
             if (!valid) {
-                expectSqlException(() -> rs.getBoolean(1), "Cannot convert to boolean: " + value);
-                expectSqlException(() -> rs.getBoolean("C"), "Cannot convert to boolean: " + value);
+                String error = "Cannot convert to boolean: " + value;
 
-                expectSqlException(() -> rs.getObject(1, Boolean.class), "Cannot convert to boolean: " + value);
-                expectSqlException(() -> rs.getObject("C", Boolean.class), "Cannot convert to boolean: " + value);
+                expectSqlException(() -> rs.getBoolean(1), error);
+                expectSqlException(() -> rs.getBoolean("C"), error);
+
+                expectSqlException(() -> rs.getObject(1, Boolean.class), error);
+                expectSqlException(() -> rs.getObject("C", Boolean.class), error);
 
             } else {
                 boolean expected = Boolean.parseBoolean(result);
+
                 assertEquals(expected, rs.getBoolean(1));
                 assertEquals(expected, rs.getBoolean("C"));
 
@@ -333,11 +336,20 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
             assertTrue(rs.next());
 
             if (!valid) {
-                expectSqlException(() -> rs.getByte(1), "Cannot convert to byte: " + value);
-                expectSqlException(() -> rs.getByte("C"), "Cannot convert to byte: " + value);
+                String error = "Cannot convert to byte: " + value;
+
+                expectSqlException(() -> rs.getByte(1), error);
+                expectSqlException(() -> rs.getByte("C"), error);
+
+                expectSqlException(() -> rs.getObject(1, Byte.class), error);
+                expectSqlException(() -> rs.getObject("C", Byte.class), error);
             } else {
-                assertEquals(Byte.parseByte(result), rs.getByte(1));
-                assertEquals(Byte.parseByte(result), rs.getByte("C"));
+                byte expected = Byte.parseByte(result);
+                assertEquals(expected, rs.getByte(1));
+                assertEquals(expected, rs.getByte("C"));
+
+                assertEquals(expected, rs.getObject(1, Byte.class));
+                assertEquals(expected, rs.getObject("C", Byte.class));
             }
         }
     }
@@ -527,11 +539,21 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
             assertTrue(rs.next());
 
             if (!valid) {
-                expectSqlException(() -> rs.getShort(1), "Cannot convert to short: " + value);
-                expectSqlException(() -> rs.getShort("C"), "Cannot convert to short: " + value);
+                String error = "Cannot convert to short: " + value;
+
+                expectSqlException(() -> rs.getShort(1), error);
+                expectSqlException(() -> rs.getShort("C"), error);
+
+                expectSqlException(() -> rs.getObject(1, Short.class), error);
+                expectSqlException(() -> rs.getObject("C", Short.class), error);
             } else {
-                assertEquals(Short.parseShort(result), rs.getShort(1));
-                assertEquals(Short.parseShort(result), rs.getShort("C"));
+                short expected = Short.parseShort(result);
+
+                assertEquals(expected, rs.getShort(1));
+                assertEquals(expected, rs.getShort("C"));
+
+                assertEquals(expected, rs.getObject(1, Short.class));
+                assertEquals(expected, rs.getObject("C", Short.class));
             }
         }
     }
@@ -726,11 +748,21 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
             assertTrue(rs.next());
 
             if (!valid) {
-                expectSqlException(() -> rs.getInt(1), "Cannot convert to int: " + value);
-                expectSqlException(() -> rs.getInt("C"), "Cannot convert to int: " + value);
+                String error = "Cannot convert to int: " + value;
+
+                expectSqlException(() -> rs.getInt(1), error);
+                expectSqlException(() -> rs.getInt("C"), error);
+
+                expectSqlException(() -> rs.getObject(1, Integer.class), error);
+                expectSqlException(() -> rs.getObject("C", Integer.class), error);
             } else {
-                assertEquals(Integer.parseInt(result), rs.getInt(1));
-                assertEquals(Integer.parseInt(result), rs.getInt("C"));
+                int expected = Integer.parseInt(result);
+
+                assertEquals(expected, rs.getInt(1));
+                assertEquals(expected, rs.getInt("C"));
+
+                assertEquals(expected, rs.getObject(1, Integer.class));
+                assertEquals(expected, rs.getObject("C", Integer.class));
             }
         }
     }
@@ -927,11 +959,21 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
             assertTrue(rs.next());
 
             if (!valid) {
-                expectSqlException(() -> rs.getLong(1), "Cannot convert to long: " + value);
-                expectSqlException(() -> rs.getLong("C"), "Cannot convert to long: " + value);
+                String error = "Cannot convert to long: " + value;
+
+                expectSqlException(() -> rs.getLong(1), error);
+                expectSqlException(() -> rs.getLong("C"), error);
+
+                expectSqlException(() -> rs.getObject(1, Long.class), error);
+                expectSqlException(() -> rs.getObject("C", Long.class), error);
             } else {
-                assertEquals(Long.parseLong(result), rs.getLong(1));
-                assertEquals(Long.parseLong(result), rs.getLong("C"));
+                long expected = Long.parseLong(result);
+
+                assertEquals(expected, rs.getLong(1));
+                assertEquals(expected, rs.getLong("C"));
+
+                assertEquals(expected, rs.getObject(1, Long.class));
+                assertEquals(expected, rs.getObject("C", Long.class));
             }
         }
     }
@@ -1119,11 +1161,21 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
             assertTrue(rs.next());
 
             if (!valid) {
-                expectSqlException(() -> rs.getFloat(1), "Cannot convert to float: " + value);
-                expectSqlException(() -> rs.getFloat("C"), "Cannot convert to float: " + value);
+                String error = "Cannot convert to float: " + value;
+
+                expectSqlException(() -> rs.getFloat(1), error);
+                expectSqlException(() -> rs.getFloat("C"), error);
+
+                expectSqlException(() -> rs.getObject(1, Float.class), error);
+                expectSqlException(() -> rs.getObject("C", Float.class), error);
             } else {
-                assertEquals(Float.parseFloat(result), rs.getFloat(1));
-                assertEquals(Float.parseFloat(result), rs.getFloat("C"));
+                float expected = Float.parseFloat(result);
+
+                assertEquals(expected, rs.getFloat(1));
+                assertEquals(expected, rs.getFloat("C"));
+
+                assertEquals(expected, rs.getObject(1, Float.class));
+                assertEquals(expected, rs.getObject("C", Float.class));
             }
         }
     }
@@ -1297,11 +1349,21 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
             assertTrue(rs.next());
 
             if (!valid) {
-                expectSqlException(() -> rs.getDouble(1), "Cannot convert to double: " + value);
-                expectSqlException(() -> rs.getDouble("C"), "Cannot convert to double: " + value);
+                String error = "Cannot convert to double: " + value;
+
+                expectSqlException(() -> rs.getDouble(1), error);
+                expectSqlException(() -> rs.getDouble("C"), error);
+
+                expectSqlException(() -> rs.getObject(1, Double.class), error);
+                expectSqlException(() -> rs.getObject("C", Double.class), error);
             } else {
-                assertEquals(Double.parseDouble(result), rs.getDouble(1));
-                assertEquals(Double.parseDouble(result), rs.getDouble("C"));
+                double expected = Double.parseDouble(result);
+
+                assertEquals(expected, rs.getDouble(1));
+                assertEquals(expected, rs.getDouble("C"));
+
+                assertEquals(expected, rs.getObject(1, Double.class));
+                assertEquals(expected, rs.getObject("C", Double.class));
             }
         }
     }
@@ -1470,11 +1532,18 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
             assertTrue(rs.next());
 
             if (!valid) {
-                expectSqlException(() -> rs.getBigDecimal(1), "Cannot convert to BigDecimal: " + value);
-                expectSqlException(() -> rs.getBigDecimal("C"), "Cannot convert to BigDecimal: " + value);
+                String error = "Cannot convert to BigDecimal: " + value;
+
+                expectSqlException(() -> rs.getBigDecimal(1), error);
+                expectSqlException(() -> rs.getBigDecimal("C"), error);
             } else {
-                assertEquals(new BigDecimal(result), rs.getBigDecimal(1));
-                assertEquals(new BigDecimal(result), rs.getBigDecimal("C"));
+                BigDecimal expected = new BigDecimal(result);
+
+                assertEquals(expected, rs.getBigDecimal(1));
+                assertEquals(expected, rs.getBigDecimal("C"));
+
+                assertEquals(expected, rs.getObject(1, BigDecimal.class));
+                assertEquals(expected, rs.getObject("C", BigDecimal.class));
             }
         }
     }

--- a/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc/JdbcResultSetBaseSelfTest.java
+++ b/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc/JdbcResultSetBaseSelfTest.java
@@ -243,12 +243,9 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
             if (value == 0) {
                 assertFalse(rs.getBoolean(1));
                 assertFalse(rs.getBoolean("C"));
-            } else if (value == 1) {
+            } else {
                 assertTrue(rs.getBoolean(1));
                 assertTrue(rs.getBoolean("C"));
-            } else {
-                expectSqlConversionError(() -> rs.getBoolean(1), "boolean");
-                expectSqlConversionError(() -> rs.getBoolean("C"), "boolean");
             }
 
             assertEquals(value, rs.getByte(1));
@@ -442,12 +439,9 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
             if (value == 0) {
                 assertFalse(rs.getBoolean(1));
                 assertFalse(rs.getBoolean("C"));
-            } else if (value == 1) {
+            } else {
                 assertTrue(rs.getBoolean(1));
                 assertTrue(rs.getBoolean("C"));
-            } else {
-                expectSqlConversionError(() -> rs.getBoolean(1), "boolean");
-                expectSqlConversionError(() -> rs.getBoolean("C"), "boolean");
             }
 
             //noinspection NumericCastThatLosesPrecision
@@ -647,12 +641,9 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
             if (value == 0) {
                 assertFalse(rs.getBoolean(1));
                 assertFalse(rs.getBoolean("C"));
-            } else if (value == 1) {
+            } else {
                 assertTrue(rs.getBoolean(1));
                 assertTrue(rs.getBoolean("C"));
-            } else {
-                expectSqlConversionError(() -> rs.getBoolean(1), "boolean");
-                expectSqlConversionError(() -> rs.getBoolean("C"), "boolean");
             }
 
             //noinspection NumericCastThatLosesPrecision
@@ -854,12 +845,9 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
             if (value == 0) {
                 assertFalse(rs.getBoolean(1));
                 assertFalse(rs.getBoolean("C"));
-            } else if (value == 1) {
+            } else {
                 assertTrue(rs.getBoolean(1));
                 assertTrue(rs.getBoolean("C"));
-            } else {
-                expectSqlConversionError(() -> rs.getBoolean(1), "boolean");
-                expectSqlConversionError(() -> rs.getBoolean("C"), "boolean");
             }
 
             //noinspection NumericCastThatLosesPrecision

--- a/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc/JdbcResultSetBaseSelfTest.java
+++ b/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc/JdbcResultSetBaseSelfTest.java
@@ -101,6 +101,18 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
         return createMultiRow(null, columns, values);
     }
 
+    private static ColumnType columnTypefromObject(Object value) {
+        if (value == null) {
+            return ColumnType.NULL;
+        }
+        for (ColumnType columnType : ColumnType.values()) {
+            if (columnType.javaClass().equals(value.getClass())) {
+                return columnType;
+            }
+        }
+        throw new IllegalArgumentException("No column type for " + value);
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void getBoolean(boolean boolValue) throws SQLException {
@@ -313,7 +325,9 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
     @ParameterizedTest
     @MethodSource("getByteNumbers")
     public void getByteFromNumber(boolean valid, Number value) throws SQLException {
-        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false), value)) {
+        ColumnType columnType = columnTypefromObject(value);
+
+        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", columnType, 0, 0, false), value)) {
             assertTrue(rs.next());
 
             if (valid) {
@@ -505,7 +519,9 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
     @ParameterizedTest
     @MethodSource("getShortNumbers")
     public void getShortFromNumber(boolean valid, Number value) throws SQLException {
-        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false), value)) {
+        ColumnType columnType = columnTypefromObject(value);
+
+        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", columnType, 0, 0, false), value)) {
             assertTrue(rs.next());
 
             if (valid) {
@@ -702,7 +718,9 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
     @ParameterizedTest
     @MethodSource("getIntNumbers")
     public void getIntFromNumber(boolean valid, Number value) throws SQLException {
-        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false), value)) {
+        ColumnType columnType = columnTypefromObject(value);
+
+        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", columnType, 0, 0, false), value)) {
             assertTrue(rs.next());
 
             if (valid) {
@@ -734,7 +752,6 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
                 Arguments.of(false, Integer.MIN_VALUE - 1L),
 
                 Arguments.of(true, 42.0f),
-                Arguments.of(false, (float) (Integer.MAX_VALUE + 1L)),
                 Arguments.of(false, Float.NaN),
                 Arguments.of(false, Float.NEGATIVE_INFINITY),
                 Arguments.of(false, Float.POSITIVE_INFINITY),
@@ -902,7 +919,9 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
     @ParameterizedTest
     @MethodSource("getLongNumbers")
     public void getLongFromNumber(boolean valid, Number value) throws SQLException {
-        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false), value)) {
+        ColumnType columnType = columnTypefromObject(value);
+
+        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", columnType, 0, 0, false), value)) {
             assertTrue(rs.next());
 
             if (valid) {
@@ -1076,7 +1095,9 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
     @ParameterizedTest
     @MethodSource("getFloatNumbers")
     public void getFloatFromNumber(boolean valid, Number value) throws SQLException {
-        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false), value)) {
+        ColumnType columnType = columnTypefromObject(value);
+
+        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", columnType, 0, 0, false), value)) {
             assertTrue(rs.next());
 
             if (valid) {
@@ -1114,7 +1135,7 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
                 Arguments.of(true, 42.0d),
                 Arguments.of(true, (double) (Long.MAX_VALUE)),
                 Arguments.of(true, (double) (Long.MIN_VALUE)),
-                Arguments.of(false, Double.NaN),
+                Arguments.of(true, Double.NaN),
                 Arguments.of(false, Double.NEGATIVE_INFINITY),
                 Arguments.of(false, Double.POSITIVE_INFINITY),
 
@@ -1252,7 +1273,9 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
     @ParameterizedTest
     @MethodSource("getDoubleNumbers")
     public void getDoubleFromNumber(boolean valid, Number value) throws SQLException {
-        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false), value)) {
+        ColumnType columnType = columnTypefromObject(value);
+
+        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", columnType, 0, 0, false), value)) {
             assertTrue(rs.next());
 
             if (valid) {
@@ -1423,7 +1446,9 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
     @ParameterizedTest
     @MethodSource("getBigDecimalNumbers")
     public void getBigDecimalFromNumber(boolean valid, Number value) throws SQLException {
-        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false), value)) {
+        ColumnType columnType = columnTypefromObject(value);
+
+        try (ResultSet rs = createSingleRow(new ColumnDefinition("C", columnType, 0, 0, false), value)) {
             assertTrue(rs.next());
 
             if (valid) {
@@ -1473,7 +1498,9 @@ public abstract class JdbcResultSetBaseSelfTest extends BaseIgniteAbstractTest {
                 Arguments.of(true, BigDecimal.valueOf(42.123d)),
                 Arguments.of(true, BigDecimal.valueOf(45.9d)),
                 Arguments.of(true, BigDecimal.valueOf(Double.MAX_VALUE)),
-                Arguments.of(true, BigDecimal.valueOf(-Double.MAX_VALUE))
+                Arguments.of(true, BigDecimal.valueOf(-Double.MAX_VALUE)),
+                Arguments.of(true, BigDecimal.valueOf(Double.MAX_VALUE).add(BigDecimal.TEN)),
+                Arguments.of(true, BigDecimal.valueOf(-Double.MAX_VALUE).add(BigDecimal.TEN.negate()))
         );
     }
 

--- a/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc/JdbcResultSetSelfTest.java
+++ b/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc/JdbcResultSetSelfTest.java
@@ -76,4 +76,46 @@ public class JdbcResultSetSelfTest extends JdbcResultSetBaseSelfTest {
     public void navigationMethods() throws SQLException {
         super.navigationMethods();
     }
+
+    // getByte does not have range checks in the current JDBC driver it is not worth fixing them
+    @Disabled("https://issues.apache.org/jira/browse/IGNITE-26140")
+    @Override
+    public void getByteFromNumber(boolean valid, Number value) throws SQLException {
+        super.getByteFromNumber(valid, value);
+    }
+
+    // getShort does not have range checks  in the current JDBC driver it is not worth fixing them
+    @Disabled("https://issues.apache.org/jira/browse/IGNITE-26140")
+    @Override
+    public void getShortFromNumber(boolean valid, Number value) throws SQLException {
+        super.getShortFromNumber(valid, value);
+    }
+
+    // getInt does not have range checks  in the current JDBC driver it is not worth fixing them
+    @Disabled("https://issues.apache.org/jira/browse/IGNITE-26140")
+    @Override
+    public void getIntFromNumber(boolean valid, Number value) throws SQLException {
+        super.getLongFromNumber(valid, value);
+    }
+
+    // getLong does not have range checks  in the current JDBC driver it is not worth fixing them
+    @Disabled("https://issues.apache.org/jira/browse/IGNITE-26140")
+    @Override
+    public void getLongFromNumber(boolean valid, Number value) throws SQLException {
+        super.getLongFromNumber(valid, value);
+    }
+
+    // getFloat does not have range checks  in the current JDBC driver it is not worth fixing them
+    @Disabled("https://issues.apache.org/jira/browse/IGNITE-26140")
+    @Override
+    public void getFloatFromNumber(boolean valid, Number value) throws SQLException {
+        super.getFloatFromNumber(valid, value);
+    }
+
+    // getDouble does not have range checks  in the current JDBC driver it is not worth fixing them
+    @Disabled("https://issues.apache.org/jira/browse/IGNITE-26140")
+    @Override
+    public void getDoubleFromNumber(boolean valid, Number value) throws SQLException {
+        super.getDoubleFromNumber(valid, value);
+    }
 }

--- a/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc2/JdbcResultSet2SelfTest.java
+++ b/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc2/JdbcResultSet2SelfTest.java
@@ -74,10 +74,6 @@ import org.mockito.internal.stubbing.answers.ThrowsException;
  */
 public class JdbcResultSet2SelfTest extends JdbcResultSetBaseSelfTest {
 
-    private static final int FETCH_SIZE = 10;
-
-    // getXXX are not implemented yet
-    // TODO https://issues.apache.org/jira/browse/IGNITE-26369: numerics
     // TODO https://issues.apache.org/jira/browse/IGNITE-26379: datetime
     @Disabled("https://issues.apache.org/jira/browse/IGNITE-26140")
     @Override
@@ -87,8 +83,6 @@ public class JdbcResultSet2SelfTest extends JdbcResultSetBaseSelfTest {
         super.wasNullPositional(columnType);
     }
 
-    // getXXX are not implemented yet
-    // TODO https://issues.apache.org/jira/browse/IGNITE-26369: numerics
     // TODO https://issues.apache.org/jira/browse/IGNITE-26379: datetime
     @Disabled("https://issues.apache.org/jira/browse/IGNITE-26140")
     @Override
@@ -137,16 +131,18 @@ public class JdbcResultSet2SelfTest extends JdbcResultSetBaseSelfTest {
     @Test
     @Override
     public void getMetadata() throws SQLException {
-        try (ResultSet rs = createResultSet(null, 
-                List.of(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false)), 
+        try (ResultSet rs = createResultSet(null,
+                List.of(new ColumnDefinition("C", ColumnType.BOOLEAN, 0, 0, false)),
                 List.of(List.of(true)))
         ) {
             ResultSetMetaData metaData = rs.getMetaData();
             assertEquals(1, metaData.getColumnCount());
         }
 
+        // Empty metadata
         try (ResultSet rs = createResultSet(null, List.of(), List.of())) {
-            expectSqlException(rs::getMetaData, "ResultSet doesn't have metadata");
+            ResultSetMetaData metaData = rs.getMetaData();
+            assertEquals(0, metaData.getColumnCount());
         }
     }
 
@@ -289,10 +285,10 @@ public class JdbcResultSet2SelfTest extends JdbcResultSetBaseSelfTest {
         return new JdbcResultSet(new ResultSetStub(apiMeta, rows), statement);
     }
 
-    protected static class ResultSetStub implements org.apache.ignite.sql.ResultSet<SqlRow> {
+    private static class ResultSetStub implements org.apache.ignite.sql.ResultSet<SqlRow> {
         private final ResultSetMetadata meta;
         private final Iterator<List<Object>> it;
-        private List<Object> current;
+        private @Nullable List<Object> current;
 
         ResultSetStub(ResultSetMetadata meta, List<List<Object>> rows) {
             this.meta = Objects.requireNonNull(meta, "meta");

--- a/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc2/JdbcResultSet2SelfTest.java
+++ b/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc2/JdbcResultSet2SelfTest.java
@@ -93,7 +93,6 @@ public class JdbcResultSet2SelfTest extends JdbcResultSetBaseSelfTest {
     }
 
     // getXXX are not implemented yet
-    // TODO https://issues.apache.org/jira/browse/IGNITE-26369: numerics
     // TODO https://issues.apache.org/jira/browse/IGNITE-26379: datetime
     @Disabled("https://issues.apache.org/jira/browse/IGNITE-26140")
     @Test

--- a/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc2/JdbcResultSet2SelfTest.java
+++ b/modules/jdbc/src/test/java/org/apache/ignite/internal/jdbc2/JdbcResultSet2SelfTest.java
@@ -74,6 +74,8 @@ import org.mockito.internal.stubbing.answers.ThrowsException;
  */
 public class JdbcResultSet2SelfTest extends JdbcResultSetBaseSelfTest {
 
+    private static final int FETCH_SIZE = 10;
+
     // getXXX are not implemented yet
     // TODO https://issues.apache.org/jira/browse/IGNITE-26369: numerics
     // TODO https://issues.apache.org/jira/browse/IGNITE-26379: datetime
@@ -141,6 +143,10 @@ public class JdbcResultSet2SelfTest extends JdbcResultSetBaseSelfTest {
         ) {
             ResultSetMetaData metaData = rs.getMetaData();
             assertEquals(1, metaData.getColumnCount());
+        }
+
+        try (ResultSet rs = createResultSet(null, List.of(), List.of())) {
+            expectSqlException(rs::getMetaData, "ResultSet doesn't have metadata");
         }
     }
 
@@ -283,7 +289,7 @@ public class JdbcResultSet2SelfTest extends JdbcResultSetBaseSelfTest {
         return new JdbcResultSet(new ResultSetStub(apiMeta, rows), statement);
     }
 
-    private static class ResultSetStub implements org.apache.ignite.sql.ResultSet<SqlRow> {
+    protected static class ResultSetStub implements org.apache.ignite.sql.ResultSet<SqlRow> {
         private final ResultSetMetadata meta;
         private final Iterator<List<Object>> it;
         private List<Object> current;


### PR DESCRIPTION
Adds accessors for  the boolean and numeric types to ResultSet backed by thin client.

https://issues.apache.org/jira/browse/IGNITE-26369

---
Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [ ] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [ ] **Design:** new code conforms with the design principles of the components it is added to.
- [ ] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [ ] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [ ] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)