### PR TITLE
IGNITE-26127 Compatibility test fails consecutive run

### DIFF
--- a/modules/compatibility-tests/build.gradle
+++ b/modules/compatibility-tests/build.gradle
@@ -53,11 +53,13 @@ dependencies {
 
     testFixturesImplementation testFixtures(project(':ignite-core'))
     testFixturesImplementation testFixtures(project(':ignite-runner'))
-    testFixturesImplementation project(':ignite-core')
     testFixturesImplementation project(':ignite-api')
-    testFixturesImplementation project(':ignite-runner')
     testFixturesImplementation project(':ignite-client')
+    testFixturesImplementation project(':ignite-core')
+    testFixturesImplementation project(':ignite-distribution-zones')
+    testFixturesImplementation project(':ignite-metastorage-api')
     testFixturesImplementation project(':ignite-rest-api')
+    testFixturesImplementation project(':ignite-runner')
 }
 
 private def resolveAllDependencies(boolean transitive, String... dependencyNotations) {

--- a/modules/compatibility-tests/src/testFixtures/java/org/apache/ignite/internal/CompatibilityTestBase.java
+++ b/modules/compatibility-tests/src/testFixtures/java/org/apache/ignite/internal/CompatibilityTestBase.java
@@ -41,7 +41,6 @@ import org.apache.ignite.internal.app.IgniteImpl;
 import org.apache.ignite.internal.distributionzones.rebalance.RebalanceUtil;
 import org.apache.ignite.internal.distributionzones.rebalance.ZoneRebalanceUtil;
 import org.apache.ignite.internal.lang.ByteArray;
-import org.apache.ignite.internal.metastorage.Entry;
 import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
 import org.apache.ignite.internal.testframework.WorkDirectory;
 import org.apache.ignite.internal.testframework.WorkDirectoryExtension;
@@ -242,7 +241,7 @@ public abstract class CompatibilityTestBase extends BaseIgniteAbstractTest {
         ByteArray prefix = pendingAssignmentsQueuePrefix(node.nodeProperties().colocationEnabled());
 
         return subscribeToList(node.metaStorageManager().prefix(prefix))
-                .thenApply(assignments -> assignments.stream().noneMatch(Predicate.not(Entry::tombstone)));
+                .thenApply(List::isEmpty);
     }
 
     private static ByteArray pendingAssignmentsQueuePrefix(boolean colocationEnabled) {

--- a/modules/compatibility-tests/src/testFixtures/java/org/apache/ignite/internal/CompatibilityTestBase.java
+++ b/modules/compatibility-tests/src/testFixtures/java/org/apache/ignite/internal/CompatibilityTestBase.java
@@ -20,18 +20,28 @@ package org.apache.ignite.internal;
 import static org.apache.ignite.internal.TestDefaultProfilesNames.DEFAULT_AIMEM_PROFILE_NAME;
 import static org.apache.ignite.internal.TestDefaultProfilesNames.DEFAULT_AIPERSIST_PROFILE_NAME;
 import static org.apache.ignite.internal.TestDefaultProfilesNames.DEFAULT_ROCKSDB_PROFILE_NAME;
+import static org.apache.ignite.internal.TestWrappers.unwrapIgniteImpl;
+import static org.apache.ignite.internal.testframework.flow.TestFlowUtils.subscribeToList;
+import static org.apache.ignite.internal.testframework.matchers.CompletableFutureMatcher.willBe;
+import static org.awaitility.Awaitility.await;
 
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.InitParametersBuilder;
 import org.apache.ignite.client.IgniteClient;
 import org.apache.ignite.internal.IgniteVersions.Version;
+import org.apache.ignite.internal.app.IgniteImpl;
+import org.apache.ignite.internal.distributionzones.rebalance.RebalanceUtil;
+import org.apache.ignite.internal.distributionzones.rebalance.ZoneRebalanceUtil;
+import org.apache.ignite.internal.lang.ByteArray;
+import org.apache.ignite.internal.metastorage.Entry;
 import org.apache.ignite.internal.testframework.BaseIgniteAbstractTest;
 import org.apache.ignite.internal.testframework.WorkDirectory;
 import org.apache.ignite.internal.testframework.WorkDirectoryExtension;
@@ -105,6 +115,7 @@ public abstract class CompatibilityTestBase extends BaseIgniteAbstractTest {
             cluster.stop();
 
             cluster.startEmbedded(nodesCount, false);
+            await().until(this::noActiveRebalance, willBe(true));
         }
     }
 
@@ -218,5 +229,26 @@ public abstract class CompatibilityTestBase extends BaseIgniteAbstractTest {
             return value.isEmpty() || "true".equals(value);
         }
         return false;
+    }
+
+    /**
+     * Checks if there is an active rebalance happening. Does this by checking for pending assignments.
+     *
+     * @return {@code true} if there are no pending assignments in the metastorage.
+     */
+    private CompletableFuture<Boolean> noActiveRebalance() {
+        IgniteImpl node = unwrapIgniteImpl(node(0));
+
+        ByteArray prefix = pendingAssignmentsQueuePrefix(node.nodeProperties().colocationEnabled());
+
+        return subscribeToList(node.metaStorageManager().prefix(prefix))
+                .thenApply(assignments -> assignments.stream().noneMatch(Predicate.not(Entry::tombstone)));
+    }
+
+    private static ByteArray pendingAssignmentsQueuePrefix(boolean colocationEnabled) {
+        byte[] prefix = colocationEnabled
+                ? ZoneRebalanceUtil.PENDING_ASSIGNMENTS_QUEUE_PREFIX_BYTES
+                : RebalanceUtil.PENDING_ASSIGNMENTS_QUEUE_PREFIX_BYTES;
+        return new ByteArray(prefix);
     }
 }

