### PR TITLE
IGNITE-28571 Fix compilation of PersistentTxStateVacuumizerTest under java 11

### DIFF
--- a/modules/transactions/src/test/java/org/apache/ignite/internal/tx/impl/PersistentTxStateVacuumizerTest.java
+++ b/modules/transactions/src/test/java/org/apache/ignite/internal/tx/impl/PersistentTxStateVacuumizerTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import org.apache.ignite.internal.hlc.HybridClockImpl;
 import org.apache.ignite.internal.hlc.TestClockService;
 import org.apache.ignite.internal.network.InternalClusterNode;
@@ -117,7 +118,7 @@ class PersistentTxStateVacuumizerTest extends BaseIgniteAbstractTest {
 
         // Each request should have at most VACUUM_BATCH_SIZE tx IDs.
         assertThat(
-                requestCaptor.getAllValues().stream().map(r -> r.transactionIds().size()).toList(),
+                requestCaptor.getAllValues().stream().map(r -> r.transactionIds().size()).collect(Collectors.toUnmodifiableList()),
                 everyItem(lessThanOrEqualTo(VACUUM_BATCH_SIZE))
         );
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-28571

he project does not compile under Java 11.

The issue is due to https://github.com/apache/ignite-3/pull/7987/changes#diff-6367281ae0f24cf7b43a2f0df789f4c90928c0b52bad3952c20f5b1ccc03a6fcR120

Method Stream.toList() was introduced in java 16.

```
> ./gradlew build testClasses -x check

ignite-3/modules/transactions/src/test/java/org/apache/ignite/internal/tx/impl/PersistentTxStateVacuumizerTest.java:120: error: cannot find symbol
                requestCaptor.getAllValues().stream().map(r -> r.transactionIds().size()).toList(),
                                                                                         ^
  symbol:   method toList()
  location: interface Stream<Integer>
```