### PR TITLE
IGNITE-28497 Revert file transfer ErrorGroups removal

### DIFF
--- a/modules/api/src/main/java/org/apache/ignite/lang/ErrorGroups.java
+++ b/modules/api/src/main/java/org/apache/ignite/lang/ErrorGroups.java
@@ -562,10 +562,20 @@ public class ErrorGroups {
         /** Address or port bind error. */
         public static final int BIND_ERR = NETWORK_ERR_GROUP.registerErrorCode((short) 2);
 
-        /** File transfer error. */
+        /**
+         * File transfer error.
+         *
+         * @deprecated This error is no longer used.
+         */
+        @Deprecated
         public static final int FILE_TRANSFER_ERR = NETWORK_ERR_GROUP.registerErrorCode((short) 3);
 
-        /** File validation error. */
+        /**
+         * File validation error.
+         *
+         * @deprecated This error is no longer used.
+         */
+        @Deprecated
         public static final int FILE_VALIDATION_ERR = NETWORK_ERR_GROUP.registerErrorCode((short) 4);
 
         /** Recipient node has left the physical topology. */

--- a/modules/api/src/main/java/org/apache/ignite/lang/ErrorGroups.java
+++ b/modules/api/src/main/java/org/apache/ignite/lang/ErrorGroups.java
@@ -562,8 +562,11 @@ public class ErrorGroups {
         /** Address or port bind error. */
         public static final int BIND_ERR = NETWORK_ERR_GROUP.registerErrorCode((short) 2);
 
-        // Error codes 3 (FILE_TRANSFER_ERR) and 4 (FILE_VALIDATION_ERR) were removed along with the file-transfer module.
-        // These codes are reserved forever and must not be reused.
+        /** File transfer error. */
+        public static final int FILE_TRANSFER_ERR = NETWORK_ERR_GROUP.registerErrorCode((short) 3);
+
+        /** File validation error. */
+        public static final int FILE_VALIDATION_ERR = NETWORK_ERR_GROUP.registerErrorCode((short) 4);
 
         /** Recipient node has left the physical topology. */
         public static final int RECIPIENT_LEFT_ERR = NETWORK_ERR_GROUP.registerErrorCode((short) 5);

--- a/modules/compatibility-tests/src/test/java/org/apache/ignite/internal/ApiCompatibilityTest.java
+++ b/modules/compatibility-tests/src/test/java/org/apache/ignite/internal/ApiCompatibilityTest.java
@@ -65,9 +65,6 @@ class ApiCompatibilityTest {
             "3.1.0", List.of(
                     // Erroneous error code remove between versions
                     "org.apache.ignite.lang.ErrorGroups$DisasterRecovery#RESTART_WITH_CLEAN_UP_ERR",
-                    // Removed along with the file-transfer module
-                    "org.apache.ignite.lang.ErrorGroups$Network#FILE_TRANSFER_ERR",
-                    "org.apache.ignite.lang.ErrorGroups$Network#FILE_VALIDATION_ERR",
                     "org.apache.ignite.table.KeyValueView" // METHOD_ABSTRACT_NOW_DEFAULT
                             + "#remove(org.apache.ignite.tx.Transaction, java.lang.Object, java.lang.Object)",
                     "org.apache.ignite.table.KeyValueView" // METHOD_ABSTRACT_NOW_DEFAULT

--- a/modules/platforms/cpp/ignite/common/error_codes.h
+++ b/modules/platforms/cpp/ignite/common/error_codes.h
@@ -167,6 +167,8 @@ enum class code : underlying_t {
     // Network group. Group code: 11
     UNRESOLVABLE_CONSISTENT_ID = 0xb0001,
     BIND = 0xb0002,
+    FILE_TRANSFER = 0xb0003,
+    FILE_VALIDATION = 0xb0004,
     RECIPIENT_LEFT = 0xb0005,
     ADDRESS_UNRESOLVED = 0xb0006,
     PORT_IN_USE [[deprecated("PORT_IN_USE is deprecated. Use BIND instead.")]] = BIND,

--- a/modules/platforms/dotnet/Apache.Ignite/ErrorCodes.g.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/ErrorCodes.g.cs
@@ -483,6 +483,12 @@ namespace Apache.Ignite
             /// <summary> Bind error. </summary>
             public const int Bind = (GroupCode << 16) | (2 & 0xFFFF);
 
+            /// <summary> FileTransfer error. </summary>
+            public const int FileTransfer = (GroupCode << 16) | (3 & 0xFFFF);
+
+            /// <summary> FileValidation error. </summary>
+            public const int FileValidation = (GroupCode << 16) | (4 & 0xFFFF);
+
             /// <summary> RecipientLeft error. </summary>
             public const int RecipientLeft = (GroupCode << 16) | (5 & 0xFFFF);
 


### PR DESCRIPTION
`ErrorGroups` are public API and can't be removed. Mark as deprecated instead.
 
https://issues.apache.org/jira/browse/IGNITE-28497