--- a/modules/replicator/src/main/java/org/apache/ignite/internal/raft/client/TopologyAwareRaftGroupService.java
+++ b/modules/replicator/src/main/java/org/apache/ignite/internal/raft/client/TopologyAwareRaftGroupService.java
@@ -27,9 +27,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 import org.apache.ignite.internal.cluster.management.topology.api.LogicalNode;
@@ -266,23 +264,27 @@ public class TopologyAwareRaftGroupService implements RaftGroupService {
                 return;
             }
 
+            Throwable invokeCause = unwrapCause(invokeThrowable);
             if (!msg.subscribe()) {
                 // We don't want to propagate exceptions when unsubscribing (if it's not an Error!).
-                if (unwrapCause(invokeThrowable) instanceof Error) {
+                if (invokeCause instanceof Error) {
                     msgSendFut.completeExceptionally(invokeThrowable);
                 } else {
                     LOG.debug("An exception while trying to unsubscribe", invokeThrowable);
 
                     msgSendFut.complete(false);
                 }
-            } else if (recoverable(invokeThrowable)) {
+            } else if (recoverable(invokeCause)) {
                 sendWithRetry(node, msg, msgSendFut);
-            } else if (invokeThrowable instanceof RecipientLeftException) {
-                LOG.info("Could not subscribe to leader update from a specific node, because the node had left the cluster: [node={}]", node);
+            } else if (invokeCause instanceof RecipientLeftException) {
+                LOG.info(
+                        "Could not subscribe to leader update from a specific node, because the node had left the cluster: [node={}]",
+                        node
+                );
 
                 msgSendFut.complete(false);
             } else {
-                if (!(unwrapCause(invokeThrowable) instanceof NodeStoppingException)) {
+                if (!(invokeCause instanceof NodeStoppingException)) {
                     LOG.error("Could not send the subscribe message to the node: [node={}, msg={}]", invokeThrowable, node, msg);
                 }
 
@@ -298,10 +300,6 @@ public class TopologyAwareRaftGroupService implements RaftGroupService {
      * @return True if the exception is recoverable, false otherwise.
      */
     private static boolean recoverable(Throwable t) {
-        if (t instanceof ExecutionException || t instanceof CompletionException) {
-            t = t.getCause();
-        }
-
         return t instanceof TimeoutException || t instanceof IOException;
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-26127

The main problem here is replica await timeout during active rebalance on cluster restart.

On a first iteration all three nodes on a current version start almost simultaneously, see that there's no data nodes history key, read the topology from the old version which contains all three nodes and continue to work normal.
On the second run (probably due to the classes already loaded and JVM is warmed up) first node reads logical topology from the metastorage and quickly adds itself to the topology. Now the second node reads the topology but sees only the first node there and this triggers a rebalance. Third node see first two nodes in the topology and triggers rebalance once again.
If at this moment the test tries to read data from a table, the replica await times out.

The easy solution for now is to wait until there is no active rebalance, which is checked by looking at the pending assignment queue in the metastorage.

Another issue was found during debugging of this - excessive retries when restarting a node. 
When a node sends a raft message using old node id but new node (which has the same consistent id) replies, messaging service throws a `RecipientLeftException`, we take a topology snapshot and check whether the node is in the topology.
If it is, we retry the send, but we pass the same old node with the old id and the same situation happens again.
After some time the loop resolves by some other means, probably retry somewhere up the stack, but it seems we can shortcut it here by getting the new recipient from the topology.

Also a small reordering of statements was made in the `TableManager` in order to get proper logs. Previously we log the assignments queue after the assignments were polled from it.