### PR TITLE
IGNITE-28505 prevent log flooding caused by TX operations when a node…

### DIFF
--- a/modules/partition-replicator/src/main/java/org/apache/ignite/internal/partition/replicator/handlers/TxCleanupRecoveryRequestHandler.java
+++ b/modules/partition-replicator/src/main/java/org/apache/ignite/internal/partition/replicator/handlers/TxCleanupRecoveryRequestHandler.java
@@ -33,6 +33,7 @@ import org.apache.ignite.internal.failure.FailureContext;
 import org.apache.ignite.internal.failure.FailureProcessor;
 import org.apache.ignite.internal.lang.IgniteBiTuple;
 import org.apache.ignite.internal.lang.IgniteInternalException;
+import org.apache.ignite.internal.lang.NodeStoppingException;
 import org.apache.ignite.internal.logger.IgniteLogger;
 import org.apache.ignite.internal.logger.IgniteThrottledLogger;
 import org.apache.ignite.internal.logger.Loggers;
@@ -156,13 +157,13 @@ public class TxCleanupRecoveryRequestHandler {
                 txMeta.commitTimestamp(),
                 txId
         ).exceptionally(throwable -> {
-            throttledLog.warn(
-                    "Failed to cleanup transaction",
-                    "Failed to cleanup transaction {}.",
-                    throwable,
-                    formatTxInfo(txId, txManager)
-            );
-
+            if (throwable != null && !hasCause(throwable, NodeStoppingException.class)) {
+                throttledLog.warn(
+                        "Failed to cleanup transaction",
+                        "Failed to cleanup transaction {}.",
+                        throwable,
+                        formatTxInfo(txId, txManager));
+            }
             return null;
         });
     }

--- a/modules/partition-replicator/src/main/java/org/apache/ignite/internal/partition/replicator/handlers/TxCleanupRecoveryRequestHandler.java
+++ b/modules/partition-replicator/src/main/java/org/apache/ignite/internal/partition/replicator/handlers/TxCleanupRecoveryRequestHandler.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.ignite.internal.failure.FailureContext;
 import org.apache.ignite.internal.failure.FailureProcessor;
+import org.apache.ignite.internal.lang.ComponentStoppingException;
 import org.apache.ignite.internal.lang.IgniteBiTuple;
 import org.apache.ignite.internal.lang.IgniteInternalException;
 import org.apache.ignite.internal.lang.NodeStoppingException;
@@ -157,7 +158,7 @@ public class TxCleanupRecoveryRequestHandler {
                 txMeta.commitTimestamp(),
                 txId
         ).exceptionally(throwable -> {
-            if (throwable != null && !hasCause(throwable, NodeStoppingException.class)) {
+            if (!hasCause(throwable, NodeStoppingException.class) && !hasCause(throwable, ComponentStoppingException.class)) {
                 throttledLog.warn(
                         "Failed to cleanup transaction",
                         "Failed to cleanup transaction {}.",


### PR DESCRIPTION
TX-related operations that fail because a node is stopping cause severe log pollution. For example, continuous failed attempts to perform TX cleanup generated. 

https://issues.apache.org/jira/browse/IGNITE-28505