### PR TITLE
IGNITE-28567 Use InvariantCulture in IgniteToStringBuilder for consistent formatting

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/IgniteDbParameterTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests/Sql/IgniteDbParameterTests.cs
@@ -19,7 +19,9 @@ namespace Apache.Ignite.Tests.Sql;
 
 using System;
 using System.Data;
-using Ignite.Sql;
+using System.Globalization;
+using System.Threading;
+using Apache.Ignite.Sql;
 using NUnit.Framework;
 
 public class IgniteDbParameterTests
@@ -56,6 +58,19 @@ public class IgniteDbParameterTests
 
     [Test]
     public void TestToString()
+    {
+        var param = new IgniteDbParameter { Value = 12.3 };
+
+        Assert.AreEqual("IgniteDbParameter { Value = 12.3 }", param.ToString());
+    }
+
+    /// <summary>
+    /// Tests that <see cref="IgniteDbParameter.ToString"/> uses invariant culture
+    /// and does not change based on the system locale (e.g. comma vs dot decimal separator).
+    /// </summary>
+    [Test]
+    [SetCulture("de-DE")]
+    public void TestToStringNonInvariantCulture()
     {
         var param = new IgniteDbParameter { Value = 12.3 };
 

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -74,7 +74,15 @@ internal record IgniteToStringBuilder
 
         _builder.Append(name);
         _builder.Append(" = ");
-        _builder.Append(value);
+
+        if (value != null)
+        {
+            _builder.Append(Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture));
+        }
+        else
+        {
+            _builder.Append(value);
+        }
 
         return this;
     }

--- a/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/Internal/Common/IgniteToStringBuilder.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Internal.Common;
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -77,7 +78,7 @@ internal record IgniteToStringBuilder
 
         if (value != null)
         {
-            _builder.Append(Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture));
+            _builder.Append(Convert.ToString(value, CultureInfo.InvariantCulture));
         }
         else
         {


### PR DESCRIPTION
This PR ensures that IgniteToStringBuilder uses CultureInfo.InvariantCulture when converting object values to strings.

https://issues.apache.org/jira/browse/IGNITE-28567