### PR TITLE
IGNITE-25974 Verify platform ErrorGroups generation

### DIFF
--- a/modules/api/build.gradle
+++ b/modules/api/build.gradle
@@ -52,4 +52,46 @@ artifacts {
     }
 }
 
+def checkGeneratedPlatformHeaders = tasks.register('checkGeneratedErrorGroupFiles', Task) {
+    description = 'Verifies that committed generated error group files (C++, C#) are in sync with Java error code definitions. ' +
+            'If this fails, run \'./gradlew :platforms:copyPlatformsHeaders\' and commit the result.'
+    dependsOn compileJava
+
+    doLast {
+        def failures = []
+
+        [
+            'cpp/ignite/common/error_codes.h',
+            'dotnet/Apache.Ignite/ErrorCodes.g.cs'
+        ].each { relativePath ->
+            def generatedFile = file("${platformsHeadersDir}/${relativePath}")
+            def committedFile = file("${rootDir}/modules/platforms/${relativePath}")
+
+            if (!generatedFile.exists()) {
+                failures << "Generated file not found: ${generatedFile}"
+                return
+            }
+
+            if (!committedFile.exists()) {
+                failures << "modules/platforms/${relativePath} is missing — run './gradlew :platforms:copyPlatformsHeaders' and commit."
+                return
+            }
+
+            if (generatedFile.text != committedFile.text) {
+                failures << "modules/platforms/${relativePath} is out of date with ErrorGroups.java."
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            throw new GradleException(
+                "Generated platform headers are out of sync with Java error code definitions.\n" +
+                "Run './gradlew :platforms:copyPlatformsHeaders' and commit the result.\n" +
+                "Affected files:\n" + failures.collect { "  - $it" }.join("\n")
+            )
+        }
+    }
+}
+
+check.dependsOn checkGeneratedErrorGroupFiles
+
 description = 'ignite-api'

--- a/modules/platforms/cpp/ignite/common/error_codes.h
+++ b/modules/platforms/cpp/ignite/common/error_codes.h
@@ -167,7 +167,6 @@ enum class code : underlying_t {
     // Network group. Group code: 11
     UNRESOLVABLE_CONSISTENT_ID = 0xb0001,
     BIND = 0xb0002,
-    // Error codes 0xb0003 (FILE_TRANSFER) and 0xb0004 (FILE_VALIDATION) were removed along with the file-transfer module.
     RECIPIENT_LEFT = 0xb0005,
     ADDRESS_UNRESOLVED = 0xb0006,
     PORT_IN_USE [[deprecated("PORT_IN_USE is deprecated. Use BIND instead.")]] = BIND,

--- a/modules/platforms/dotnet/Apache.Ignite/ErrorCodes.g.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/ErrorCodes.g.cs
@@ -483,12 +483,6 @@ namespace Apache.Ignite
             /// <summary> Bind error. </summary>
             public const int Bind = (GroupCode << 16) | (2 & 0xFFFF);
 
-            /// <summary> FileTransfer error. </summary>
-            public const int FileTransfer = (GroupCode << 16) | (3 & 0xFFFF);
-
-            /// <summary> FileValidation error. </summary>
-            public const int FileValidation = (GroupCode << 16) | (4 & 0xFFFF);
-
             /// <summary> RecipientLeft error. </summary>
             public const int RecipientLeft = (GroupCode << 16) | (5 & 0xFFFF);
 


### PR DESCRIPTION
Verifies that committed generated error group files (C++, C#) are in sync with Java error code definitions.

https://issues.apache.org/jira/browse/IGNITE-25974