### PR TITLE
IGNITE-26474 .NET: Fix metrics test flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/FakeServer.cs
@@ -36,6 +36,8 @@ namespace Apache.Ignite.Tests
     using Internal.Proto.BinaryTuple;
     using Internal.Proto.MsgPack;
     using MessagePack;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Logging.Abstractions;
     using Network;
 
     /// <summary>
@@ -147,6 +149,11 @@ namespace Apache.Ignite.Tests
 
             cfg.Endpoints.Clear();
             cfg.Endpoints.Add(Endpoint);
+
+            if (cfg.LoggerFactory is NullLoggerFactory)
+            {
+                cfg.LoggerFactory = TestUtils.GetConsoleLoggerFactory(LogLevel.Trace);
+            }
 
             return await IgniteClient.StartAsync(cfg);
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -43,6 +43,7 @@ public class MetricsTests
     [TearDown]
     public void TearDown()
     {
+        AssertMetric(MetricNames.ConnectionsActive, 0);
         _listener.Dispose();
 
         TestUtils.CheckByteArrayPoolLeak(5000);
@@ -329,7 +330,8 @@ public class MetricsTests
         new()
         {
             SocketTimeout = TimeSpan.FromMilliseconds(100),
-            RetryPolicy = new RetryNonePolicy()
+            RetryPolicy = new RetryNonePolicy(),
+            ReconnectInterval = TimeSpan.Zero
         };
 
     private static IgniteClientConfiguration GetConfigWithDelay() =>
@@ -337,7 +339,8 @@ public class MetricsTests
         {
             HeartbeatInterval = TimeSpan.FromMilliseconds(50),
             SocketTimeout = TimeSpan.FromMilliseconds(50),
-            RetryPolicy = new RetryNonePolicy()
+            RetryPolicy = new RetryNonePolicy(),
+            ReconnectInterval = TimeSpan.Zero
         };
 
     private static Guid? GetClientId(IIgniteClient? client) => ((IgniteClientInternal?)client)?.Socket.ClientId;

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -40,7 +40,7 @@ public class MetricsTests
     private volatile Listener _listener = null!;
 
     [SetUp]
-    public void SetUp() => _listener = new Listener();
+    public void SetUp() => _listener = new Listener(TestContext.CurrentContext.Test.Name);
 
     [TearDown]
     public void TearDown()
@@ -361,14 +361,18 @@ public class MetricsTests
 
     internal sealed class Listener : IDisposable
     {
+        private readonly string _name;
+
         private readonly MeterListener _listener = new();
 
         private readonly ConcurrentDictionary<string, long> _metrics = new();
 
         private readonly ConcurrentDictionary<string, long> _metricsWithTags = new();
 
-        public Listener()
+        public Listener(string name)
         {
+            _name = name;
+
             _listener.InstrumentPublished = (instrument, listener) =>
             {
                 if (instrument.Meter.Name == "Apache.Ignite")
@@ -441,6 +445,8 @@ public class MetricsTests
         private void Handle<T>(Instrument instrument, T measurement, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state)
         {
             var newVal = Convert.ToInt64(measurement);
+
+            Console.WriteLine($"{_name} measurement: {instrument.Name} = {newVal}");
 
             if (instrument.IsObservable)
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -439,7 +439,9 @@ public class MetricsTests
 
         public void Dispose()
         {
+            Console.WriteLine("Disposing listener: " + _name);
             _listener.Dispose();
+            Console.WriteLine("Disposed listener: " + _name);
         }
 
         private void Handle<T>(Instrument instrument, T measurement, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state)

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -446,20 +446,23 @@ public class MetricsTests
 
         private void Handle<T>(Instrument instrument, T measurement, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state)
         {
-            var newVal = Convert.ToInt64(measurement);
-
-            Console.WriteLine($"{_name} measurement: {instrument.Name} = {newVal}");
-
-            if (instrument.IsObservable)
+            lock (_listener)
             {
-                _metrics[instrument.Name] = newVal;
-            }
-            else
-            {
-                _metrics.AddOrUpdate(instrument.Name, newVal, (_, val) => val + newVal);
+                var newVal = Convert.ToInt64(measurement);
 
-                var taggedName = $"{instrument.Name}_{string.Join(",", tags.ToArray().Select(x => $"{x.Key}={x.Value}"))}";
-                _metricsWithTags.AddOrUpdate(taggedName, newVal, (_, val) => val + newVal);
+                Console.WriteLine($"{_name} measurement: {instrument.Name} = {newVal}");
+
+                if (instrument.IsObservable)
+                {
+                    _metrics[instrument.Name] = newVal;
+                }
+                else
+                {
+                    _metrics.AddOrUpdate(instrument.Name, newVal, (_, val) => val + newVal);
+
+                    var taggedName = $"{instrument.Name}_{string.Join(",", tags.ToArray().Select(x => $"{x.Key}={x.Value}"))}";
+                    _metricsWithTags.AddOrUpdate(taggedName, newVal, (_, val) => val + newVal);
+                }
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/MetricsTests.cs
@@ -35,6 +35,8 @@ using NUnit.Framework;
 /// </summary>
 public class MetricsTests
 {
+    private const int DefaultTimeoutMs = 3000;
+
     private volatile Listener _listener = null!;
 
     [SetUp]
@@ -345,7 +347,7 @@ public class MetricsTests
 
     private static Guid? GetClientId(IIgniteClient? client) => ((IgniteClientInternal?)client)?.Socket.ClientId;
 
-    private void AssertMetric(string name, int value, int timeoutMs = 1000) =>
+    private void AssertMetric(string name, int value, int timeoutMs = DefaultTimeoutMs) =>
         _listener.AssertMetric(name, value, timeoutMs);
 
     private void AssertTaggedMetric(string name, int value, FakeServer server, IIgniteClient? client) =>
@@ -354,7 +356,7 @@ public class MetricsTests
     private void AssertTaggedMetric(string name, int value, string nodeAddr, Guid? clientId) =>
         _listener.AssertTaggedMetric(name, value, nodeAddr, clientId);
 
-    private void AssertMetricGreaterOrEqual(string name, int value, int timeoutMs = 1000) =>
+    private void AssertMetricGreaterOrEqual(string name, int value, int timeoutMs = DefaultTimeoutMs) =>
         _listener.AssertMetricGreaterOrEqual(name, value, timeoutMs);
 
     internal sealed class Listener : IDisposable
@@ -408,7 +410,7 @@ public class MetricsTests
                 .SingleOrDefault();
         }
 
-        public void AssertMetric(string name, int value, int timeoutMs = 1000)
+        public void AssertMetric(string name, int value, int timeoutMs = DefaultTimeoutMs)
         {
             TestUtils.WaitForCondition(
                 condition: () => GetMetric(name) == value,
@@ -416,7 +418,7 @@ public class MetricsTests
                 messageFactory: () => $"{name}: expected '{value}', but was '{GetMetric(name)}'");
         }
 
-        public void AssertTaggedMetric(string name, int value, string nodeAddr, Guid? clientId, int timeoutMs = 1000)
+        public void AssertTaggedMetric(string name, int value, string nodeAddr, Guid? clientId, int timeoutMs = DefaultTimeoutMs)
         {
             TestUtils.WaitForCondition(
                 condition: () => GetTaggedMetric(name, nodeAddr, clientId) == value,
@@ -425,7 +427,7 @@ public class MetricsTests
                                       $"but was '{GetTaggedMetric(name, nodeAddr, clientId)}'");
         }
 
-        public void AssertMetricGreaterOrEqual(string name, int value, int timeoutMs = 1000) =>
+        public void AssertMetricGreaterOrEqual(string name, int value, int timeoutMs = DefaultTimeoutMs) =>
             TestUtils.WaitForCondition(
                 condition: () => GetMetric(name) >= value,
                 timeoutMs: timeoutMs,


### PR DESCRIPTION
* Disable reconnect
* Add lock
* Increase timeout
* Add logging